### PR TITLE
Make ColorRepresentable a struct and add color tests

### DIFF
--- a/Examples/Examples/All Examples/AnimateLayerExample.swift
+++ b/Examples/Examples/All Examples/AnimateLayerExample.swift
@@ -72,7 +72,7 @@ public class AnimateLayerExample: UIViewController, ExampleProtocol {
         airplaneRoute.source.data = .feature(Feature(routeLine))
         var lineLayer = LineLayer(id: "line-layer")
         lineLayer.source = airplaneRoute.identifier
-        lineLayer.paint?.lineColor = .constant(ColorRepresentable(color: UIColor.red))
+        lineLayer.paint?.lineColor = .constant(ColorRepresentable(color: UIColor.red)!)
         lineLayer.paint?.lineWidth = .constant(3.0)
         lineLayer.layout?.lineCap = .round
 

--- a/Examples/Examples/All Examples/BuildingExtrusionsExample.swift
+++ b/Examples/Examples/All Examples/BuildingExtrusionsExample.swift
@@ -40,7 +40,7 @@ public class BuildingExtrusionsExample: UIViewController, ExampleProtocol {
         layer.source                      = "composite"
         layer.minZoom                     = 15
         layer.sourceLayer                 = "building"
-        layer.paint?.fillExtrusionColor   = .constant(ColorRepresentable(color: .lightGray))
+        layer.paint?.fillExtrusionColor   = .constant(ColorRepresentable(color: .lightGray)!)
         layer.paint?.fillExtrusionOpacity = .constant(0.6)
 
         layer.filter = Exp(.eq) {

--- a/Examples/Examples/All Examples/ExternalVectorSourceExample.swift
+++ b/Examples/Examples/All Examples/ExternalVectorSourceExample.swift
@@ -38,7 +38,7 @@ public class ExternalVectorSourceExample: UIViewController, ExampleProtocol {
         var lineLayer = LineLayer(id: "line-layer")
         lineLayer.source = sourceIdentifier
         lineLayer.sourceLayer = "mapillary-sequences"
-        let lineColor = ColorRepresentable(color: UIColor(red: 0.21, green: 0.69, blue: 0.43, alpha: 1.00))
+        let lineColor = ColorRepresentable(color: UIColor(red: 0.21, green: 0.69, blue: 0.43, alpha: 1.00))!
         lineLayer.paint?.lineColor = .constant(lineColor)
         lineLayer.paint?.lineOpacity = .constant(0.6)
         lineLayer.paint?.lineWidth = .constant(2.0)

--- a/Examples/Examples/All Examples/FeaturesAtPointExample.swift
+++ b/Examples/Examples/All Examples/FeaturesAtPointExample.swift
@@ -46,9 +46,9 @@ public class FeaturesAtPointExample: UIViewController, ExampleProtocol {
         fillLayer.source = sourceIdentifier
 
         // Apply basic styling to the fill layer.
-        fillLayer.paint?.fillColor = .constant(ColorRepresentable(color: UIColor.blue))
+        fillLayer.paint?.fillColor = .constant(ColorRepresentable(color: UIColor.blue)!)
         fillLayer.paint?.fillOpacity = .constant(0.3)
-        fillLayer.paint?.fillOutlineColor = .constant(ColorRepresentable(color: UIColor.black))
+        fillLayer.paint?.fillOutlineColor = .constant(ColorRepresentable(color: UIColor.black)!)
 
         // Add the data source and style layer to the map.
         _ = mapView.style.addSource(source: geoJSONSource, identifier: sourceIdentifier)

--- a/Examples/Examples/All Examples/FitCameraToGeometryExample.swift
+++ b/Examples/Examples/All Examples/FitCameraToGeometryExample.swift
@@ -45,7 +45,7 @@ public class FitCameraToGeometryExample: UIViewController, ExampleProtocol {
 
         var polygonLayer = FillLayer(id: "triangle-style")
         polygonLayer.paint?.fillOpacity = .constant(0.5)
-        polygonLayer.paint?.fillColor = .constant(ColorRepresentable(color: .gray))
+        polygonLayer.paint?.fillColor = .constant(ColorRepresentable(color: .gray)!)
         polygonLayer.source = sourceIdentifier
 
         let addSourceResult = mapView.style?.addSource(source: source, identifier: sourceIdentifier)

--- a/Examples/Examples/All Examples/GeoJSONSourceExample.swift
+++ b/Examples/Examples/All Examples/GeoJSONSourceExample.swift
@@ -67,7 +67,7 @@ public class GeoJSONSourceExample: UIViewController, ExampleProtocol {
             "Point"
         }
         circleLayer.source = geoJSONDataSourceIdentifier
-        circleLayer.paint?.circleColor = .constant(ColorRepresentable(color: UIColor.yellow))
+        circleLayer.paint?.circleColor = .constant(ColorRepresentable(color: UIColor.yellow)!)
         circleLayer.paint?.circleOpacity = .constant(0.6)
         circleLayer.paint?.circleRadius = .constant(8.0)
         // Follow the same steps to create a line layer
@@ -77,7 +77,7 @@ public class GeoJSONSourceExample: UIViewController, ExampleProtocol {
             "LineString"
         }
         lineLayer.source = geoJSONDataSourceIdentifier
-        lineLayer.paint?.lineColor = .constant(ColorRepresentable(color: UIColor.red))
+        lineLayer.paint?.lineColor = .constant(ColorRepresentable(color: UIColor.red)!)
         lineLayer.paint?.lineWidth = .constant(1.4)
         // Follow the same steps to create a polygon (fill) layer
         var polygonLayer = FillLayer(id: "fill-layer")
@@ -86,9 +86,9 @@ public class GeoJSONSourceExample: UIViewController, ExampleProtocol {
             "Polygon"
         }
         polygonLayer.source = geoJSONDataSourceIdentifier
-        polygonLayer.paint?.fillColor = .constant(ColorRepresentable(color: UIColor.green))
+        polygonLayer.paint?.fillColor = .constant(ColorRepresentable(color: UIColor.green)!)
         polygonLayer.paint?.fillOpacity = .constant(0.3)
-        polygonLayer.paint?.fillOutlineColor = .constant(ColorRepresentable(color: UIColor.purple))
+        polygonLayer.paint?.fillOutlineColor = .constant(ColorRepresentable(color: UIColor.purple)!)
         // Add the source and style layers to the map style.
         _ = mapView.style.addSource(source: geoJSONSource, identifier: geoJSONDataSourceIdentifier)
         _ = mapView.style.addLayer(layer: circleLayer, layerPosition: nil)

--- a/Examples/Examples/All Examples/LayerPositionExample.swift
+++ b/Examples/Examples/All Examples/LayerPositionExample.swift
@@ -97,8 +97,8 @@ public class LayerPositionExample: UIViewController, ExampleProtocol {
         layer = FillLayer(id: "polygon-layer")
         layer.source = sourceIdentifier
         // Apply basic styling to the fill layer.
-        layer.paint?.fillColor = .constant(ColorRepresentable(color: #colorLiteral(red: 0.9764705896, green: 0.850980401, blue: 0.5490196347, alpha: 1)))
-        layer.paint?.fillOutlineColor = .constant(ColorRepresentable(color: #colorLiteral(red: 0.8039215803, green: 0.8039215803, blue: 0.8039215803, alpha: 1)))
+        layer.paint?.fillColor = .constant(ColorRepresentable(color: #colorLiteral(red: 0.9764705896, green: 0.850980401, blue: 0.5490196347, alpha: 1))!)
+        layer.paint?.fillOutlineColor = .constant(ColorRepresentable(color: #colorLiteral(red: 0.8039215803, green: 0.8039215803, blue: 0.8039215803, alpha: 1))!)
 
         // Create a new GeoJSON data source which gets its data from a polygon.
         source = GeoJSONSource()

--- a/Mapbox/MapboxMapsLocation/Pucks/PuckLocationIndicatorLayer.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/PuckLocationIndicatorLayer.swift
@@ -209,8 +209,8 @@ private extension PuckLocationIndicatorLayer {
 
         paint.emphasisCircleRadiusTransition = StyleTransition(duration: 0, delay: 0)
         paint.bearingTransition = StyleTransition(duration: 0, delay: 0)
-        paint.accuracyRadiusColor = .constant(ColorRepresentable(color: UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
-        paint.accuracyRadiusBorderColor = .constant(ColorRepresentable(color: .lightGray))
+        paint.accuracyRadiusColor = .constant(ColorRepresentable(color: UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))!)
+        paint.accuracyRadiusBorderColor = .constant(ColorRepresentable(color: .lightGray)!)
 
         layer.paint = paint
 
@@ -249,8 +249,8 @@ private extension PuckLocationIndicatorLayer {
         }
         paint.accuracyRadius = .expression(exp)
 
-        paint.accuracyRadiusColor = .constant(ColorRepresentable(color: UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
-        paint.accuracyRadiusBorderColor = .constant(ColorRepresentable(color: .lightGray))
+        paint.accuracyRadiusColor = .constant(ColorRepresentable(color: UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))!)
+        paint.accuracyRadiusBorderColor = .constant(ColorRepresentable(color: .lightGray)!)
         layer.paint = paint
 
         // Add layer to style

--- a/Mapbox/MapboxMapsStyle/Types/Color.swift
+++ b/Mapbox/MapboxMapsStyle/Types/Color.swift
@@ -33,12 +33,19 @@ public struct ColorRepresentable: Codable, Equatable {
     internal let colorRepresentation: String?
 
     /// Initialize a `ColorRepresentable` with a `UIColor`
-    public init(color: UIColor) {
+    /// - Parameter color: A `UIColor` in sRGB color space
+    /// - Returns: Returns a valid `ColorRepresentable` if initialized with a color in sRGB color space. Returns `nil` otherwise.
+    public init?(color: UIColor) {
         var red: CGFloat = 0.0
         var green: CGFloat = 0.0
         var blue: CGFloat = 0.0
         var alpha: CGFloat = 0.0
-        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        let success = color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        if !success {
+            return nil
+        }
+
         self.colorRepresentation = "rgba(\(red * 255.0), \(green * 255.0), \(blue * 255.0), \(alpha))"
     }
 

--- a/Mapbox/MapboxMapsStyleTests/ColorRepresentableTests.swift
+++ b/Mapbox/MapboxMapsStyleTests/ColorRepresentableTests.swift
@@ -8,7 +8,7 @@ import XCTest
 internal class ColorRepresentableTests: XCTestCase {
 
     func testEncodingAndDecoding() throws {
-        let colorRepresentable = ColorRepresentable(color: .systemRed)
+        let colorRepresentable = ColorRepresentable(color: .systemRed)!
 
         var data: Data?
         do {

--- a/Mapbox/MapboxMapsStyleTests/Fixtures/Value+Fixtures.swift
+++ b/Mapbox/MapboxMapsStyleTests/Fixtures/Value+Fixtures.swift
@@ -25,7 +25,7 @@ internal extension Value where T == String {
 
 internal extension Value where T == ColorRepresentable {
     static func testConstantValue() -> Value<ColorRepresentable> {
-        return .constant(ColorRepresentable(color: .red))
+        return .constant(ColorRepresentable(color: .red)!)
     }
 }
 


### PR DESCRIPTION
This PR does the following:
- Changes `ColorRepresentable` to be a struct instead of `typealias` on `String` -- Doing this because initializing a `ColorRepresentable` felt obscure due to autocomplete being polluted with common String inits.
- Adds color tests to ensure validity.