### PR TITLE
Update to Turf 2.0.0-alpha.2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon-ios.json" == 10.0.0-beta.8
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-core/MapboxCoreMaps.json" == 10.0.0-beta.13
-github "mapbox/turf-swift" "build-for-distribution"
+github "mapbox/turf-swift" == 2.0.0-alpha.2
 github "mapbox/mapbox-events-ios" ~> 0.10

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon-ios.json" "10.0.0-beta.8"
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-core/MapboxCoreMaps.json" "10.0.0-beta.13"
 github "mapbox/mapbox-events-ios" "v0.10.7"
-github "mapbox/turf-swift" "17c5fd8a7757b4a37a859e75f0a3c4f8f6f177e3"
+github "mapbox/turf-swift" "v2.0.0-alpha.2"

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -25,23 +25,6 @@ Pod::Spec.new do |m|
   m.dependency 'MapboxCoreMaps', '10.0.0-beta.13'
   m.dependency 'MapboxCommon', '10.0.0-beta.8'
   m.dependency 'MapboxMobileEvents', '0.10.7'
-
-  # The consuming app must specify Turf in their Podfile because this version of MapboxMaps depends on an unreleased Turf version:
-  #
-  #   pod 'Turf', git: 'https://github.com/mapbox/turf-swift.git', commit: '17c5fd8a7757b4a37a859e75f0a3c4f8f6f177e3'
-  #
-  # Additionally, you must add a post-install hook to your Podfile to add a configuration to the Turf target:
-  #
-  #   post_install do |installer|
-  #     installer.pods_project.targets.each do |target|
-  #       if target.name == 'Turf'
-  #         target.build_configurations.each do |config|
-  #           config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
-  #         end
-  #       end
-  #     end
-  #   end
-  #
-  m.dependency 'Turf'
+  m.dependency 'Turf', '2.0.0-alpha.2'
 
 end

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@
 
  let package = Package(
      name: "MapboxMaps",
-     platforms: [.iOS(.v10), .macOS(.v10_15)],
+     platforms: [.iOS(.v11)],
      products: [
          .library(
              name: "MapboxMaps",

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@
         .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("10.0.0-beta.8")),
         .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.0.0-beta.13")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", .exact("0.12.0-alpha.1")),
-        .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", .exact("2.0.0-alpha.1")),
+        .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", .exact("2.0.0-alpha.2")),
      ],
      targets: [
          .target(

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,6 @@
          ),
          registry.mapboxMapsTarget(version: version, checksum: checksum),
      ],
-     cxxLanguageStandard: .cxx14
  )
 
  struct SDKRegistry {


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.

### Summary of changes

- Updates to Turf 2.0.0-alpha.2
- Fixes list of supported platforms in Package.swift
- Removes an unnecessary C++ setting in Package.swift

### Changelog

- Apps consuming the Maps SDK via CocoaPods may now remove the post-install hook to enable library evolution for Turf.
