### PR TITLE
[ornaments] Honor updates to the ornament options

### DIFF
--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -108,6 +108,8 @@
 		0C1AF567244F6A80008D2A10 /* OrnamentConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1AF566244F6A80008D2A10 /* OrnamentConfig.swift */; };
 		0C26425524EECD14001FE2E3 /* AllExpressions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C26425424EECD14001FE2E3 /* AllExpressions.swift */; };
 		0C26425624EECD14001FE2E3 /* AllExpressions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C26425424EECD14001FE2E3 /* AllExpressions.swift */; };
+		0C2CD9E325D19D30006D068F /* OptionsIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2CD9E225D19D30006D068F /* OptionsIntegrationTests.swift */; };
+		0C2CD9F625D19D75006D068F /* OptionsIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2CD9E225D19D30006D068F /* OptionsIntegrationTests.swift */; };
 		0C31F7AA25AF87AB00DCFB28 /* PuckModelLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C31F7A925AF87AB00DCFB28 /* PuckModelLayer.swift */; };
 		0C31F7AB25AF87AB00DCFB28 /* PuckModelLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C31F7A925AF87AB00DCFB28 /* PuckModelLayer.swift */; };
 		0C37B1E325CB05F000DCDD3D /* ColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C37B1E225CB05F000DCDD3D /* ColorTests.swift */; };
@@ -850,6 +852,7 @@
 		0C1AF564244F65E6008D2A10 /* OrnamentOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrnamentOptions.swift; sourceTree = "<group>"; };
 		0C1AF566244F6A80008D2A10 /* OrnamentConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrnamentConfig.swift; sourceTree = "<group>"; };
 		0C26425424EECD14001FE2E3 /* AllExpressions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllExpressions.swift; sourceTree = "<group>"; };
+		0C2CD9E225D19D30006D068F /* OptionsIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionsIntegrationTests.swift; sourceTree = "<group>"; };
 		0C31F7A925AF87AB00DCFB28 /* PuckModelLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PuckModelLayer.swift; sourceTree = "<group>"; };
 		0C37B1E225CB05F000DCDD3D /* ColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTests.swift; sourceTree = "<group>"; };
 		0C3B1E8A24DDADD000CC29E8 /* EventsStringTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventsStringTokens.swift; sourceTree = "<group>"; };
@@ -1598,6 +1601,7 @@
 				C69F017225435BAE001AB49B /* Mocks */,
 				CA2E498725380AE10096DEDE /* Integration Tests */,
 				0CD34FDD242AADDB00943687 /* Info.plist */,
+				0C2CD9E225D19D30006D068F /* OptionsIntegrationTests.swift */,
 			);
 			path = MapboxMapsTests;
 			sourceTree = "<group>";
@@ -3484,6 +3488,7 @@
 				CA548FA0251C3DA800F829A3 /* StyleURLTests.swift in Sources */,
 				CAD7BA0525A368DE00E64C78 /* ExampleIntegrationTest.swift in Sources */,
 				CA2E4A662538DCE10096DEDE /* MapViewIntegrationTestCase.swift in Sources */,
+				0C2CD9E325D19D30006D068F /* OptionsIntegrationTests.swift in Sources */,
 				CA548F27251C3D7200F829A3 /* PanGestureHandlerTests.swift in Sources */,
 				CA548F23251C3D7200F829A3 /* QuickZoomGestureHandlerTests.swift in Sources */,
 				0C5CFD7725BE25210001E753 /* RasterSourceTests.swift in Sources */,
@@ -3734,6 +3739,7 @@
 				CA548FDB251C404B00F829A3 /* LineStringTests.swift in Sources */,
 				0C5CFCF425BB951B0001E753 /* FillLayerTests.swift in Sources */,
 				0C5CFCEB25BB951B0001E753 /* HillshadeLayerTests.swift in Sources */,
+				0C2CD9F625D19D75006D068F /* OptionsIntegrationTests.swift in Sources */,
 				0C5CFCF125BB951B0001E753 /* SkyLayerTests.swift in Sources */,
 				CA548FDE251C404B00F829A3 /* MapboxMapsStyleTests.swift in Sources */,
 				CA548FDF251C404B00F829A3 /* MapboxMapsSnapshotTests.swift in Sources */,

--- a/Mapbox/MapboxMaps/MapView+Managers.swift
+++ b/Mapbox/MapboxMaps/MapView+Managers.swift
@@ -76,7 +76,7 @@ extension MapView {
     }
 
     internal func updateOrnaments(with newOptions: OrnamentOptions) {
-        ornamentsManager.ornamentConfig = mapOptions.ornaments.makeConfig()
+        ornamentsManager.ornamentConfig = newOptions.makeConfig()
     }
 
     internal func setupUserLocationManager(with locationSupportableMapView: LocationSupportableMapView, options: LocationOptions) {

--- a/Mapbox/MapboxMapsTests/OptionsIntegrationTests.swift
+++ b/Mapbox/MapboxMapsTests/OptionsIntegrationTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import MapboxMaps
+import CoreLocation
+
+internal class OptionsIntegrationTest: MapViewIntegrationTestCase {
+
+    internal func testBaseClass() throws {
+        // Do nothing
+    }
+
+    internal func testOptionsAreUpdated() throws {
+        guard let mapView = mapView else {
+            XCTFail("There should be valid MapView and Style objects created by setUp.")
+            return
+        }
+
+        var newOptions = MapboxMaps.MapOptions()
+        newOptions.location.showUserLocation = true
+        newOptions.camera.animationDuration = 0.1
+        newOptions.gestures.scrollEnabled = false
+        newOptions.ornaments.showsScale = false
+        newOptions.ornaments.showsCompass = false
+
+        mapView.update { (options) in
+            options = newOptions
+        }
+
+        XCTAssert(mapView.gestureManager.gestureOptions == newOptions.gestures)
+        XCTAssert(mapView.cameraManager.mapCameraOptions == newOptions.camera)
+        XCTAssert(mapView.locationManager.locationOptions == newOptions.location)
+        XCTAssert(!mapView.ornamentsManager.ornamentConfig.ornaments.contains(where: {$0.type == .compass
+                                                                                || $0.type == .mapboxScaleBar}))
+    }
+}

--- a/Mapbox/MapboxMapsTests/OptionsIntegrationTests.swift
+++ b/Mapbox/MapboxMapsTests/OptionsIntegrationTests.swift
@@ -4,10 +4,6 @@ import CoreLocation
 
 internal class OptionsIntegrationTest: MapViewIntegrationTestCase {
 
-    internal func testBaseClass() throws {
-        // Do nothing
-    }
-
     internal func testOptionsAreUpdated() throws {
         guard let mapView = mapView else {
             XCTFail("There should be valid MapView and Style objects created by setUp.")
@@ -25,10 +21,13 @@ internal class OptionsIntegrationTest: MapViewIntegrationTestCase {
             options = newOptions
         }
 
-        XCTAssert(mapView.gestureManager.gestureOptions == newOptions.gestures)
-        XCTAssert(mapView.cameraManager.mapCameraOptions == newOptions.camera)
-        XCTAssert(mapView.locationManager.locationOptions == newOptions.location)
-        XCTAssert(!mapView.ornamentsManager.ornamentConfig.ornaments.contains(where: {$0.type == .compass
-                                                                                || $0.type == .mapboxScaleBar}))
+        XCTAssertEqual(mapView.gestureManager.gestureOptions, newOptions.gestures)
+        XCTAssertEqual(mapView.cameraManager.mapCameraOptions, newOptions.camera)
+        XCTAssertEqual(mapView.locationManager.locationOptions, newOptions.location)
+        XCTAssertFalse(
+            mapView.ornamentsManager.ornamentConfig.ornaments.contains {
+                $0.type == .compass || $0.type == .mapboxScaleBar
+            }
+        )
     }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes https://github.com/mapbox/mapbox-maps-ios/issues/31

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Fix issue where updates to ornament options were not honored</changelog>`.

### Summary of changes

This PR ensures that updates to ornament options are honored. The bug was in the `updateOrnaments` method where the MapView was incorrectly re-using the old ornament options instead of the new one.
