### PR TITLE
Update MapboxCoreMaps and MapboxCommon

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/MapboxMaps.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/MapboxMaps.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "TOKEN_FILE=~/.mapbox&#10;TOKEN_FILE_2=~/mapbox&#10;TOKEN=&quot;$(cat $TOKEN_FILE 2&gt;/dev/null || cat $TOKEN_FILE_2 2&gt;/dev/null)&quot;&#10;if [ &quot;$TOKEN&quot; ]; then&#10;  MBX_ROOT=$(echo &quot;$WORKSPACE_PATH&quot; | rev | cut -d&apos;/&apos; -f4- | rev)&#10;  echo $TOKEN &gt; &quot;$MBX_ROOT/Tests/MapboxMapsTests/TestHelpers/MapboxAccessToken&quot;&#10;fi&#10;">
+               scriptText = "TOKEN_FILE=~/.mapbox&#10;TOKEN_FILE_2=~/mapbox&#10;TOKEN=&quot;$(cat $TOKEN_FILE 2&gt;/dev/null || cat $TOKEN_FILE_2 2&gt;/dev/null)&quot;&#10;if [ &quot;$TOKEN&quot; ]; then&#10;  MBX_ROOT=$(echo &quot;$WORKSPACE_PATH&quot; | rev | cut -d&apos;/&apos; -f4- | rev)&#10;  echo $TOKEN &gt; &quot;$MBX_ROOT/Tests/MapboxMapsTests/Helpers/MapboxAccessToken&quot;&#10;fi&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon-ios.json" == 10.0.0-beta.11
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-core/MapboxCoreMaps-dynamic.json" == 10.0.0-beta.15
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon-ios.json" == 10.0.0-beta.12
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-core/MapboxCoreMaps-dynamic.json" == 10.0.0-beta.16
 github "mapbox/turf-swift" == 2.0.0-alpha.3
 github "mapbox/mapbox-events-ios" ~> 0.10

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon-ios.json" "10.0.0-beta.11"
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-core/MapboxCoreMaps-dynamic.json" "10.0.0-beta.15"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon-ios.json" "10.0.0-beta.12"
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-core/MapboxCoreMaps-dynamic.json" "10.0.0-beta.16"
 github "mapbox/mapbox-events-ios" "v0.10.8"
 github "mapbox/turf-swift" "v2.0.0-alpha.3"

--- a/Examples/Examples/All Examples/SwiftUIExample.swift
+++ b/Examples/Examples/All Examples/SwiftUIExample.swift
@@ -120,13 +120,13 @@ internal class SwiftUIMapViewCoordinator {
 
     /// This `mapView` property needs to be weak because
     /// the map view takes a strong reference to the coordinator
-    /// when we make the coordinator observe the `.cameraDidChange`
+    /// when we make the coordinator observe the `.cameraChanged`
     /// event
     weak var mapView: MapView? {
         didSet {
-            /// The coordinator observes the `.cameraDidChange` event, and
+            /// The coordinator observes the `.cameraChanged` event, and
             /// whenever the camera changes, it updates the camera binding
-            mapView?.on(.cameraDidChange, handler: notify(for:))
+            mapView?.on(.cameraChanged, handler: notify(for:))
 
             /// The coordinator also observes the `.mapLoadingFinished` event
             /// so that it can sync annotations whenever the map reloads
@@ -147,7 +147,7 @@ internal class SwiftUIMapViewCoordinator {
         /// As the camera changes, we update the binding. SwiftUI
         /// will propagate this change to any other UI elements connected
         /// to the same binding.
-        case .cameraDidChange:
+        case .cameraChanged:
             camera.center = mapView.centerCoordinate
             camera.zoom = mapView.zoom
 
@@ -234,7 +234,7 @@ internal struct ContentView: View {
             ///
             /// Map to Slider:
             ///     - User interacts with the map, adjusting the zoom
-            ///     - Map sends the `.cameraDidChange` event, which is observed by the coordinator
+            ///     - Map sends the `.cameraChanged` event, which is observed by the coordinator
             ///     - The coordinator updates the value of the zoom on the `camera` binding
             ///     - SwiftUI updates the Slider accordingly
             Slider(value: $camera.zoom, in: 0...20)

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -21,8 +21,8 @@ Pod::Spec.new do |m|
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
   m.resources = 'Sources/**/*.{xcassets,strings}'
 
-  m.dependency 'MapboxCoreMaps', '10.0.0-beta.15'
-  m.dependency 'MapboxCommon', '10.0.0-beta.11'
+  m.dependency 'MapboxCoreMaps', '10.0.0-beta.16'
+  m.dependency 'MapboxCommon', '10.0.0-beta.12'
   m.dependency 'MapboxMobileEvents', '0.10.8'
   m.dependency 'Turf', '2.0.0-alpha.3'
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "70e396ff7bd960ac5b181ea9c7e6d8557b3a33d1",
-          "version": "10.0.0-beta.11"
+          "revision": "a1ffbf8abecef7637b458dd2e561500854757705",
+          "version": "10.0.0-beta.12"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "207ece35e4d1107b806d2f8bd03e79653b3dc64e",
-          "version": "10.0.0-beta.15"
+          "revision": "bcc62bfa190604685d43be18e9226f39f9878afe",
+          "version": "10.0.0-beta.16"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
             targets: ["MapboxMaps"]),
     ],
     dependencies: [
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("10.0.0-beta.11")),
-        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.0.0-beta.15")),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("10.0.0-beta.12")),
+        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.0.0-beta.16")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", .exact("0.10.8")),
         .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", .exact("2.0.0-alpha.3")),
     ],

--- a/Sources/MapboxMaps/Annotations/AnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationManager.swift
@@ -117,7 +117,7 @@ public class AnnotationManager: Observer {
 
     deinit {
         self.tapGesture = nil
-        try! self.mapView?.observable?.unsubscribe(for: self, events: [MapEvents.mapLoadingStarted])
+        try! self.mapView?.observable?.unsubscribe(for: self, events: [MapEvents.mapLoadingFinished])
     }
 
     /**
@@ -140,7 +140,7 @@ public class AnnotationManager: Observer {
         self.userInteractionEnabled = true
 
         configureTapGesture()
-        try! mapView.observable?.subscribe(for: self, events: [MapEvents.mapLoadingStarted])
+        try! mapView.observable?.subscribe(for: self, events: [MapEvents.mapLoadingFinished])
     }
 
     // MARK: - Public functions
@@ -618,7 +618,7 @@ public class AnnotationManager: Observer {
     }
 
     public func notify(for event: MapboxCoreMaps.Event) {
-        guard event.type == MapEvents.mapLoadingStarted else {
+        guard event.type == MapEvents.mapLoadingFinished else {
             return
         }
 

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -116,8 +116,7 @@ open class BaseMapView: UIView, MapClient, MBMMetalViewProvider {
 
         let size = MapboxCoreMaps.Size(width: Float(frame.width), height: Float(frame.height))
 
-        let mapOptions = MapboxCoreMaps.MapOptions(__mapMode: nil,
-                                                   contextMode: nil,
+        let mapOptions = MapboxCoreMaps.MapOptions(__contextMode: nil,
                                                    constrainMode: nil,
                                                    viewportMode: nil,
                                                    orientation: nil,

--- a/Sources/MapboxMaps/Foundation/Events/Event.swift
+++ b/Sources/MapboxMaps/Foundation/Events/Event.swift
@@ -11,9 +11,7 @@ public enum EventType {
     case memoryWarning
 
     public enum Maps {
-        case mapLoaded
-        case mapResumedRendering
-        case mapPausedRendering
+        case loaded
     }
 
     public enum Metrics {

--- a/Sources/MapboxMaps/Foundation/Events/EventsManager.swift
+++ b/Sources/MapboxMaps/Foundation/Events/EventsManager.swift
@@ -40,12 +40,7 @@ internal class EventsManager: EventsListener {
 
     private func process(mapEvent: EventType.Maps) {
         switch mapEvent {
-        case .mapLoaded:
-            telemetry?.turnstile()
-            telemetry?.send(event: mapEvent.typeString)
-        case .mapPausedRendering:
-            telemetry?.flush()
-        case .mapResumedRendering:
+        case .loaded:
             telemetry?.turnstile()
             telemetry?.send(event: mapEvent.typeString)
         }

--- a/Sources/MapboxMaps/Foundation/Events/EventsStringTokens.swift
+++ b/Sources/MapboxMaps/Foundation/Events/EventsStringTokens.swift
@@ -4,11 +4,7 @@ import MapboxMobileEvents
 extension EventType.Maps {
     var typeString: String {
         switch self {
-        case .mapLoaded:
-            return MMEEventTypeMapLoad
-        case .mapPausedRendering:
-            return "map.pause"
-        case .mapResumedRendering:
+        case .loaded:
             return MMEEventTypeMapLoad
         }
     }

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/MapEvents.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/MapEvents.swift
@@ -5,7 +5,6 @@ import Foundation
 public extension MapEvents {
 
     enum EventKind: RawRepresentable, CaseIterable {
-        case mapLoadingStarted
         case mapLoadingFinished
         case mapLoadingError
         case mapIdle
@@ -14,20 +13,16 @@ public extension MapEvents {
         case styleImageMissing
         case styleImageRemoveUnused
         case sourceChanged
+        case sourceAdded
+        case sourceRemoved
         case renderFrameStarted
         case renderFrameFinished
-        case renderMapStarted
-        case renderMapFinished
-        case cameraWillChange
-        case cameraIsChanging
-        case cameraDidChange
+        case cameraChanged
         case resourceRequest
 
         // swiftlint:disable:next cyclomatic_complexity
         public init?(rawValue: String) {
             switch rawValue {
-            case MapEvents.mapLoadingStarted :
-                self = .mapLoadingStarted
             case MapEvents.mapLoadingFinished:
                 self = .mapLoadingFinished
             case MapEvents.mapLoadingError:
@@ -44,20 +39,16 @@ public extension MapEvents {
                 self = .styleImageRemoveUnused
             case MapEvents.sourceChanged:
                 self = .sourceChanged
+            case MapEvents.sourceAdded:
+                self = .sourceAdded
+            case MapEvents.sourceRemoved:
+                self = .sourceRemoved
             case MapEvents.renderFrameStarted:
                 self = .renderFrameStarted
             case MapEvents.renderFrameFinished:
                 self = .renderFrameFinished
-            case MapEvents.renderMapStarted:
-                self = .renderMapStarted
-            case MapEvents.renderMapFinished:
-                self = .renderMapFinished
-            case MapEvents.cameraWillChange:
-                self = .cameraWillChange
-            case MapEvents.cameraIsChanging:
-                self = .cameraIsChanging
-            case MapEvents.cameraDidChange:
-                self = .cameraDidChange
+            case MapEvents.cameraChanged:
+                self = .cameraChanged
             case MapEvents.resourceRequest:
                 self = .resourceRequest
             default:
@@ -67,8 +58,6 @@ public extension MapEvents {
 
         public var rawValue: String {
             switch self {
-            case .mapLoadingStarted:
-                return MapEvents.mapLoadingStarted
             case .mapLoadingFinished:
                 return MapEvents.mapLoadingFinished
             case .mapLoadingError:
@@ -85,20 +74,16 @@ public extension MapEvents {
                 return MapEvents.styleImageRemoveUnused
             case .sourceChanged:
                 return MapEvents.sourceChanged
+            case .sourceAdded:
+                return MapEvents.sourceAdded
+            case .sourceRemoved:
+                return MapEvents.sourceRemoved
             case .renderFrameStarted:
                 return MapEvents.renderFrameStarted
             case .renderFrameFinished:
                 return MapEvents.renderFrameFinished
-            case .renderMapStarted:
-                return MapEvents.renderMapStarted
-            case .renderMapFinished:
-                return MapEvents.renderMapFinished
-            case .cameraWillChange:
-                return MapEvents.cameraWillChange
-            case .cameraIsChanging:
-                return MapEvents.cameraIsChanging
-            case .cameraDidChange:
-                return MapEvents.cameraDidChange
+            case .cameraChanged:
+                return MapEvents.cameraChanged
             case .resourceRequest:
                 return MapEvents.resourceRequest
             }

--- a/Sources/MapboxMaps/MapView/MapView+Supportable.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Supportable.swift
@@ -18,7 +18,7 @@ extension MapView: OrnamentSupportableView {
     }
 
     public func subscribeCameraChangeHandler(_ handler: @escaping (CameraOptions) -> Void) {
-        self.on(.cameraDidChange) { [weak self] _ in
+        self.on(.cameraChanged) { [weak self] _ in
             guard let validSelf = self else { return }
             handler(try! validSelf.__map.getCameraOptions(forPadding: nil))
         }

--- a/Sources/MapboxMaps/MapView/MapView.swift
+++ b/Sources/MapboxMaps/MapView/MapView.swift
@@ -54,16 +54,9 @@ extension MapView {
     internal func setUpTelemetryLogging() {
         guard let validResourceOptions = resourceOptions else { return }
         self.eventsListener = EventsManager(accessToken: validResourceOptions.accessToken)
-        self.on(.renderMapFinished) { [weak self] _ in
-            self?.eventsListener?.push(event: .map(event: .mapPausedRendering))
-        }
-
-        self.on(.renderMapStarted) { [weak self] _ in
-            self?.eventsListener?.push(event: .map(event: .mapResumedRendering))
-        }
 
         self.on(.mapLoadingFinished) { [weak self] _ in
-            self?.eventsListener?.push(event: .map(event: .mapLoaded))
+            self?.eventsListener?.push(event: .map(event: .loaded))
         }
     }
 }

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/Map/MapViewIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/Map/MapViewIntegrationTests.swift
@@ -30,12 +30,12 @@ class MapViewIntegrationTests: IntegrationTestCase {
             let expectation = self.expectation(description: "wait for map")
 
             let resourceOptions = ResourceOptions(accessToken: accessToken)
-            let mapView = MapView(with: CGRect(origin: .zero, size: rootView.bounds.size), resourceOptions: resourceOptions, styleURL: .streets)
+            let mapView = MapView(with: rootView.bounds, resourceOptions: resourceOptions, styleURL: .streets)
             weakMapView = mapView
 
             rootView.addSubview(mapView)
 
-            mapView.on(.renderMapFinished) { [weak mapView] _ in
+            mapView.on(.mapLoadingFinished) { [weak mapView] _ in
                 let dest = CameraOptions(center: CLLocationCoordinate2D(latitude: 10, longitude: 10), zoom: 10)
                 mapView?.cameraManager.setCamera(to: dest, animated: true, duration: 5) { _ in
                     expectation.fulfill()


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Updates to MapboxCoreMaps v10.0.0-beta.16 and MapboxCommon v10.0.0-beta.12.</changelog>`.

### Summary of changes

- Updates to MapboxCoreMaps v10.0.0-beta.16
- Updates to MapboxCommon v10.0.0-beta.12
- Fixes a path in the pre-build token script
- `AnnotationManager` now resets the annotation source and default layers upon `mapLoadingFinished` instead of upon the now-removed `mapLoadingStarted`. This is expected to produce an equivalent end result due to the fact that `AnnotationManager` will receive the event before any consumers due to the fact it will have subscribed first and the observer API delivers events to observers in the order in which they subscribed.
- Added `MapEvents.EventKind.sourceAdded` and `MapEvents.EventKind.sourceRemoved`

### Breaking changes

- Removed `EventType.Maps.mapResumedRendering` and `EventType.Maps.mapPausedRendering` which depended on the now-removed map events `mapPausedRendering` and `mapResumedRendering`
- Renamed `EventType.Map.mapLoaded` to `EventType.Map.loaded` to be less redundant.
- Removed `MapEvents.EventKind.mapLoadingStarted`, `.renderMapStarted`, `.renderMapFinished`, `.cameraWillChange`, and `.cameraIsChanging`.
- Renamed `MapEvents.EventKind.cameraDidChange` to `MapEvents.EventKind.cameraChanged` for consistency with MapboxCoreMaps.
