### PR TITLE
Add custom PreferredFPS option

### DIFF
--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -5,7 +5,27 @@ import Turf
 
 // swiftlint:disable file_length
 
-public enum PreferredFPS: Equatable {
+public enum PreferredFPS: RawRepresentable, Equatable {
+
+    /**
+     Create a `PreferredFPS` value from an `Int`.
+     - Parameter rawValue: The `Int` value to use as the preferred frames per second.
+     */
+    public init?(rawValue: Int) {
+        switch rawValue {
+        case Self.lowPower.fps:
+            self = .lowPower
+        case Self.normal.fps:
+            self = .normal
+        case Self.maximum.fps:
+            self = .maximum
+        default:
+            self = .custom(fps: rawValue)
+        }
+    }
+
+    public typealias RawValue = Int
+
     /// The default frame rate. This can be either 30 FPS or 60 FPS, depending on
     /// device capabilities.
     case normal
@@ -17,11 +37,11 @@ public enum PreferredFPS: Equatable {
     case maximum
 
     /// A custom frame rate. The default value is 30 FPS.
-    case custom(Int)
-}
+    case custom(fps: Int)
 
-extension PreferredFPS {
-    public var fps: Int {
+    /// :nodoc:
+    /// `RawRepresentable` conformance
+    public var rawValue: Int {
         switch self {
         case .lowPower:
             return 30
@@ -29,10 +49,15 @@ extension PreferredFPS {
             return -1
         case .maximum:
             return 0
-        case let .custom(value):
+        case .custom(let fps):
             // TODO: Check that value is a valid FPS value
-            return value
+            return fps
         }
+    }
+
+    /// The preferred frames per second as an `Int` value.
+    public var fps: Int {
+        return rawValue
     }
 }
 
@@ -267,7 +292,7 @@ open class BaseMapView: UIView, MapClient, MBMMetalViewProvider {
                 newFrameRate = preferredFPS
             }
 
-            displayLink.preferredFramesPerSecond = newFrameRate.fps
+            displayLink.preferredFramesPerSecond = newFrameRate.rawValue
         }
     }
 

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -23,7 +23,7 @@ public enum PreferredFPS: Equatable {
 }
 
 extension PreferredFPS {
-    public var fps : Int {
+    public var fps: Int {
         switch self {
         case .lowPower:
             return -1

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -77,7 +77,7 @@ open class BaseMapView: UIView, MapClient, MBMMetalViewProvider {
     /// Returns the camera view managed by this object.
     public var cameraView: CameraView!
 
-    public var preferredFPS: PreferredFPS = .normal {
+    internal var preferredFPS: PreferredFPS = .normal {
         didSet {
             self.updateDisplayLinkPreferredFramesPerSecond()
         }

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -32,11 +32,8 @@ extension PreferredFPS {
         case .maximum:
             return 0
         case let .custom(value):
-            if value >= PreferredFPS.lowPower.fps && value <= PreferredFPS.maximum.fps {
-                return value
-            } else {
-                return 30
-            }
+            // TODO: Check that value is a valid FPS value
+            return value
         }
     }
 }

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -18,11 +18,11 @@ public enum PreferredFPS: Equatable {
     /// The maximum supported frame rate; typically 60 FPS.
     case maximum
 
+    /// A custom frame rate. The default value is 30 FPS.
     case custom(Int)
 }
 
 extension PreferredFPS {
-
     public var fps : Int {
         switch self {
         case .lowPower:
@@ -32,7 +32,11 @@ extension PreferredFPS {
         case .maximum:
             return 0
         case let .custom(value):
-            return value
+            if value >= PreferredFPS.lowPower.fps && value <= PreferredFPS.maximum.fps {
+                return value
+            } else {
+                return 30
+            }
         }
     }
 }

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -13,11 +13,11 @@ public enum PreferredFPS: RawRepresentable, Equatable {
      */
     public init?(rawValue: Int) {
         switch rawValue {
-        case Self.lowPower.fps:
+        case Self.lowPower.rawValue:
             self = .lowPower
-        case Self.normal.fps:
+        case Self.normal.rawValue:
             self = .normal
-        case Self.maximum.fps:
+        case Self.maximum.rawValue:
             self = .maximum
         default:
             self = .custom(fps: rawValue)
@@ -39,8 +39,7 @@ public enum PreferredFPS: RawRepresentable, Equatable {
     /// A custom frame rate. The default value is 30 FPS.
     case custom(fps: Int)
 
-    /// :nodoc:
-    /// `RawRepresentable` conformance
+    /// The preferred frames per second as an `Int` value.
     public var rawValue: Int {
         switch self {
         case .lowPower:
@@ -55,10 +54,6 @@ public enum PreferredFPS: RawRepresentable, Equatable {
         }
     }
 
-    /// The preferred frames per second as an `Int` value.
-    public var fps: Int {
-        return rawValue
-    }
 }
 
 open class ObserverConcrete: Observer {

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -6,8 +6,6 @@ import Turf
 // swiftlint:disable file_length
 
 public enum PreferredFPS: Equatable {
-    public typealias RawValue = Int
-
     /// The default frame rate. This can be either 30 FPS or 60 FPS, depending on
     /// device capabilities.
     case normal
@@ -26,9 +24,9 @@ extension PreferredFPS {
     public var fps: Int {
         switch self {
         case .lowPower:
-            return -1
-        case .normal:
             return 30
+        case .normal:
+            return -1
         case .maximum:
             return 0
         case let .custom(value):

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -5,16 +5,36 @@ import Turf
 
 // swiftlint:disable file_length
 
-public enum PreferredFPS: Int, Equatable {
+public enum PreferredFPS: Equatable {
+    public typealias RawValue = Int
+
     /// The default frame rate. This can be either 30 FPS or 60 FPS, depending on
     /// device capabilities.
-    case normal = -1
+    case normal
 
     /// A conservative frame rate; typically 30 FPS.
-    case lowPower = 30
+    case lowPower
 
     /// The maximum supported frame rate; typically 60 FPS.
-    case maximum = 0
+    case maximum
+
+    case custom(Int)
+}
+
+extension PreferredFPS {
+
+    public var fps : Int {
+        switch self {
+        case .lowPower:
+            return -1
+        case .normal:
+            return 30
+        case .maximum:
+            return 0
+        case let .custom(value):
+            return value
+        }
+    }
 }
 
 open class ObserverConcrete: Observer {
@@ -248,7 +268,7 @@ open class BaseMapView: UIView, MapClient, MBMMetalViewProvider {
                 newFrameRate = preferredFPS
             }
 
-            displayLink.preferredFramesPerSecond = newFrameRate.rawValue
+            displayLink.preferredFramesPerSecond = newFrameRate.fps
         }
     }
 

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -50,7 +50,7 @@ public enum PreferredFPS: RawRepresentable, Equatable {
         case .maximum:
             return 0
         case .custom(let fps):
-            // TODO: Check that value is a valid FPS value
+            // TODO: Check that value is a valid FPS value.
             return fps
         }
     }

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/Map/MapViewIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/Map/MapViewIntegrationTests.swift
@@ -52,10 +52,10 @@ class MapViewIntegrationTests: IntegrationTestCase {
     func testUpdatePreferredFPS() {
         let originalFPS = mapView.preferredFPS
         XCTAssertNotNil(originalFPS)
-        XCTAssertEqual(originalFPS.fps, 30)
+        XCTAssertEqual(originalFPS.fps, -1)
 
         let newFPS = 12
-        mapView.preferredFPS = .custom(newFPS)
+        mapView.preferredFPS = .custom(fps: newFPS)
         XCTAssertNotEqual(originalFPS, mapView.preferredFPS)
         XCTAssertEqual(mapView.preferredFPS.fps, newFPS)
     }

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/Map/MapViewIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/Map/MapViewIntegrationTests.swift
@@ -49,12 +49,23 @@ class MapViewIntegrationTests: IntegrationTestCase {
         XCTAssertNil(weakMapView)
     }
 
+    func testUpdatePreferredFPS() {
+        let originalFPS = mapView.preferredFPS
+        XCTAssertNotNil(originalFPS)
+        XCTAssertEqual(originalFPS.fps, 30)
+
+        let newFPS = 12
+        mapView.preferredFPS = .custom(newFPS)
+        XCTAssertNotEqual(originalFPS, mapView.preferredFPS)
+        XCTAssertEqual(mapView.preferredFPS.fps, newFPS)
+    }
+
     func testUpdateFromDisplayLink() {
         let originalFPS = mapView.preferredFPS
         XCTAssertNotNil(mapView.displayLink)
         mapView.preferredFPS = .lowPower
         XCTAssertNotEqual(originalFPS, mapView.preferredFPS)
-        XCTAssertEqual(mapView.preferredFPS.rawValue, mapView.displayLink?.preferredFramesPerSecond)
+        XCTAssertEqual(mapView.preferredFPS.fps, mapView.displayLink?.preferredFramesPerSecond)
     }
 
     func testUpdateFromDisplayLinkWhenNil() {
@@ -62,6 +73,6 @@ class MapViewIntegrationTests: IntegrationTestCase {
         mapView.preferredFPS = .maximum
 
         XCTAssertNil(mapView.displayLink?.preferredFramesPerSecond)
-        XCTAssertNotEqual(mapView.preferredFPS.rawValue, mapView.displayLink?.preferredFramesPerSecond)
+        XCTAssertNotEqual(mapView.preferredFPS.fps, mapView.displayLink?.preferredFramesPerSecond)
     }
 }

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/Map/MapViewIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/Map/MapViewIntegrationTests.swift
@@ -52,12 +52,12 @@ class MapViewIntegrationTests: IntegrationTestCase {
     func testUpdatePreferredFPS() {
         let originalFPS = mapView.preferredFPS
         XCTAssertNotNil(originalFPS)
-        XCTAssertEqual(originalFPS.fps, -1)
+        XCTAssertEqual(originalFPS.rawValue, -1)
 
         let newFPS = 12
         mapView.preferredFPS = .custom(fps: newFPS)
         XCTAssertNotEqual(originalFPS, mapView.preferredFPS)
-        XCTAssertEqual(mapView.preferredFPS.fps, newFPS)
+        XCTAssertEqual(mapView.preferredFPS.rawValue, newFPS)
     }
 
     func testUpdateFromDisplayLink() {
@@ -65,7 +65,7 @@ class MapViewIntegrationTests: IntegrationTestCase {
         XCTAssertNotNil(mapView.displayLink)
         mapView.preferredFPS = .lowPower
         XCTAssertNotEqual(originalFPS, mapView.preferredFPS)
-        XCTAssertEqual(mapView.preferredFPS.fps, mapView.displayLink?.preferredFramesPerSecond)
+        XCTAssertEqual(mapView.preferredFPS.rawValue, mapView.displayLink?.preferredFramesPerSecond)
     }
 
     func testUpdateFromDisplayLinkWhenNil() {
@@ -73,6 +73,6 @@ class MapViewIntegrationTests: IntegrationTestCase {
         mapView.preferredFPS = .maximum
 
         XCTAssertNil(mapView.displayLink?.preferredFramesPerSecond)
-        XCTAssertNotEqual(mapView.preferredFPS.fps, mapView.displayLink?.preferredFramesPerSecond)
+        XCTAssertNotEqual(mapView.preferredFPS.rawValue, mapView.displayLink?.preferredFramesPerSecond)
     }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes n/a

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Add PreferredFPS.custom() to add support for custom preferred frames per second values.</changelog>`.

### Summary of changes

This PR:
- Adds `PreferredFPS.custom()`, which accepts `Int` values so users can specify preferredFPS.
    - Tailwork: Check that this is a valid value.
- Makes `BaseMapView.preferredFPS` internal.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
