### PR TITLE
Fix crash when initializing a mapView from storyboard

### DIFF
--- a/Mapbox/MapboxMapsFoundation/BaseMapView.swift
+++ b/Mapbox/MapboxMapsFoundation/BaseMapView.swift
@@ -157,12 +157,11 @@ open class BaseMapView: UIView, MapClient, MBMMetalViewProvider {
         super.awakeFromNib()
 
         guard let accessToken = BaseMapView.parseIBString(ibString: accessToken__) else {
-            fatalError("Must provide access token to the MapView in Interface Builder")
+            fatalError("Must provide access token to the MapView in Interface Builder / Storyboard")
         }
 
-        guard let styleURL = BaseMapView.parseIBStringAsURL(ibString: self.styleURL__) else {
-            return
-        }
+        let ibStyleURL = BaseMapView.parseIBStringAsURL(ibString: self.styleURL__)
+        let styleURL = ibStyleURL ?? URL(string: "mapbox://styles/mapbox/streets-v11")!
 
         let baseURL = BaseMapView.parseIBString(ibString: self.baseURL__)
         let resourceOptions = ResourceOptions(accessToken: accessToken, baseUrl: baseURL)


### PR DESCRIPTION
This PR fixes a crash which occurs when a MapView is only partially setup in the storyboard. The crash would occur because `awakeFromNib()` would return early in `BaseMapView` without actually intializing the renderer when a user would not set the `styleURL`. 

This PR makes it so that setting a styleURL is optional.. The code defaults to using `streets-v11` if a style url hasn't been provided.