### PR TITLE
[Examples] Add building extrusion example.

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		A4211CE62592549900D215B4 /* RestrictCoordinateBoundsExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4211CE52592549900D215B4 /* RestrictCoordinateBoundsExample.swift */; };
 		CA252D782587DD9500A989CD /* MapboxMaps.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA252D772587DD9500A989CD /* MapboxMaps.framework */; };
 		CA252D792587DD9500A989CD /* MapboxMaps.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CA252D772587DD9500A989CD /* MapboxMaps.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CA86E81825BE7C2300E5A1D9 /* BuildingExtrusionsExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA86E81725BE7C2200E5A1D9 /* BuildingExtrusionsExample.swift */; };
 		CAC195B725AC098A00F69FEA /* CameraUIViewAnimationExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC195B625AC098A00F69FEA /* CameraUIViewAnimationExample.swift */; };
 		CADCF71D2584990E0065C51B /* CustomPointAnnotationExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64ED3C42540DD6E00ADADFB /* CustomPointAnnotationExample.swift */; };
 		CADCF71E2584990E0065C51B /* ExternalVectorSourceExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077E3B2B2581810600564A3E /* ExternalVectorSourceExample.swift */; };
@@ -141,6 +142,7 @@
 		C64ED3C82541CA3A00ADADFB /* LineAnnotationExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineAnnotationExample.swift; sourceTree = "<group>"; };
 		C69F01EC2543646A001AB49B /* DataDrivenSymbolsExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDrivenSymbolsExample.swift; sourceTree = "<group>"; };
 		CA252D772587DD9500A989CD /* MapboxMaps.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MapboxMaps.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CA86E81725BE7C2200E5A1D9 /* BuildingExtrusionsExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingExtrusionsExample.swift; sourceTree = "<group>"; };
 		CAC195B625AC098A00F69FEA /* CameraUIViewAnimationExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraUIViewAnimationExample.swift; sourceTree = "<group>"; };
 		CADCF742258499570065C51B /* BasicMapExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicMapExample.swift; sourceTree = "<group>"; };
 		CADCF76A25854AEF0065C51B /* MapboxMobileEvents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = MapboxMobileEvents.framework; sourceTree = "<group>"; };
@@ -237,6 +239,7 @@
 				0C52BA9725AF8C880054ECA8 /* PuckModelLayerExample.swift */,
 				0706C4A525B1181A008733C0 /* TerrainExample.swift */,
 				0CC4ECE925B8AD3000F998B8 /* CustomLocationIndicatorLayerExample.swift */,
+				CA86E81725BE7C2200E5A1D9 /* BuildingExtrusionsExample.swift */,
 			);
 			path = "All Examples";
 			sourceTree = "<group>";
@@ -530,6 +533,7 @@
 				0CC4ECEA25B8AD3000F998B8 /* CustomLocationIndicatorLayerExample.swift in Sources */,
 				CADCF71F2584990E0065C51B /* DataDrivenSymbolsExample.swift in Sources */,
 				CADCF7302584990E0065C51B /* LayerPositionExample.swift in Sources */,
+				CA86E81825BE7C2300E5A1D9 /* BuildingExtrusionsExample.swift in Sources */,
 				0706C4A625B1181A008733C0 /* TerrainExample.swift in Sources */,
 				CADCF7282584990E0065C51B /* LineAnnotationExample.swift in Sources */,
 				CADCF72F2584990E0065C51B /* SnapshotterCoreGraphicsExample.swift in Sources */,

--- a/Examples/Examples/All Examples/BuildingExtrusionsExample.swift
+++ b/Examples/Examples/All Examples/BuildingExtrusionsExample.swift
@@ -1,0 +1,79 @@
+import Foundation
+import MapboxMaps
+
+@objc(BuildingExtrusionsExample)
+public class BuildingExtrusionsExample: UIViewController, ExampleProtocol {
+
+    internal var mapView: MapView!
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+
+        mapView = MapView(with: view.bounds, resourceOptions: resourceOptions(), styleURL: .light)
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(mapView)
+
+        mapView.on(.styleLoadingFinished) { [weak self] _ in
+            self?.setupExample()
+        }
+    }
+
+    internal func setupExample() {
+        addBuildingExtrusions()
+
+        let cameraOptions = CameraOptions(center: CLLocationCoordinate2D(latitude: 40.7135, longitude: -74.0066),
+                                          zoom: 15.5,
+                                          bearing: -17.6,
+                                          pitch: 45)
+        mapView.cameraManager.setCamera(to: cameraOptions)
+
+        // The below lines are used for internal testing purposes only.
+        DispatchQueue.main.asyncAfter(deadline: .now()+5.0) {
+            self.finish()
+        }
+    }
+
+    // See https://docs.mapbox.com/mapbox-gl-js/example/3d-buildings/ for equivalent gl-js example
+    internal func addBuildingExtrusions() {
+        var layer = FillExtrusionLayer(id: "3d-buildings")
+
+        layer.source                      = "composite"
+        layer.minZoom                     = 15
+        layer.sourceLayer                 = "building"
+        layer.paint?.fillExtrusionColor   = .constant(ColorRepresentable(color: .lightGray))
+        layer.paint?.fillExtrusionOpacity = .constant(0.6)
+
+        layer.filter = Exp(.eq) {
+            Exp(.get) {
+                "extrude"
+            }
+            "true"
+        }
+
+        layer.paint?.fillExtrusionHeight = .expression(
+            Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.zoom)
+                15
+                0
+                15.05
+                Exp(.get) {
+                    "height"
+                }
+            }
+        )
+
+        layer.paint?.fillExtrusionBase = .expression(
+            Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.zoom)
+                15
+                0
+                15.05
+                Exp(.get) { "min_height"}
+            }
+        )
+
+        mapView.style.addLayer(layer: layer)
+    }
+}

--- a/Examples/Examples/All Examples/ColorExpressionExample.swift
+++ b/Examples/Examples/All Examples/ColorExpressionExample.swift
@@ -21,7 +21,7 @@ public class ColorExpressionExample: UIViewController, ExampleProtocol {
         mapView.cameraManager.setCamera(centerCoordinate: centerCoordinate,
                                                   zoom: 3)
 
-        // Allows the view controller to recieve information about map events.
+        // Allows the view controller to receive information about map events.
         mapView.on(.mapLoadingFinished) { [weak self] _ in
             guard let self = self else { return }
             self.setupExample()

--- a/Examples/Examples/All Examples/CustomLocationIndicatorLayerExample.swift
+++ b/Examples/Examples/All Examples/CustomLocationIndicatorLayerExample.swift
@@ -22,7 +22,7 @@ public class CustomLocationIndicatorLayerExample: UIViewController, ExampleProto
 
     override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-         // The below line is used for internal testing purposes only.
+        // The below line is used for internal testing purposes only.
         self.finish()
     }
 

--- a/Examples/Examples/All Examples/FitCameraToGeometryExample.swift
+++ b/Examples/Examples/All Examples/FitCameraToGeometryExample.swift
@@ -20,7 +20,7 @@ public class FitCameraToGeometryExample: UIViewController, ExampleProtocol {
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
 
-        // Allows the view controller to recieve information about map events.
+        // Allows the view controller to receive information about map events.
         mapView.on(.mapLoadingFinished) { [weak self] _ in
             guard let self = self else { return }
             self.fitToCameraToGeometry()

--- a/Examples/Examples/All Examples/FlyToExample.swift
+++ b/Examples/Examples/All Examples/FlyToExample.swift
@@ -21,7 +21,7 @@ public class FlyToExample: UIViewController, ExampleProtocol {
         mapView.cameraManager.setCamera(centerCoordinate: centerCoordinate,
                                                   zoom: 3)
 
-        // Allows the view controller to recieve information about map events.
+        // Allows the view controller to receive information about map events.
         mapView.on(.mapLoadingFinished) { [weak self] _ in
             guard let self = self else { return }
             self.setupExample()

--- a/Examples/Examples/All Examples/LayerPositionExample.swift
+++ b/Examples/Examples/All Examples/LayerPositionExample.swift
@@ -24,7 +24,7 @@ public class LayerPositionExample: UIViewController, ExampleProtocol {
         mapView.cameraManager.setCamera(centerCoordinate: centerCoordinate,
                                                   zoom: 3)
 
-        // Allows the view controller to recieve information about map events.
+        // Allows the view controller to receive information about map events.
         mapView.on(.mapLoadingFinished) { [weak self] _ in
             guard let self = self else { return }
             self.setupExample()

--- a/Examples/Examples/All Examples/UpdatePointAnnotationPositionExample.swift
+++ b/Examples/Examples/All Examples/UpdatePointAnnotationPositionExample.swift
@@ -23,7 +23,7 @@ public class UpdatePointAnnotationPositionExample: UIViewController, ExampleProt
                                         zoom: 12)
         self.view.addSubview(mapView)
 
-        // Allows the view controller to recieve information about map events.
+        // Allows the view controller to receive information about map events.
         mapView.on(.mapLoadingFinished) { [weak self] _ in
             guard let self = self else { return }
             self.addPointAnnotation()

--- a/Examples/Examples/Models/Examples.swift
+++ b/Examples/Examples/Models/Examples.swift
@@ -128,7 +128,7 @@ public struct Examples {
                 description: "Prevent the map from panning outside the specified coordinate bounds.",
                 type: RestrictCoordinateBoundsExample.self),
         Example(title: "Use a 3D model to show the user's location",
-                description: "A 3D model is used to represent the user's location",
+                description: "A 3D model is used to represent the user's location.",
                 type: PuckModelLayerExample.self),
         Example(title: "Add a custom rendered layer",
                 description: "Add a custom rendered Metal layer.",
@@ -137,8 +137,10 @@ public struct Examples {
                 description: "Show realistic elevation by enabling terrain.",
                 type: TerrainExample.self),
         Example(title: "Customize the location puck",
-                description: "Use a different asset to represent the puck",
-                type: CustomLocationIndicatorLayerExample.self)
-
+                description: "Use a different asset to represent the puck.",
+                type: CustomLocationIndicatorLayerExample.self),
+        Example(title: "Display buildings in 3D",
+                description: "Use extrusions to display buildings' height in 3D.",
+                type: BuildingExtrusionsExample.self)
     ]
 }

--- a/Mapbox/MapboxMapsFoundation/Camera/CameraManager.swift
+++ b/Mapbox/MapboxMapsFoundation/Camera/CameraManager.swift
@@ -168,7 +168,7 @@ public class CameraManager {
     public func setCamera(to newCamera: CameraOptions,
                              animated: Bool = false,
                              duration: TimeInterval? = 0,
-                             completion: ((Bool) -> Void)?) {
+                             completion: ((Bool) -> Void)? = nil) {
         guard let mapView = mapView else {
             assertionFailure("MapView is nil.")
             completion?(false)


### PR DESCRIPTION
This PR adds the Swift equivalent of https://docs.mapbox.com/mapbox-gl-js/example/3d-buildings/