### PR TITLE
Ensure Examples' finish is called only once.

### DIFF
--- a/Examples/Examples/Models/Examples.swift
+++ b/Examples/Examples/Models/Examples.swift
@@ -15,6 +15,16 @@ public protocol ExampleProtocol {
     func finish()
 }
 
+fileprivate struct ExampleProtocolFinish {
+    static var postNotification: Void = {
+        // Lazy initialization to ensure that this is called once only.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+            let center = CFNotificationCenterGetDarwinNotifyCenter()
+            CFNotificationCenterPostNotification(center, CFNotificationName(Example.finishNotificationName as CFString), nil, nil, true)
+        }
+    }()
+}
+
 extension ExampleProtocol {
     public func resourceOptions() -> ResourceOptions {
         guard let accessToken = AccountManager.shared.accessToken else {
@@ -30,10 +40,7 @@ extension ExampleProtocol {
     }
 
     public func finish() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-            let center = CFNotificationCenterGetDarwinNotifyCenter()
-            CFNotificationCenterPostNotification(center, CFNotificationName(Example.finishNotificationName as CFString), nil, nil, true)
-        }
+        _ = ExampleProtocolFinish.postNotification
     }
 }
 

--- a/Examples/Examples/Models/Examples.swift
+++ b/Examples/Examples/Models/Examples.swift
@@ -15,7 +15,7 @@ public protocol ExampleProtocol {
     func finish()
 }
 
-fileprivate struct ExampleProtocolFinish {
+private struct ExampleProtocolFinish {
     static var postNotification: Void = {
         // Lazy initialization to ensure that this is called once only.
         DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [ ] ~Include before/after visuals or gifs if this PR includes visual changes.~
 - [ ] ~Write tests for all new functionality. If tests were not written, please explain why.~
 - [ ] ~Add example if relevant.~
 - [ ] ~Document any changes to public APIs.~
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] ~Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.~

### Summary of changes

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

This PR ensures that if an example calls `finish` multiple times that only one notification is sent. This change is being made to accommodate #154
