### PR TITLE
[Location] Draw approximate ring with location indicator layer for reduced accuracy location permissions

### DIFF
--- a/Mapbox/MapboxMapsLocation/Pucks/PuckLocationIndicatorLayer.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/PuckLocationIndicatorLayer.swift
@@ -181,7 +181,18 @@ private extension PuckLocationIndicatorLayer {
         paint.location = .constant([location.coordinate.latitude,
                                     location.coordinate.longitude,
                                     location.internalLocation.altitude])
-        paint.accuracyRadius = .constant(5000)
+        let exp = Exp(.interpolate) {
+            Exp(.linear) 
+            Exp(.zoom)
+            0
+            400000
+            4
+            200000
+            8
+            5000
+        }
+        paint.accuracyRadius = .expression(exp)
+
         paint.accuracyRadiusColor = .constant(ColorRepresentable(color: UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
         paint.accuracyRadiusBorderColor = .constant(ColorRepresentable(color: .lightGray))
         layer.paint = paint


### PR DESCRIPTION
Fixes #3 

This PR allows an approximate ring to be drawn when the location accuracy drops to `.reducedAccuracy`.

![simulator_screenshot_FD01BC56-1379-42EF-8823-AA9180140522](https://user-images.githubusercontent.com/6844889/105072196-9267e580-5a53-11eb-86b5-13d13248a58a.png)
