### PR TITLE
[location] Rely on consumer provided view models directly to customize location pucks

### DIFF
--- a/Examples/Examples/All Examples/CustomLocationIndicatorLayerExample.swift
+++ b/Examples/Examples/All Examples/CustomLocationIndicatorLayerExample.swift
@@ -30,12 +30,10 @@ public class CustomLocationIndicatorLayerExample: UIViewController, ExampleProto
 
         self.mapView.update { (mapOptions) in
             mapOptions.location.showUserLocation = true
-            mapOptions.location.locationPuck = .puck2D(customize: { (locationIndicatorLayerVM) in
 
-                let topImage = UIImage(named: "star")
-                locationIndicatorLayerVM.topImage = topImage
-                // Perform additional styling here
-            })
+            // Granularly style the location puck with a `LocationIndicatorLayerViewModel`
+            let locationIndicatorLayerVM = LocationIndicatorLayerViewModel(topImage: UIImage(named: "star"))
+            mapOptions.location.locationPuck = .puck2D(locationIndicatorLayerVM)
         }
 
         let coordinate = CLLocationCoordinate2D(latitude: 39.085006, longitude: -77.150925)

--- a/Examples/Examples/All Examples/PuckModelLayerExample.swift
+++ b/Examples/Examples/All Examples/PuckModelLayerExample.swift
@@ -32,48 +32,47 @@ public class PuckModelLayerExample: UIViewController, ExampleProtocol {
 
             mapOptions.location.showUserLocation = true
 
-            mapOptions.location.locationPuck = .puck3D { (puckModelLayerViewModel) in
-                let uri = Bundle.main.url(forResource: "race_car_model",
-                                          withExtension: "gltf")
+            // Fetch the `gltf` asset
+            let uri = Bundle.main.url(forResource: "race_car_model",
+                                      withExtension: "gltf")
 
-                let myModel = Model(uri: uri,
-                                    position: [-177.150925, 39.085006],
-                                    orientation: [0, 0, 0])
+            // Instantiate the model
+            let myModel = Model(uri: uri,
+                                position: [-177.150925, 39.085006],
+                                orientation: [0, 0, 0])
 
-                puckModelLayerViewModel.model = myModel
-
-                /// Setting an expression to  scale the model based on camera zoom
-                let scalingExpression = Exp(.interpolate) {
-                    Exp(.linear)
-                    Exp(.zoom)
-                    0
-                    Exp(.literal) {
-                        [256000.0, 256000.0, 256000.0]
-                    }
-                    4
-                    Exp(.literal) {
-                        [40000.0, 40000.0, 40000.0]
-                    }
-                    8
-                    Exp(.literal) {
-                        [2000.0, 2000.0, 2000.0]
-                    }
-                    12
-                    Exp(.literal) {
-                        [100.0, 100.0, 100.0]
-                    }
-                    16
-                    Exp(.literal) {
-                        [7.0, 7.0, 7.0]
-                    }
-                    20
-                    Exp(.literal) {
-                        [1.0, 1.0, 1.0]
-                    }
+            // Setting an expression to  scale the model based on camera zoom
+            let scalingExpression = Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.zoom)
+                0
+                Exp(.literal) {
+                    [256000.0, 256000.0, 256000.0]
                 }
-
-                puckModelLayerViewModel.modelScale = .expression(scalingExpression)
+                4
+                Exp(.literal) {
+                    [40000.0, 40000.0, 40000.0]
+                }
+                8
+                Exp(.literal) {
+                    [2000.0, 2000.0, 2000.0]
+                }
+                12
+                Exp(.literal) {
+                    [100.0, 100.0, 100.0]
+                }
+                16
+                Exp(.literal) {
+                    [7.0, 7.0, 7.0]
+                }
+                20
+                Exp(.literal) {
+                    [1.0, 1.0, 1.0]
+                }
             }
+
+            let puckModelLayerViewModel = PuckModelLayerViewModel(model: myModel, modelScale: .expression(scalingExpression))
+            mapOptions.location.locationPuck = .puck3D(puckModelLayerViewModel)
         }
 
         let coordinate = CLLocationCoordinate2D(latitude: 39.085006, longitude: -77.150925)

--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -110,6 +110,9 @@
 		0C26425624EECD14001FE2E3 /* AllExpressions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C26425424EECD14001FE2E3 /* AllExpressions.swift */; };
 		0C2CD9E325D19D30006D068F /* OptionsIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2CD9E225D19D30006D068F /* OptionsIntegrationTests.swift */; };
 		0C2CD9F625D19D75006D068F /* OptionsIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2CD9E225D19D30006D068F /* OptionsIntegrationTests.swift */; };
+		0C2CDA2E25D1A51C006D068F /* LocationPuckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2CDA2D25D1A51C006D068F /* LocationPuckTests.swift */; };
+		0C2CDA2F25D1A51C006D068F /* LocationPuckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2CDA2D25D1A51C006D068F /* LocationPuckTests.swift */; };
+		0C2CDA3025D1A51C006D068F /* LocationPuckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2CDA2D25D1A51C006D068F /* LocationPuckTests.swift */; };
 		0C31F7AA25AF87AB00DCFB28 /* PuckModelLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C31F7A925AF87AB00DCFB28 /* PuckModelLayer.swift */; };
 		0C31F7AB25AF87AB00DCFB28 /* PuckModelLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C31F7A925AF87AB00DCFB28 /* PuckModelLayer.swift */; };
 		0C37B1E325CB05F000DCDD3D /* ColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C37B1E225CB05F000DCDD3D /* ColorTests.swift */; };
@@ -877,6 +880,7 @@
 		0C1AF566244F6A80008D2A10 /* OrnamentConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrnamentConfig.swift; sourceTree = "<group>"; };
 		0C26425424EECD14001FE2E3 /* AllExpressions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllExpressions.swift; sourceTree = "<group>"; };
 		0C2CD9E225D19D30006D068F /* OptionsIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionsIntegrationTests.swift; sourceTree = "<group>"; };
+		0C2CDA2D25D1A51C006D068F /* LocationPuckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationPuckTests.swift; sourceTree = "<group>"; };
 		0C31F7A925AF87AB00DCFB28 /* PuckModelLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PuckModelLayer.swift; sourceTree = "<group>"; };
 		0C37B1E225CB05F000DCDD3D /* ColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTests.swift; sourceTree = "<group>"; };
 		0C3B1E8A24DDADD000CC29E8 /* EventsStringTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventsStringTokens.swift; sourceTree = "<group>"; };
@@ -1862,6 +1866,7 @@
 				C64ED305253F7CF500ADADFB /* LocationSupportableMapViewMock.swift */,
 				C64ED320253F7E9100ADADFB /* LocationManagerTests.swift */,
 				C64ED33B253F819B00ADADFB /* LocationConsumerMock.swift */,
+				0C2CDA2D25D1A51C006D068F /* LocationPuckTests.swift */,
 			);
 			path = MapboxMapsLocationTests;
 			sourceTree = "<group>";
@@ -3519,6 +3524,7 @@
 				0C5CFCE725BB951B0001E753 /* LineLayerTests.swift in Sources */,
 				0CC6EF2225C3263400BFB153 /* SkyLayerIntegrationTests.swift in Sources */,
 				CA548F24251C3D7200F829A3 /* PitchGestureHandlerTests.swift in Sources */,
+				0C2CDA2E25D1A51C006D068F /* LocationPuckTests.swift in Sources */,
 				CAC1964325AEAFD500F69FEA /* GlyphsRasterizationOptionsTests.swift in Sources */,
 				0C5CFDAE25BE28D20001E753 /* Fixtures.swift in Sources */,
 				C69F011225431AF4001AB49B /* LocationManagerIntegrationTests.swift in Sources */,
@@ -3705,6 +3711,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C64ED323253F7E9100ADADFB /* LocationManagerTests.swift in Sources */,
+				0C2CDA3025D1A51C006D068F /* LocationPuckTests.swift in Sources */,
 				C69F017625435C55001AB49B /* LocationProviderMock.swift in Sources */,
 				C64ED33E253F819B00ADADFB /* LocationConsumerMock.swift in Sources */,
 				C64ED308253F7CF500ADADFB /* LocationSupportableMapViewMock.swift in Sources */,
@@ -3858,6 +3865,7 @@
 				CA548FE8251C404B00F829A3 /* OrnamentSupportableViewMock.swift in Sources */,
 				C64ED322253F7E9100ADADFB /* LocationManagerTests.swift in Sources */,
 				CA9481572554AA9E00D93C3C /* TestConveniences.swift in Sources */,
+				0C2CDA2F25D1A51C006D068F /* LocationPuckTests.swift in Sources */,
 				CA548FE9251C404B00F829A3 /* GeometryCollectionTests.swift in Sources */,
 				0C5CFCD925BB951B0001E753 /* CircleLayerTests.swift in Sources */,
 				0C5CFCE525BB951B0001E753 /* HeatmapLayerTests.swift in Sources */,

--- a/Mapbox/MapboxMapsLocation/Pucks/LocationPuckManager.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/LocationPuckManager.swift
@@ -20,24 +20,18 @@ internal enum PuckStyle {
 // MARK: PuckBackend
 /// This enum represents the different backends that can be used for Pucks
 public enum LocationPuck: Equatable {
-    case puck2D(customize: ((inout LocationIndicatorLayerViewModel) -> Void)? = nil) // Backed by `LocationIndicatorLayer`. Implement customize block to granularly modify the puck's styling.
-    case puck3D(customize: ((inout PuckModelLayerViewModel) -> Void))// Backed by `ModelLayer`. Implement customize block to granularly modify the puck's styling.
+    /// Backed by `LocationIndicatorLayer`. Optionally provide `LocationIndicatorViewModel` to granularly modify the puck's styling.
+    case puck2D(LocationIndicatorLayerViewModel? = nil)
+
+    /// Backed by `ModelLayer`.
+    case puck3D(PuckModelLayerViewModel)
 
     public static func == (lhs: LocationPuck, rhs: LocationPuck) -> Bool {
         switch (lhs, rhs) {
-        case (.puck2D(let lhsClosure), .puck2D(let rhsClosure)):
-            guard let lhsClosure = lhsClosure, let rhsClosure = rhsClosure else { return false }
-            var lhsViewModel = LocationIndicatorLayerViewModel()
-            var rhsViewModel = LocationIndicatorLayerViewModel()
-            lhsClosure(&lhsViewModel)
-            rhsClosure(&rhsViewModel)
-            return lhsViewModel == rhsViewModel
-        case (.puck3D(let lhsClosure), .puck3D(let rhsClosure)):
-            var lhsViewModel = PuckModelLayerViewModel()
-            var rhsViewModel = PuckModelLayerViewModel()
-            lhsClosure(&lhsViewModel)
-            rhsClosure(&rhsViewModel)
-            return lhsViewModel == rhsViewModel
+        case (.puck2D(let lhsVM), .puck2D(let rhsVM)):
+            return lhsVM == rhsVM
+        case (.puck3D(let lhsVM), .puck3D(let rhsVM)):
+            return lhsVM == rhsVM
         default:
             return false
         }
@@ -97,10 +91,10 @@ public class LocationPuckManager: LocationConsumer {
         var puck: Puck
 
         switch self.currentPuckBackend {
-        case let .puck2D(customizationHandler):
-            puck = PuckLocationIndicatorLayer(currentPuckStyle: self.currentPuckStyle, locationSupportableMapView: locationSupportableMapView, customizationHandler: customizationHandler)
-        case let .puck3D(customizationHandler):
-            puck = PuckModelLayer(currentPuckStyle: self.currentPuckStyle, locationSupportableMapView: locationSupportableMapView, customizationHandler: customizationHandler)
+        case let .puck2D(viewModel):
+            puck = PuckLocationIndicatorLayer(currentPuckStyle: self.currentPuckStyle, locationSupportableMapView: locationSupportableMapView, viewModel: viewModel)
+        case let .puck3D(viewModel):
+            puck = PuckModelLayer(currentPuckStyle: self.currentPuckStyle, locationSupportableMapView: locationSupportableMapView, viewModel: viewModel)
         }
 
         if let location = self.latestLocation {

--- a/Mapbox/MapboxMapsLocation/Pucks/LocationPuckManager.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/LocationPuckManager.swift
@@ -25,10 +25,19 @@ public enum LocationPuck: Equatable {
 
     public static func == (lhs: LocationPuck, rhs: LocationPuck) -> Bool {
         switch (lhs, rhs) {
-        case (.puck2D(_), .puck2D(_)):
-            return true
-        case (.puck3D(_), .puck3D(_)):
-            return true
+        case (.puck2D(let lhsClosure), .puck2D(let rhsClosure)):
+            guard let lhsClosure = lhsClosure, let rhsClosure = rhsClosure else { return false }
+            var lhsViewModel = LocationIndicatorLayerViewModel()
+            var rhsViewModel = LocationIndicatorLayerViewModel()
+            lhsClosure(&lhsViewModel)
+            rhsClosure(&rhsViewModel)
+            return lhsViewModel == rhsViewModel
+        case (.puck3D(let lhsClosure), .puck3D(let rhsClosure)):
+            var lhsViewModel = PuckModelLayerViewModel()
+            var rhsViewModel = PuckModelLayerViewModel()
+            lhsClosure(&lhsViewModel)
+            rhsClosure(&rhsViewModel)
+            return lhsViewModel == rhsViewModel
         default:
             return false
         }

--- a/Mapbox/MapboxMapsLocation/Pucks/LocationPuckManager.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/LocationPuckManager.swift
@@ -26,16 +26,6 @@ public enum LocationPuck: Equatable {
     /// Backed by `ModelLayer`.
     case puck3D(PuckModelLayerViewModel)
 
-    public static func == (lhs: LocationPuck, rhs: LocationPuck) -> Bool {
-        switch (lhs, rhs) {
-        case (.puck2D(let lhsVM), .puck2D(let rhsVM)):
-            return lhsVM == rhsVM
-        case (.puck3D(let lhsVM), .puck3D(let rhsVM)):
-            return lhsVM == rhsVM
-        default:
-            return false
-        }
-    }
 }
 
 // MARK: LocationPuckManager

--- a/Mapbox/MapboxMapsLocation/Pucks/PuckLocationIndicatorLayer.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/PuckLocationIndicatorLayer.swift
@@ -24,7 +24,7 @@ public struct LocationIndicatorLayerViewModel: Equatable {
     /// The size of the images, as a scale factor applied to the size of the specified image.
     public var scale: Value<Double>?
 
-    public init(topImage: UIImage?, bearingImage: UIImage?, shadowImage: UIImage?, scale: Value<Double>?) {
+    public init(topImage: UIImage? = nil, bearingImage: UIImage? = nil, shadowImage: UIImage? = nil, scale: Value<Double>? = nil) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage

--- a/Mapbox/MapboxMapsLocation/Pucks/PuckLocationIndicatorLayer.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/PuckLocationIndicatorLayer.swift
@@ -30,31 +30,24 @@ public struct LocationIndicatorLayerViewModel: Equatable {
         self.shadowImage = shadowImage
         self.scale = scale
     }
-
-    public static func == (lhs: LocationIndicatorLayerViewModel, rhs: LocationIndicatorLayerViewModel) -> Bool {
-        return lhs.topImage == rhs.topImage && lhs.bearingImage == rhs.bearingImage && lhs.shadowImage == rhs.shadowImage
-    }
 }
 
 internal class PuckLocationIndicatorLayer: Puck {
 
     // MARK: Properties
     internal var locationIndicatorLayer: LocationIndicatorLayer?
-    internal var locationIndicatorLayerVM: LocationIndicatorLayerViewModel
+    internal var locationIndicatorLayerVM: LocationIndicatorLayerViewModel?
 
     // MARK: Protocol Properties
     internal var puckStyle: PuckStyle
 
     internal weak var locationSupportableMapView: LocationSupportableMapView?
 
-    internal var customizationHandler: ((inout LocationIndicatorLayerViewModel) -> Void)?
-
     // MARK: Initializers
-    internal init(currentPuckStyle: PuckStyle, locationSupportableMapView: LocationSupportableMapView, customizationHandler: ((inout LocationIndicatorLayerViewModel) -> Void)? = nil) {
+    internal init(currentPuckStyle: PuckStyle, locationSupportableMapView: LocationSupportableMapView, viewModel: LocationIndicatorLayerViewModel?) {
         self.locationSupportableMapView = locationSupportableMapView
-        self.locationIndicatorLayerVM = LocationIndicatorLayerViewModel(topImage: nil, bearingImage: nil, shadowImage: nil, scale: nil)
+        self.locationIndicatorLayerVM = viewModel
         self.puckStyle = currentPuckStyle
-        self.customizationHandler = customizationHandler
     }
 
     // MARK: Protocol Implementation
@@ -140,10 +133,10 @@ private extension PuckLocationIndicatorLayer {
 
         _ = style.removeStyleLayer(forLayerId: "approximate-puck")
         // Call customizationHandler to allow developers to granularly modify the layer
-        self.customizationHandler?(&locationIndicatorLayerVM)
+
 
         // Add images to sprite sheet
-        if let validTopImage = locationIndicatorLayerVM.topImage {
+        if let validTopImage = locationIndicatorLayerVM?.topImage {
             let setStyleImageResult = style.setStyleImage(image: validTopImage, with: "locationIndicatorLayerTopImage", scale: 44.0)
 
             if case .failure(let imageError) = setStyleImageResult {
@@ -161,7 +154,7 @@ private extension PuckLocationIndicatorLayer {
             }
         }
 
-        if let validBearingImage = locationIndicatorLayerVM.bearingImage {
+        if let validBearingImage = locationIndicatorLayerVM?.bearingImage {
             let setStyleImageResult = style.setStyleImage(image: validBearingImage, with: "locationIndicatorLayerBearingImage", scale: 44.0)
 
             if case .failure(let imageError) = setStyleImageResult {
@@ -178,7 +171,7 @@ private extension PuckLocationIndicatorLayer {
             }
         }
 
-        if let validShadowImage = locationIndicatorLayerVM.shadowImage {
+        if let validShadowImage = locationIndicatorLayerVM?.shadowImage {
             let setStyleImageResultInner = style.setStyleImage(image: validShadowImage, with: "locationIndicatorLayerShadowImage", scale: 44.0)
 
             if case .failure(let imageError) = setStyleImageResultInner {
@@ -202,9 +195,9 @@ private extension PuckLocationIndicatorLayer {
                                     location.coordinate.longitude,
                                     location.internalLocation.altitude])
         paint.locationTransition = StyleTransition(duration: 0, delay: 0)
-        paint.topImageSize = locationIndicatorLayerVM.scale ?? .constant(1.0)
-        paint.bearingImageSize = locationIndicatorLayerVM.scale ?? .constant(1.0)
-        paint.shadowImageSize = locationIndicatorLayerVM.scale ?? .constant(1.0)
+        paint.topImageSize = locationIndicatorLayerVM?.scale ?? .constant(1.0)
+        paint.bearingImageSize = locationIndicatorLayerVM?.scale ?? .constant(1.0)
+        paint.shadowImageSize = locationIndicatorLayerVM?.scale ?? .constant(1.0)
         paint.accuracyRadius = .constant(location.horizontalAccuracy)
 
         paint.emphasisCircleRadiusTransition = StyleTransition(duration: 0, delay: 0)

--- a/Mapbox/MapboxMapsLocation/Pucks/PuckModelLayer.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/PuckModelLayer.swift
@@ -13,7 +13,7 @@ import MapboxMapsStyle
 public struct PuckModelLayerViewModel: Equatable {
 
     /// The model to use as the locaiton puck
-    public var model: Model?
+    public var model: Model
 
     /// The scale of the model.
     public var modelScale: Value<[Double]>?
@@ -25,6 +25,13 @@ public struct PuckModelLayerViewModel: Equatable {
         return lhs.model == rhs.model
             && lhs.modelScale == rhs.modelScale
             && lhs.modelRotation == rhs.modelRotation
+    }
+
+    /// Initialize a PuckModelLayerViewModel with a model, scale and rotation
+    public init(model: Model, modelScale: Value<[Double]>? = nil, modelRotation: Value<[Double]>? = nil) {
+        self.model = model
+        self.modelScale = modelScale
+        self.modelRotation = modelRotation
     }
 }
 
@@ -40,31 +47,26 @@ internal class PuckModelLayer: Puck {
     internal var puckStyle: PuckStyle
     internal weak var locationSupportableMapView: LocationSupportableMapView?
     public var style: Style!
-    
-    // Customization hook
-    internal var customizationHandler: ((inout PuckModelLayerViewModel) -> Void)
 
     // MARK: Initializers
-    internal init(currentPuckStyle: PuckStyle, locationSupportableMapView: LocationSupportableMapView, customizationHandler: @escaping ((inout PuckModelLayerViewModel) -> Void)) {
+    internal init(currentPuckStyle: PuckStyle, locationSupportableMapView: LocationSupportableMapView, viewModel: PuckModelLayerViewModel) {
         modelLayer = ModelLayer(id: "puck-model-layer")
         modelSource = ModelSource()
-        puckModelLayerVM = PuckModelLayerViewModel()
+        puckModelLayerVM = viewModel
         self.locationSupportableMapView = locationSupportableMapView
         style = locationSupportableMapView.style
         puckStyle = currentPuckStyle
-        self.customizationHandler = customizationHandler
-        setup()
+        self.setup()
     }
 
     internal func setup() {
 
-        customizationHandler(&puckModelLayerVM)
         modelLayer.source = "puck-model-source"
 
-        if let validModel = puckModelLayerVM.model {
-            modelSource.models = ["puck-model": validModel]
-            initialPuckOrientation = validModel.orientation
-        }
+        // Set the model to the source
+        modelSource.models = ["puck-model": puckModelLayerVM.model]
+        initialPuckOrientation = puckModelLayerVM.model.orientation
+
 
         if let validModelScale = puckModelLayerVM.modelScale {
             modelLayer.paint?.modelScale = validModelScale

--- a/Mapbox/MapboxMapsLocation/Pucks/PuckModelLayer.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/PuckModelLayer.swift
@@ -23,6 +23,8 @@ public struct PuckModelLayerViewModel: Equatable {
 
     public static func == (lhs: PuckModelLayerViewModel, rhs: PuckModelLayerViewModel) -> Bool {
         return lhs.model == rhs.model
+            && lhs.modelScale == rhs.modelScale
+            && lhs.modelRotation == rhs.modelRotation
     }
 }
 

--- a/Mapbox/MapboxMapsLocation/Pucks/PuckModelLayer.swift
+++ b/Mapbox/MapboxMapsLocation/Pucks/PuckModelLayer.swift
@@ -21,12 +21,6 @@ public struct PuckModelLayerViewModel: Equatable {
     /// The rotation of the model in euler angles [lon, lat, z].
     public var modelRotation: Value<[Double]>?
 
-    public static func == (lhs: PuckModelLayerViewModel, rhs: PuckModelLayerViewModel) -> Bool {
-        return lhs.model == rhs.model
-            && lhs.modelScale == rhs.modelScale
-            && lhs.modelRotation == rhs.modelRotation
-    }
-
     /// Initialize a PuckModelLayerViewModel with a model, scale and rotation
     public init(model: Model, modelScale: Value<[Double]>? = nil, modelRotation: Value<[Double]>? = nil) {
         self.model = model

--- a/Mapbox/MapboxMapsLocationTests/LocationPuckTests.swift
+++ b/Mapbox/MapboxMapsLocationTests/LocationPuckTests.swift
@@ -35,7 +35,6 @@ internal class LocationPuckTests: XCTestCase {
         let puck2 = LocationPuck.puck2D(vm2)
 
         XCTAssertEqual(puck1, puck2)
-
     }
 
     func testLocationPuck2DAreNotEqual() throws {
@@ -47,7 +46,6 @@ internal class LocationPuckTests: XCTestCase {
         let puck2 = LocationPuck.puck2D(vm2)
 
         XCTAssertNotEqual(puck1, puck2)
-
     }
 
     func testLocationPuck3DAreEqual() throws {

--- a/Mapbox/MapboxMapsLocationTests/LocationPuckTests.swift
+++ b/Mapbox/MapboxMapsLocationTests/LocationPuckTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+
+#if canImport(MapboxMaps)
+@testable import MapboxMaps
+#else
+@testable import MapboxMapsLocation
+import MapboxMapsFoundation
+import MapboxMapsStyle
+#endif
+
+internal class LocationPuckTests: XCTestCase {
+
+    func testLocationPuck2DAreEqual() throws {
+
+        let puck1 = LocationPuck.puck2D { (vm) in
+            vm.scale = .constant(10.0)
+            if #available(iOS 13.0, *) {
+                vm.topImage = UIImage(systemName: "house")
+            }
+        }
+
+        let puck2 = LocationPuck.puck2D { (vm) in
+            vm.scale = .constant(10.0)
+            if #available(iOS 13.0, *) {
+                vm.topImage = UIImage(systemName: "house")
+            }
+        }
+
+        XCTAssertEqual(puck1, puck2)
+
+    }
+
+    func testLocationPuck2DAreNotEqual() throws {
+
+        let puck1 = LocationPuck.puck2D { (vm) in
+            vm.scale = .constant(10.0)
+            if #available(iOS 13.0, *) {
+                vm.topImage = UIImage(systemName: "house")
+            }
+        }
+
+        let puck2 = LocationPuck.puck2D { (vm) in
+            vm.scale = .constant(10.0)
+        }
+
+        XCTAssertNotEqual(puck1, puck2)
+
+    }
+
+    func testLocationPuck3DAreEqual() throws {
+
+        let puck1 = LocationPuck.puck3D { (vm) in
+            vm.modelScale = .constant([0.1, 0.2])
+            vm.modelRotation = .constant([0.3, 0.4])
+            vm.model = Model(uri: URL(string: "some-url"), position: [1.0, 2.0])
+        }
+
+        let puck2 = LocationPuck.puck3D { (vm) in
+            vm.modelScale = .constant([0.1, 0.2])
+            vm.modelRotation = .constant([0.3, 0.4])
+            vm.model = Model(uri: URL(string: "some-url"), position: [1.0, 2.0])
+        }
+
+        XCTAssertEqual(puck1, puck2)
+    }
+
+    func testLocationPuck3DAreNotEqual() throws {
+
+        let puck1 = LocationPuck.puck3D { (vm) in
+            vm.modelScale = .constant([0.1, 0.2])
+            vm.modelRotation = .constant([0.3, 0.4])
+        }
+
+        let puck2 = LocationPuck.puck3D { (vm) in
+            vm.modelScale = .constant([0.1, 0.2])
+            vm.modelRotation = .constant([0.2, 0.4])
+            vm.model = Model(uri: URL(string: "some-url"), position: [1.0, 2.0])
+        }
+
+        XCTAssertNotEqual(puck1, puck2)
+    }
+}

--- a/Mapbox/MapboxMapsLocationTests/LocationPuckTests.swift
+++ b/Mapbox/MapboxMapsLocationTests/LocationPuckTests.swift
@@ -10,21 +10,29 @@ import MapboxMapsStyle
 
 internal class LocationPuckTests: XCTestCase {
 
+    var image: UIImage? {
+        if #available(iOS 13.0, *) {
+            return UIImage(systemName: "house")
+        } else {
+            return nil
+        }
+    }
+
+    var model1: Model {
+        return Model(uri: URL(string: "some-url"), position: [1.0, 2.0])
+    }
+
+    var model2: Model {
+        return Model(uri: URL(string: "some-other-url"), position: [1.0, 2.0])
+    }
+
     func testLocationPuck2DAreEqual() throws {
 
-        let puck1 = LocationPuck.puck2D { (vm) in
-            vm.scale = .constant(10.0)
-            if #available(iOS 13.0, *) {
-                vm.topImage = UIImage(systemName: "house")
-            }
-        }
+        let vm1 = LocationIndicatorLayerViewModel(topImage: image, scale: .constant(10))
+        let puck1 = LocationPuck.puck2D(vm1)
 
-        let puck2 = LocationPuck.puck2D { (vm) in
-            vm.scale = .constant(10.0)
-            if #available(iOS 13.0, *) {
-                vm.topImage = UIImage(systemName: "house")
-            }
-        }
+        let vm2 = LocationIndicatorLayerViewModel(topImage: image, scale: .constant(10))
+        let puck2 = LocationPuck.puck2D(vm2)
 
         XCTAssertEqual(puck1, puck2)
 
@@ -32,16 +40,11 @@ internal class LocationPuckTests: XCTestCase {
 
     func testLocationPuck2DAreNotEqual() throws {
 
-        let puck1 = LocationPuck.puck2D { (vm) in
-            vm.scale = .constant(10.0)
-            if #available(iOS 13.0, *) {
-                vm.topImage = UIImage(systemName: "house")
-            }
-        }
+        let vm1 = LocationIndicatorLayerViewModel(topImage: image, scale: .constant(12))
+        let puck1 = LocationPuck.puck2D(vm1)
 
-        let puck2 = LocationPuck.puck2D { (vm) in
-            vm.scale = .constant(10.0)
-        }
+        let vm2 = LocationIndicatorLayerViewModel(topImage: image, scale: .constant(10))
+        let puck2 = LocationPuck.puck2D(vm2)
 
         XCTAssertNotEqual(puck1, puck2)
 
@@ -49,33 +52,22 @@ internal class LocationPuckTests: XCTestCase {
 
     func testLocationPuck3DAreEqual() throws {
 
-        let puck1 = LocationPuck.puck3D { (vm) in
-            vm.modelScale = .constant([0.1, 0.2])
-            vm.modelRotation = .constant([0.3, 0.4])
-            vm.model = Model(uri: URL(string: "some-url"), position: [1.0, 2.0])
-        }
+        let vm1 = PuckModelLayerViewModel(model: model1, modelScale: .constant([0.1, 0.2]), modelRotation: .constant([0.3, 0.4]))
+        let puck1 = LocationPuck.puck3D(vm1)
 
-        let puck2 = LocationPuck.puck3D { (vm) in
-            vm.modelScale = .constant([0.1, 0.2])
-            vm.modelRotation = .constant([0.3, 0.4])
-            vm.model = Model(uri: URL(string: "some-url"), position: [1.0, 2.0])
-        }
+        let vm2 = PuckModelLayerViewModel(model: model1, modelScale: .constant([0.1, 0.2]), modelRotation: .constant([0.3, 0.4]))
+        let puck2 = LocationPuck.puck3D(vm2)
 
         XCTAssertEqual(puck1, puck2)
     }
 
     func testLocationPuck3DAreNotEqual() throws {
 
-        let puck1 = LocationPuck.puck3D { (vm) in
-            vm.modelScale = .constant([0.1, 0.2])
-            vm.modelRotation = .constant([0.3, 0.4])
-        }
+        let vm1 = PuckModelLayerViewModel(model: model1, modelScale: .constant([0.1, 0.2]), modelRotation: .constant([0.3, 0.4]))
+        let puck1 = LocationPuck.puck3D(vm1)
 
-        let puck2 = LocationPuck.puck3D { (vm) in
-            vm.modelScale = .constant([0.1, 0.2])
-            vm.modelRotation = .constant([0.2, 0.4])
-            vm.model = Model(uri: URL(string: "some-url"), position: [1.0, 2.0])
-        }
+        let vm2 = PuckModelLayerViewModel(model: model2, modelScale: .constant([0.1, 0.3]), modelRotation: .constant([0.4, 0.5]))
+        let puck2 = LocationPuck.puck3D(vm2)
 
         XCTAssertNotEqual(puck1, puck2)
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Rely on consumer provided view models directly to customize location pucks </changelog>`.

### Summary of changes

This PR makes the `LocationManager` directly use consumer provided viewModels (`PuckModelLayerViewModel` and `LocationIndicatorLayerViewModel`) instead of calling a closure.
