### PR TITLE
Fix quick zoom gesture at high zoom levels

### DIFF
--- a/Mapbox/Configurations/unitTests.xcconfig
+++ b/Mapbox/Configurations/unitTests.xcconfig
@@ -3,5 +3,4 @@
 
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/../lib
 
-
-
+IPHONEOS_DEPLOYMENT_TARGET = 12.2

--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -410,6 +410,19 @@
 		B51DE65B25D7038900A80AC9 /* Comparable+Clamped.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51DE62125D7032C00A80AC9 /* Comparable+Clamped.swift */; };
 		B51DE66E25D7039700A80AC9 /* Comparable+ClampedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51DE64725D7038300A80AC9 /* Comparable+ClampedTests.swift */; };
 		B51DE68125D7039700A80AC9 /* Comparable+ClampedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51DE64725D7038300A80AC9 /* Comparable+ClampedTests.swift */; };
+		B54B7F0A25DB192C003FD6CA /* MockCameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F0925DB192C003FD6CA /* MockCameraManager.swift */; };
+		B54B7F0B25DB192C003FD6CA /* MockCameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F0925DB192C003FD6CA /* MockCameraManager.swift */; };
+		B54B7F0C25DB192C003FD6CA /* MockCameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F0925DB192C003FD6CA /* MockCameraManager.swift */; };
+		B54B7F2025DB1ABA003FD6CA /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F1F25DB1ABA003FD6CA /* Stub.swift */; };
+		B54B7F2125DB1ABA003FD6CA /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F1F25DB1ABA003FD6CA /* Stub.swift */; };
+		B54B7F2225DB1ABA003FD6CA /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F1F25DB1ABA003FD6CA /* Stub.swift */; };
+		B54B7F2325DB1ABA003FD6CA /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F1F25DB1ABA003FD6CA /* Stub.swift */; };
+		B54B7F2425DB1ABA003FD6CA /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F1F25DB1ABA003FD6CA /* Stub.swift */; };
+		B54B7F2525DB1ABA003FD6CA /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F1F25DB1ABA003FD6CA /* Stub.swift */; };
+		B54B7F2625DB1ABA003FD6CA /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F1F25DB1ABA003FD6CA /* Stub.swift */; };
+		B54B7F2725DB1ABA003FD6CA /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F1F25DB1ABA003FD6CA /* Stub.swift */; };
+		B54B7F2825DB1ABA003FD6CA /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F1F25DB1ABA003FD6CA /* Stub.swift */; };
+		B54B7F2925DB1ABB003FD6CA /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F1F25DB1ABA003FD6CA /* Stub.swift */; };
 		C64994A9258D5ADE0052C21C /* LocationPuckManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64994A5258D5ADD0052C21C /* LocationPuckManager.swift */; };
 		C64994AA258D5ADE0052C21C /* LocationPuckManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64994A5258D5ADD0052C21C /* LocationPuckManager.swift */; };
 		C64994AB258D5ADE0052C21C /* Puck.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64994A6258D5ADE0052C21C /* Puck.swift */; };
@@ -1072,6 +1085,8 @@
 		A4E82010255A10A100926E90 /* MapboxAnimationGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxAnimationGroupTests.swift; sourceTree = "<group>"; };
 		B51DE62125D7032C00A80AC9 /* Comparable+Clamped.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comparable+Clamped.swift"; sourceTree = "<group>"; };
 		B51DE64725D7038300A80AC9 /* Comparable+ClampedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comparable+ClampedTests.swift"; sourceTree = "<group>"; };
+		B54B7F0925DB192C003FD6CA /* MockCameraManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCameraManager.swift; sourceTree = "<group>"; };
+		B54B7F1F25DB1ABA003FD6CA /* Stub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stub.swift; sourceTree = "<group>"; };
 		C64994A5258D5ADD0052C21C /* LocationPuckManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationPuckManager.swift; sourceTree = "<group>"; };
 		C64994A6258D5ADE0052C21C /* Puck.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Puck.swift; sourceTree = "<group>"; };
 		C64994A7258D5ADE0052C21C /* IndicatorAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = IndicatorAssets.xcassets; sourceTree = "<group>"; };
@@ -1780,6 +1795,7 @@
 				0C8D2C5B2447797E008127AF /* RotateGestureHandlerTests.swift */,
 				079EC07A245207DA000EDC84 /* PitchGestureHandlerTests.swift */,
 				0765213C2457444600FDD209 /* GestureUtilitiesTests.swift */,
+				B54B7F0925DB192C003FD6CA /* MockCameraManager.swift */,
 			);
 			path = MapboxMapsGesturesTests;
 			sourceTree = "<group>";
@@ -2055,6 +2071,7 @@
 			isa = PBXGroup;
 			children = (
 				CA9481552554AA9E00D93C3C /* TestConveniences.swift */,
+				B54B7F1F25DB1ABA003FD6CA /* Stub.swift */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -3326,6 +3343,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				076C4526242D59AD00A5E0C4 /* OrnamentSupportableViewMock.swift in Sources */,
+				B54B7F2725DB1ABA003FD6CA /* Stub.swift in Sources */,
 				CAF9A67D25828BBE007EF9EC /* DistanceFormatterTests.swift in Sources */,
 				07797FA1242C21BC00229F7D /* OrnamentManagerTests.swift in Sources */,
 				5A35937A2476DEB800E67344 /* MapboxCompassOrnamentViewTests.swift in Sources */,
@@ -3345,6 +3363,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				07C1B3982446B0550044A3C6 /* MapboxMapsOfflineTests.swift in Sources */,
+				B54B7F2625DB1ABA003FD6CA /* Stub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3362,6 +3381,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				07C1B3DC2446B6F40044A3C6 /* MapboxMapsSnapshotTests.swift in Sources */,
+				B54B7F2825DB1ABA003FD6CA /* Stub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3388,6 +3408,7 @@
 				CAD4164D252D667B005FB636 /* LineAnnotationTests.swift in Sources */,
 				CAD4166C252D667E005FB636 /* UIImage+CGColor.swift in Sources */,
 				CAD4164F252D667B005FB636 /* AnnotationStyleDelegateMock.swift in Sources */,
+				B54B7F2225DB1ABA003FD6CA /* Stub.swift in Sources */,
 				CAD41652252D667B005FB636 /* AnnotationManagerTests.swift in Sources */,
 				CAD4164E252D667B005FB636 /* AnnotationSupportableMapMock.swift in Sources */,
 				CAD41654252D667B005FB636 /* PolygonAnnotationTests.swift in Sources */,
@@ -3573,9 +3594,11 @@
 				0CDFEAFB25A77459008BC505 /* UtilsTests.swift in Sources */,
 				CA548F29251C3D7200F829A3 /* GestureSupportableViewMock.swift in Sources */,
 				CA57257D2568D15E005ED95E /* ObservableIntegrationTests.swift in Sources */,
+				B54B7F0A25DB192C003FD6CA /* MockCameraManager.swift in Sources */,
 				CA548F28251C3D7200F829A3 /* TapGestureHandlerTests.swift in Sources */,
 				0C5CFCD525BB951B0001E753 /* FillExtrusionLayerTests.swift in Sources */,
 				CA548F70251C3D9400F829A3 /* OrnamentSupportableViewMock.swift in Sources */,
+				B54B7F2025DB1ABA003FD6CA /* Stub.swift in Sources */,
 				C64ED321253F7E9100ADADFB /* LocationManagerTests.swift in Sources */,
 				CA548EFD251C3D5500F829A3 /* GeometryCollectionTests.swift in Sources */,
 				CA548E7E251C3CD200F829A3 /* AnnotationManagerTests.swift in Sources */,
@@ -3673,6 +3696,7 @@
 				07DA757125840A5100AD0446 /* GeoJSONManagerTests.swift in Sources */,
 				0CDFEAD825A77430008BC505 /* UtilsTests.swift in Sources */,
 				07DA74B525840A3200AD0446 /* Geometry+MBXGeometryTests.swift in Sources */,
+				B54B7F2325DB1ABA003FD6CA /* Stub.swift in Sources */,
 				B51DE64825D7038300A80AC9 /* Comparable+ClampedTests.swift in Sources */,
 				CAC1962025AEAE6600F69FEA /* GlyphsRasterizationOptionsTests.swift in Sources */,
 				A4FE88C2255F366F00FBF117 /* MapboxAnimationGroupTests.swift in Sources */,
@@ -3707,7 +3731,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C71B4C7242C19DF0076D6C4 /* GestureSupportableViewMock.swift in Sources */,
+				B54B7F2425DB1ABA003FD6CA /* Stub.swift in Sources */,
 				079EC07C245208F5000EDC84 /* PitchGestureHandlerTests.swift in Sources */,
+				B54B7F0C25DB192C003FD6CA /* MockCameraManager.swift in Sources */,
 				0C71B4CD242CE7000076D6C4 /* TapGestureHandlerTests.swift in Sources */,
 				A44EE619244F7140006FE97E /* QuickZoomGestureHandlerTests.swift in Sources */,
 				0765213D2457444600FDD209 /* GestureUtilitiesTests.swift in Sources */,
@@ -3742,6 +3768,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C64ED323253F7E9100ADADFB /* LocationManagerTests.swift in Sources */,
+				B54B7F2525DB1ABA003FD6CA /* Stub.swift in Sources */,
 				0C2CDA3025D1A51C006D068F /* LocationPuckTests.swift in Sources */,
 				C69F017625435C55001AB49B /* LocationProviderMock.swift in Sources */,
 				C64ED33E253F819B00ADADFB /* LocationConsumerMock.swift in Sources */,
@@ -3795,6 +3822,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C5CFD7625BE25210001E753 /* GeoJsonSourceTests.swift in Sources */,
+				B54B7F2925DB1ABB003FD6CA /* Stub.swift in Sources */,
 				0C59ED2425CC6D7E00C72E7A /* ExpressionBuilderTests.swift in Sources */,
 				0C5CFDD625BE29BC0001E753 /* SouceProperties+Fixtures.swift in Sources */,
 				0C9DE383252C299800880CC8 /* GeoJSONSourceDataTests.swift in Sources */,
@@ -3872,6 +3900,7 @@
 				CA548FDB251C404B00F829A3 /* LineStringTests.swift in Sources */,
 				0CC6EF1125C3263400BFB153 /* CircleLayerIntegrationTests.swift in Sources */,
 				0C5CFCF425BB951B0001E753 /* FillLayerTests.swift in Sources */,
+				B54B7F0B25DB192C003FD6CA /* MockCameraManager.swift in Sources */,
 				0C5CFCEB25BB951B0001E753 /* HillshadeLayerTests.swift in Sources */,
 				0C2CD9F625D19D75006D068F /* OptionsIntegrationTests.swift in Sources */,
 				0C5CFCF125BB951B0001E753 /* SkyLayerTests.swift in Sources */,
@@ -3943,6 +3972,7 @@
 				CA548FFB251C404B00F829A3 /* StyleURLTests.swift in Sources */,
 				CA2E4A1B2538D3530096DEDE /* MapViewIntegrationTestCase.swift in Sources */,
 				0C5CFCD625BB951B0001E753 /* FillExtrusionLayerTests.swift in Sources */,
+				B54B7F2125DB1ABA003FD6CA /* Stub.swift in Sources */,
 				0C01C0B925486E7200E4AA46 /* ExpressionTests.swift in Sources */,
 				CA548FFC251C404B00F829A3 /* PanGestureHandlerTests.swift in Sources */,
 				CA548FFD251C404B00F829A3 /* QuickZoomGestureHandlerTests.swift in Sources */,

--- a/Mapbox/MapboxMapsFoundation/Camera/CameraManager.swift
+++ b/Mapbox/MapboxMapsFoundation/Camera/CameraManager.swift
@@ -24,7 +24,7 @@ public extension Notification.Name {
 public class CameraManager {
 
     /// Used to set up camera specific configuration
-    public var mapCameraOptions: MapCameraOptions!
+    public internal(set) var mapCameraOptions: MapCameraOptions
 
     /// Used to update the map's camera options and pass them to the core Map.
     internal func updateMapCameraOptions(newOptions: MapCameraOptions) {
@@ -167,7 +167,7 @@ public class CameraManager {
 
     public func setCamera(to camera: CameraOptions,
                              animated: Bool = false,
-                             duration: TimeInterval? = 0,
+                             duration: TimeInterval = 0,
                              completion: ((Bool) -> Void)? = nil) {
         guard let mapView = mapView else {
             assertionFailure("MapView is nil.")
@@ -217,7 +217,7 @@ public class CameraManager {
                           bearing: CLLocationDirection? = nil,
                           pitch: CGFloat? = nil,
                           animated: Bool = false,
-                          duration: TimeInterval? = nil,
+                          duration: TimeInterval = 0,
                           completion: ((Bool) -> Void)? = nil) {
         let newCamera = CameraOptions(center: centerCoordinate,
                                       padding: padding,
@@ -244,9 +244,9 @@ public class CameraManager {
         - animation: closure to perform
         - completion: animation block called on completion
      */
-    fileprivate func performCameraAnimation(animated: Bool, duration: TimeInterval?, animation: @escaping () -> Void, completion: ((Bool) -> Void)? = nil) {
+    fileprivate func performCameraAnimation(animated: Bool, duration: TimeInterval, animation: @escaping () -> Void, completion: ((Bool) -> Void)? = nil) {
         if animated {
-            UIView.animate(withDuration: duration ?? 0,
+            UIView.animate(withDuration: duration,
                            delay: 0,
                            options: [.curveEaseOut, .allowUserInteraction],
                            animations: animation,

--- a/Mapbox/MapboxMapsGestures/GestureHandlers/PinchGestureHandler.swift
+++ b/Mapbox/MapboxMapsGestures/GestureHandlers/PinchGestureHandler.swift
@@ -27,7 +27,7 @@ internal class PinchGestureHandler: GestureHandler {
 
         if pinchGestureRecognizer.state == .began {
 
-            self.scale = self.delegate.scaleForZoom()
+            self.scale = pow(2, self.delegate.scaleForZoom())
             self.delegate.gestureBegan(for: .pinch)
 
             /**
@@ -38,7 +38,7 @@ internal class PinchGestureHandler: GestureHandler {
         } else if pinchGestureRecognizer.state == .changed {
 
             let newScale = self.scale * pinchGestureRecognizer.scale
-            self.delegate.pinchScaleChanged(with: newScale, andAnchor: pinchCenterPoint)
+            self.delegate.pinchScaleChanged(with: log2(newScale), andAnchor: pinchCenterPoint)
 
         } else if pinchGestureRecognizer.state == .ended
             || pinchGestureRecognizer.state == .cancelled {
@@ -64,7 +64,7 @@ internal class PinchGestureHandler: GestureHandler {
 
             let possibleDrift = velocity > 0.0 && duration > 0.0
 
-            self.delegate.pinchEnded(with: newScale, andDrift: possibleDrift, andAnchor: pinchCenterPoint)
+            self.delegate.pinchEnded(with: log2(newScale), andDrift: possibleDrift, andAnchor: pinchCenterPoint)
         }
     }
 }

--- a/Mapbox/MapboxMapsGestures/GestureHandlers/QuickZoomGestureHandler.swift
+++ b/Mapbox/MapboxMapsGestures/GestureHandlers/QuickZoomGestureHandler.swift
@@ -4,10 +4,10 @@ import UIKit
 /// infrastructure. The `quickZoom` gesture recognizer is triggered by
 /// a tap gesture followed by a long press gesture.
 internal class QuickZoomGestureHandler: GestureHandler {
-    internal var quickZoomStart: CGFloat = 0.0
-    internal var scale: CGFloat = 0.0
+    private var quickZoomStart: CGFloat = 0.0
+    private var scale: CGFloat = 0.0
 
-    override internal init(for view: UIView, withDelegate delegate: GestureHandlerDelegate) {
+    override init(for view: UIView, withDelegate delegate: GestureHandlerDelegate) {
         super.init(for: view, withDelegate: delegate)
 
         let quickZoom = UILongPressGestureRecognizer(target: self, action: #selector(self.handleQuickZoom(_:)))
@@ -18,28 +18,28 @@ internal class QuickZoomGestureHandler: GestureHandler {
     }
 
     // Register the location of the touches in the view.
-    @objc internal func handleQuickZoom(_ quickZoom: UILongPressGestureRecognizer) {
+    @objc func handleQuickZoom(_ gestureRecognizer: UILongPressGestureRecognizer) {
         guard let view = view else {
             return
         }
 
-        let touchPoint = quickZoom.location(in: view)
+        let touchPoint = gestureRecognizer.location(in: view)
 
-        if quickZoom.state == .began {
+        if gestureRecognizer.state == .began {
             self.delegate.gestureBegan(for: .quickZoom)
             self.quickZoomStart = touchPoint.y
             self.scale = self.delegate.scaleForZoom()
-        } else if quickZoom.state == .changed {
+        } else if gestureRecognizer.state == .changed {
             let distance = touchPoint.y - self.quickZoomStart
             let bounds = view.bounds
             let anchor = CGPoint(x: bounds.midX, y: bounds.midY)
 
-            var newScale = log2(self.scale + (distance / 75))
+            var newScale = scale + distance / 75
 
             if newScale.isNaN { newScale = 0 }
 
             self.delegate.quickZoomChanged(with: newScale, and: anchor)
-        } else if quickZoom.state == .ended || quickZoom.state == .cancelled {
+        } else if gestureRecognizer.state == .ended || gestureRecognizer.state == .cancelled {
             self.delegate.quickZoomEnded()
         }
     }

--- a/Mapbox/MapboxMapsGestures/GestureManager.swift
+++ b/Mapbox/MapboxMapsGestures/GestureManager.swift
@@ -106,27 +106,50 @@ public protocol GestureManagerDelegate {
     func gestureBegan(for gestureType: GestureType) -> Void
 }
 
-public class GestureManager: NSObject {
+internal protocol CameraManagerProtocol: AnyObject {
+
+    var mapView: BaseMapView? { get }
+
+    var mapCameraOptions: MapCameraOptions { get }
+
+    func setCamera(to camera: CameraOptions,
+                   animated: Bool,
+                   duration: TimeInterval,
+                   completion: ((Bool) -> Void)?)
+
+    func moveCamera(by offset: CGPoint?,
+                    rotation: CGFloat?,
+                    pitch: CGFloat?,
+                    zoom: CGFloat?,
+                    animated: Bool)
+
+    func cancelTransitions()
+}
+
+extension CameraManager: CameraManagerProtocol {
+}
+
+public final class GestureManager: NSObject {
 
     /// The `GestureOptions` that are used to set up the required gestures on the map
-    internal var gestureOptions: GestureOptions!
+    private(set) var gestureOptions: GestureOptions
 
     /// Map of GestureType --> GestureHandler. We mantain a map to allow us to remove gestures arbitrarily.
-    internal var gestureHandlers: [GestureType: GestureHandler] = [:]
+    private(set) var gestureHandlers: [GestureType: GestureHandler] = [:]
 
     /// The view that all gestures operate on
-    internal weak var view: UIView?
+    private weak var view: UIView?
 
     /// The camera manager that responds to gestures.
-    private var cameraManager: CameraManager!
+    private let cameraManager: CameraManagerProtocol
 
     public var delegate: GestureManagerDelegate?
 
-    internal init(for view: UIView, options: GestureOptions, cameraManager: CameraManager) {
-        super.init()
-        self.view = view
-        self.gestureOptions = options
+    internal init(for view: UIView, options: GestureOptions, cameraManager: CameraManagerProtocol) {
         self.cameraManager = cameraManager
+        self.gestureOptions = options
+        self.view = view
+        super.init()
         self.configureGestureHandlers(for: options)
     }
 
@@ -267,25 +290,33 @@ extension GestureManager: GestureHandlerDelegate {
 
         // Single tapping twice with one finger will cause the map to zoom in
         if numberOfTaps == 2 && numberOfTouches == 1 {
-            self.cameraManager.setCamera(zoom: mapView.cameraView.zoom + 1.0)
+            cameraManager.setCamera(
+                to: CameraOptions(zoom: mapView.cameraView.zoom + 1.0),
+                animated: false,
+                duration: 0,
+                completion: nil)
         }
 
         // Double tapping twice with two fingers will cause the map to zoom out
         if numberOfTaps == 2 && numberOfTouches == 2 {
-            self.cameraManager.setCamera(zoom: mapView.zoom - 1.0)
+            cameraManager.setCamera(
+                to: CameraOptions(zoom: mapView.cameraView.zoom - 1.0),
+                animated: false,
+                duration: 0,
+                completion: nil)
         }
     }
 
     // MapView has been panned
     internal func panned(by displacement: CGPoint) {
-        self.cameraManager.moveCamera(by: displacement)
+        self.cameraManager.moveCamera(by: displacement, rotation: nil, pitch: nil, zoom: nil, animated: false)
     }
 
     // Pan has ended on the MapView with a residual `offset`
     internal func panEnded(with offset: CGPoint) {
         if let pitch = self.cameraManager.mapView?.pitch,
            pitch == 0.0 {
-            self.cameraManager.moveCamera(by: offset, animated: true)
+            self.cameraManager.moveCamera(by: offset, rotation: nil, pitch: nil, zoom: nil, animated: true)
         }
     }
 
@@ -299,25 +330,33 @@ extension GestureManager: GestureHandlerDelegate {
     }
 
     internal func scaleForZoom() -> CGFloat {
-        guard let mapView = cameraManager.mapView else {
-            return 0
-        }
-        return pow(2, mapView.zoom)
+        cameraManager.mapView?.zoom ?? 0
     }
 
     internal func pinchScaleChanged(with newScale: CGFloat, andAnchor anchor: CGPoint) {
-        cameraManager.setCamera(anchor: anchor, zoom: log2(newScale))
+        cameraManager.setCamera(
+            to: CameraOptions(anchor: anchor, zoom: newScale),
+            animated: false,
+            duration: 0,
+            completion: nil)
     }
 
     internal func pinchEnded(with finalScale: CGFloat, andDrift possibleDrift: Bool, andAnchor anchor: CGPoint) {
-        cameraManager.setCamera(anchor: anchor, zoom: log2(finalScale))
+        cameraManager.setCamera(
+            to: CameraOptions(anchor: anchor, zoom: finalScale),
+            animated: false,
+            duration: 0,
+            completion: nil)
         self.unrotateIfNeededForGesture(with: .ended)
     }
 
     internal func quickZoomChanged(with newScale: CGFloat, and anchor: CGPoint) {
         let zoom = max(newScale, cameraManager.mapCameraOptions.minimumZoomLevel)
-
-        cameraManager.setCamera(anchor: anchor, zoom: zoom)
+        cameraManager.setCamera(
+            to: CameraOptions(anchor: anchor, zoom: zoom),
+            animated: false,
+            duration: 0,
+            completion: nil)
     }
 
     internal func quickZoomEnded() {
@@ -349,13 +388,21 @@ extension GestureManager: GestureHandlerDelegate {
             changedAngleInDegrees = changedAngleInDegrees > 30.0 ? 30.0 : changedAngleInDegrees
         }
 
-        self.cameraManager.setCamera(bearing: CLLocationDirection(changedAngleInDegrees))
+        cameraManager.setCamera(
+            to: CameraOptions(bearing: CLLocationDirection(changedAngleInDegrees)),
+            animated: false,
+            duration: 0,
+            completion: nil)
     }
 
     internal func rotationEnded(with finalAngle: CGFloat, and anchor: CGPoint, with pinchState: UIGestureRecognizer.State) {
         var finalAngleInDegrees = finalAngle * 180.0 / .pi * -1
         finalAngleInDegrees = finalAngleInDegrees.truncatingRemainder(dividingBy: 360.0)
-        self.cameraManager.setCamera(bearing: CLLocationDirection(finalAngleInDegrees))
+        cameraManager.setCamera(
+            to: CameraOptions(bearing: CLLocationDirection(finalAngleInDegrees)),
+            animated: false,
+            duration: 0,
+            completion: nil)
     }
 
     internal func unrotateIfNeededForGesture(with pinchState: UIGestureRecognizer.State) {
@@ -369,7 +416,11 @@ extension GestureManager: GestureHandlerDelegate {
             && pinchState != .began
             && pinchState != .changed {
             if mapView.cameraView.bearing != 0.0 && self.isRotationAllowed() == false {
-                self.cameraManager.setCamera(bearing: 0.0)
+                cameraManager.setCamera(
+                    to: CameraOptions(bearing: 0),
+                    animated: false,
+                    duration: 0,
+                    completion: nil)
             }
 
             // TODO: Add snapping behavior to "north" if bearing is less than some tolerance
@@ -392,7 +443,11 @@ extension GestureManager: GestureHandlerDelegate {
     }
 
     internal func pitchChanged(newPitch: CGFloat) {
-        self.cameraManager.setCamera(pitch: newPitch)
+        cameraManager.setCamera(
+            to: CameraOptions(pitch: newPitch),
+            animated: false,
+            duration: 0,
+            completion: nil)
     }
 
     internal func pitchEnded() {

--- a/Mapbox/MapboxMapsGesturesTests/GestureSupportableViewMock.swift
+++ b/Mapbox/MapboxMapsGesturesTests/GestureSupportableViewMock.swift
@@ -15,7 +15,6 @@ class GestureHandlerDelegateMock: GestureHandlerDelegate {
 
     var pannedCalled = false
 
-    var scaleForZoomCalled = false
     var pinchScaleChangedMethod: (wasCalled: Bool, newScale: CGFloat?, anchor: CGPoint?) = (false, nil, nil)
     var pinchEndedMethod: (wasCalled: Bool, drift: Bool?, anchor: CGPoint?) = (false, nil, nil)
 
@@ -25,10 +24,6 @@ class GestureHandlerDelegateMock: GestureHandlerDelegate {
     var rotationStartCalled = false
     var rotationChangedMethod: (wasCalled: Bool, newAngle: CGFloat?, anchor: CGPoint?) = (false, nil, nil)
     var rotationEndedMethod: (wasCalled: Bool, finalAngle: CGFloat?, anchor: CGPoint?) = (false, nil, nil)
-
-    var quickZoomCalled = false
-    var quickZoomChangedMethod: (wasCalled: Bool, newScale: CGFloat?, anchor: CGPoint?) = (false, nil, nil)
-    var quickZoomEndedMethod = false
 
     var initialPitch = 0.0
     var pitchTolerance = 45.0
@@ -54,9 +49,9 @@ class GestureHandlerDelegateMock: GestureHandlerDelegate {
         gestureBeganMethod.type = gestureType
     }
 
+    let scaleForZoomStub = Stub<Void, CGFloat>(defaultReturnValue: 0)
     func scaleForZoom() -> CGFloat {
-        scaleForZoomCalled = true
-        return -1.0
+        scaleForZoomStub.call()
     }
 
     func pinchScaleChanged(with newScale: CGFloat, andAnchor anchor: CGPoint) {
@@ -88,15 +83,21 @@ class GestureHandlerDelegateMock: GestureHandlerDelegate {
         rotationEndedMethod.anchor = anchor
     }
 
+    struct QuickZoomChangedParameters {
+        var newScale: CGFloat
+        var anchor: CGPoint
+    }
+    let quickZoomChangedStub = Stub<QuickZoomChangedParameters, Void>()
     func quickZoomChanged(with newScale: CGFloat, and anchor: CGPoint) {
-        quickZoomChangedMethod.wasCalled = true
-        quickZoomChangedMethod.newScale = newScale
-        quickZoomChangedMethod.anchor = anchor
+        quickZoomChangedStub.call(
+            with: QuickZoomChangedParameters(
+                newScale: newScale,
+                anchor: anchor))
     }
 
+    let quickZoomEndedStub = Stub<Void, Void>()
     func quickZoomEnded() {
-        quickZoomCalled = true
-        quickZoomEndedMethod = true
+        quickZoomEndedStub.call()
     }
 
     func pitchChanged(newPitch: CGFloat) {

--- a/Mapbox/MapboxMapsGesturesTests/MockCameraManager.swift
+++ b/Mapbox/MapboxMapsGesturesTests/MockCameraManager.swift
@@ -1,0 +1,43 @@
+import Foundation
+#if canImport(MapboxMaps)
+@testable import MapboxMaps
+#else
+import MapboxMapsFoundation
+@testable import MapboxMapsGestures
+#endif
+
+final class MockCameraManager: CameraManagerProtocol {
+
+    var mapView: BaseMapView?
+
+    var mapCameraOptions = MapCameraOptions()
+
+    struct SetCameraParameters {
+        var camera: CameraOptions
+        var animated: Bool
+        var duration: TimeInterval
+        var completion: ((Bool) -> Void)?
+    }
+    let setCameraStub = Stub<SetCameraParameters, Void>()
+    func setCamera(to camera: CameraOptions,
+                   animated: Bool,
+                   duration: TimeInterval,
+                   completion: ((Bool) -> Void)?) {
+        setCameraStub.call(
+            with: SetCameraParameters(
+                camera: camera,
+                animated: animated,
+                duration: duration,
+                completion: completion))
+    }
+
+    func moveCamera(by offset: CGPoint?,
+                    rotation: CGFloat?,
+                    pitch: CGFloat?,
+                    zoom: CGFloat?,
+                    animated: Bool) {
+    }
+
+    func cancelTransitions() {
+    }
+}

--- a/Mapbox/MapboxMapsGesturesTests/PinchGestureHandlerTests.swift
+++ b/Mapbox/MapboxMapsGesturesTests/PinchGestureHandlerTests.swift
@@ -36,7 +36,7 @@ class PinchGestureHandlerTests: XCTestCase {
         XCTAssertTrue(self.delegate.cancelTransitionsCalled,
                       "Cancel Transitions was not called before commencing gesture processing")
 
-        XCTAssertTrue(self.delegate.scaleForZoomCalled, "Initial scale was not calculated")
+        XCTAssertEqual(self.delegate.scaleForZoomStub.invocations.count, 1, "Initial scale was not calculated")
 
         XCTAssertTrue(self.delegate.gestureBeganMethod.wasCalled,
                       "Gesture Supportable view should be notified when gesture begins")
@@ -45,7 +45,7 @@ class PinchGestureHandlerTests: XCTestCase {
     func testPinchChanged() {
 
         let pinchGestureHandler = PinchGestureHandler(for: self.view, withDelegate: self.delegate)
-        pinchGestureHandler.scale = 10.0
+        pinchGestureHandler.scale = pow(2, 10.0)
 
         let pinchGestureRecognizerMock = UIPinchGestureRecognizerMock()
         pinchGestureRecognizerMock.mockState = .changed
@@ -58,7 +58,7 @@ class PinchGestureHandlerTests: XCTestCase {
 
         XCTAssertTrue(self.delegate.pinchScaleChangedMethod.wasCalled, "Pinch scale not recalculated")
 
-        XCTAssertTrue(self.delegate.pinchScaleChangedMethod.newScale == 20.0, "New scale not calculated properly")
+        XCTAssertEqual(self.delegate.pinchScaleChangedMethod.newScale, 11.0, "New scale not calculated properly")
 
         XCTAssertTrue(self.delegate.pinchScaleChangedMethod.anchor == CGPoint(x: 0.0, y: 0.0),
                       "Invalid pinch center point")

--- a/Mapbox/TestHelpers/Stub.swift
+++ b/Mapbox/TestHelpers/Stub.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+final class Stub<ParametersType, ReturnType> {
+
+    struct Invocation {
+        var parameters: ParametersType
+        var returnValue: ReturnType
+    }
+
+    private(set) var invocations = [Invocation]()
+
+    var defaultReturnValue: ReturnType
+
+    var returnValueQueue = [ReturnType]()
+
+    init(defaultReturnValue: ReturnType) {
+        self.defaultReturnValue = defaultReturnValue
+    }
+
+    var returnedValues: [ReturnType] {
+        invocations.map(\.returnValue)
+    }
+
+    var parameters: [ParametersType] {
+        invocations.map(\.parameters)
+    }
+
+    func call(with parameters: ParametersType) -> ReturnType {
+        let invocation = Invocation(
+            parameters: parameters,
+            returnValue: returnValueQueue.isEmpty ? defaultReturnValue : returnValueQueue.removeFirst())
+        invocations.append(invocation)
+        return invocation.returnValue
+    }
+
+    func reset() {
+        invocations.removeAll()
+    }
+}
+
+extension Stub where ReturnType == Void {
+    convenience init() {
+        self.init(defaultReturnValue: ())
+    }
+}
+
+extension Stub where ParametersType == Void {
+    func call() -> ReturnType {
+        call(with: ())
+    }
+}


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Fixed an issue where quick zoom did not work at higher zoom levels. Also made the duration argument of the setCamera methods non-optional with default of 0.</changelog>`.

### Summary of changes

Public API changes:

- Made the duration argument of the setCamera methods non-optional with default of 0

Other changes:

- Updates GestureManager.scaleForZoom(), pinchScaleChanged(with:andAnchor:), and pinchEnded(with:andDrift:andAnchor:) to not use log2 or pow(2, ...). These transformations are now confined to the respective gesture handlers
- Partially protocolized CameraManager for easier mocking
- Made GestureManager final
- Made properties private where possible
- Made several IUOs non-optional
- Fixed the math in QuickZoomGestureHandler's gesture changed logic
- Did some refactoring in GestureManagerTests and added tests for scaleForZoom, pinchScaleChanged, and pinchEnded
- Introduced Stub to help with writing mocks
- Applied Stub to several methods in GestureSupportableViewMock
- Added a MockCameraManager
- Refactored and improved QuickZoomGestureHandlerTests to avoid regressions
- Increased the deployment target for test targets to iOS 12.2 to work around an issue in which under a specific set of circumstances, an entire test case may not run. The necessary conditions are: test case with a deployment target of iOS 12.1 or lower declares a property of a public, non-frozen, struct or enum type from a library built in library evolution mode. The only one of these conditions that seems reasonable to change in our case is the deployment target of the test target.

### User impact (optional)

Quick zoom works correctly now.