### PR TITLE
Add example to customize location indicator layer

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		073475D725AFAE520049B0B8 /* CustomLayerExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073475D625AFAE520049B0B8 /* CustomLayerExample.swift */; };
 		0706C4A625B1181A008733C0 /* TerrainExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0706C4A525B1181A008733C0 /* TerrainExample.swift */; };
+		073475D725AFAE520049B0B8 /* CustomLayerExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073475D625AFAE520049B0B8 /* CustomLayerExample.swift */; };
 		077C4EFA252F7E89007636F1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 077C4EF8252F7E89007636F1 /* LaunchScreen.storyboard */; };
 		077C4F05252F7E89007636F1 /* ExamplesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077C4F04252F7E89007636F1 /* ExamplesTests.swift */; };
 		077C4F10252F7E89007636F1 /* ExamplesUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077C4F0F252F7E89007636F1 /* ExamplesUITests.swift */; };
@@ -16,6 +16,7 @@
 		07DC84422538B1F100F4AF14 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 07DC84412538B1F100F4AF14 /* Assets.xcassets */; };
 		0C52BA9825AF8C880054ECA8 /* PuckModelLayerExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C52BA9725AF8C880054ECA8 /* PuckModelLayerExample.swift */; };
 		0C52BA9C25AFB5940054ECA8 /* arrow.gltf in Resources */ = {isa = PBXBuildFile; fileRef = 0C52BA9B25AFB5940054ECA8 /* arrow.gltf */; };
+		0CC4ECEA25B8AD3000F998B8 /* CustomLocationIndicatorLayerExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC4ECE925B8AD3000F998B8 /* CustomLocationIndicatorLayerExample.swift */; };
 		0CE8ED88258928200066E56C /* race_car_model.gltf in Resources */ = {isa = PBXBuildFile; fileRef = 0CE8ED87258928200066E56C /* race_car_model.gltf */; };
 		0CE8ED8C2589285C0066E56C /* ModelExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE8ED8B2589285C0066E56C /* ModelExample.swift */; };
 		A4211CE62592549900D215B4 /* RestrictCoordinateBoundsExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4211CE52592549900D215B4 /* RestrictCoordinateBoundsExample.swift */; };
@@ -126,6 +127,7 @@
 		07DC84412538B1F100F4AF14 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0C52BA9725AF8C880054ECA8 /* PuckModelLayerExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PuckModelLayerExample.swift; sourceTree = "<group>"; };
 		0C52BA9B25AFB5940054ECA8 /* arrow.gltf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = arrow.gltf; sourceTree = "<group>"; };
+		0CC4ECE925B8AD3000F998B8 /* CustomLocationIndicatorLayerExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomLocationIndicatorLayerExample.swift; sourceTree = "<group>"; };
 		0CE3D3BE25818626000585A2 /* ColorExpressionExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExpressionExample.swift; sourceTree = "<group>"; };
 		0CE3D3C225818786000585A2 /* FlyToExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlyToExample.swift; sourceTree = "<group>"; };
 		0CE8ED87258928200066E56C /* race_car_model.gltf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = race_car_model.gltf; sourceTree = "<group>"; };
@@ -234,6 +236,7 @@
 				073475D625AFAE520049B0B8 /* CustomLayerExample.swift */,
 				0C52BA9725AF8C880054ECA8 /* PuckModelLayerExample.swift */,
 				0706C4A525B1181A008733C0 /* TerrainExample.swift */,
+				0CC4ECE925B8AD3000F998B8 /* CustomLocationIndicatorLayerExample.swift */,
 			);
 			path = "All Examples";
 			sourceTree = "<group>";
@@ -524,6 +527,7 @@
 				CADCF72C2584990E0065C51B /* PointAnnotationExample.swift in Sources */,
 				CADCF7242584990E0065C51B /* AnimateLayerExample.swift in Sources */,
 				073475D725AFAE520049B0B8 /* CustomLayerExample.swift in Sources */,
+				0CC4ECEA25B8AD3000F998B8 /* CustomLocationIndicatorLayerExample.swift in Sources */,
 				CADCF71F2584990E0065C51B /* DataDrivenSymbolsExample.swift in Sources */,
 				CADCF7302584990E0065C51B /* LayerPositionExample.swift in Sources */,
 				0706C4A625B1181A008733C0 /* TerrainExample.swift in Sources */,

--- a/Examples/Examples/All Examples/CustomLocationIndicatorLayerExample.swift
+++ b/Examples/Examples/All Examples/CustomLocationIndicatorLayerExample.swift
@@ -1,0 +1,46 @@
+import UIKit
+import MapboxMaps
+
+@objc(CustomLocationIndicatorLayerExample)
+
+public class CustomLocationIndicatorLayerExample: UIViewController, ExampleProtocol {
+
+    internal var mapView: MapView!
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        self.view.addSubview(mapView)
+
+        self.mapView.on(.styleLoadingFinished) { [weak self] _ in
+            guard let self = self else { return }
+            self.setupExample()
+        }
+    }
+
+    override public func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+         // The below line is used for internal testing purposes only.
+        self.finish()
+    }
+
+    internal func setupExample() {
+
+        guard let star = UIImage(named: "star") else { return }
+        mapView.style.setStyleImage(image: star, with: "star-puck", scale: 50.0)
+
+        self.mapView.update { (mapOptions) in
+            mapOptions.location.showUserLocation = true
+            mapOptions.location.puckBackend = .layer2d(customize: { (layer) in
+                layer.layout?.topImage = .constant(.name("star-puck"))
+                // Perform additional styling here
+            })
+        }
+
+        let coordinate = CLLocationCoordinate2D(latitude: 39.085006, longitude: -77.150925)
+        self.mapView.cameraManager.setCamera(centerCoordinate: coordinate,
+                                             zoom: 14,
+                                             pitch: 0)
+    }
+}

--- a/Examples/Examples/All Examples/PuckModelLayerExample.swift
+++ b/Examples/Examples/All Examples/PuckModelLayerExample.swift
@@ -77,8 +77,8 @@ public class PuckModelLayerExample: UIViewController, ExampleProtocol {
             }
         }
 
-        let sanFrancisco = CLLocationCoordinate2D(latitude: 39.085006, longitude: -77.150925)
-        self.mapView.cameraManager.setCamera(centerCoordinate: sanFrancisco,
+        let coordinate = CLLocationCoordinate2D(latitude: 39.085006, longitude: -77.150925)
+        self.mapView.cameraManager.setCamera(centerCoordinate: coordinate,
                                              zoom: 14,
                                              pitch: 80)
     }

--- a/Examples/Examples/Models/Examples.swift
+++ b/Examples/Examples/Models/Examples.swift
@@ -135,6 +135,10 @@ public struct Examples {
                 type: CustomLayerExample.self),
         Example(title: "Show 3D terrain",
                 description: "Show realistic elevation by enabling terrain.",
-                type: TerrainExample.self)
+                type: TerrainExample.self),
+        Example(title: "Customize the location puck",
+                description: "Use a different asset to represent the puck",
+                type: CustomLocationIndicatorLayerExample.self)
+
     ]
 }

--- a/Mapbox/MapboxMapsStyle/Style.swift
+++ b/Mapbox/MapboxMapsStyle/Style.swift
@@ -170,6 +170,7 @@ public class Style {
      - Returns: A boolean associated with a `Result` type if the operation is successful.
                 Otherwise, this will return a `StyleError` as part of the `Result` failure case.
      */
+    @discardableResult
     public func setStyleImage(image: UIImage,
                               with identifier: String,
                               sdf: Bool = false,


### PR DESCRIPTION
This PR adds an example on customizing the look/feel of the location indicator layer. This new example shows how to change the asset rendered by the `LocationIndicatorLayer`.

