### PR TITLE
Fix pan drift with non-zero bearing

### DIFF
--- a/Mapbox/MapboxMapsFoundation/BaseMapView.swift
+++ b/Mapbox/MapboxMapsFoundation/BaseMapView.swift
@@ -63,7 +63,11 @@ open class BaseMapView: UIView, MapClient, MBMMetalViewProvider {
 
     /// The map's current center coordinate.
     public var centerCoordinate: CLLocationCoordinate2D {
-        return cameraView.centerCoordinate
+        // cameraView.centerCoordinate is allowed to exceed [-180, 180]
+        // so that core animation interpolation works correctly when
+        // crossing the antimeridian. We wrap here to hide that implementation
+        // detail when accessing centerCoordinate via BaseMapView
+        return cameraView.centerCoordinate.wrap()
     }
 
     /// The map's current zoom level.

--- a/Mapbox/MapboxMapsFoundationTests/Camera/MapboxMapsCameraTests.swift
+++ b/Mapbox/MapboxMapsFoundationTests/Camera/MapboxMapsCameraTests.swift
@@ -235,4 +235,70 @@ class CameraManagerTests: XCTestCase {
         optimizedBearing = cameraManager.optimizeBearing(startBearing: 180, endBearing: -520)
         XCTAssertEqual(optimizedBearing, 200)
     }
+
+    func verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing bearing: CLLocationDirection,
+                                                                               offset: CGPoint,
+                                                                               line: UInt = #line) {
+        cameraManager.setCamera(
+            centerCoordinate: CLLocationCoordinate2D(
+                latitude: 0,
+                longitude: 179.999),
+            zoom: 0,
+            bearing: bearing,
+            animated: false)
+
+        let shiftedCenterCoordinate = cameraManager.shiftCenterCoordinate(by: offset)
+
+        XCTAssertGreaterThan(shiftedCenterCoordinate.longitude, 180, line: line)
+    }
+
+    func verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing bearing: CLLocationDirection,
+                                                                               offset: CGPoint,
+                                                                               line: UInt = #line) {
+        cameraManager.setCamera(
+            centerCoordinate: CLLocationCoordinate2D(
+                latitude: 0,
+                longitude: -179.999),
+            zoom: 0,
+            bearing: bearing,
+            animated: false)
+
+        let shiftedCenterCoordinate = cameraManager.shiftCenterCoordinate(by: offset)
+
+        XCTAssertLessThan(shiftedCenterCoordinate.longitude, -180, line: line)
+    }
+
+    func testShiftCenterCoordinateHandlesAntimeridianCrossingWhileHeadingEast() {
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: 0, offset: CGPoint(x: -10, y: 0))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: 45, offset: CGPoint(x: -10, y: 0))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: 135, offset: CGPoint(x: 10, y: 0))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: 180, offset: CGPoint(x: 10, y: 0))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: -180, offset: CGPoint(x: 10, y: 0))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: -135, offset: CGPoint(x: 10, y: 0))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: -45, offset: CGPoint(x: -10, y: 0))
+
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: 45, offset: CGPoint(x: 0, y: 10))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: 90, offset: CGPoint(x: 0, y: 10))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: 135, offset: CGPoint(x: 0, y: 10))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: -135, offset: CGPoint(x: 0, y: -10))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: -90, offset: CGPoint(x: 0, y: -10))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: -45, offset: CGPoint(x: 0, y: -10))
+    }
+
+    func testShiftCenterCoordinateHandlesAntimeridianCrossingWhileHeadingWest() {
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: 0, offset: CGPoint(x: 10, y: 0))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: 45, offset: CGPoint(x: 10, y: 0))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: 135, offset: CGPoint(x: -10, y: 0))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: 180, offset: CGPoint(x: -10, y: 0))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: -180, offset: CGPoint(x: -10, y: 0))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: -135, offset: CGPoint(x: -10, y: 0))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: -45, offset: CGPoint(x: 10, y: 0))
+
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: 45, offset: CGPoint(x: 0, y: -10))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: 90, offset: CGPoint(x: 0, y: -10))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: 135, offset: CGPoint(x: 0, y: -10))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: -135, offset: CGPoint(x: 0, y: 10))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: -90, offset: CGPoint(x: 0, y: 10))
+        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: -45, offset: CGPoint(x: 0, y: 10))
+    }
 }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Fixed: Pan drift did not work correctly when bearing was non-zero.</changelog>`.

### Summary of changes

- The directionality of the antimeridian correction was being calculated under the assumption that the bearing was 0. With a non-zero bearing, we need to instead consider the component of the offset vector that runs due east.
