### PR TITLE
Add maps-sdk as code owner for repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# iOS
+* @mapbox/maps-sdk


### PR DESCRIPTION
This PR adds @mapbox/maps-sdk  as a code owner for this repository. 