### PR TITLE
Prevent pitch and zoom from exceeding limits

### DIFF
--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -405,6 +405,11 @@
 		A4FE88C2255F366F00FBF117 /* MapboxAnimationGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E82010255A10A100926E90 /* MapboxAnimationGroupTests.swift */; };
 		A4FE8908255F368A00FBF117 /* CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC8DA51243BECC400A19318 /* CameraManager.swift */; };
 		A4FE8966255F369900FBF117 /* MapCameraOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C07948D2452331A0006A9C4 /* MapCameraOptions.swift */; };
+		B51DE62225D7032C00A80AC9 /* Comparable+Clamped.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51DE62125D7032C00A80AC9 /* Comparable+Clamped.swift */; };
+		B51DE64825D7038300A80AC9 /* Comparable+ClampedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51DE64725D7038300A80AC9 /* Comparable+ClampedTests.swift */; };
+		B51DE65B25D7038900A80AC9 /* Comparable+Clamped.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51DE62125D7032C00A80AC9 /* Comparable+Clamped.swift */; };
+		B51DE66E25D7039700A80AC9 /* Comparable+ClampedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51DE64725D7038300A80AC9 /* Comparable+ClampedTests.swift */; };
+		B51DE68125D7039700A80AC9 /* Comparable+ClampedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51DE64725D7038300A80AC9 /* Comparable+ClampedTests.swift */; };
 		C64994A9258D5ADE0052C21C /* LocationPuckManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64994A5258D5ADD0052C21C /* LocationPuckManager.swift */; };
 		C64994AA258D5ADE0052C21C /* LocationPuckManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64994A5258D5ADD0052C21C /* LocationPuckManager.swift */; };
 		C64994AB258D5ADE0052C21C /* Puck.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64994A6258D5ADE0052C21C /* Puck.swift */; };
@@ -1065,6 +1070,8 @@
 		A4BDC0CC244A23EB00AA9B64 /* QuickZoomGestureHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickZoomGestureHandler.swift; sourceTree = "<group>"; };
 		A4C786602440EAF0000CEF1E /* StyleURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleURLTests.swift; sourceTree = "<group>"; };
 		A4E82010255A10A100926E90 /* MapboxAnimationGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxAnimationGroupTests.swift; sourceTree = "<group>"; };
+		B51DE62125D7032C00A80AC9 /* Comparable+Clamped.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comparable+Clamped.swift"; sourceTree = "<group>"; };
+		B51DE64725D7038300A80AC9 /* Comparable+ClampedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comparable+ClampedTests.swift"; sourceTree = "<group>"; };
 		C64994A5258D5ADD0052C21C /* LocationPuckManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationPuckManager.swift; sourceTree = "<group>"; };
 		C64994A6258D5ADE0052C21C /* Puck.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Puck.swift; sourceTree = "<group>"; };
 		C64994A7258D5ADE0052C21C /* IndicatorAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = IndicatorAssets.xcassets; sourceTree = "<group>"; };
@@ -1372,6 +1379,7 @@
 				0782B036258C14A400D5FCE5 /* NSNumber.swift */,
 				0782B141258C1CAB00D5FCE5 /* NSValue.swift */,
 				0782B04B258C14FC00D5FCE5 /* Int.swift */,
+				B51DE62125D7032C00A80AC9 /* Comparable+Clamped.swift */,
 				0782B1DB258C254400D5FCE5 /* Core */,
 				0782B1A1258C24EC00D5FCE5 /* Turf */,
 			);
@@ -1740,6 +1748,7 @@
 				1F11C11E2421B05600F8397B /* Info.plist */,
 				07182014256C1F6100F22489 /* Assets.xcassets */,
 				0CDFEAD725A77430008BC505 /* UtilsTests.swift */,
+				B51DE64725D7038300A80AC9 /* Comparable+ClampedTests.swift */,
 			);
 			path = MapboxMapsFoundationTests;
 			sourceTree = "<group>";
@@ -3503,6 +3512,7 @@
 				0CA3DD61257AAE3B00B12C8F /* SkyLayer.swift in Sources */,
 				0C708F2B24EB1EE2003CE791 /* FillLayer.swift in Sources */,
 				0782AFFB258BFE5800D5FCE5 /* CoreGraphics.swift in Sources */,
+				B51DE65B25D7038900A80AC9 /* Comparable+Clamped.swift in Sources */,
 				0CECCCCD253491A80000FC64 /* LocationSupportableMapView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3547,6 +3557,7 @@
 				C69F011225431AF4001AB49B /* LocationManagerIntegrationTests.swift in Sources */,
 				0C5CFCDB25BB951B0001E753 /* ModelLayerTests.swift in Sources */,
 				0C59ED2225CC6D7E00C72E7A /* ExpressionBuilderTests.swift in Sources */,
+				B51DE66E25D7039700A80AC9 /* Comparable+ClampedTests.swift in Sources */,
 				CA548F26251C3D7200F829A3 /* GestureUtilitiesTests.swift in Sources */,
 				0C5CFD7425BE25210001E753 /* GeoJsonSourceTests.swift in Sources */,
 				0CC6EF0A25C3263400BFB153 /* ModelLayerIntegrationTests.swift in Sources */,
@@ -3629,6 +3640,7 @@
 				A4FE8908255F368A00FBF117 /* CameraManager.swift in Sources */,
 				0782AFE7258BFD2300D5FCE5 /* CoreLocation.swift in Sources */,
 				07625C172587F2A0002EEBCC /* Event.swift in Sources */,
+				B51DE62225D7032C00A80AC9 /* Comparable+Clamped.swift in Sources */,
 				0782B04D258C14FC00D5FCE5 /* Int.swift in Sources */,
 				CAC1960C25AE98F400F69FEA /* GlyphsRasterizationOptions.swift in Sources */,
 				1F4B7D7C2464C39000745F05 /* CameraLayer.swift in Sources */,
@@ -3661,6 +3673,7 @@
 				07DA757125840A5100AD0446 /* GeoJSONManagerTests.swift in Sources */,
 				0CDFEAD825A77430008BC505 /* UtilsTests.swift in Sources */,
 				07DA74B525840A3200AD0446 /* Geometry+MBXGeometryTests.swift in Sources */,
+				B51DE64825D7038300A80AC9 /* Comparable+ClampedTests.swift in Sources */,
 				CAC1962025AEAE6600F69FEA /* GlyphsRasterizationOptionsTests.swift in Sources */,
 				A4FE88C2255F366F00FBF117 /* MapboxAnimationGroupTests.swift in Sources */,
 				07DA753225840A4600AD0446 /* MultiLineStringTests.swift in Sources */,
@@ -3873,6 +3886,7 @@
 				CA050571259104E200FF7D02 /* FeatureQueryingTest.swift in Sources */,
 				CA548FE2251C404B00F829A3 /* PitchGestureHandlerTests.swift in Sources */,
 				CA548FE3251C404B00F829A3 /* GestureUtilitiesTests.swift in Sources */,
+				B51DE68125D7039700A80AC9 /* Comparable+ClampedTests.swift in Sources */,
 				CA548FE4251C404B00F829A3 /* GestureManagerTests.swift in Sources */,
 				CA4AE123252D656600183075 /* AnnotationStyleDelegateMock.swift in Sources */,
 				0C5CFD4125BBA06D0001E753 /* Enums+Fixtures.swift in Sources */,

--- a/Mapbox/MapboxMapsFoundation/Camera/FlyToInterpolator.swift
+++ b/Mapbox/MapboxMapsFoundation/Camera/FlyToInterpolator.swift
@@ -74,10 +74,8 @@ public struct FlyToInterpolator {
 
         // Note that the source arguments are NOT clamped - these are assumed to be valid parameters
         let compilerWorkaround = sourceZoom
-        let destZoom    = (dest.zoom ?? compilerWorkaround).clamp(withMax: mapCameraOptions.maximumZoomLevel,
-                                                          andMin: mapCameraOptions.minimumZoomLevel)
-        destPitch   = (dest.pitch ?? sourcePitchParam).clamp(withMax: mapCameraOptions.maximumPitch,
-                                                            andMin: mapCameraOptions.minimumPitch)
+        let destZoom = (dest.zoom ?? compilerWorkaround).clamped(to: mapCameraOptions.minimumZoomLevel...mapCameraOptions.maximumZoomLevel)
+        destPitch = (dest.pitch ?? sourcePitchParam).clamped(to: mapCameraOptions.minimumPitch...mapCameraOptions.maximumPitch)
         destBearing = dest.bearing ?? sourceBearingParam
 
         // Unwrap

--- a/Mapbox/MapboxMapsFoundation/Camera/MapCameraOptions.swift
+++ b/Mapbox/MapboxMapsFoundation/Camera/MapCameraOptions.swift
@@ -38,12 +38,12 @@ public struct MapCameraOptions: Equatable {
         The maximum pitch of the map’s camera toward the horizon measured in degrees.
 
         If the value of this property is smaller than that of the `minimumPitch`
-        property, the behavior is undefined. The pitch may not exceed 60 degrees
+        property, the behavior is undefined. The pitch may not exceed 85 degrees
         regardless of this property.
 
-        The default value of this property is 60 degrees.
+        The default value of this property is 85 degrees.
     */
-    public var maximumPitch: CGFloat = 60.0
+    public var maximumPitch: CGFloat = 85.0
 
     /**
         A time interval that represents the amount of time the camera view is animated for.

--- a/Mapbox/MapboxMapsFoundation/Extensions/Comparable+Clamped.swift
+++ b/Mapbox/MapboxMapsFoundation/Extensions/Comparable+Clamped.swift
@@ -1,0 +1,11 @@
+internal extension Comparable {
+    func clamped(to limits: ClosedRange<Self>) -> Self {
+        if self > limits.upperBound {
+            return limits.upperBound
+        } else if self < limits.lowerBound {
+            return limits.lowerBound
+        } else {
+            return self
+        }
+    }
+}

--- a/Mapbox/MapboxMapsFoundationTests/Camera/MapboxMapsCameraTests.swift
+++ b/Mapbox/MapboxMapsFoundationTests/Camera/MapboxMapsCameraTests.swift
@@ -32,7 +32,6 @@ class CameraManagerTests: XCTestCase {
         cameraManager.setCamera(zoom: 10.0)
 
         XCTAssertEqual(mapView.zoom, 10.0, "Camera manager did not set camera view zoom value.")
-
     }
 
     func testCameraForCoordinateArray() {
@@ -128,13 +127,14 @@ class CameraManagerTests: XCTestCase {
     }
 
     func testSetCamera() {
-
         let expectedCamera = CameraOptions(center: CLLocationCoordinate2D(latitude: 50, longitude: 50),
-                                           padding: .zero,
-                                           anchor: .zero,
-                                           zoom: 8,
-                                           bearing: .zero,
-                                           pitch: 0)
+                                           padding: UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
+                                           anchor: CGPoint(x: 5, y: 6),
+                                           zoom: 7,
+                                           bearing: 8,
+                                           pitch: 9)
+
+        let originalCamera = mapView.cameraView.camera
 
         cameraManager.setCamera(to: expectedCamera, completion: nil)
 
@@ -146,6 +146,80 @@ class CameraManagerTests: XCTestCase {
         XCTAssertEqual(expectedCamera.zoom, actualCamera.zoom)
         XCTAssertEqual(expectedCamera.bearing, actualCamera.bearing)
         XCTAssertEqual(expectedCamera.pitch, actualCamera.pitch)
+        XCTAssertNotEqual(originalCamera.center, actualCamera.center)
+        XCTAssertNotEqual(originalCamera.padding, actualCamera.padding)
+        XCTAssertNotEqual(originalCamera.anchor, actualCamera.anchor)
+        XCTAssertNotEqual(originalCamera.zoom, actualCamera.zoom)
+        XCTAssertNotEqual(originalCamera.bearing, actualCamera.bearing)
+        XCTAssertNotEqual(originalCamera.pitch, actualCamera.pitch)
+    }
+
+    func testSetCameraEnforcesMinZoom() {
+        cameraManager.mapCameraOptions.minimumZoomLevel = CGFloat.random(in: 0..<cameraManager.mapCameraOptions.maximumZoomLevel)
+        let expectedCamera = CameraOptions(zoom: -1)
+
+        cameraManager.setCamera(to: expectedCamera)
+
+        XCTAssertEqual(mapView.cameraView.camera.zoom, cameraManager.mapCameraOptions.minimumZoomLevel)
+    }
+
+    func testSetCameraEnforcesMaxZoom() {
+        cameraManager.mapCameraOptions.maximumZoomLevel = CGFloat.random(in: cameraManager.mapCameraOptions.minimumZoomLevel...25.5)
+        let expectedCamera = CameraOptions(zoom: 26)
+
+        cameraManager.setCamera(to: expectedCamera)
+
+        XCTAssertEqual(mapView.cameraView.camera.zoom, cameraManager.mapCameraOptions.maximumZoomLevel)
+    }
+
+    func testSetCameraEnforcesMinPitch() {
+        cameraManager.mapCameraOptions.minimumPitch = CGFloat.random(in: 0..<cameraManager.mapCameraOptions.maximumPitch)
+        let expectedCamera = CameraOptions(pitch: -1)
+
+        cameraManager.setCamera(to: expectedCamera)
+
+        XCTAssertEqual(mapView.cameraView.camera.pitch, cameraManager.mapCameraOptions.minimumPitch)
+    }
+
+    func testSetCameraEnforcesMaxPitch() {
+        cameraManager.mapCameraOptions.maximumPitch = CGFloat.random(in: cameraManager.mapCameraOptions.minimumPitch...60)
+        let expectedCamera = CameraOptions(pitch: 61)
+
+        cameraManager.setCamera(to: expectedCamera)
+
+        XCTAssertEqual(mapView.cameraView.camera.pitch, cameraManager.mapCameraOptions.maximumPitch)
+    }
+
+    func testSetCameraByComponentEnforcesMinZoom() {
+        cameraManager.mapCameraOptions.minimumZoomLevel = CGFloat.random(in: 0..<cameraManager.mapCameraOptions.maximumZoomLevel)
+
+        cameraManager.setCamera(zoom: -1)
+
+        XCTAssertEqual(mapView.cameraView.camera.zoom, cameraManager.mapCameraOptions.minimumZoomLevel)
+    }
+
+    func testSetCameraByComponentEnforcesMaxZoom() {
+        cameraManager.mapCameraOptions.maximumZoomLevel = CGFloat.random(in: cameraManager.mapCameraOptions.minimumZoomLevel...25.5)
+
+        cameraManager.setCamera(zoom: 26)
+
+        XCTAssertEqual(mapView.cameraView.camera.zoom, cameraManager.mapCameraOptions.maximumZoomLevel)
+    }
+
+    func testSetCameraByComponentEnforcesMinPitch() {
+        cameraManager.mapCameraOptions.minimumPitch = CGFloat.random(in: 0..<cameraManager.mapCameraOptions.maximumPitch)
+
+        cameraManager.setCamera(pitch: -1)
+
+        XCTAssertEqual(mapView.cameraView.camera.pitch, cameraManager.mapCameraOptions.minimumPitch)
+    }
+
+    func testSetCameraByComponentEnforcesMaxPitch() {
+        cameraManager.mapCameraOptions.maximumPitch = CGFloat.random(in: cameraManager.mapCameraOptions.minimumPitch...60)
+
+        cameraManager.setCamera(pitch: 61)
+
+        XCTAssertEqual(mapView.cameraView.camera.pitch, cameraManager.mapCameraOptions.maximumPitch)
     }
 
     func testMoveCamera() {

--- a/Mapbox/MapboxMapsFoundationTests/Comparable+ClampedTests.swift
+++ b/Mapbox/MapboxMapsFoundationTests/Comparable+ClampedTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+#if canImport(MapboxMaps)
+@testable import MapboxMaps
+#else
+@testable import MapboxMapsFoundation
+#endif
+
+final class Comparable_ClampedTests: XCTestCase {
+    func testClampedWithValueLessThanLowerBound() throws {
+        let limits = 0...10
+        let value = -1
+
+        let actual = value.clamped(to: limits)
+
+        XCTAssertEqual(actual, limits.lowerBound)
+    }
+
+    func testClampedWithValueGreaterThanUpperBound() throws {
+        let limits = 0...10
+        let value = 11
+
+        let actual = value.clamped(to: limits)
+
+        XCTAssertEqual(actual, limits.upperBound)
+    }
+
+    func testClampedWithValueWithinLimits() throws {
+        let limits = 0...10
+        let value = 5
+
+        let actual = value.clamped(to: limits)
+
+        XCTAssertEqual(actual, value)
+    }
+}


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Prevent pitch and zoom from exceeding limits. Also updates default maximum pitch to 85 degrees.</changelog>`.

### Summary of changes

- Consolidates logic from `setCamera(centerCoordinate:padding:anchor:zoom:bearing:pitch:animated:duration:completion:)` into `setCamera(to:animated:duration:completion:)`
- Clamps pitch to min and max from `MapCameraOptions`
- Refactors the clamp helper into an extension on `Comparable` that uses a ClosedRange parameter
- Improves `testSetCamera()` which had several assertions that checked for "changes" that were identical to the initial values.
- Updates default maximumPitch to 85 degrees

### User impact (optional)

When continuing to use the pitch gesture after reaching the maximum or minimum pitch, the map will no longer require you to "undo" those superfluous gestures to reverse the pitch.