### PR TITLE
Disable flaky test

### DIFF
--- a/Mapbox/MapboxMapsTests/Integration Tests/CacheManager/CacheManagerIntegrationTests.swift
+++ b/Mapbox/MapboxMapsTests/Integration Tests/CacheManager/CacheManagerIntegrationTests.swift
@@ -159,41 +159,42 @@ class CacheManagerIntegrationTests: IntegrationTestCase {
         wait(for: [expectation], timeout: 5.0)
     }
 
-    func testCacheManagerIsReleasedAndHandlerRetainingManagerIsCalled() throws {
-        weak var cacheManager: CacheManager?
-
-        let expectation = self.expectation(description: "callback is called")
-        let closureDeallocation = self.expectation(description: "Closure has been destroyed")
-
-        autoreleasepool {
-            cacheManager = setupCacheManager()
-
-            let observer = DeallocationObserver(closureDeallocation.fulfill)
-
-            // Strong copy
-            let cmcopy = cm
-
-            try! cm.clearAmbientCache { _ in
-                // Retain the cachemanager. Notice this variable is scoped inside the autoreleasepool.
-                print(String(describing: cmcopy))
-                print(String(describing: observer))
-
-                expectation.fulfill()
-            }
-
-            cm = nil
-            resourceOptions = nil
-            XCTAssertNotNil(cacheManager) // Not nil (compared with above), since the closure retains it.
-        }
-
-        XCTAssertNotNil(cacheManager)
-        wait(for: [expectation], timeout: 1.0)
-
-        // Closure was called, but not yet deallocated, since it's retained by C++ and will be
-        // released async from ClosureTask::~ClosureTask, called from mbgl::util::RunLoop::process()
-        wait(for: [closureDeallocation], timeout: 5.0)
-        XCTAssertNil(cacheManager)
-    }
+// TODO: Re-enable once test is stabilized
+//    func testCacheManagerIsReleasedAndHandlerRetainingManagerIsCalled() throws {
+//        weak var cacheManager: CacheManager?
+//
+//        let expectation = self.expectation(description: "callback is called")
+//        let closureDeallocation = self.expectation(description: "Closure has been destroyed")
+//
+//        autoreleasepool {
+//            cacheManager = setupCacheManager()
+//
+//            let observer = DeallocationObserver(closureDeallocation.fulfill)
+//
+//            // Strong copy
+//            let cmcopy = cm
+//
+//            try! cm.clearAmbientCache { _ in
+//                // Retain the cachemanager. Notice this variable is scoped inside the autoreleasepool.
+//                print(String(describing: cmcopy))
+//                print(String(describing: observer))
+//
+//                expectation.fulfill()
+//            }
+//
+//            cm = nil
+//            resourceOptions = nil
+//            XCTAssertNotNil(cacheManager) // Not nil (compared with above), since the closure retains it.
+//        }
+//
+//        XCTAssertNotNil(cacheManager)
+//        wait(for: [expectation], timeout: 1.0)
+//
+//        // Closure was called, but not yet deallocated, since it's retained by C++ and will be
+//        // released async from ClosureTask::~ClosureTask, called from mbgl::util::RunLoop::process()
+//        wait(for: [closureDeallocation], timeout: 5.0)
+//        XCTAssertNil(cacheManager)
+//    }
 
     // TODO add tests for:
     // - preloadDataForUrl


### PR DESCRIPTION
This PR disables a flaky cache manager test. To be re-enabled once the test is stabilized.