### PR TITLE
[style] Fix issue where color components were not in the correct range for use by renderer

### DIFF
--- a/Mapbox/MapboxMapsStyleTests/ColorTests.swift
+++ b/Mapbox/MapboxMapsStyleTests/ColorTests.swift
@@ -36,7 +36,10 @@ internal class ColorTests: XCTestCase {
 
         do {
             let decodedColor = try JSONDecoder().decode(ColorRepresentable.self, from: validData)
-            XCTAssert(decodedColor == color, "Color should not change after encoding - decoding pass", line: line)
+            XCTAssert(decodedColor == color, "ColorRepresentable instance should not change after encoding - decoding pass", line: line)
+            XCTAssertNotNil(decodedColor.uiColor)
+            XCTAssertEqual(decodedColor.uiColor, color.uiColor)
+
         } catch {
             XCTFail("Could not decode color", line: line)
         }


### PR DESCRIPTION

<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Fix issue where color components were in incorrect range</changelog>`.

### Summary of changes

This change fixes a bug where the color components passed to the renderer as part of the underlying `rgba` expression maintained by the `ColorRepresentable` class were in the incorrect range.

Instead of the color components being in the range of 0-255 ( as the renderer expects ), the colors were in the range of 0-1 (which is what the `getRed(_:green:blue:alpha:)` returns).

This PR fixes this by correctly multiplying when the colors are converted to an expression ( and dividing when colors are converted "from" an expression).

This appears to be a regression that was introduced by #98 . 

Additionally, this PR adds a new computed var `uiColor` that allows a developer to get the `UIColor` instance that a `ColorRepresentable` is representing.