### PR TITLE
Add script to select higher version of Xcode.

### DIFF
--- a/scripts/device-farm/testspec.yml
+++ b/scripts/device-farm/testspec.yml
@@ -8,6 +8,14 @@ phases:
   # Farm are already installed.
   install:
     commands:
+      - XCODE_VERSION=$(xcodebuild -version |head -n 1|cut -d" " -f2|cut -d"." -f1)
+      - >-
+       if [ "$XCODE_VERSION" -lt 12 ];
+       then
+         echo "Xcode version is $XCODE_VERSION; switching to a higher version";
+         sudo /usr/bin/xcode-select --switch /Applications/Xcode.app/;
+         xcodebuild -version;
+       fi;
 
   # The pre-test phase includes commands that setup your test environment.
   pre_test:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [ ] ~Include before/after visuals or gifs if this PR includes visual changes.~
 - [ ] ~Write tests for all new functionality. If tests were not written, please explain why.~
 - [ ] ~Add example if relevant.~
 - [ ] ~Document any changes to public APIs.~
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] ~Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.~

### Summary of changes

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

This PR updates the Device Farm "test spec" script to select a higher version of Xcode (other than the default Xcode 10 used for iOS < 12.2).