### PR TITLE
[location] Fix bug where locationOptions were not being set correctly

### DIFF
--- a/Mapbox/MapboxMapsLocation/LocationManager.swift
+++ b/Mapbox/MapboxMapsLocation/LocationManager.swift
@@ -86,15 +86,13 @@ public class LocationManager: NSObject {
 
         guard newOptions != locationOptions else { return }
 
+        // Update the location options
+        self.locationOptions = newOptions
+        self.locationProvider.locationProviderOptions = newOptions
+
         if newOptions.showUserLocation != showUserLocation {
             self.showUserLocation = newOptions.showUserLocation
             toggleUserLocationUpdates(showUserLocation: self.showUserLocation)
-
-            if !newOptions.showUserLocation {
-                // If we should not show user location, then we should
-                // not try and change source or style below
-                return
-            }
         }
 
         if newOptions.locationPuck != locationOptions.locationPuck {
@@ -102,10 +100,6 @@ public class LocationManager: NSObject {
                 locationPuckManager.changePuckBackend(newPuckBackend: newOptions.locationPuck)
             }
         }
-
-        self.locationProvider.locationProviderOptions = newOptions
-
-        self.locationOptions = newOptions
     }
 
     /// Allows a custom case to request full accuracy

--- a/Mapbox/MapboxMapsLocation/LocationManager.swift
+++ b/Mapbox/MapboxMapsLocation/LocationManager.swift
@@ -93,6 +93,12 @@ public class LocationManager: NSObject {
         if newOptions.showUserLocation != showUserLocation {
             self.showUserLocation = newOptions.showUserLocation
             toggleUserLocationUpdates(showUserLocation: self.showUserLocation)
+
+            if !newOptions.showUserLocation {
+                // If we should not show user location, then we should
+                // not try and change source or style below
+                return
+            }
         }
 
         if newOptions.locationPuck != locationOptions.locationPuck {

--- a/Mapbox/MapboxMapsTests/OptionsIntegrationTests.swift
+++ b/Mapbox/MapboxMapsTests/OptionsIntegrationTests.swift
@@ -11,7 +11,8 @@ internal class OptionsIntegrationTest: MapViewIntegrationTestCase {
         }
 
         var newOptions = MapboxMaps.MapOptions()
-        newOptions.location.showUserLocation = true
+        newOptions.location.showUserLocation = false
+        newOptions.location.activityType = .automotiveNavigation
         newOptions.camera.animationDuration = 0.1
         newOptions.gestures.scrollEnabled = false
         newOptions.ornaments.showsScale = false


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Fix issue where toggling LocationOptions.showsUserLocation resulted in options not being updated</changelog>`.

### Summary of changes

This change ensures that the stored value of `LocationOptions` in `LocationManager` is updated with the newly passed in values before the `updateLocationOptions()` method returns.

This fixes a bug where location options would not get updated if `showsUserLocation == false`.
