### PR TITLE
Add crash symbolication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,12 +316,14 @@ jobs:
                 app-name: << parameters.app-name >>
                 configuration: Release
             - gather-xcresults # get xcresults here, may be zipped with more than one result
-            
+            - run:
+                  name: Symbolicate crash logs
+                  command: make symbolicate
+                  when: always
             - run:
                 name: Converting and uploading coverage
                 command: |
                     make device-update-codecov-with-profdata SCHEME=<< parameters.scheme >> APP_NAME=<< parameters.app-name >> CONFIGURATION=Release
-
             - store-device-farm-artifacts
             - store-logs
             - report-failure:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,7 +318,7 @@ jobs:
             - gather-xcresults # get xcresults here, may be zipped with more than one result
             - run:
                   name: Symbolicate crash logs
-                  command: make symbolicate
+                  command: make symbolicate SCHEME=<< parameters.scheme >> APP_NAME=<< parameters.app-name >> CONFIGURATION=Release
                   when: always
             - run:
                 name: Converting and uploading coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,6 +316,7 @@ jobs:
                 app-name: << parameters.app-name >>
                 configuration: Release
             - gather-xcresults # get xcresults here, may be zipped with more than one result
+            - parse-xcresults
             - run:
                   name: Symbolicate crash logs
                   command: make symbolicate SCHEME=<< parameters.scheme >> APP_NAME=<< parameters.app-name >> CONFIGURATION=Release
@@ -575,14 +576,22 @@ commands:
                 when: always
 
     gather-xcresults:
-        description: "Gathering results"
+        name: "Gathering results"
         steps:
             - run:
                 command: |
                     make gather-results
+
+    parse-xcresults:
+        name: "Parsing xcresults for errors"
+        steps:
+            - run:
+                command: |
                     RESULTS=`find build/testruns -name '*.xcresult'`
-                    cd scripts/xcparty && xargs swift run xcparty \<<< "$RESULTS"                    
-                when: always
+                    pushd scripts/xcparty && swift build
+                    popd
+                    xargs ./scripts/xcparty/.build/debug/xcparty <<< "$RESULTS" | tee build/testruns/failures.txt
+                when: on_fail
 
     store-logs:
         parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -580,6 +580,8 @@ commands:
             - run:
                 command: |
                     make gather-results
+                    RESULTS=`find build/testruns -name '*.xcresult'`
+                    cd scripts/xcparty && xargs swift run xcparty <<< "$RESULTS"                    
                 when: always
 
     store-logs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -581,6 +581,7 @@ commands:
                 name: "Gathering results"
                 command: |
                     make gather-results
+                when: always
 
     parse-xcresults:        
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -576,21 +576,21 @@ commands:
                 when: always
 
     gather-xcresults:
-        name: "Gathering results"
         steps:
             - run:
+                name: "Gathering results"
                 command: |
                     make gather-results
 
-    parse-xcresults:
-        name: "Parsing xcresults for errors"
+    parse-xcresults:        
         steps:
             - run:
+                name: "Parsing xcresults for errors"
                 command: |
                     RESULTS=`find build/testruns -name '*.xcresult'`
                     pushd scripts/xcparty && swift build
                     popd
-                    xargs ./scripts/xcparty/.build/debug/xcparty <<< "$RESULTS" | tee build/testruns/failures.txt
+                    xargs ./scripts/xcparty/.build/debug/xcparty \<<< "$RESULTS" | tee build/testruns/failures.txt
                 when: on_fail
 
     store-logs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ jobs:
             - store-logs
             - report-failure:
                 report_failure: << parameters.report_failure >>
-                message: "maps-device-unit-tests"
+                message: "`<< parameters.scheme >>` device tests"
     
     create-xcframework:
         <<: *default-job
@@ -686,4 +686,4 @@ commands:
                 include_visit_job_action: true
                 mentions: '$CIRCLE_USERNAME'
                 only_for_branches: main
-                failure_message: ':tests-fail-red-cross: <$CIRCLE_BUILD_URL| \`<< parameters.message >>\` failed.>'
+                failure_message: ':tests-fail-red-cross: <$CIRCLE_BUILD_URL| << parameters.message >> failed.>'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -581,7 +581,7 @@ commands:
                 command: |
                     make gather-results
                     RESULTS=`find build/testruns -name '*.xcresult'`
-                    cd scripts/xcparty && xargs swift run xcparty <<< "$RESULTS"                    
+                    cd scripts/xcparty && xargs swift run xcparty \<<< "$RESULTS"                    
                 when: always
 
     store-logs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 /build
-/.build
+.build
 /Packages
 xcuserdata
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ api-docs
 MapboxAccessToken
 scripts/release/packager/artifacts
 scripts/release/packager/build
+scripts/xcparty/.swiftpm

--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,7 @@ $(DEVICE_FARM_UPLOAD_IPA): $(XCTESTRUN_PACKAGE) | $(DEVICE_TEST_PATH) $(PAYLOAD_
 gather-results:
 	python3 ./scripts/device-farm/extract-xcresult.py --outdir $(BUILD_DIR)/testruns
 
+# Although symbolicatecrash is supposed to work with a search directory, this call needed explicit paths
 .PHONY: symbolicate
 symbolicate:
 	@echo Symbolicating crash reports

--- a/Makefile
+++ b/Makefile
@@ -297,33 +297,20 @@ $(DEVICE_FARM_UPLOAD_IPA): $(XCTESTRUN_PACKAGE) | $(DEVICE_TEST_PATH) $(PAYLOAD_
 gather-results:
 	python3 ./scripts/device-farm/extract-xcresult.py --outdir $(BUILD_DIR)/testruns
 
-
-# TODO: Add dSYM for associated tests
-# 			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app/Plugins/$(TESTSCHEME).xctest.dSYM/Contents/Resources/DWARF/$(TESTSCHEME) \
 .PHONY: symbolicate
 symbolicate:
-	@echo Symbolicating crash reports
+	@echo Symbolicating crash reports	
 	@export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer; \
 	CRASHES=`find $(DEVICE_TEST_PATH) -name Application_Crash_Report.ips` ; \
 	for CRASH in $${CRASHES[@]} ; \
 	do \
-		if [ ! -f $${CRASH}.symbolicated.txt ]; then \
-			echo "Symbolicating $${CRASH}" . ; \
-			ls -la $(BUILT_DEVICE_PRODUCTS_DIR) || true ; \
-			/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/iOSSupport/Library/PrivateFrameworks/DVTFoundation.framework/Versions/A/Resources/symbolicatecrash \
+		echo "Symbolicating $${CRASH}" . ; \
+		ls -la $(BUILT_DEVICE_PRODUCTS_DIR) || true ; \
+		/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/iOSSupport/Library/PrivateFrameworks/DVTFoundation.framework/Versions/A/Resources/symbolicatecrash \
 			$${CRASH} \
-			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app/$(APP_NAME) \
-			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app.dSYM/Contents/Resources/DWARF/$(APP_NAME) \
-			$(BUILT_DEVICE_PRODUCTS_DIR)/MapboxMaps.framework/Mapbox \
-			$(BUILT_DEVICE_PRODUCTS_DIR)/MapboxMaps.framework.dSYM/Contents/Resources/DWARF/MapboxMaps \
-			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app/Frameworks/MapboxCoreMaps.framework/Mapbox \
-			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app/Frameworks/MapboxCommon.framework/Mapbox \
-			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app/Frameworks/MapboxMobileEvents.framework/MapboxMobileEvents \
-			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app/Frameworks/Turf.framework/Mapbox \
+			$(BUILT_DEVICE_PRODUCTS_DIR) \
 			-o $${CRASH}.symbolicated.txt ; \
-		fi ; \
 	done
-
 
 # Codecov.io appears to struggle with the raw coverage data from Xcode (in this Device Farm testing scenario). 
 # Explicitly converting it to an lcov format helps.

--- a/Makefile
+++ b/Makefile
@@ -293,9 +293,35 @@ $(DEVICE_FARM_UPLOAD_IPA): $(XCTESTRUN_PACKAGE) | $(DEVICE_TEST_PATH) $(PAYLOAD_
 	cd $(BUILD_DIR) && zip -r $(notdir $(DEVICE_FARM_UPLOAD_IPA)) Payload
 
 
-.PHONY: gather-results
+.PHONY: gather-results symbolicate
 gather-results:
 	python3 ./scripts/device-farm/extract-xcresult.py --outdir $(BUILD_DIR)/testruns
+
+
+# TODO: Add dSYM for associated tests
+# 			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app/Plugins/$(TESTSCHEME).xctest.dSYM/Contents/Resources/DWARF/$(TESTSCHEME) \
+symbolicate:
+	@echo Symbolicating crash reports
+	@export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer; \
+	CRASHES=`find $(DEVICE_TEST_PATH) -name Application_Crash_Report.ips` ; \
+	for CRASH in $${CRASHES[@]} ; \
+	do \
+		if [ ! -f $${CRASH}.symbolicated.txt ]; then \
+			printf . ; \
+			/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/iOSSupport/Library/PrivateFrameworks/DVTFoundation.framework/Versions/A/Resources/symbolicatecrash \
+			$${CRASH} \
+			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app/$(APP_NAME) \
+			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app.dSYM/Contents/Resources/DWARF/$(APP_NAME) \
+			$(BUILT_DEVICE_PRODUCTS_DIR)/MapboxMaps.framework/Mapbox \
+			$(BUILT_DEVICE_PRODUCTS_DIR)/MapboxMaps.framework.dSYM/Contents/Resources/DWARF/MapboxMaps \
+			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app/Frameworks/MapboxCoreMaps.framework/Mapbox \
+			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app/Frameworks/MapboxCommon.framework/Mapbox \
+			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app/Frameworks/MapboxMobileEvents.framework/MapboxMobileEvents \
+			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app/Frameworks/Turf.framework/Mapbox \
+			-o $${CRASH}.symbolicated.txt ; \
+		fi ; \
+	done
+
 
 # Codecov.io appears to struggle with the raw coverage data from Xcode (in this Device Farm testing scenario). 
 # Explicitly converting it to an lcov format helps.

--- a/Makefile
+++ b/Makefile
@@ -293,13 +293,14 @@ $(DEVICE_FARM_UPLOAD_IPA): $(XCTESTRUN_PACKAGE) | $(DEVICE_TEST_PATH) $(PAYLOAD_
 	cd $(BUILD_DIR) && zip -r $(notdir $(DEVICE_FARM_UPLOAD_IPA)) Payload
 
 
-.PHONY: gather-results symbolicate
+.PHONY: gather-results
 gather-results:
 	python3 ./scripts/device-farm/extract-xcresult.py --outdir $(BUILD_DIR)/testruns
 
 
 # TODO: Add dSYM for associated tests
 # 			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app/Plugins/$(TESTSCHEME).xctest.dSYM/Contents/Resources/DWARF/$(TESTSCHEME) \
+.PHONY: symbolicate
 symbolicate:
 	@echo Symbolicating crash reports
 	@export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer; \
@@ -307,7 +308,8 @@ symbolicate:
 	for CRASH in $${CRASHES[@]} ; \
 	do \
 		if [ ! -f $${CRASH}.symbolicated.txt ]; then \
-			printf . ; \
+			echo "Symbolicating $${CRASH}" . ; \
+			ls -la $(BUILT_DEVICE_PRODUCTS_DIR) || true ; \
 			/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/iOSSupport/Library/PrivateFrameworks/DVTFoundation.framework/Versions/A/Resources/symbolicatecrash \
 			$${CRASH} \
 			$(BUILT_DEVICE_PRODUCTS_DIR)/$(APP_NAME).app/$(APP_NAME) \

--- a/scripts/xcparty/Package.resolved
+++ b/scripts/xcparty/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "XCResultKit",
+        "repositoryURL": "https://github.com/davidahouse/XCResultKit",
+        "state": {
+          "branch": null,
+          "revision": "2259be4e7e3c6e16b6d8e89c29df43b5cc098c9a",
+          "version": "0.8.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/scripts/xcparty/Package.swift
+++ b/scripts/xcparty/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/davidahouse/XCResultKit",
-                 from: "0.7.1"),
+                 from: "0.7.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/scripts/xcparty/Package.swift
+++ b/scripts/xcparty/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "xcparty",
+    platforms: [
+        .macOS(.v10_15)
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(url: "https://github.com/davidahouse/XCResultKit",
+                 from: "0.7.1"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(name: "xcparty",
+                dependencies: ["XCResultKit"])
+    ]
+)

--- a/scripts/xcparty/README.md
+++ b/scripts/xcparty/README.md
@@ -1,0 +1,3 @@
+# xcparty
+
+Parse xcresult files. Currently displays test failures only.

--- a/scripts/xcparty/Sources/xcparty/main.swift
+++ b/scripts/xcparty/Sources/xcparty/main.swift
@@ -1,0 +1,168 @@
+import Foundation
+import XCResultKit
+
+// Convenience struct
+struct TestFailure: Hashable {
+    var testCase: String
+    var message: String
+    var fileName: String?
+    var startingLineNumber: String?
+
+    init(testCase: String, message: String) {
+        self.testCase = testCase
+        self.message = message
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(testCase)
+        hasher.combine(message)
+        if let fileName = fileName {
+            hasher.combine(fileName)
+        }
+        if let startingLineNumber = startingLineNumber {
+            hasher.combine(startingLineNumber)
+        }
+    }
+}
+
+guard CommandLine.arguments.count >= 2 else {
+    print("Usage: xcparty <path/to/xcresult> ... ")
+    exit(1)
+}
+
+var failureDict = [String : Set<TestFailure>]()
+
+let currentDirectoryURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+for xcresultFile in CommandLine.arguments[1...] {
+
+    let xcresultPath = URL(fileURLWithPath: xcresultFile, relativeTo: currentDirectoryURL)
+
+    // Parse using XCResultKit
+    let resultFile = XCResultFile(url: xcresultPath)
+    let invocationRecord = resultFile.getInvocationRecord()
+
+    guard let failures = invocationRecord?.issues.testFailureSummaries else {
+        continue
+    }
+
+    for failure in failures {
+        let testCaseNameArray = failure.testCaseName.components(separatedBy: ".")
+
+        guard testCaseNameArray.count == 2 else {
+            continue
+        }
+
+        var testFailure = TestFailure(testCase: testCaseNameArray[1],
+                                      message: failure.message)
+
+        // Look for file name and line
+        if let file = failure.documentLocationInCreatingWorkspace?.url,
+           let url = URL(string: file) {
+            testFailure.fileName = url.lastPathComponent
+
+            if let fragment = url.fragment {
+                let params = fragment.components(separatedBy: "&").map {
+                    $0.components(separatedBy: "=")
+                }
+
+                let dict = params.reduce(into: [String:String]()) { (dict, keyValues) in
+                    if keyValues.count == 2 {
+                        dict[keyValues[0]] = keyValues[1]
+                    }
+                }
+
+                testFailure.startingLineNumber = dict["StartingLineNumber"]
+            }
+        }
+
+        // Group failures together
+        failureDict[testCaseNameArray[0], default: []].update(with: testFailure)
+    }
+}
+
+// Dump
+if failureDict.count == 0 {
+    print("No test failures detected.")
+} else {
+    for (key, value) in failureDict {
+        let line = String(repeating: "-", count: key.count)
+        print("\(key)\n\(line)")
+        for test in value {
+            print("• \(test.testCase)")
+
+            if let fileName = test.fileName,
+               let lineNumber = test.startingLineNumber {
+                print("\t\(fileName) # \(lineNumber)")
+            }
+            print("\t\"\(test.message)\"")
+        }
+        print("")
+    }
+}
+
+
+
+//    print("\t\(failure.testCaseName)\n\t\t\(failure.message)")
+//    if let file = failure.documentLocationInCreatingWorkspace?.url {
+//        let url = URL(fileURLWithPath: file)
+//        if let file2 = url.pathComponents.last {
+//            print("\t\t\(file2)<<<<")
+//        }
+//    }
+//}
+
+
+//    resultFile.getTestPlanRunSummaries(id: invocationRecord?.issues.errorSummaries)
+
+//    guard let dict = NSDictionary(contentsOf: testSummaries) else {
+//        print("can't parse")
+//        exit(1)
+//    }
+//
+//    guard let testableSummaries = dict["TestableSummaries"] as? [[String:Any]],
+//          testableSummaries.count == 1 else {
+//        print("can't parse 2")
+//        exit(1)
+//    }
+//
+//    guard let tests = testableSummaries.first?["Tests"] as? [[String:Any]] else {
+//        print("can't parse 2")
+//        exit(1)
+//    }
+//
+//    guard let test = tests.first, tests.count == 1 else {
+//        print("can't find first")
+//        exit(1)
+//    }
+//    let indent = ""
+//    recurse(indent, tests: test)
+
+
+
+//}
+//else {
+//    print("v2")
+//    let resultFile = XCResultFile(url: fullpath)
+//    let invocationRecord = resultFile.getInvocationRecord()
+//    print("\(invocationRecord)")
+//}
+
+
+func recurse(_ indent: String, tests: [String:Any]) {
+
+    if let result = tests["TestStatus"] as? String,
+       let name = tests["TestName"] as? String {
+        print("\(indent)\(name) .... \(result)")
+    }
+
+    if let subtests = tests["Subtests"] as? [[String:Any]],
+       let name = tests["TestName"] as? String {
+
+        print("\(indent)\(name):")
+        for subtest in subtests {
+            recurse(indent+"\t", tests: subtest)
+        }
+    }
+}
+

--- a/scripts/xcparty/Sources/xcparty/main.swift
+++ b/scripts/xcparty/Sources/xcparty/main.swift
@@ -15,12 +15,15 @@ struct TestFailure: Hashable {
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(testCase)
-        hasher.combine(message)
-        if let fileName = fileName {
+
+        if let fileName = fileName,
+           let startingLineNumber = startingLineNumber {
             hasher.combine(fileName)
-        }
-        if let startingLineNumber = startingLineNumber {
             hasher.combine(startingLineNumber)
+        } else if !message.contains("<external symbol>") {
+            // If no line information, try and use the message to differentiate.
+            // But only do this if 
+            hasher.combine(message)
         }
     }
 }
@@ -30,7 +33,7 @@ guard CommandLine.arguments.count >= 2 else {
     exit(1)
 }
 
-var failureDict = [String : Set<TestFailure>]()
+var failureDict = [String: Set<TestFailure>]()
 
 let currentDirectoryURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
 
@@ -66,7 +69,7 @@ for xcresultFile in CommandLine.arguments[1...] {
                     $0.components(separatedBy: "=")
                 }
 
-                let dict = params.reduce(into: [String:String]()) { (dict, keyValues) in
+                let dict = params.reduce(into: [String: String]()) { (dict, keyValues) in
                     if keyValues.count == 2 {
                         dict[keyValues[0]] = keyValues[1]
                     }
@@ -100,69 +103,3 @@ if failureDict.count == 0 {
         print("")
     }
 }
-
-
-
-//    print("\t\(failure.testCaseName)\n\t\t\(failure.message)")
-//    if let file = failure.documentLocationInCreatingWorkspace?.url {
-//        let url = URL(fileURLWithPath: file)
-//        if let file2 = url.pathComponents.last {
-//            print("\t\t\(file2)<<<<")
-//        }
-//    }
-//}
-
-
-//    resultFile.getTestPlanRunSummaries(id: invocationRecord?.issues.errorSummaries)
-
-//    guard let dict = NSDictionary(contentsOf: testSummaries) else {
-//        print("can't parse")
-//        exit(1)
-//    }
-//
-//    guard let testableSummaries = dict["TestableSummaries"] as? [[String:Any]],
-//          testableSummaries.count == 1 else {
-//        print("can't parse 2")
-//        exit(1)
-//    }
-//
-//    guard let tests = testableSummaries.first?["Tests"] as? [[String:Any]] else {
-//        print("can't parse 2")
-//        exit(1)
-//    }
-//
-//    guard let test = tests.first, tests.count == 1 else {
-//        print("can't find first")
-//        exit(1)
-//    }
-//    let indent = ""
-//    recurse(indent, tests: test)
-
-
-
-//}
-//else {
-//    print("v2")
-//    let resultFile = XCResultFile(url: fullpath)
-//    let invocationRecord = resultFile.getInvocationRecord()
-//    print("\(invocationRecord)")
-//}
-
-
-func recurse(_ indent: String, tests: [String:Any]) {
-
-    if let result = tests["TestStatus"] as? String,
-       let name = tests["TestName"] as? String {
-        print("\(indent)\(name) .... \(result)")
-    }
-
-    if let subtests = tests["Subtests"] as? [[String:Any]],
-       let name = tests["TestName"] as? String {
-
-        print("\(indent)\(name):")
-        for subtest in subtests {
-            recurse(indent+"\t", tests: subtest)
-        }
-    }
-}
-

--- a/scripts/xcparty/Sources/xcparty/main.swift
+++ b/scripts/xcparty/Sources/xcparty/main.swift
@@ -18,15 +18,15 @@ struct TestFailure: Hashable {
 
         // Same crash (with "external symbol") can have slightly different messages; this is an
         // attempt to match them.
-        if !message.contains("<external symbol>") {            
-            hasher.combine(message)            
+        if !message.contains("<external symbol>") {
+            hasher.combine(message)
         }
 
         if let fileName = fileName,
            let startingLineNumber = startingLineNumber {
             hasher.combine(fileName)
             hasher.combine(startingLineNumber)
-        } 
+        }
     }
 }
 

--- a/scripts/xcparty/Sources/xcparty/main.swift
+++ b/scripts/xcparty/Sources/xcparty/main.swift
@@ -16,15 +16,17 @@ struct TestFailure: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(testCase)
 
+        // Same crash (with "external symbol") can have slightly different messages; this is an
+        // attempt to match them.
+        if !message.contains("<external symbol>") {            
+            hasher.combine(message)            
+        }
+
         if let fileName = fileName,
            let startingLineNumber = startingLineNumber {
             hasher.combine(fileName)
             hasher.combine(startingLineNumber)
-        } else if !message.contains("<external symbol>") {
-            // If no line information, try and use the message to differentiate.
-            // But only do this if 
-            hasher.combine(message)
-        }
+        } 
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] ~Write tests for all new functionality. If tests were not written, please explain why.~
 - [ ] ~Add example if relevant.~
 - [ ] ~Document any changes to public APIs.~
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] ~Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.~

### Summary of changes

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

This PR:

- Adds some basic `xcresult` parsing to detect failed XCTests; this is currently logged as part of the CircleCI job.
- Adds crash symbolication for crashes that occur for device tests, and includes this file in the CircleCI artifact.

<img width="924" alt="Screen Shot 2021-03-01 at 6 36 38 PM" src="https://user-images.githubusercontent.com/3765757/109591786-2a89cd80-7adc-11eb-941d-3b6e3195bbf5.png">

<img width="569" alt="Screen Shot 2021-03-01 at 6 39 16 PM" src="https://user-images.githubusercontent.com/3765757/109591844-47be9c00-7adc-11eb-94a7-9f18c70daed1.png">



