### PR TITLE
Fix bottom ornament layout

### DIFF
--- a/Mapbox/MapboxMapsOrnaments/OrnamentsManager.swift
+++ b/Mapbox/MapboxMapsOrnaments/OrnamentsManager.swift
@@ -224,7 +224,7 @@ internal class OrnamentsManager: NSObject {
                 ornamentView.trailingAnchor.constraint(equalTo: self.universalLayoutGuide.trailingAnchor,
                                                        constant: -ornament.margins.x),
                 ornamentView.bottomAnchor.constraint(equalTo: self.universalLayoutGuide.bottomAnchor,
-                                                     constant: ornament.margins.y)
+                                                     constant: -ornament.margins.y)
             ])
         case .bottomCenter:
             print("bottom center")
@@ -233,7 +233,7 @@ internal class OrnamentsManager: NSObject {
                 ornamentView.leadingAnchor.constraint(equalTo: self.universalLayoutGuide.leadingAnchor,
                                                       constant: ornament.margins.x),
                 ornamentView.bottomAnchor.constraint(equalTo: self.universalLayoutGuide.bottomAnchor,
-                                                     constant: ornament.margins.y)
+                                                     constant: -ornament.margins.y)
             ])
         case .centerLeft:
             print("center left")


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/205658/105515487-5c687280-5c9a-11eb-8a7e-1f30c70b8125.png" height="400" />

The bottom ornaments are too low. This is happening because their bottom constraints are set up as `ornamentView.bottom = universalLayoutGuide.bottom + ornament.margins.y` instead of `ornamentView.bottom = universalLayoutGuide.bottom - ornament.margins.y`

## Changes

- [x] Negates the bottom anchor constraint constants for .bottomRight and .bottomLeft ornaments in OrnamentsManager.swift.

Fixes #15 