### PR TITLE
Snapshotter Bounds Getter

### DIFF
--- a/Mapbox/MapboxMapsSnapshot/Snapshotter.swift
+++ b/Mapbox/MapboxMapsSnapshot/Snapshotter.swift
@@ -76,6 +76,13 @@ public class Snapshotter: Observer {
         }
     }
 
+    /// Rectangular bounds to which the snapshot is restricted
+    public var bounds: CoordinateBounds {
+        get {
+            return try! mapSnapshotter.getRegion()
+        }
+    }
+
     /// In the tile mode, the snapshotter fetches the still image of a single tile.
     public var tileMode: Bool {
         get {


### PR DESCRIPTION
This is adding back a getter for Snapshotter that was removed prematurely