### PR TITLE
[Example] Add an animate a line example

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		0CC4ECEA25B8AD3000F998B8 /* CustomLocationIndicatorLayerExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC4ECE925B8AD3000F998B8 /* CustomLocationIndicatorLayerExample.swift */; };
 		0CE8ED88258928200066E56C /* race_car_model.gltf in Resources */ = {isa = PBXBuildFile; fileRef = 0CE8ED87258928200066E56C /* race_car_model.gltf */; };
 		0CE8ED8C2589285C0066E56C /* ModelExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE8ED8B2589285C0066E56C /* ModelExample.swift */; };
+		58A3C0C925C4B93600CAE5F0 /* AnimateGeoJSONLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A3C0C825C4B93600CAE5F0 /* AnimateGeoJSONLine.swift */; };
 		A4211CE62592549900D215B4 /* RestrictCoordinateBoundsExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4211CE52592549900D215B4 /* RestrictCoordinateBoundsExample.swift */; };
 		CA252D782587DD9500A989CD /* MapboxMaps.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA252D772587DD9500A989CD /* MapboxMaps.framework */; };
 		CA252D792587DD9500A989CD /* MapboxMaps.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CA252D772587DD9500A989CD /* MapboxMaps.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -138,6 +139,7 @@
 		0CE3D3C225818786000585A2 /* FlyToExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlyToExample.swift; sourceTree = "<group>"; };
 		0CE8ED87258928200066E56C /* race_car_model.gltf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = race_car_model.gltf; sourceTree = "<group>"; };
 		0CE8ED8B2589285C0066E56C /* ModelExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelExample.swift; sourceTree = "<group>"; };
+		58A3C0C825C4B93600CAE5F0 /* AnimateGeoJSONLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimateGeoJSONLine.swift; sourceTree = "<group>"; };
 		666E0D4925664EE7000B8AF5 /* LayerPositionExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerPositionExample.swift; sourceTree = "<group>"; };
 		A4211CE52592549900D215B4 /* RestrictCoordinateBoundsExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestrictCoordinateBoundsExample.swift; sourceTree = "<group>"; };
 		A4AC5DEB2542CB2200995E4C /* CustomStyleURLExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomStyleURLExample.swift; sourceTree = "<group>"; };
@@ -248,6 +250,7 @@
 				CA86E81725BE7C2200E5A1D9 /* BuildingExtrusionsExample.swift */,
 				CA86E86825BF551F00E5A1D9 /* OfflineRegionManagerExample.swift */,
 				0C78AC2825BF70E40057F570 /* LineGradientExample.swift */,
+				58A3C0C825C4B93600CAE5F0 /* AnimateGeoJSONLine.swift */,
 			);
 			path = "All Examples";
 			sourceTree = "<group>";
@@ -553,6 +556,7 @@
 				CADCF72D2584990E0065C51B /* GeoJSONSourceExample.swift in Sources */,
 				CADCF72E2584990E0065C51B /* MapViewExample.swift in Sources */,
 				CADCF73F258499240065C51B /* SceneDelegate.swift in Sources */,
+				58A3C0C925C4B93600CAE5F0 /* AnimateGeoJSONLine.swift in Sources */,
 				CADCF736258499170065C51B /* ExampleTableViewController.swift in Sources */,
 				A4211CE62592549900D215B4 /* RestrictCoordinateBoundsExample.swift in Sources */,
 				0C52BA9825AF8C880054ECA8 /* PuckModelLayerExample.swift in Sources */,
@@ -667,6 +671,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Debug;
 		};
@@ -743,6 +748,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Debug;
 		};

--- a/Examples/Examples/All Examples/AnimateGeoJSONLine.swift
+++ b/Examples/Examples/All Examples/AnimateGeoJSONLine.swift
@@ -2,56 +2,54 @@ import UIKit
 import MapboxMaps
 import Turf
 
-
-
 @objc(AnimateGeoJSONLine)
 public class AnimateGeoJSONLine: UIViewController, ExampleProtocol {
-    
+
     internal var mapView: MapView!
     internal let sourceIdentifier = "route-source-identifier"
     internal var routeLineSource: GeoJSONSource!
     var currentIndex = 0
-    
+
     public var geoJSONLine = (identifier: "routeLine", source: GeoJSONSource())
-    
+
     override public func viewDidLoad() {
         super.viewDidLoad()
-        
+
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
-        
+
         let centerCoordinate = CLLocationCoordinate2D(latitude: 45.5076, longitude: -122.6736)
-        
+
         mapView.cameraManager.setCamera(centerCoordinate: centerCoordinate,
                                         zoom: 11.0)
-        
+
         // Allows the delegate to receive information about map events.
         mapView.on(.mapLoadingFinished) { [weak self] _ in
-            
+
             guard let self = self else { return }
             self.addLine()
             self.animatePolyline()
-            
+
             // The below line is used for internal testing purposes only.
             self.finish()
         }
     }
-    
+
     func addLine() {
-        
+
         // Create a GeoJSON data source.
         routeLineSource = GeoJSONSource()
         routeLineSource.data = .feature(Feature(LineString([allCoordinates[currentIndex]])))
-        
+
         // Create a line layer
         var lineLayer = LineLayer(id: "line-layer")
         lineLayer.source = sourceIdentifier
         lineLayer.paint?.lineColor = .constant(ColorRepresentable(color: UIColor.red))
-        
+
         let lowZoomWidth = 5
         let highZoomWidth = 20
-        
+
         // Use an expression to define the line width at different zoom extents
         lineLayer.paint?.lineWidth = .expression(
             Exp(.interpolate) {
@@ -65,37 +63,37 @@ public class AnimateGeoJSONLine: UIViewController, ExampleProtocol {
         )
         lineLayer.layout?.lineCap = .round
         lineLayer.layout?.lineJoin = .round
-        
+
         // Add the lineLayer to the map.
         self.mapView.style.addSource(source: routeLineSource,
                                      identifier: sourceIdentifier)
         self.mapView.style.addLayer(layer: lineLayer)
-        
+
     }
-    
+
     func animatePolyline() {
         var currentCoordinates = [CLLocationCoordinate2D]()
-        
+
         // Start a timer that will add a new coordinate to the line and redraw it every time it repeats.
         Timer.scheduledTimer(withTimeInterval: 0.10, repeats: true) { ( timer ) in
-            
+
             if self.currentIndex > self.allCoordinates.count {
                 timer.invalidate()
                 return
             }
-            
+
             self.currentIndex += 1
-            
+
             // Create a subarray of locations up to the current index.
             currentCoordinates = Array(self.allCoordinates[0..<self.currentIndex - 1])
-            
+
             let updatedLine = Feature(LineString(currentCoordinates))
             self.routeLineSource.data = .feature(updatedLine)
             _ = self.mapView.style.updateGeoJSON(for: self.sourceIdentifier,
                                                  with: updatedLine)
         }
     }
-    
+
     let allCoordinates = [
         CLLocationCoordinate2D(latitude: 45.52214, longitude: -122.63748),
         CLLocationCoordinate2D(latitude: 45.52218, longitude: -122.64855),
@@ -169,6 +167,6 @@ public class AnimateGeoJSONLine: UIViewController, ExampleProtocol {
         CLLocationCoordinate2D(latitude: 45.49798, longitude: -122.70807),
         CLLocationCoordinate2D(latitude: 45.49798, longitude: -122.70717),
         CLLocationCoordinate2D(latitude: 45.4984, longitude: -122.70713),
-        CLLocationCoordinate2D(latitude: 45.49893, longitude: -122.70774),
+        CLLocationCoordinate2D(latitude: 45.49893, longitude: -122.70774)
     ]
 }

--- a/Examples/Examples/All Examples/AnimateGeoJSONLine.swift
+++ b/Examples/Examples/All Examples/AnimateGeoJSONLine.swift
@@ -1,0 +1,8 @@
+//
+//  AnimateGeoJSONLine.swift
+//  Examples
+//
+//  Created by ZiZi Miles on 1/29/21.
+//
+
+import Foundation

--- a/Examples/Examples/All Examples/AnimateGeoJSONLine.swift
+++ b/Examples/Examples/All Examples/AnimateGeoJSONLine.swift
@@ -1,8 +1,174 @@
-//
-//  AnimateGeoJSONLine.swift
-//  Examples
-//
-//  Created by ZiZi Miles on 1/29/21.
-//
+import UIKit
+import MapboxMaps
+import Turf
 
-import Foundation
+
+
+@objc(AnimateGeoJSONLine)
+public class AnimateGeoJSONLine: UIViewController, ExampleProtocol {
+    
+    internal var mapView: MapView!
+    internal let sourceIdentifier = "route-source-identifier"
+    internal var routeLineSource: GeoJSONSource!
+    var currentIndex = 0
+    
+    public var geoJSONLine = (identifier: "routeLine", source: GeoJSONSource())
+    
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        
+        mapView = MapView(with: view.bounds, resourceOptions: resourceOptions())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        self.view.addSubview(mapView)
+        
+        let centerCoordinate = CLLocationCoordinate2D(latitude: 45.5076, longitude: -122.6736)
+        
+        mapView.cameraManager.setCamera(centerCoordinate: centerCoordinate,
+                                        zoom: 11.0)
+        
+        // Allows the delegate to receive information about map events.
+        mapView.on(.mapLoadingFinished) { [weak self] _ in
+            
+            guard let self = self else { return }
+            self.addLine()
+            self.animatePolyline()
+            
+            // The below line is used for internal testing purposes only.
+            self.finish()
+        }
+    }
+    
+    func addLine() {
+        
+        // Create a GeoJSON data source.
+        routeLineSource = GeoJSONSource()
+        routeLineSource.data = .feature(Feature(LineString([allCoordinates[currentIndex]])))
+        
+        // Create a line layer
+        var lineLayer = LineLayer(id: "line-layer")
+        lineLayer.source = sourceIdentifier
+        lineLayer.paint?.lineColor = .constant(ColorRepresentable(color: UIColor.red))
+        
+        let lowZoomWidth = 5
+        let highZoomWidth = 20
+        
+        // Use an expression to define the line width at different zoom extents
+        lineLayer.paint?.lineWidth = .expression(
+            Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.zoom)
+                14
+                lowZoomWidth
+                18
+                highZoomWidth
+            }
+        )
+        lineLayer.layout?.lineCap = .round
+        lineLayer.layout?.lineJoin = .round
+        
+        // Add the lineLayer to the map.
+        self.mapView.style.addSource(source: routeLineSource,
+                                     identifier: sourceIdentifier)
+        self.mapView.style.addLayer(layer: lineLayer)
+        
+    }
+    
+    func animatePolyline() {
+        var currentCoordinates = [CLLocationCoordinate2D]()
+        
+        // Start a timer that will add a new coordinate to the line and redraw it every time it repeats.
+        Timer.scheduledTimer(withTimeInterval: 0.10, repeats: true) { ( timer ) in
+            
+            if self.currentIndex > self.allCoordinates.count {
+                timer.invalidate()
+                return
+            }
+            
+            self.currentIndex += 1
+            
+            // Create a subarray of locations up to the current index.
+            currentCoordinates = Array(self.allCoordinates[0..<self.currentIndex - 1])
+            
+            let updatedLine = Feature(LineString(currentCoordinates))
+            self.routeLineSource.data = .feature(updatedLine)
+            _ = self.mapView.style.updateGeoJSON(for: self.sourceIdentifier,
+                                                 with: updatedLine)
+        }
+    }
+    
+    let allCoordinates = [
+        CLLocationCoordinate2D(latitude: 45.52214, longitude: -122.63748),
+        CLLocationCoordinate2D(latitude: 45.52218, longitude: -122.64855),
+        CLLocationCoordinate2D(latitude: 45.52219, longitude: -122.6545),
+        CLLocationCoordinate2D(latitude: 45.52196, longitude: -122.65497),
+        CLLocationCoordinate2D(latitude: 45.52104, longitude: -122.65631),
+        CLLocationCoordinate2D(latitude: 45.51935, longitude: -122.6578),
+        CLLocationCoordinate2D(latitude: 45.51848, longitude: -122.65867),
+        CLLocationCoordinate2D(latitude: 45.51293, longitude: -122.65872),
+        CLLocationCoordinate2D(latitude: 45.51295, longitude: -122.66576),
+        CLLocationCoordinate2D(latitude: 45.51252, longitude: -122.66745),
+        CLLocationCoordinate2D(latitude: 45.51244, longitude: -122.66813),
+        CLLocationCoordinate2D(latitude: 45.51385, longitude: -122.67359),
+        CLLocationCoordinate2D(latitude: 45.51406, longitude: -122.67415),
+        CLLocationCoordinate2D(latitude: 45.51484, longitude: -122.67481),
+        CLLocationCoordinate2D(latitude: 45.51532, longitude: -122.676),
+        CLLocationCoordinate2D(latitude: 45.51668, longitude: -122.68106),
+        CLLocationCoordinate2D(latitude: 45.50934, longitude: -122.68503),
+        CLLocationCoordinate2D(latitude: 45.50858, longitude: -122.68546),
+        CLLocationCoordinate2D(latitude: 45.50783, longitude: -122.6852),
+        CLLocationCoordinate2D(latitude: 45.50714, longitude: -122.68424),
+        CLLocationCoordinate2D(latitude: 45.50585, longitude: -122.68433),
+        CLLocationCoordinate2D(latitude: 45.50521, longitude: -122.68429),
+        CLLocationCoordinate2D(latitude: 45.50445, longitude: -122.68456),
+        CLLocationCoordinate2D(latitude: 45.50371, longitude: -122.68538),
+        CLLocationCoordinate2D(latitude: 45.50311, longitude: -122.68653),
+        CLLocationCoordinate2D(latitude: 45.50292, longitude: -122.68731),
+        CLLocationCoordinate2D(latitude: 45.50253, longitude: -122.68742),
+        CLLocationCoordinate2D(latitude: 45.50239, longitude: -122.6867),
+        CLLocationCoordinate2D(latitude: 45.5026, longitude: -122.68545),
+        CLLocationCoordinate2D(latitude: 45.50294, longitude: -122.68407),
+        CLLocationCoordinate2D(latitude: 45.50271, longitude: -122.68357),
+        CLLocationCoordinate2D(latitude: 45.50055, longitude: -122.68236),
+        CLLocationCoordinate2D(latitude: 45.49994, longitude: -122.68233),
+        CLLocationCoordinate2D(latitude: 45.49955, longitude: -122.68267),
+        CLLocationCoordinate2D(latitude: 45.49919, longitude: -122.68257),
+        CLLocationCoordinate2D(latitude: 45.49842, longitude: -122.68376),
+        CLLocationCoordinate2D(latitude: 45.49821, longitude: -122.68428),
+        CLLocationCoordinate2D(latitude: 45.49798, longitude: -122.68573),
+        CLLocationCoordinate2D(latitude: 45.49805, longitude: -122.68923),
+        CLLocationCoordinate2D(latitude: 45.49857, longitude: -122.68926),
+        CLLocationCoordinate2D(latitude: 45.49911, longitude: -122.68814),
+        CLLocationCoordinate2D(latitude: 45.49921, longitude: -122.68865),
+        CLLocationCoordinate2D(latitude: 45.49905, longitude: -122.6897),
+        CLLocationCoordinate2D(latitude: 45.49917, longitude: -122.69346),
+        CLLocationCoordinate2D(latitude: 45.49902, longitude: -122.69404),
+        CLLocationCoordinate2D(latitude: 45.49796, longitude: -122.69438),
+        CLLocationCoordinate2D(latitude: 45.49697, longitude: -122.69504),
+        CLLocationCoordinate2D(latitude: 45.49661, longitude: -122.69624),
+        CLLocationCoordinate2D(latitude: 45.4955, longitude: -122.69781),
+        CLLocationCoordinate2D(latitude: 45.49517, longitude: -122.69803),
+        CLLocationCoordinate2D(latitude: 45.49508, longitude: -122.69711),
+        CLLocationCoordinate2D(latitude: 45.4948, longitude: -122.69688),
+        CLLocationCoordinate2D(latitude: 45.49368, longitude: -122.69744),
+        CLLocationCoordinate2D(latitude: 45.49311, longitude: -122.69702),
+        CLLocationCoordinate2D(latitude: 45.49294, longitude: -122.69665),
+        CLLocationCoordinate2D(latitude: 45.49212, longitude: -122.69788),
+        CLLocationCoordinate2D(latitude: 45.49264, longitude: -122.69771),
+        CLLocationCoordinate2D(latitude: 45.49332, longitude: -122.69835),
+        CLLocationCoordinate2D(latitude: 45.49334, longitude: -122.7007),
+        CLLocationCoordinate2D(latitude: 45.49358, longitude: -122.70167),
+        CLLocationCoordinate2D(latitude: 45.49401, longitude: -122.70215),
+        CLLocationCoordinate2D(latitude: 45.49439, longitude: -122.70229),
+        CLLocationCoordinate2D(latitude: 45.49566, longitude: -122.70185),
+        CLLocationCoordinate2D(latitude: 45.49635, longitude: -122.70215),
+        CLLocationCoordinate2D(latitude: 45.49674, longitude: -122.70346),
+        CLLocationCoordinate2D(latitude: 45.49758, longitude: -122.70517),
+        CLLocationCoordinate2D(latitude: 45.49736, longitude: -122.70614),
+        CLLocationCoordinate2D(latitude: 45.49736, longitude: -122.70663),
+        CLLocationCoordinate2D(latitude: 45.49767, longitude: -122.70807),
+        CLLocationCoordinate2D(latitude: 45.49798, longitude: -122.70807),
+        CLLocationCoordinate2D(latitude: 45.49798, longitude: -122.70717),
+        CLLocationCoordinate2D(latitude: 45.4984, longitude: -122.70713),
+        CLLocationCoordinate2D(latitude: 45.49893, longitude: -122.70774),
+    ]
+}

--- a/Examples/Examples/All Examples/AnimateGeoJSONLine.swift
+++ b/Examples/Examples/All Examples/AnimateGeoJSONLine.swift
@@ -24,7 +24,7 @@ public class AnimateGeoJSONLine: UIViewController, ExampleProtocol {
         mapView.cameraManager.setCamera(centerCoordinate: centerCoordinate,
                                         zoom: 11.0)
 
-        // Allows the delegate to receive information about map events.
+        // Wait for the map to load its style before adding data.
         mapView.on(.mapLoadingFinished) { [weak self] _ in
 
             guard let self = self else { return }

--- a/Examples/Examples/Models/Examples.swift
+++ b/Examples/Examples/Models/Examples.swift
@@ -147,6 +147,9 @@ public struct Examples {
                 type: OfflineRegionManagerExample.self),
         Example(title: "Add a line with a color gradient",
                 description: "Add a line with a rainbow color gradient",
-                type: LineGradientExample.self)
+                type: LineGradientExample.self),
+        Example(title: "Animate a GeoJSON line",
+                description: "Update a map's style to animate a line over time.",
+                type: AnimateGeoJSONLine.self)
     ]
 }


### PR DESCRIPTION
This PR adds an animate a geoJSON line example.

Screen recording:
![animation](https://user-images.githubusercontent.com/44972592/106195998-e757da00-617e-11eb-9005-b0099ab61706.gif)
