### PR TITLE
Make PuckStyle internal-only

### DIFF
--- a/Mapbox/MapboxMapsLocation/LocationManager.swift
+++ b/Mapbox/MapboxMapsLocation/LocationManager.swift
@@ -13,7 +13,7 @@ public class LocationManager: NSObject {
     public private(set) var latestLocation: Location?
 
     /// Represents the style of the user location puck
-    public var currentPuckStyle: PuckStyle = .precise {
+    internal var currentPuckStyle: PuckStyle = .precise {
         didSet {
             self.locationPuckManager?.changePuckStyle(newPuckStyle: currentPuckStyle)
         }
@@ -51,9 +51,6 @@ public class LocationManager: NSObject {
 
         /// Allows location updates to be reflected on screen using delegate method
         self.locationSupportableMapView = locationSupportableMapView
-
-        /// Set the current  puck style
-        self.currentPuckStyle = locationOptions.puckStyle
 
         /// Sets our default `locationProvider`
         self.locationProvider = AppleLocationProvider()
@@ -106,9 +103,6 @@ public class LocationManager: NSObject {
             }
         }
 
-        if newOptions.puckStyle != locationOptions.puckStyle {
-            self.currentPuckStyle = newOptions.puckStyle
-        }
 
         self.locationProvider.locationProviderOptions = newOptions
 
@@ -190,7 +184,7 @@ extension LocationManager: LocationProviderDelegate {
                     provider.requestTemporaryFullAccuracyAuthorization(withPurposeKey: purposeKey)
                     self.currentPuckStyle = .approximate
                 } else {
-                    self.currentPuckStyle = self.locationOptions.puckStyle
+                    self.currentPuckStyle = .precise
                 }
             }
             showUserLocation = true
@@ -225,7 +219,6 @@ private extension LocationManager {
             else {
                 let locationPuckManager = LocationPuckManager(shouldTrackLocation: true,
                                                               locationSupportableMapView: self.locationSupportableMapView,
-                                                              currentPuckStyle: currentPuckStyle,
                                                               currentPuckSource: self.locationProvider.locationProviderOptions.puckBackend)
 
                 self.consumers.add(locationPuckManager)

--- a/Mapbox/MapboxMapsLocation/LocationOptions.swift
+++ b/Mapbox/MapboxMapsLocation/LocationOptions.swift
@@ -25,10 +25,7 @@ public struct LocationOptions: Equatable {
     public var showUserLocation: Bool = false
 
     /// Sets the type of backend that should be used for the PuckView
-    public var puckBackend: PuckBackend = .view
-
-    /// Set the style of the puck that will be shown on the screen
-    public var puckStyle: PuckStyle = .precise
+    public var puckBackend: LocationPuck = .view
     
     public init() {}
 

--- a/Mapbox/MapboxMapsLocation/Pucks/LocationPuckManager.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/LocationPuckManager.swift
@@ -12,22 +12,19 @@ import MapboxMapsStyle
 
 // MARK: PuckStyle Enum
 /// This enum represents the different styles of pucks that can be generated
-public enum PuckStyle {
+internal enum PuckStyle {
     case approximate
-    case arrow
-    case headingArrow
-    case headingBeam
     case precise
 }
 
 // MARK: PuckBackend
 /// This enum represents the different backends that can be used for Pucks
-public enum PuckBackend: Equatable {
+public enum LocationPuck: Equatable {
     case layer2d(customize: ((inout LocationIndicatorLayer) -> Void)? = nil) // Backed by `LocationIndicatorLayer`. Implement customize block to granularly modify the puck's styling.
     case layer3d(customize: ((inout ModelLayer, inout ModelSource) -> Void))// Backed by `ModelLayer`
     case view // Backed by `PuckView` which is a `UIView`
 
-    public static func == (lhs: PuckBackend, rhs: PuckBackend) -> Bool {
+    public static func == (lhs: LocationPuck, rhs: LocationPuck) -> Bool {
         switch (lhs, rhs) {
         case (.view, .view):
             return true
@@ -61,13 +58,12 @@ public class LocationPuckManager: LocationConsumer {
     internal var currentPuckStyle: PuckStyle
 
     /// Stores the current backend that should be used to render the puck
-    internal var currentPuckBackend: PuckBackend
+    internal var currentPuckBackend: LocationPuck
 
     public init(shouldTrackLocation: Bool,
                 locationSupportableMapView: LocationSupportableMapView,
-                currentPuckStyle: PuckStyle,
-                currentPuckSource: PuckBackend) {
-        self.currentPuckStyle = currentPuckStyle
+                currentPuckSource: LocationPuck) {
+        self.currentPuckStyle = .precise
         self.currentPuckBackend = currentPuckSource
         self.shouldTrackLocation = shouldTrackLocation
         self.locationSupportableMapView = locationSupportableMapView
@@ -118,7 +114,7 @@ public class LocationPuckManager: LocationConsumer {
         self.puck = nil
     }
 
-    internal func changePuckBackend(newPuckBackend: PuckBackend) {
+    internal func changePuckBackend(newPuckBackend: LocationPuck) {
         removePuck()
         self.currentPuckBackend = newPuckBackend
         createPuck()

--- a/Mapbox/MapboxMapsLocation/Pucks/Puck.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/Puck.swift
@@ -3,7 +3,7 @@ import MapboxMapsFoundation
 #endif
 
 /// This protocol is used to help manipulate the different type of puck views we have
-public protocol Puck {
+internal protocol Puck {
 
     /// Property that stores the current `PuckStyle` of the puck
     var puckStyle: PuckStyle { get set }

--- a/Mapbox/MapboxMapsLocation/Pucks/PuckLocationIndicatorLayer.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/PuckLocationIndicatorLayer.swift
@@ -76,12 +76,6 @@ internal class PuckLocationIndicatorLayer: Puck {
                     try self.createPreciseLocationIndicatorLayer(location: location)
                 case .approximate:
                     try self.createApproximateLocationIndicatorLayer(location: location)
-                case .headingArrow:
-                    try self.createHeadingArrowLocationIndicatorLayer(location: location)
-                case .headingBeam:
-                    try self.createHeadingBeamLocationIndicatorLayer(location: location)
-                case .arrow:
-                    try self.createArrowLocationIndicatorLayer(location: location)
                 }
             } catch {
                 try! Log.error(forMessage: "Error when creating location indicator layer: \(error)", category: "Location")

--- a/Mapbox/MapboxMapsLocation/Pucks/PuckView.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/PuckView.swift
@@ -37,7 +37,6 @@ class PuckView: Puck {
             self.updateStyle(puckStyle: self.puckStyle, location: location)
         }
 
-        handleRotationForView(location: location)
     }
 
     func updateStyle(puckStyle: PuckStyle, location: Location) {
@@ -56,18 +55,6 @@ class PuckView: Puck {
         case .approximate:
             let puckView = ApproximatePuckView(origin: center)
             puckView.configure(with: locationSupportableMapView.tintColor, and: calculateAccuracyRing(location: location))
-            self.puckView = puckView
-        case .headingArrow:
-            let puckView = HeadingArrowPuckView(origin: center)
-            puckView.configure(with: locationSupportableMapView.tintColor, and: calculateAccuracyRing(location: location))
-            self.puckView = puckView
-        case .headingBeam:
-            let puckView = HeadingBeamPuckView(origin: center)
-            puckView.configure(with: locationSupportableMapView.tintColor, and: calculateAccuracyRing(location: location))
-            self.puckView = puckView
-        case .arrow:
-            let puckView = ArrowPuckView(origin: center)
-            puckView.configure(with: locationSupportableMapView.tintColor)
             self.puckView = puckView
         }
 
@@ -124,19 +111,6 @@ private extension PuckView {
         guard let magneticHeading = location.headingDirection else { return 0.0 }
 
         return CGFloat(magneticHeading)
-    }
-
-    func handleRotationForView(location: Location) {
-        if puckStyle == .headingArrow,
-           let puckView = self.puckView as? HeadingArrowPuckView {
-            rotate(for: puckView.arrowLayer, headingDirection: getHeadingDirectionAsFloat(location: location))
-        } else if puckStyle == .headingBeam,
-                  let puckView = self.puckView as? HeadingBeamPuckView {
-            rotate(for: puckView.headingIndicatorLayer, headingDirection: getHeadingDirectionAsFloat(location: location))
-        } else if puckStyle == .arrow,
-                  let puckView = self.puckView as? ArrowPuckView {
-            rotate(for: puckView.puckArrowLayer, headingDirection: getHeadingDirectionAsFloat(location: location))
-        }
     }
 
     func rotate(for layer: CALayer, headingDirection: CGFloat) {


### PR DESCRIPTION
This PR makes `PuckStyle` internal-only and deprecates some unsupported puck styles to better align with android.