### PR TITLE
Use https url for jazzy-theme submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "jazzy-theme"]
 	path = jazzy-theme
-	url = git@github.com:mapbox/jazzy-theme.git
+	url = https://github.com/mapbox/jazzy-theme.git


### PR DESCRIPTION
- Fixes SPM-based installation for users who have not configured SSH for GitHub

## Steps to reproduce

1. Switch to a macOS user account that does not have SSH configured for GitHub. The account must, however, have its `.netrc` set up.
2. Create an Xcode project and add the Maps SDK via SPM.

## Expected result

The package is installed successfully.

## Actual result

The package installation fails when SPM attempts to initialize the git submodules in the mapbox-maps-ios repo.
