### PR TITLE
[Examples] Support rotation on all examples

### DIFF
--- a/Examples/Examples/All Examples/AnimateLayerExample.swift
+++ b/Examples/Examples/All Examples/AnimateLayerExample.swift
@@ -16,6 +16,7 @@ public class AnimateLayerExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         // Set the map's center coordinate and zoom level

--- a/Examples/Examples/All Examples/BasicMapExample.swift
+++ b/Examples/Examples/All Examples/BasicMapExample.swift
@@ -11,6 +11,7 @@ public class BasicMapExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         self.mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.update { (mapOptions) in
             mapOptions.ornaments.showsScale = true
         }

--- a/Examples/Examples/All Examples/CameraAnimationExample.swift
+++ b/Examples/Examples/All Examples/CameraAnimationExample.swift
@@ -16,6 +16,7 @@ public class CameraAnimationExample: UIViewController, ExampleProtocol {
 
         let resourceOptions = ResourceOptions(accessToken: accessToken)
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions)
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         // Allows the delegate to receive information about map events.

--- a/Examples/Examples/All Examples/CameraUIViewAnimationExample.swift
+++ b/Examples/Examples/All Examples/CameraUIViewAnimationExample.swift
@@ -16,6 +16,7 @@ public class CameraUIViewAnimationExample: UIViewController, ExampleProtocol {
 
         let resourceOptions = ResourceOptions(accessToken: accessToken)
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions)
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         self.mapView.cameraView.centerCoordinate = CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194)

--- a/Examples/Examples/All Examples/ColorExpressionExample.swift
+++ b/Examples/Examples/All Examples/ColorExpressionExample.swift
@@ -11,6 +11,7 @@ public class ColorExpressionExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         // Center the map over the United States.

--- a/Examples/Examples/All Examples/CustomLayerExample.swift
+++ b/Examples/Examples/All Examples/CustomLayerExample.swift
@@ -15,6 +15,7 @@ public class CustomLayerExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         self.mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         self.mapView.on(.styleLoadingFinished) { [weak self] _ in

--- a/Examples/Examples/All Examples/CustomLocationIndicatorLayerExample.swift
+++ b/Examples/Examples/All Examples/CustomLocationIndicatorLayerExample.swift
@@ -11,6 +11,7 @@ public class CustomLocationIndicatorLayerExample: UIViewController, ExampleProto
         super.viewDidLoad()
 
         self.mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         self.mapView.on(.styleLoadingFinished) { [weak self] _ in

--- a/Examples/Examples/All Examples/CustomPointAnnotationExample.swift
+++ b/Examples/Examples/All Examples/CustomPointAnnotationExample.swift
@@ -11,6 +11,7 @@ public class CustomPointAnnotationExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         // Center the map camera over New York City

--- a/Examples/Examples/All Examples/CustomStyleURLExample.swift
+++ b/Examples/Examples/All Examples/CustomStyleURLExample.swift
@@ -15,6 +15,7 @@ internal class CustomStyleURLExample: UIViewController, ExampleProtocol {
         }
 
         self.mapView = MapView(with: view.bounds, resourceOptions: resourceOptions(), styleURL: .custom(url: customStyleURL))
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         self.mapView.on(.styleLoadingFinished) { _ in

--- a/Examples/Examples/All Examples/DataDrivenSymbolsExample.swift
+++ b/Examples/Examples/All Examples/DataDrivenSymbolsExample.swift
@@ -11,6 +11,7 @@ public class DataDrivenSymbolsExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions(), styleURL: .outdoors)
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         // Set center location

--- a/Examples/Examples/All Examples/ExternalVectorSourceExample.swift
+++ b/Examples/Examples/All Examples/ExternalVectorSourceExample.swift
@@ -9,6 +9,7 @@ public class ExternalVectorSourceExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.style.styleURL = .light
         let centerCoordinate = CLLocationCoordinate2D(latitude: 41.878781, longitude: -87.622088)
         mapView.cameraManager.setCamera(centerCoordinate: centerCoordinate,

--- a/Examples/Examples/All Examples/FeaturesAtPointExample.swift
+++ b/Examples/Examples/All Examples/FeaturesAtPointExample.swift
@@ -11,6 +11,7 @@ public class FeaturesAtPointExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         // Center the map over the United States.

--- a/Examples/Examples/All Examples/FitCameraToGeometryExample.swift
+++ b/Examples/Examples/All Examples/FitCameraToGeometryExample.swift
@@ -17,6 +17,7 @@ public class FitCameraToGeometryExample: UIViewController, ExampleProtocol {
 
         let resourceOptions = ResourceOptions(accessToken: accessToken)
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions)
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         // Allows the view controller to recieve information about map events.

--- a/Examples/Examples/All Examples/FlyToExample.swift
+++ b/Examples/Examples/All Examples/FlyToExample.swift
@@ -11,6 +11,7 @@ public class FlyToExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         // Center the map over the United States.

--- a/Examples/Examples/All Examples/GeoJSONSourceExample.swift
+++ b/Examples/Examples/All Examples/GeoJSONSourceExample.swift
@@ -11,6 +11,7 @@ public class GeoJSONSourceExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         // Set the center coordinate and zoom level.

--- a/Examples/Examples/All Examples/LayerPositionExample.swift
+++ b/Examples/Examples/All Examples/LayerPositionExample.swift
@@ -14,6 +14,7 @@ public class LayerPositionExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         // Center the map over the United States.

--- a/Examples/Examples/All Examples/LineAnnotationExample.swift
+++ b/Examples/Examples/All Examples/LineAnnotationExample.swift
@@ -11,6 +11,7 @@ public class LineAnnotationExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         let centerCoordinate = CLLocationCoordinate2D(latitude: 39.7128, longitude: -75.0060)

--- a/Examples/Examples/All Examples/MapViewExample.swift
+++ b/Examples/Examples/All Examples/MapViewExample.swift
@@ -8,6 +8,7 @@ public class MapViewExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         let mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         view.addSubview(mapView)
         NSLayoutConstraint.activate([
             mapView.leadingAnchor.constraint(equalTo: view.leadingAnchor),

--- a/Examples/Examples/All Examples/ModelExample.swift
+++ b/Examples/Examples/All Examples/ModelExample.swift
@@ -11,6 +11,7 @@ public class ModelExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         self.mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         self.mapView.on(.styleLoadingFinished) { [weak self] _ in

--- a/Examples/Examples/All Examples/PointAnnotationExample.swift
+++ b/Examples/Examples/All Examples/PointAnnotationExample.swift
@@ -11,7 +11,7 @@ public class PointAnnotationExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
-
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         // Center the map camera over New York City.

--- a/Examples/Examples/All Examples/PolygonAnnotationExample.swift
+++ b/Examples/Examples/All Examples/PolygonAnnotationExample.swift
@@ -10,6 +10,7 @@ public class PolygonAnnotationExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         let centerCoordinate = CLLocationCoordinate2D(latitude: 25.04579, longitude: -88.90136)

--- a/Examples/Examples/All Examples/PuckModelLayerExample.swift
+++ b/Examples/Examples/All Examples/PuckModelLayerExample.swift
@@ -11,6 +11,7 @@ public class PuckModelLayerExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         self.mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         self.mapView.on(.styleLoadingFinished) { [weak self] _ in

--- a/Examples/Examples/All Examples/RestrictCoordinateBoundsExample.swift
+++ b/Examples/Examples/All Examples/RestrictCoordinateBoundsExample.swift
@@ -10,6 +10,7 @@ public class RestrictCoordinateBoundsExample: UIViewController, ExampleProtocol 
         super.viewDidLoad()
 
         let mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         let bounds = CoordinateBounds(southwest: CLLocationCoordinate2D(latitude: 63.33, longitude: -25.52),

--- a/Examples/Examples/All Examples/SelectAnnotationExample.swift
+++ b/Examples/Examples/All Examples/SelectAnnotationExample.swift
@@ -23,6 +23,7 @@ public class SelectAnnotationExample: UIViewController, ExampleProtocol {
         super.viewDidLoad()
 
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
         // Set the center coordinate and zoom level over southern Iceland.

--- a/Examples/Examples/All Examples/SnapshotterCoreGraphicsExample.swift
+++ b/Examples/Examples/All Examples/SnapshotterCoreGraphicsExample.swift
@@ -16,6 +16,7 @@ public class SnapshotterCoreGraphicsExample: UIViewController, ExampleProtocol {
         // TODO: Fix crash that occurs when omitting MapViewController.
         let testRect = CGRect(x: 0, y: 0, width: view.bounds.width, height: view.bounds.height)
         self.mapView = MapView(with: testRect, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
         // Add the `UIImageView` that will eventually render the snapshot.
         snapshotView = UIImageView(frame: CGRect.zero)

--- a/Examples/Examples/All Examples/SnapshotterExample.swift
+++ b/Examples/Examples/All Examples/SnapshotterExample.swift
@@ -20,6 +20,7 @@ public class SnapshotterExample: UIViewController, ExampleProtocol {
 
         let testRect = CGRect(x: 0, y: 0, width: view.bounds.width, height: view.bounds.height / 2)
         mapView = MapView(with: testRect, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.style.styleURL = .dark
         mapView.cameraManager.setCamera(centerCoordinate: CLLocationCoordinate2D(latitude: 37.858, longitude: 138.472),
                                                   zoom: 3.5)

--- a/Examples/Examples/All Examples/TerrainExample.swift
+++ b/Examples/Examples/All Examples/TerrainExample.swift
@@ -18,6 +18,7 @@ public class TerrainExample: UIViewController, ExampleProtocol {
         self.mapView = MapView(with: view.bounds,
                                resourceOptions: resourceOptions,
                                styleURL: .custom(url: URL(string: "mapbox://styles/mapbox-map-design/ckhqrf2tz0dt119ny6azh975y")!))
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
         self.view.addSubview(mapView)
 

--- a/Examples/Examples/All Examples/UpdatePointAnnotationPositionExample.swift
+++ b/Examples/Examples/All Examples/UpdatePointAnnotationPositionExample.swift
@@ -18,7 +18,7 @@ public class UpdatePointAnnotationPositionExample: UIViewController, ExampleProt
 
         let resourceOptions = ResourceOptions(accessToken: accessToken)
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions)
-
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.cameraManager.setCamera(centerCoordinate: CLLocationCoordinate2D(latitude: 59.3, longitude: 8.06),
                                         zoom: 12)
         self.view.addSubview(mapView)


### PR DESCRIPTION
Simple PR that sets the `autoResizingMask` on any MapView being initialized in examples. This results in `layoutSubviews` being called on the map view when any rotation occurs -- resulting in a proper map resize.