### PR TITLE
Removes back-ticks for CI slack output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,73 +73,74 @@ workflows:
     steve:
         jobs:
 
-            - build-all-targets:
-                matrix:
-                    parameters:
-                        xcode: ["12.2.0"]
-                        configuration: ["Debug", "Release"]
+            - test-something
+            # - build-all-targets:
+            #     matrix:
+            #         parameters:
+            #             xcode: ["12.2.0"]
+            #             configuration: ["Debug", "Release"]
 
-            - binary-size:
-                requires: 
-                    - build-all-targets
+            # - binary-size:
+            #     requires: 
+            #         - build-all-targets
 
-            - metrics:
-                requires: 
-                    - build-all-targets
-                filters:
-                    branches:
-                        only: main
+            # - metrics:
+            #     requires: 
+            #         - build-all-targets
+            #     filters:
+            #         branches:
+            #             only: main
 
-            - maps-unit-tests:
-                name: "Run Unit tests"
+            # - maps-unit-tests:
+            #     name: "Run Unit tests"
 
-            # Not on main
-            - run-tests-on-devices:
-                name: "Run MapboxTestHost tests on devices"
-                device-farm-project: $(AWS_DEVICE_FARM_PROJECT_MAPS)
-                device-pool: $(AWS_DEVICE_FARM_1_PHONE_POOL)
-                scheme: "MapboxMapsTestsWithHost"
-                app-name: "MapboxTestHost"
-                filters:
-                    branches:
-                        ignore: main                
+            # # Not on main
+            # - run-tests-on-devices:
+            #     name: "Run MapboxTestHost tests on devices"
+            #     device-farm-project: $(AWS_DEVICE_FARM_PROJECT_MAPS)
+            #     device-pool: $(AWS_DEVICE_FARM_1_PHONE_POOL)
+            #     scheme: "MapboxMapsTestsWithHost"
+            #     app-name: "MapboxTestHost"
+            #     filters:
+            #         branches:
+            #             ignore: main                
 
-            - run-tests-on-devices:
-                name: "Run Examples tests on devices"
-                device-farm-project: $(AWS_DEVICE_FARM_PROJECT_EXAMPLES)
-                device-pool: $(AWS_DEVICE_FARM_EXAMPLES_POOL)
-                scheme: "Examples"
-                app-name: "Examples"
-                filters:
-                    branches:
-                        ignore: main                
+            # - run-tests-on-devices:
+            #     name: "Run Examples tests on devices"
+            #     device-farm-project: $(AWS_DEVICE_FARM_PROJECT_EXAMPLES)
+            #     device-pool: $(AWS_DEVICE_FARM_EXAMPLES_POOL)
+            #     scheme: "Examples"
+            #     app-name: "Examples"
+            #     filters:
+            #         branches:
+            #             ignore: main                
 
-            - create-xcframework
+            # - create-xcframework
 
-            # On main
-            - run-tests-on-devices:
-                name: "Run MapboxTestHost tests on devices (main)"
-                device-farm-project: $(AWS_DEVICE_FARM_PROJECT_MAPS)
-                device-pool: $(AWS_DEVICE_FARM_5_DEVICE_POOL)
-                scheme: "MapboxMapsTestsWithHost"
-                app-name: "MapboxTestHost"
-                device-tests-always-run: true
-                report_failure: true
-                filters:
-                    branches:
-                        only: main                
+            # # On main
+            # - run-tests-on-devices:
+            #     name: "Run MapboxTestHost tests on devices (main)"
+            #     device-farm-project: $(AWS_DEVICE_FARM_PROJECT_MAPS)
+            #     device-pool: $(AWS_DEVICE_FARM_5_DEVICE_POOL)
+            #     scheme: "MapboxMapsTestsWithHost"
+            #     app-name: "MapboxTestHost"
+            #     device-tests-always-run: true
+            #     report_failure: true
+            #     filters:
+            #         branches:
+            #             only: main                
 
-            - run-tests-on-devices:
-                name: "Run Examples tests on devices (main)"
-                device-farm-project: $(AWS_DEVICE_FARM_PROJECT_EXAMPLES)
-                device-pool: $(AWS_DEVICE_FARM_EXAMPLES_POOL)
-                scheme: "Examples"
-                app-name: "Examples"
-                device-tests-always-run: true
-                report_failure: true                
-                filters:
-                    branches:
-                        only: main
+            # - run-tests-on-devices:
+            #     name: "Run Examples tests on devices (main)"
+            #     device-farm-project: $(AWS_DEVICE_FARM_PROJECT_EXAMPLES)
+            #     device-pool: $(AWS_DEVICE_FARM_EXAMPLES_POOL)
+            #     scheme: "Examples"
+            #     app-name: "Examples"
+            #     device-tests-always-run: true
+            #     report_failure: true                
+            #     filters:
+            #         branches:
+            #             only: main
             
     public-beta:
         jobs:
@@ -203,6 +204,11 @@ jobs:
             # Don't run the default job
             - run: exit 1
 
+    test-something:
+        <<: *default-job
+        steps:
+            - run: echo "\\`ls\\`" 
+                   
     build-all-targets:
         <<: *default-job
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,74 +73,73 @@ workflows:
     steve:
         jobs:
 
-            - test-something
-            # - build-all-targets:
-            #     matrix:
-            #         parameters:
-            #             xcode: ["12.2.0"]
-            #             configuration: ["Debug", "Release"]
+            - build-all-targets:
+                matrix:
+                    parameters:
+                        xcode: ["12.2.0"]
+                        configuration: ["Debug", "Release"]
 
-            # - binary-size:
-            #     requires: 
-            #         - build-all-targets
+            - binary-size:
+                requires: 
+                    - build-all-targets
 
-            # - metrics:
-            #     requires: 
-            #         - build-all-targets
-            #     filters:
-            #         branches:
-            #             only: main
+            - metrics:
+                requires: 
+                    - build-all-targets
+                filters:
+                    branches:
+                        only: main
 
-            # - maps-unit-tests:
-            #     name: "Run Unit tests"
+            - maps-unit-tests:
+                name: "Run Unit tests"
 
-            # # Not on main
-            # - run-tests-on-devices:
-            #     name: "Run MapboxTestHost tests on devices"
-            #     device-farm-project: $(AWS_DEVICE_FARM_PROJECT_MAPS)
-            #     device-pool: $(AWS_DEVICE_FARM_1_PHONE_POOL)
-            #     scheme: "MapboxMapsTestsWithHost"
-            #     app-name: "MapboxTestHost"
-            #     filters:
-            #         branches:
-            #             ignore: main                
+            # Not on main
+            - run-tests-on-devices:
+                name: "Run MapboxTestHost tests on devices"
+                device-farm-project: $(AWS_DEVICE_FARM_PROJECT_MAPS)
+                device-pool: $(AWS_DEVICE_FARM_1_PHONE_POOL)
+                scheme: "MapboxMapsTestsWithHost"
+                app-name: "MapboxTestHost"
+                filters:
+                    branches:
+                        ignore: main                
 
-            # - run-tests-on-devices:
-            #     name: "Run Examples tests on devices"
-            #     device-farm-project: $(AWS_DEVICE_FARM_PROJECT_EXAMPLES)
-            #     device-pool: $(AWS_DEVICE_FARM_EXAMPLES_POOL)
-            #     scheme: "Examples"
-            #     app-name: "Examples"
-            #     filters:
-            #         branches:
-            #             ignore: main                
+            - run-tests-on-devices:
+                name: "Run Examples tests on devices"
+                device-farm-project: $(AWS_DEVICE_FARM_PROJECT_EXAMPLES)
+                device-pool: $(AWS_DEVICE_FARM_EXAMPLES_POOL)
+                scheme: "Examples"
+                app-name: "Examples"
+                filters:
+                    branches:
+                        ignore: main                
 
-            # - create-xcframework
+            - create-xcframework
 
-            # # On main
-            # - run-tests-on-devices:
-            #     name: "Run MapboxTestHost tests on devices (main)"
-            #     device-farm-project: $(AWS_DEVICE_FARM_PROJECT_MAPS)
-            #     device-pool: $(AWS_DEVICE_FARM_5_DEVICE_POOL)
-            #     scheme: "MapboxMapsTestsWithHost"
-            #     app-name: "MapboxTestHost"
-            #     device-tests-always-run: true
-            #     report_failure: true
-            #     filters:
-            #         branches:
-            #             only: main                
+            # On main
+            - run-tests-on-devices:
+                name: "Run MapboxTestHost tests on devices (main)"
+                device-farm-project: $(AWS_DEVICE_FARM_PROJECT_MAPS)
+                device-pool: $(AWS_DEVICE_FARM_5_DEVICE_POOL)
+                scheme: "MapboxMapsTestsWithHost"
+                app-name: "MapboxTestHost"
+                device-tests-always-run: true
+                report_failure: true
+                filters:
+                    branches:
+                        only: main                
 
-            # - run-tests-on-devices:
-            #     name: "Run Examples tests on devices (main)"
-            #     device-farm-project: $(AWS_DEVICE_FARM_PROJECT_EXAMPLES)
-            #     device-pool: $(AWS_DEVICE_FARM_EXAMPLES_POOL)
-            #     scheme: "Examples"
-            #     app-name: "Examples"
-            #     device-tests-always-run: true
-            #     report_failure: true                
-            #     filters:
-            #         branches:
-            #             only: main
+            - run-tests-on-devices:
+                name: "Run Examples tests on devices (main)"
+                device-farm-project: $(AWS_DEVICE_FARM_PROJECT_EXAMPLES)
+                device-pool: $(AWS_DEVICE_FARM_EXAMPLES_POOL)
+                scheme: "Examples"
+                app-name: "Examples"
+                device-tests-always-run: true
+                report_failure: true                
+                filters:
+                    branches:
+                        only: main
             
     public-beta:
         jobs:
@@ -204,12 +203,6 @@ jobs:
             # Don't run the default job
             - run: exit 1
 
-    test-something:
-        <<: *default-job
-        steps:
-            - run: ls -laF
-            - run: echo "\\`ls -laF\\`" 
-                   
     build-all-targets:
         <<: *default-job
         steps:
@@ -336,7 +329,7 @@ jobs:
             - store-logs
             - report-failure:
                 report_failure: << parameters.report_failure >>
-                message: "\\`<< parameters.scheme >>\\` device tests"
+                message: "<< parameters.scheme >> device tests"
     
     create-xcframework:
         <<: *default-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ jobs:
             - store-logs
             - report-failure:
                 report_failure: << parameters.report_failure >>
-                message: "`<< parameters.scheme >>` device tests"
+                message: "\`<< parameters.scheme >>\` device tests"
     
     create-xcframework:
         <<: *default-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,8 @@ jobs:
     test-something:
         <<: *default-job
         steps:
-            - run: echo "\\`ls\\`" 
+            - run: ls -laF
+            - run: echo "\\`ls -laF\\`" 
                    
     build-all-targets:
         <<: *default-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ jobs:
             - store-logs
             - report-failure:
                 report_failure: << parameters.report_failure >>
-                message: "\`<< parameters.scheme >>\` device tests"
+                message: "\\`<< parameters.scheme >>\\` device tests"
     
     create-xcframework:
         <<: *default-job


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [ ] ~Include before/after visuals or gifs if this PR includes visual changes.~
 - [ ] ~Write tests for all new functionality. If tests were not written, please explain why.~
 - [ ] ~Add example if relevant.~
 - [ ] ~Document any changes to public APIs.~
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] ~Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.~

### Summary of changes

Removes back-ticks in Slack error message, so that the scheme name is included in the slack message.