### PR TITLE
[annotations] Update PointAnnotation.coordinate so that it has a private setter

### DIFF
--- a/Mapbox/MapboxMapsAnnotations/LineAnnotation.swift
+++ b/Mapbox/MapboxMapsAnnotations/LineAnnotation.swift
@@ -32,6 +32,11 @@ public struct LineAnnotation: Annotation {
      */
     public var isSelected: Bool = false
 
+    /**
+     The optional properties associated with the line annotation.
+     */
+    public var properties: [String: Any]?
+
     // MARK: - Internal properties
 
     /**
@@ -40,11 +45,6 @@ public struct LineAnnotation: Annotation {
      The annotation is rendered on the map at this location.
      */
     private(set) public var coordinates: [CLLocationCoordinate2D]
-
-    /**
-     The optional properties associated with the line annotation.
-     */
-    public var properties: [String: Any]?
 
     // MARK: - Initialization
 

--- a/Mapbox/MapboxMapsAnnotations/PointAnnotation.swift
+++ b/Mapbox/MapboxMapsAnnotations/PointAnnotation.swift
@@ -50,7 +50,7 @@ public struct PointAnnotation: Annotation {
 
      The annotation is rendered on the map at this location.
      */
-    public var coordinate: CLLocationCoordinate2D
+    public private(set) var coordinate: CLLocationCoordinate2D
 
     /**
      The optional properties associated with the point annotation.

--- a/Mapbox/MapboxMapsAnnotations/PolygonAnnotation.swift
+++ b/Mapbox/MapboxMapsAnnotations/PolygonAnnotation.swift
@@ -32,6 +32,11 @@ public struct PolygonAnnotation: Annotation {
      */
     public var isSelected: Bool = false
 
+    /**
+     The optional properties associated with the polygon annotation.
+     */
+    public var properties: [String: Any]?
+
     // MARK: - Internal properties
 
     /**
@@ -45,10 +50,6 @@ public struct PolygonAnnotation: Annotation {
      */
     private(set) public var interiorPolygons: [[CLLocationCoordinate2D]]?
 
-    /**
-     The optional properties associated with the polygon annotation.
-     */
-    public var properties: [String: Any]?
 
     // MARK: - Initialization
 


### PR DESCRIPTION
This PR updates `PointAnnotation.coordinate` so that it has a private setter. A few properties are also moved from the `Internal` section based on access.