### PR TITLE
[MapView] Added check for iOS 13 & simulators.

### DIFF
--- a/Mapbox/MapboxMapsFoundation/BaseMapView.swift
+++ b/Mapbox/MapboxMapsFoundation/BaseMapView.swift
@@ -84,6 +84,23 @@ open class BaseMapView: UIView, MapClient, MBMMetalViewProvider {
     }
 
     private func commonInit(resourceOptions: ResourceOptions, glyphsRasterizationOptions: GlyphsRasterizationOptions, styleURL: URL?) {
+
+        if MTLCreateSystemDefaultDevice() == nil {
+            // Check if we're running on a simulator on iOS 11 or 12
+            var loggedWarning = false
+
+            #if targetEnvironment(simulator)
+            if !ProcessInfo().isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 13, minorVersion: 0, patchVersion: 0)) {
+                try! Log.warning(forMessage: "Metal rendering is not supported on iOS versions < iOS 13. Please test on device or on iOS version >= 13.", category: "MapView")
+                loggedWarning = true
+            }
+            #endif
+
+            if !loggedWarning {
+                try! Log.error(forMessage: "No suitable Metal device or simulator can be found.", category: "MapView")
+            }
+        }
+
         self.resourceOptions = resourceOptions
         observerConcrete = ObserverConcrete()
 


### PR DESCRIPTION
This PR adds a runtime check to `BaseMapView` to check the iOS simulator version in case there is no Metal device found. 

Metal is not supported on simulators < iOS 13; on earlier versions developers will be presented with a blank map. This check should help to reduce potential confusion.