### PR TITLE
[ci] Temporarily disable the make-docs step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,7 @@ jobs:
                 commit-text: "[create xcframework]"
                 always-run: << parameters.create-xcframework-always-run >>
             - make-deps
-            - make-docs
+            # - make-docs
             - make-xcframework-zip
             - make-xcframeworks-bundle
             - danger


### PR DESCRIPTION
This PR temporarily disables the documentation generation step from the nightly xcframework job, which is failing due to tag issues.