### PR TITLE
[Camera Animations v2] Introduce refreshed CameraView with proxy layer properties

### DIFF
--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -29,6 +29,21 @@ public class DebugViewController: UIViewController {
             mapOptions.location.showUserLocation = true
         }
 
-        view.addSubview(mapView)
+        mapView.on(.mapLoadingFinished) { _ in
+
+            let coordinate = CLLocationCoordinate2D(latitude: 39.085006, longitude: -77.150925)
+            self.mapView.cameraManager.setCamera(centerCoordinate: coordinate,
+                                                 zoom: 12)
+
+            UIViewPropertyAnimator.runningPropertyAnimator(withDuration: 10, delay: 2, options: .curveLinear) {
+
+                let coordinate2 = CLLocationCoordinate2D(latitude: 39.085006, longitude: -78.12)
+                self.mapView.cameraManager.setCamera(centerCoordinate: coordinate2, zoom: 16)
+
+            } completion: { (_) in
+                print("Camera animation complete!!!")
+            }
+        }
+        self.view.addSubview(mapView)
     }
 }

--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -147,6 +147,8 @@
 		0C37B1E325CB05F000DCDD3D /* ColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C37B1E225CB05F000DCDD3D /* ColorTests.swift */; };
 		0C37B1E425CB05F000DCDD3D /* ColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C37B1E225CB05F000DCDD3D /* ColorTests.swift */; };
 		0C37B1E525CB05F000DCDD3D /* ColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C37B1E225CB05F000DCDD3D /* ColorTests.swift */; };
+		0C390EE925FBFD8E00F99C05 /* MBXEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C390EE825FBFD8E00F99C05 /* MBXEdgeInsets.swift */; };
+		0C390EEA25FBFD8E00F99C05 /* MBXEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C390EE825FBFD8E00F99C05 /* MBXEdgeInsets.swift */; };
 		0C3B1E8E24DDADD000CC29E8 /* EventsStringTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3B1E8A24DDADD000CC29E8 /* EventsStringTokens.swift */; };
 		0C3B1E9024DDADD000CC29E8 /* EventsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3B1E8B24DDADD000CC29E8 /* EventsManager.swift */; };
 		0C3B1E9224DDADD000CC29E8 /* MapboxMobileEvents+TelemetryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3B1E8C24DDADD000CC29E8 /* MapboxMobileEvents+TelemetryProtocol.swift */; };
@@ -336,7 +338,6 @@
 		0CD62F12245885AA006421D1 /* AccountManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2AD70A2421BCBF006592F4 /* AccountManager.swift */; };
 		0CD62F15245885B6006421D1 /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11C12E2421B23700F8397B /* MapView.swift */; };
 		0CD62F1624588647006421D1 /* CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC8DA51243BECC400A19318 /* CameraManager.swift */; };
-		0CD62F1724588652006421D1 /* CameraLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC8DA53243BECE000A19318 /* CameraLayer.swift */; };
 		0CD62F182458865A006421D1 /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC8DA55243BED0500A19318 /* CameraView.swift */; };
 		0CD62F1924588661006421D1 /* MapCameraOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C07948D2452331A0006A9C4 /* MapCameraOptions.swift */; };
 		0CD62F1A245886E7006421D1 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF65A67244E34000069B561 /* LocationManager.swift */; };
@@ -374,7 +375,6 @@
 		1F2AD73D2421C462006592F4 /* GestureManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2AD73C2421C462006592F4 /* GestureManagerTests.swift */; };
 		1F2AD73F2421C462006592F4 /* Gestures.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F2AD7312421C462006592F4 /* Gestures.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F4B7D7B2464C39000745F05 /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC8DA55243BED0500A19318 /* CameraView.swift */; };
-		1F4B7D7C2464C39000745F05 /* CameraLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC8DA53243BECE000A19318 /* CameraLayer.swift */; };
 		1F4B7D7D2464C39000745F05 /* CameraOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07729A5724623E9B00440187 /* CameraOptions.swift */; };
 		1F99DE8C252FA569004AE304 /* MapboxMapsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F11C10F2421B05600F8397B /* MapboxMapsFoundation.framework */; };
 		1FECC9E02474519D00B63910 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FECC9DF2474519D00B63910 /* Expression.swift */; };
@@ -946,6 +946,7 @@
 		0C3574EE25DD8D5C0085D775 /* StyleErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleErrors.swift; sourceTree = "<group>"; };
 		0C35751525DD8E010085D775 /* StyleIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleIntegrationTests.swift; sourceTree = "<group>"; };
 		0C37B1E225CB05F000DCDD3D /* ColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTests.swift; sourceTree = "<group>"; };
+		0C390EE825FBFD8E00F99C05 /* MBXEdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBXEdgeInsets.swift; sourceTree = "<group>"; };
 		0C3B1E8A24DDADD000CC29E8 /* EventsStringTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventsStringTokens.swift; sourceTree = "<group>"; };
 		0C3B1E8B24DDADD000CC29E8 /* EventsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventsManager.swift; sourceTree = "<group>"; };
 		0C3B1E8C24DDADD000CC29E8 /* MapboxMobileEvents+TelemetryProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MapboxMobileEvents+TelemetryProtocol.swift"; sourceTree = "<group>"; };
@@ -1059,7 +1060,6 @@
 		1F2AD73E2421C462006592F4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1FC8DA47243BE4A400A19318 /* MapboxMapsCameraTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxMapsCameraTests.swift; sourceTree = "<group>"; };
 		1FC8DA51243BECC400A19318 /* CameraManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraManager.swift; sourceTree = "<group>"; };
-		1FC8DA53243BECE000A19318 /* CameraLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraLayer.swift; sourceTree = "<group>"; };
 		1FC8DA55243BED0500A19318 /* CameraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraView.swift; sourceTree = "<group>"; };
 		1FECC9DF2474519D00B63910 /* Expression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Expression.swift; sourceTree = "<group>"; };
 		1FF65A50244E33E10069B561 /* MapboxMapsLocation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxMapsLocation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1417,6 +1417,7 @@
 				0CAC3CA92534E8CC00D031E7 /* ResourceOptions.swift */,
 				0782B060258C16B200D5FCE5 /* Utils.swift */,
 				CAC1960A25AE98F400F69FEA /* GlyphsRasterizationOptions.swift */,
+				0C390EE825FBFD8E00F99C05 /* MBXEdgeInsets.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1850,7 +1851,6 @@
 			isa = PBXGroup;
 			children = (
 				1FC8DA55243BED0500A19318 /* CameraView.swift */,
-				1FC8DA53243BECE000A19318 /* CameraLayer.swift */,
 				07729A5724623E9B00440187 /* CameraOptions.swift */,
 				1FC8DA51243BECC400A19318 /* CameraManager.swift */,
 				0C07948D2452331A0006A9C4 /* MapCameraOptions.swift */,
@@ -3524,7 +3524,6 @@
 				0782B17B258C236B00D5FCE5 /* MBXGeometry.swift in Sources */,
 				0CD62F26245887D5006421D1 /* OrnamentConfig.swift in Sources */,
 				0C3B1E9224DDADD000CC29E8 /* MapboxMobileEvents+TelemetryProtocol.swift in Sources */,
-				0CD62F1724588652006421D1 /* CameraLayer.swift in Sources */,
 				0C9640E12531056700CABD3E /* LocationConsumer.swift in Sources */,
 				0C708F4D24EB23C7003CE791 /* RasterDemSource.swift in Sources */,
 				0CD62F23245887C8006421D1 /* OrnamentsManager.swift in Sources */,
@@ -3587,6 +3586,7 @@
 				1FECC9E02474519D00B63910 /* Expression.swift in Sources */,
 				0CD62F1124588532006421D1 /* GestureHandlerDelegate.swift in Sources */,
 				07D71591257994430025BF61 /* MapboxLogoView.swift in Sources */,
+				0C390EE925FBFD8E00F99C05 /* MBXEdgeInsets.swift in Sources */,
 				0782B061258C16B200D5FCE5 /* Utils.swift in Sources */,
 				0CD62F2C24588937006421D1 /* Style.swift in Sources */,
 				0CAC3CAA2534E8CC00D031E7 /* ResourceOptions.swift in Sources */,
@@ -3733,10 +3733,10 @@
 				B51DE62225D7032C00A80AC9 /* Comparable+Clamped.swift in Sources */,
 				0782B04D258C14FC00D5FCE5 /* Int.swift in Sources */,
 				CAC1960C25AE98F400F69FEA /* GlyphsRasterizationOptions.swift in Sources */,
-				1F4B7D7C2464C39000745F05 /* CameraLayer.swift in Sources */,
 				1F2AD70D2421BCBF006592F4 /* AccountManager.swift in Sources */,
 				0782B143258C1CAB00D5FCE5 /* NSValue.swift in Sources */,
 				0782B062258C16B200D5FCE5 /* Utils.swift in Sources */,
+				0C390EEA25FBFD8E00F99C05 /* MBXEdgeInsets.swift in Sources */,
 				07A0BC9E2582F15B00B8E109 /* GeoJSONManager.swift in Sources */,
 				A4FE8966255F369900FBF117 /* MapCameraOptions.swift in Sources */,
 				0C8AA1F4257FE1830037FD6B /* MapEvents.swift in Sources */,

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -3,7 +3,7 @@
 import UIKit
 import Turf
 
-// swiftlint:disable file_length
+// swiftlint:disable file_length type_body_length
 
 public enum PreferredFPS: RawRepresentable, Equatable {
 
@@ -72,7 +72,7 @@ open class ObserverConcrete: Observer {
     }
 }
 
-open class BaseMapView: UIView, MapClient, MBMMetalViewProvider {
+open class BaseMapView: UIView, MapClient, MBMMetalViewProvider, CameraViewDelegate {
 
     /// The underlying renderer object responsible for rendering the map
     public var __map: Map!
@@ -93,43 +93,110 @@ open class BaseMapView: UIView, MapClient, MBMMetalViewProvider {
     @IBInspectable var baseURL__: String = ""
     @IBInspectable var accessToken__: String = ""
 
-    /// Returns the camera view managed by this object.
-    public var cameraView: CameraView!
-
     internal var preferredFPS: PreferredFPS = .normal {
         didSet {
             updateDisplayLinkPreferredFramesPerSecond()
         }
     }
 
+    /// Returns the camera view managed by this object.
+    public var cameraView: CameraView!
+
+    /// The map's current camera
+    public var camera: CameraOptions {
+        get {
+            do {
+                let options = try __map.getCameraOptions(forPadding: nil)
+                return options
+            } catch {
+                fatalError("Could not retrieve camera options due to error: \(error)")
+            }
+        } set {
+            cameraView.camera = newValue
+        }
+    }
+
     /// The map's current center coordinate.
     public var centerCoordinate: CLLocationCoordinate2D {
-        // cameraView.centerCoordinate is allowed to exceed [-180, 180]
-        // so that core animation interpolation works correctly when
-        // crossing the antimeridian. We wrap here to hide that implementation
-        // detail when accessing centerCoordinate via BaseMapView
-        return cameraView.centerCoordinate.wrap()
+        get {
+            guard let center = camera.center else {
+                fatalError("Center is nil in camera options")
+            }
+            return center
+        } set {
+            cameraView.centerCoordinate = newValue
+        }
     }
 
-    /// The map's current zoom level.
+    /// The map's  zoom level.
     public var zoom: CGFloat {
-        return cameraView.zoom
+        get {
+            guard let zoom = camera.zoom else {
+                fatalError("Zoom is nil in camera options")
+            }
+            return CGFloat(zoom)
+        } set {
+            cameraView.zoom = newValue
+        }
     }
 
-    /// The map's current bearing, measured clockwise from 0° north.
+    /// The map's bearing, measured clockwise from 0° north.
     public var bearing: CLLocationDirection {
-        return CLLocationDirection(cameraView.bearing)
+        get {
+            guard let bearing = camera.bearing else {
+                fatalError("Bearing is nil in camera options")
+            }
+            return CLLocationDirection(bearing)
+        } set {
+            cameraView.bearing = CGFloat(newValue)
+        }
     }
 
-    /// The map's current pitch, falling within a range of 0 to 60.
+    /// The map's pitch, falling within a range of 0 to 60.
     public var pitch: CGFloat {
-        return cameraView.pitch
+        get {
+            guard let pitch = camera.pitch else {
+                fatalError("Pitch is nil in camera options")
+            }
+
+            return pitch
+        } set {
+            cameraView.pitch = newValue
+        }
+    }
+
+    /// The map's camera padding
+    public var padding: UIEdgeInsets {
+        get {
+            return camera.padding ?? .zero
+        } set {
+            cameraView.padding = newValue
+        }
+    }
+
+    public var anchor: CGPoint {
+        get {
+            // TODO: Evaluate whether we should get the anchor from CameraView or not
+            return cameraView.anchor
+        } set {
+            cameraView.anchor = newValue
+        }
+    }
+
+    func jumpTo(camera: CameraOptions) {
+        do {
+            try __map.jumpTo(forCamera: camera)
+        } catch {
+            fatalError("Exception raised when jumping to new camera options: \(camera). Error: \(error)")
+        }
     }
 
     // MARK: Init
     public init(with frame: CGRect, resourceOptions: ResourceOptions, glyphsRasterizationOptions: GlyphsRasterizationOptions, styleURL: URL?) {
         super.init(frame: frame)
-        commonInit(resourceOptions: resourceOptions, glyphsRasterizationOptions: glyphsRasterizationOptions, styleURL: styleURL)
+        self.commonInit(resourceOptions: resourceOptions,
+                        glyphsRasterizationOptions: glyphsRasterizationOptions,
+                        styleURL: styleURL)
     }
 
     private func commonInit(resourceOptions: ResourceOptions, glyphsRasterizationOptions: GlyphsRasterizationOptions, styleURL: URL?) {
@@ -171,15 +238,8 @@ open class BaseMapView: UIView, MapClient, MBMMetalViewProvider {
         let events = MapEvents.EventKind.allCases.map({ $0.rawValue })
         try! __map.subscribe(for: observerConcrete, events: events)
 
-        cameraView = CameraView(frame: frame, map: __map)
-        addSubview(cameraView)
-
-        NSLayoutConstraint.activate([
-            cameraView.leftAnchor.constraint(equalTo: leftAnchor),
-            cameraView.topAnchor.constraint(equalTo: topAnchor),
-            cameraView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            cameraView.rightAnchor.constraint(equalTo: rightAnchor)
-        ])
+        self.cameraView = CameraView(delegate: self)
+        self.addSubview(cameraView)
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(willTerminate),
@@ -272,7 +332,8 @@ open class BaseMapView: UIView, MapClient, MBMMetalViewProvider {
 
         if needsDisplayRefresh {
             needsDisplayRefresh = false
-            displayCallback?()
+            self.cameraView.update()
+            self.displayCallback?()
         }
     }
 
@@ -350,7 +411,7 @@ open class BaseMapView: UIView, MapClient, MBMMetalViewProvider {
         metalView.layer.isOpaque = isOpaque
         metalView.isPaused = true
         metalView.enableSetNeedsDisplay = true
-        metalView.presentsWithTransaction = false
+        metalView.presentsWithTransaction = true
 
         insertSubview(metalView, at: 0)
         self.metalView = metalView

--- a/Sources/MapboxMaps/Foundation/Camera/CameraView.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraView.swift
@@ -1,218 +1,235 @@
 import UIKit
 
-public protocol CameraViewDelegate: AnyObject {
-    /// A method that is called whenever the cameraView is manipulated
-    func cameraViewManipulated(for cameraView: CameraView)
+/// Internal protocol that provides needed information / methods for the `CameraView`
+internal protocol CameraViewDelegate: class {
+    /// The map's current camera
+    var camera: CameraOptions { get }
+
+    /// The map's current center coordinate.
+    var centerCoordinate: CLLocationCoordinate2D { get }
+
+    /// The map's  zoom level.
+    var zoom: CGFloat { get }
+
+    /// The map's bearing, measured clockwise from 0° north.
+    var bearing: CLLocationDirection { get }
+
+    /// The map's pitch, falling within a range of 0 to 60.
+    var pitch: CGFloat { get }
+
+    /// The map's camera padding
+    var padding: UIEdgeInsets { get }
+
+    /// The map's camera anchor
+    var anchor: CGPoint { get }
+
+    /// The map should jumpt to some camera
+    func jumpTo(camera: CameraOptions)
 }
 
 /// A view that represents a camera view port.
 public class CameraView: UIView {
 
-    public override class var layerClass: AnyClass {
-        return CameraLayer.self
-    }
-
-    private var cameraLayer: CameraLayer {
-        // swiftlint:disable force_cast
-        return layer as! CameraLayer
-        // swiftlint:enable force_cast
-    }
-
     public var camera: CameraOptions {
         get {
-            let camera = CameraOptions(center: centerCoordinate,
-                                       padding: padding,
-                                       anchor: anchor,
-                                       zoom: zoom,
-                                       bearing: CLLocationDirection(bearing),
-                                       pitch: pitch)
-            return camera
+            return delegate.camera
         }
-
         set {
-            if let zoom = newValue.zoom {
-                self.zoom = zoom
+            if let newZoom = newValue.zoom {
+                zoom = newZoom
             }
 
-            if let bearing = newValue.bearing {
-                self.bearing = CGFloat(bearing)
+            if let newBearing = newValue.bearing {
+                bearing = CGFloat(newBearing)
             }
 
-            if let pitch = newValue.pitch {
-                self.pitch = pitch
+            if let newPitch = newValue.pitch {
+                pitch = newPitch
             }
 
-            if let padding = newValue.padding {
-                self.padding = padding
+            if let newPadding = newValue.padding {
+                padding = newPadding
             }
 
-            if let anchor = newValue.anchor {
-                self.anchor = anchor
+            if let newAnchor = newValue.anchor {
+                anchor = newAnchor
             }
 
-            if let centerCoordinate = newValue.center {
-                self.centerCoordinate = centerCoordinate
+            if let newCenterCoordinate = newValue.center {
+                centerCoordinate = newCenterCoordinate
             }
         }
-
     }
 
     /// The camera's zoom. Animatable.
     @objc dynamic public var zoom: CGFloat {
         get {
-            return cameraLayer.zoom
+            return delegate.zoom
         }
-
         set {
-            cameraLayer.zoom = newValue
+            layer.opacity = Float(newValue)
         }
     }
 
     /// The camera's bearing. Animatable.
     @objc dynamic public var bearing: CGFloat {
         get {
-            return cameraLayer.bearing
+            return CGFloat(delegate.bearing)
         }
 
         set {
-            cameraLayer.bearing = newValue
-        }
-    }
-
-    /// The camera's anchor. Not Animatable.
-    /// The anchor will be updated in the next rendering frame.
-    @objc dynamic public var anchor: CGPoint {
-        get {
-            return cameraLayer.anchor
-        }
-
-        set {
-            cameraLayer.anchor = newValue
-        }
-    }
-
-    /// The camera's padding around the interior of the view that affects the frame
-    /// of reference for centerCoordinate. Not Animatable.
-    /// The padding will be updated in the next rendering frame.
-    @objc dynamic public var padding: UIEdgeInsets {
-        get {
-            return cameraLayer.padding
-        }
-
-        set {
-            cameraLayer.padding = newValue
+            layer.cornerRadius = newValue
         }
     }
 
     /// Coordinate at the center of the camera. Animatable.
     @objc dynamic public var centerCoordinate: CLLocationCoordinate2D {
         get {
-            let latitude = CLLocationDegrees(cameraLayer.centerCoordinateLatitude)
-            let longitude = CLLocationDegrees(cameraLayer.centerCoordinateLongitude)
-            return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+            return delegate.centerCoordinate
         }
 
         set {
-            cameraLayer.centerCoordinateLatitude = CGFloat(newValue.latitude)
-            cameraLayer.centerCoordinateLongitude = CGFloat(newValue.longitude)
+            layer.position = CGPoint(x: newValue.longitude, y: newValue.latitude)
         }
+    }
 
+    /// The camera's padding. Animatable.
+    @objc dynamic public var padding: UIEdgeInsets {
+        get {
+            return delegate.padding
+        }
+        set {
+            layer.bounds = CGRect(x: newValue.left,
+                                  y: newValue.right,
+                                  width: newValue.bottom,
+                                  height: newValue.top)
+        }
     }
 
     /// The camera's pitch. Animatable.
     @objc dynamic public var pitch: CGFloat {
         get {
-            return cameraLayer.pitch
+            return delegate.pitch
+        }
+        set {
+            layer.zPosition = newValue
+        }
+    }
+
+    /// The screen coordinate that the map rotates, pitches and zooms around. Setting this also affects the horizontal vanishing point when pitched. Animatable.
+    @objc dynamic public var anchor: CGPoint {
+        get {
+            return layer.presentation()?.anchorPoint ?? layer.anchorPoint
         }
 
         set {
-            cameraLayer.pitch = newValue
+            layer.anchorPoint = newValue
         }
     }
 
-    @objc public var visibleCoordinateBounds: CoordinateBounds {
-        let padding = self.padding.toMBXEdgeInsetsValue()
-        let currentCamera = try! map.getCameraOptions(forPadding: padding)
-        return try! map.coordinateBoundsForCamera(forCamera: currentCamera)
+    internal var localCenterCoordinate: CLLocationCoordinate2D {
+        let proxyCoord = layer.presentation()?.position ?? layer.position
+        return CLLocationCoordinate2D(latitude: CLLocationDegrees(proxyCoord.y),
+                                      longitude: CLLocationDegrees(proxyCoord.x))
     }
 
-    private var map: Map
-
-    public weak var delegate: CameraViewDelegate?
-
-    public init(frame: CGRect, map: Map) {
-        self.map = map
-
-        super.init(frame: frame)
-
-        // Sync default values from renderer
-        let defaultCameraOptions = try! self.map.getCameraOptions(forPadding: nil)
-        zoom = defaultCameraOptions.zoom ?? 0.0
-        bearing = CGFloat(defaultCameraOptions.bearing ?? 0.0)
-        anchor = defaultCameraOptions.anchor ?? .zero
-        pitch = defaultCameraOptions.pitch ?? 0.0
-        padding = defaultCameraOptions.padding ?? .zero
-
-        if let coordinate = defaultCameraOptions.center {
-            centerCoordinate = coordinate
-        }
-
-        translatesAutoresizingMaskIntoConstraints = false
+    internal var localZoom: CGFloat {
+        return CGFloat(layer.presentation()?.opacity ?? layer.opacity)
     }
 
-    public convenience init(frame: CGRect, map: Map, camera: CameraOptions) {
-        self.init(frame: frame, map: map)
-        self.camera = camera
+    internal var localBearing: CLLocationDirection {
+        return CLLocationDirection(layer.presentation()?.cornerRadius ?? layer.cornerRadius)
+    }
+
+    internal var localPitch: CGFloat {
+        return layer.presentation()?.zPosition ?? layer.zPosition
+    }
+
+    internal var localAnchorPoint: CGPoint {
+        return layer.presentation()?.anchorPoint ?? layer.anchorPoint
+    }
+
+    internal var localPadding: UIEdgeInsets {
+        let proxyPadding = layer.presentation()?.bounds ?? layer.bounds
+        return UIEdgeInsets(top: proxyPadding.size.height,
+                            left: proxyPadding.origin.x,
+                            bottom: proxyPadding.size.width,
+                            right: proxyPadding.origin.y)
+    }
+
+    internal var localCamera: CameraOptions {
+        return CameraOptions(center: localCenterCoordinate,
+                             padding: localPadding,
+                             anchor: localAnchorPoint,
+                             zoom: localZoom,
+                             bearing: localBearing,
+                             pitch: localPitch)
+    }
+
+    private unowned var delegate: CameraViewDelegate!
+
+    init(delegate: CameraViewDelegate, edgeInsets: UIEdgeInsets = .zero) {
+        self.delegate = delegate
+        super.init(frame: .zero)
+
+        self.isHidden = true
+        self.isUserInteractionEnabled = false
+
+        // Sync default values from MBXMap
+        setFromValuesWithMapView()
     }
 
     internal required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func display(_ layer: CALayer) {
+    private func setFromValuesWithMapView() {
+        zoom = delegate.zoom
+        bearing = CGFloat(delegate.bearing)
+        pitch = delegate.pitch
+        padding = delegate.padding
+        centerCoordinate = delegate.centerCoordinate
+    }
 
-        let displayLayer = layer.presentation() ?? layer
+    internal func update() {
 
-        if let cameraLayer = displayLayer as? CameraLayer {
+        // Retrieve currently rendered camera
+        let currentCamera = delegate.camera
 
-            let zoom = NSNumber(value: Double(cameraLayer.zoom))
-            let bearing = NSNumber(value: Double(cameraLayer.bearing))
-            let anchor = ScreenCoordinate(x: Double(cameraLayer.anchor.x),
-                                          y: Double(cameraLayer.anchor.y))
+        // Get the latest interpolated values of the camera properties (if they exist)
+        let targetCamera = localCamera
 
-            let padding = cameraLayer.padding.toMBXEdgeInsetsValue()
-            let pitch = NSNumber(value: Double(cameraLayer.pitch))
+        // Apply targetCamera options only if they are different from currentCamera options
+        if currentCamera != targetCamera {
 
-            let center = CLLocation(latitude: CLLocationDegrees(cameraLayer.centerCoordinateLatitude),
-                                    longitude: CLLocationDegrees(cameraLayer.centerCoordinateLongitude))
+            // Diff the targetCamera with the currentCamera and apply diffed camera properties to map
+            let diffedCamera = CameraOptions()
 
-            let updatedCameraOptions = CameraOptions(__center: center,
-                                                     padding: padding,
-                                                     anchor: anchor,
-                                                     zoom: zoom,
-                                                     bearing: bearing,
-                                                     pitch: pitch)
+            if targetCamera.zoom != currentCamera.zoom {
+                diffedCamera.zoom = targetCamera.zoom
+            }
 
-            try! map.jumpTo(forCamera: updatedCameraOptions)
-            delegate?.cameraViewManipulated(for: self)
+            if targetCamera.bearing != currentCamera.bearing {
+                diffedCamera.bearing = targetCamera.bearing
+            }
+
+            if targetCamera.pitch != currentCamera.pitch {
+                diffedCamera.pitch = targetCamera.pitch
+            }
+
+            if targetCamera.center != currentCamera.center {
+                diffedCamera.center = targetCamera.center
+            }
+
+            if targetCamera.anchor != currentCamera.anchor {
+                diffedCamera.anchor = targetCamera.anchor
+            }
+
+            if targetCamera.padding != currentCamera.padding {
+                diffedCamera.padding = targetCamera.padding
+            }
+
+            delegate.jumpTo(camera: diffedCamera)
         }
-    }
-}
-
-public extension EdgeInsets {
-    func toUIEdgeInsetsValue() -> UIEdgeInsets {
-        return UIEdgeInsets(top: CGFloat(top),
-                            left: CGFloat(left),
-                            bottom: CGFloat(bottom),
-                            right: CGFloat(right))
-    }
-}
-
-public extension UIEdgeInsets {
-    func toMBXEdgeInsetsValue() -> EdgeInsets {
-        return EdgeInsets(top: Double(top),
-                          left: Double(left),
-                          bottom: Double(bottom),
-                          right: Double(right))
     }
 }

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/MBXEdgeInsets.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/MBXEdgeInsets.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public extension EdgeInsets {
+    func toUIEdgeInsetsValue() -> UIEdgeInsets {
+        return UIEdgeInsets(top: CGFloat(self.top),
+                            left: CGFloat(self.left),
+                            bottom: CGFloat(self.bottom),
+                            right: CGFloat(self.right))
+    }
+}
+
+public extension UIEdgeInsets {
+    func toMBXEdgeInsetsValue() -> EdgeInsets {
+        return EdgeInsets(top: Double(self.top),
+                          left: Double(self.left),
+                          bottom: Double(self.bottom),
+                          right: Double(self.right))
+    }
+}

--- a/Sources/MapboxMaps/MapView/Configuration/RenderOptions.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/RenderOptions.swift
@@ -22,15 +22,4 @@ public struct RenderOptions: Equatable {
     ///
     ///  The default value of this property is `true`.
     public var prefetchesTiles: Bool = true
-
-    /// A Boolean value that indicates whether the underlying `CAMetalLayer` of the `MapView`
-    /// presents its content using a CoreAnimation transaction
-    ///
-    /// By default, this is `false` resulting in the output of a rendering pass being displayed on
-    /// the `CAMetalLayer` as quickly as possible (and asynchronously). This typically results
-    /// in the fastest rendering performance.
-    ///
-    /// If, however, the `MapView` is overlaid with a `UIKit` element which must be pinned to a
-    /// particular lat-long, then setting this to `true` will result in better synchronization and less jitter.
-    public var presentsWithTransaction: Bool = false
 }

--- a/Sources/MapboxMaps/MapView/MapView+Managers.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Managers.swift
@@ -46,17 +46,15 @@ extension MapView {
 
         // Set prefetch zoom delta
         let defaultPrefetchZoomDelta: UInt8 = 4
-        try! __map.setPrefetchZoomDeltaForDelta(renderOptions.prefetchesTiles ? defaultPrefetchZoomDelta : 0)
-        metalView?.presentsWithTransaction = renderOptions.presentsWithTransaction
-        preferredFPS = renderOptions.preferredFramesPerSecond
+        try! self.__map.setPrefetchZoomDeltaForDelta(renderOptions.prefetchesTiles ? defaultPrefetchZoomDelta : 0)
+        self.preferredFPS = renderOptions.preferredFramesPerSecond
     }
 
     internal func updateMapView(with newOptions: RenderOptions) {
         // Set prefetch zoom delta
         let defaultPrefetchZoomDelta: UInt8 = 4
-        try! __map.setPrefetchZoomDeltaForDelta(newOptions.prefetchesTiles ? defaultPrefetchZoomDelta : 0)
-        metalView?.presentsWithTransaction = newOptions.presentsWithTransaction
-        preferredFPS = newOptions.preferredFramesPerSecond
+        try! self.__map.setPrefetchZoomDeltaForDelta(newOptions.prefetchesTiles ? defaultPrefetchZoomDelta : 0)
+        self.preferredFPS = newOptions.preferredFramesPerSecond
     }
 
     internal func setupGestures(with view: UIView, options: GestureOptions, cameraManager: CameraManager) {

--- a/Tests/MapboxMapsTests/Foundation/Camera/MapboxMapsCameraTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Camera/MapboxMapsCameraTests.swift
@@ -233,14 +233,13 @@ class CameraManagerTests: XCTestCase {
         XCTAssertEqual(mapView.cameraView.localBearing, -212.957, accuracy: 0.001, "Check that the new bearing matches the expected value.")
         XCTAssertEqual(mapView.cameraView.localCenterCoordinate, CLLocationCoordinate2D(latitude: 0, longitude: 0))
 
-        
         cameraManager.moveCamera(by: .zero, pitch: 10, zoom: 10.0)
         XCTAssertEqual(mapView.cameraView.localPitch, -10)
         XCTAssertEqual(mapView.cameraView.localZoom, 10.0, accuracy: 0.001, "The value for zoom should be 10.0")
 
         cameraManager.moveCamera(by: CGPoint(x: -10, y: 10))
         XCTAssertEqual(mapView.cameraView.localCenterCoordinate.latitude, 7.013668, accuracy: 0.0001, "The new latitude should be approximately 7.013668")
-        XCTAssertEqual(mapView.cameraView.localCenterCoordinate.longitude,-352.96875, accuracy: 0.0001, "The new longitude should be approximately -352.96875")
+        XCTAssertEqual(mapView.cameraView.localCenterCoordinate.longitude, -352.96875, accuracy: 0.0001, "The new longitude should be approximately -352.96875")
     }
 
     func testOptimizeBearingClockwise() {

--- a/Tests/MapboxMapsTests/Foundation/Camera/MapboxMapsCameraTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Camera/MapboxMapsCameraTests.swift
@@ -233,13 +233,14 @@ class CameraManagerTests: XCTestCase {
         XCTAssertEqual(mapView.cameraView.localBearing, -212.957, accuracy: 0.001, "Check that the new bearing matches the expected value.")
         XCTAssertEqual(mapView.cameraView.localCenterCoordinate, CLLocationCoordinate2D(latitude: 0, longitude: 0))
 
+        
         cameraManager.moveCamera(by: .zero, pitch: 10, zoom: 10.0)
         XCTAssertEqual(mapView.cameraView.localPitch, -10)
         XCTAssertEqual(mapView.cameraView.localZoom, 10.0, accuracy: 0.001, "The value for zoom should be 10.0")
 
         cameraManager.moveCamera(by: CGPoint(x: -10, y: 10))
         XCTAssertEqual(mapView.cameraView.localCenterCoordinate.latitude, 7.013668, accuracy: 0.0001, "The new latitude should be approximately 7.013668")
-        XCTAssertEqual(mapView.cameraView.localCenterCoordinate.longitude, 7.03125, accuracy: 0.0001, "The new longitude should be approximately 7.03125")
+        XCTAssertEqual(mapView.cameraView.localCenterCoordinate.longitude,-352.96875, accuracy: 0.0001, "The new longitude should be approximately -352.96875")
     }
 
     func testOptimizeBearingClockwise() {

--- a/Tests/MapboxMapsTests/Foundation/MapboxMapsFoundationTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapboxMapsFoundationTests.swift
@@ -188,29 +188,6 @@ class MapboxMapsFoundationTests: XCTestCase {
         XCTAssertEqual(expectedRect, actualRect)
     }
 
-    func testRectToCoordinateBounds() {
-        let convertedBounds = mapView.cameraView.visibleCoordinateBounds
-        let convertedBounds2 = mapView.coordinateBounds(for: mapView)
-
-        XCTAssertEqual(convertedBounds.southwest.latitude, convertedBounds2.southwest.latitude, accuracy: accuracy)
-        XCTAssertEqual(convertedBounds.southwest.longitude, convertedBounds2.southwest.longitude, accuracy: accuracy)
-        XCTAssertEqual(convertedBounds.northeast.latitude, convertedBounds2.northeast.latitude, accuracy: accuracy)
-        XCTAssertEqual(convertedBounds.northeast.longitude, convertedBounds2.northeast.longitude, accuracy: accuracy)
-
-        // Test southwest points are equal
-        let southwestBoundsPoint = mapView.point(for: convertedBounds.southwest, in: mapView)
-        let southwestFramePoint = CGPoint(x: mapView.bounds.minX, y: mapView.bounds.maxY)
-        XCTAssertEqual(southwestBoundsPoint.x, southwestFramePoint.x, accuracy: 0.01)
-        XCTAssertEqual(southwestBoundsPoint.y, southwestFramePoint.y, accuracy: 0.01)
-
-        // Test northeast points are equal
-        let northeastBoundsPoint = mapView.point(for: convertedBounds.northeast, in: mapView)
-        let northeastFramePoint = CGPoint(x: mapView.bounds.maxX, y: mapView.bounds.minY)
-
-        XCTAssertEqual(northeastBoundsPoint.x, northeastFramePoint.x, accuracy: 0.01)
-        XCTAssertEqual(northeastBoundsPoint.y, northeastFramePoint.y, accuracy: 0.01)
-    }
-
     func testCoordinateBoundsToRect() {
         let southwest = CLLocationCoordinate2D(latitude: -20, longitude: -20)
         let northeast = CLLocationCoordinate2D(latitude: 20, longitude: 20)

--- a/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
@@ -17,7 +17,6 @@ internal class OptionsIntegrationTest: MapViewIntegrationTestCase {
         newOptions.gestures.scrollEnabled = false
         newOptions.ornaments.showsScale = false
         newOptions.ornaments.showsCompass = false
-        newOptions.render.presentsWithTransaction = true
 
         mapView.update { (options) in
             options = newOptions


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] ~Include before/after visuals or gifs if this PR includes visual changes.~
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] ~Add example if relevant.~ **Will be added in a future PR**
 - [ ] ~Document any changes to public APIs.~ **Will be added in a future PR**

### Summary of changes

This PR productizes a new approach for animating the camera (Camera Animations v2). It works by reusing existing layer properties on `UIView`s. 

- [x] Introduce replacement CameraView (reference origin/nishantk/camera-animation)
- [x] Set up proxy layer properties
- [x] Write CameraView.updateCamera method that calls map.jumpTo
- [x] Ensure that CameraView.updateCamera is invoked on every tick of the displayLink.
- [x] Ensure that presentsWithTransaction is set on the metal view.

### User impact (optional)

None at this time.