### PR TITLE
[style] Make internal representation of colorRepresentable an expression

### DIFF
--- a/DebugApp/DebugApp/DebugViewController.swift
+++ b/DebugApp/DebugApp/DebugViewController.swift
@@ -26,7 +26,6 @@ public class DebugViewController: UIViewController {
 
         self.mapView = MapView(with: view.bounds, resourceOptions: resourceOptions)
         mapView.update { (mapOptions) in
-            mapOptions.render.presentsWithTransaction = false
             mapOptions.location.showUserLocation = true
         }
 

--- a/DebugApp/DebugApp/DebugViewController.swift
+++ b/DebugApp/DebugApp/DebugViewController.swift
@@ -26,6 +26,7 @@ public class DebugViewController: UIViewController {
 
         self.mapView = MapView(with: view.bounds, resourceOptions: resourceOptions)
         mapView.update { (mapOptions) in
+            mapOptions.render.presentsWithTransaction = false
             mapOptions.location.showUserLocation = true
         }
 

--- a/Mapbox/MapboxMapsStyle/Types/Color.swift
+++ b/Mapbox/MapboxMapsStyle/Types/Color.swift
@@ -3,13 +3,14 @@ import UIKit
 /// Container to represent `UIColor`for use by the map renderer
 public struct ColorRepresentable: Codable, Equatable {
 
-    /// String representation of a `UIColor` used by the renderer
-    public let colorRepresentation: String?
+    /// Expression representation of a `UIColor` used by the renderer
+    public let colorRepresentation: Expression?
 
     /// Create a string representation of a `UIColor`
     /// - Parameter color: A `UIColor` instance in the sRGB color space
     /// - Returns: Initializes a `ColorRepresentable` instance if the `color` is in sRGB color space.
     public init(color: UIColor) {
+
         var red: CGFloat = 0.0
         var green: CGFloat = 0.0
         var blue: CGFloat = 0.0
@@ -17,7 +18,12 @@ public struct ColorRepresentable: Codable, Equatable {
         let success = color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
         let validColorComponents = Self.isValidColor(red: red, green: red, blue: blue, alpha: alpha)
         if success && validColorComponents {
-            self.colorRepresentation = "rgba(\(red * 255.0), \(green * 255.0), \(blue * 255.0), \(alpha))"
+            self.colorRepresentation = Exp(.rgba) {
+                Double(red)
+                Double(green)
+                Double(blue)
+                Double(alpha)
+            }
         } else {
             fatalError("Please use a color in the sRGB color space")
         }
@@ -39,7 +45,7 @@ public struct ColorRepresentable: Codable, Equatable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self.colorRepresentation = try container.decode(String.self)
+        self.colorRepresentation = try container.decode(Expression.self)
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Make internal representation of colorRepresentable an expression </changelog>`.

### Summary of changes

This PR makes the internal representation of ColorRepresentable an expression instead of a string.
