### PR TITLE
[Bugfix] Fix for location options not being honored

### DIFF
--- a/Mapbox/MapboxMapsLocation/LocationManager.swift
+++ b/Mapbox/MapboxMapsLocation/LocationManager.swift
@@ -48,6 +48,8 @@ public class LocationManager: NSObject {
         super.init()
 
         self.locationOptions = locationOptions
+        /// Sets the local options needed to configure the user location puck
+        self.showUserLocation = locationOptions.showUserLocation
 
         /// Allows location updates to be reflected on screen using delegate method
         self.locationSupportableMapView = locationSupportableMapView
@@ -57,8 +59,6 @@ public class LocationManager: NSObject {
         self.locationProvider.setDelegate(self)
         self.locationProvider.locationProviderOptions = locationOptions
 
-        /// Sets the local options needed to configure the user location puck
-        self.showUserLocation = locationOptions.showUserLocation
         toggleUserLocationUpdates(showUserLocation: locationOptions.showUserLocation)
     }
 
@@ -186,7 +186,7 @@ extension LocationManager: LocationProviderDelegate {
                     self.currentPuckStyle = .precise
                 }
             }
-            showUserLocation = true
+            showUserLocation = locationOptions.showUserLocation
         } else {
             showUserLocation = false
         }
@@ -218,7 +218,7 @@ private extension LocationManager {
             else {
                 let locationPuckManager = LocationPuckManager(shouldTrackLocation: true,
                                                               locationSupportableMapView: self.locationSupportableMapView,
-                                                              currentPuckSource: self.locationProvider.locationProviderOptions.locationPuck)
+                                                              currentPuckSource: self.locationOptions.locationPuck)
 
                 self.consumers.add(locationPuckManager)
                 self.locationPuckManager = locationPuckManager

--- a/Mapbox/MapboxMapsLocation/Pucks/PuckLocationIndicatorLayer.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/PuckLocationIndicatorLayer.swift
@@ -138,6 +138,7 @@ private extension PuckLocationIndicatorLayer {
     func createPreciseLocationIndicatorLayer(location: Location) throws {
         guard let style = self.locationSupportableMapView?.style else { return }
 
+        _ = style.removeStyleLayer(forLayerId: "approximate-puck")
         // Call customizationHandler to allow developers to granularly modify the layer
         self.customizationHandler?(&locationIndicatorLayerVM)
 
@@ -225,9 +226,11 @@ private extension PuckLocationIndicatorLayer {
 
     func createApproximateLocationIndicatorLayer(location: Location) throws {
         guard let style = self.locationSupportableMapView?.style else { return }
+        // TODO: Handle removal of precise indicator properly.
+        _ = style.removeStyleLayer(forLayerId: "puck")
 
         // Create Layer
-        var layer = LocationIndicatorLayer(id: "puck")
+        var layer = LocationIndicatorLayer(id: "approximate-puck")
 
         // Create and set Paint property
         var paint = LocationIndicatorLayer.Paint()


### PR DESCRIPTION
This PR fixes a small bug where developer-provided location options weren't being honored. The issue was that the SDK was mistakenly setting the `showsUserLocation` value to be `true` when permissions were provided.