### PR TITLE
Add basic rotation support to the map view

### DIFF
--- a/DebugApp/DebugApp/DebugViewController.swift
+++ b/DebugApp/DebugApp/DebugViewController.swift
@@ -31,4 +31,9 @@ public class DebugViewController: UIViewController {
 
         self.view.addSubview(mapView)
     }
+
+    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        self.mapView.frame.size = size
+    }
 }

--- a/Mapbox/MapboxMapsFoundation/BaseMapView.swift
+++ b/Mapbox/MapboxMapsFoundation/BaseMapView.swift
@@ -188,10 +188,8 @@ open class BaseMapView: UIView, MapClient, MBMMetalViewProvider {
 
     public override func layoutSubviews() {
         super.layoutSubviews()
-
         let size = MapboxCoreMaps.Size(width: Float(self.bounds.size.width),
                                        height: Float(self.bounds.size.height))
-        print("width: \(Float(self.bounds.size.width)) \n height : \(Float(self.bounds.size.height))")
         try! self.__map?.setSizeFor(size)
     }
 


### PR DESCRIPTION
This PR adds preliminary rotation support to the map view and an associated example in the debug app.

Screenshots:
![Simulator Screen Shot - iPhone 11 - 2021-01-20 at 13 19 28](https://user-images.githubusercontent.com/6844889/105217869-6c5d4680-5b22-11eb-98d0-0bbee0fa535f.png)

![Simulator Screen Shot - iPhone 11 - 2021-01-20 at 13 19 23](https://user-images.githubusercontent.com/6844889/105217879-6ff0cd80-5b22-11eb-99a9-62647ddbcb25.png)


