### PR TITLE
Add layerId to AnnotationManager

### DIFF
--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -488,6 +488,11 @@
 		CA0B380D25C4C01400B3396E /* IntegrationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5361862537EE0600A8AE38 /* IntegrationTestCase.swift */; };
 		CA0C426926028ED30054D9D0 /* AnnotationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C426826028ED30054D9D0 /* AnnotationOptions.swift */; };
 		CA0C426A26028ED30054D9D0 /* AnnotationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C426826028ED30054D9D0 /* AnnotationOptions.swift */; };
+		CA0C427E2602BECE0054D9D0 /* LayerPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C427D2602BECE0054D9D0 /* LayerPosition.swift */; };
+		CA0C427F2602BECE0054D9D0 /* LayerPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C427D2602BECE0054D9D0 /* LayerPosition.swift */; };
+		CA0C42CD2602BF2A0054D9D0 /* LayerPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C42942602BF000054D9D0 /* LayerPositionTests.swift */; };
+		CA0C42F22602BF2D0054D9D0 /* LayerPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C42942602BF000054D9D0 /* LayerPositionTests.swift */; };
+		CA0C43052602BF2D0054D9D0 /* LayerPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C42942602BF000054D9D0 /* LayerPositionTests.swift */; };
 		CA2E4A1B2538D3530096DEDE /* MapViewIntegrationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA53616D2537ECA600A8AE38 /* MapViewIntegrationTestCase.swift */; };
 		CA2E4A1C2538D3530096DEDE /* IntegrationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5361862537EE0600A8AE38 /* IntegrationTestCase.swift */; };
 		CA2E4A1D2538D3530096DEDE /* DidIdleFailureIntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2E498825380B300096DEDE /* DidIdleFailureIntegrationTest.swift */; };
@@ -1137,6 +1142,8 @@
 		CA05A71E2551C89600ABF902 /* CacheManagerIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheManagerIntegrationTests.swift; sourceTree = "<group>"; };
 		CA0B374325C4BEAE00B3396E /* MapboxMapsHTTPTestsWithHost.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxMapsHTTPTestsWithHost.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA0C426826028ED30054D9D0 /* AnnotationOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnnotationOptions.swift; sourceTree = "<group>"; };
+		CA0C427D2602BECE0054D9D0 /* LayerPosition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayerPosition.swift; sourceTree = "<group>"; };
+		CA0C42942602BF000054D9D0 /* LayerPositionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayerPositionTests.swift; sourceTree = "<group>"; };
 		CA2E498825380B300096DEDE /* DidIdleFailureIntegrationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DidIdleFailureIntegrationTest.swift; sourceTree = "<group>"; };
 		CA355C06256EEA7C00FD1DB7 /* FlyToInterpolator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlyToInterpolator.swift; sourceTree = "<group>"; };
 		CA4453C52436E71500477B4F /* MapboxTestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MapboxTestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1413,13 +1420,14 @@
 		0782B1DB258C254400D5FCE5 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				0782B17A258C236B00D5FCE5 /* MBXGeometry.swift */,
-				0C8AA1F2257FE1830037FD6B /* MapEvents.swift */,
-				0782B00F258C051900D5FCE5 /* ScreenCoordinate.swift */,
 				0782B075258C190C00D5FCE5 /* CoordinateBounds.swift */,
-				0CAC3CA92534E8CC00D031E7 /* ResourceOptions.swift */,
-				0782B060258C16B200D5FCE5 /* Utils.swift */,
 				CAC1960A25AE98F400F69FEA /* GlyphsRasterizationOptions.swift */,
+				CA0C427D2602BECE0054D9D0 /* LayerPosition.swift */,
+				0C8AA1F2257FE1830037FD6B /* MapEvents.swift */,
+				0782B17A258C236B00D5FCE5 /* MBXGeometry.swift */,
+				0CAC3CA92534E8CC00D031E7 /* ResourceOptions.swift */,
+				0782B00F258C051900D5FCE5 /* ScreenCoordinate.swift */,
+				0782B060258C16B200D5FCE5 /* Utils.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1803,6 +1811,7 @@
 		1F11C11B2421B05600F8397B /* MapboxMapsFoundationTests */ = {
 			isa = PBXGroup;
 			children = (
+				CA0C42922602BF000054D9D0 /* Extensions */,
 				CAC1961E25AEAE2800F69FEA /* Glyphs */,
 				07DA743A258409AF00AD0446 /* GeoJSON */,
 				A4FE887B255F364600FBF117 /* Camera */,
@@ -2079,6 +2088,22 @@
 				CA0C426826028ED30054D9D0 /* AnnotationOptions.swift */,
 			);
 			path = Configuration;
+			sourceTree = "<group>";
+		};
+		CA0C42922602BF000054D9D0 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				CA0C42932602BF000054D9D0 /* Core */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		CA0C42932602BF000054D9D0 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				CA0C42942602BF000054D9D0 /* LayerPositionTests.swift */,
+			);
+			path = Core;
 			sourceTree = "<group>";
 		};
 		CA2E498725380AE10096DEDE /* Integration Tests */ = {
@@ -3541,6 +3566,7 @@
 				0C9640E12531056700CABD3E /* LocationConsumer.swift in Sources */,
 				0C708F4D24EB23C7003CE791 /* RasterDemSource.swift in Sources */,
 				0CD62F23245887C8006421D1 /* OrnamentsManager.swift in Sources */,
+				CA0C427E2602BECE0054D9D0 /* LayerPosition.swift in Sources */,
 				07A0BCCB2582F16300B8E109 /* GeoJSONManager.swift in Sources */,
 				0C708F2724EB1EE2003CE791 /* LineLayer.swift in Sources */,
 				07A5DE852515576E00A27F8B /* AnnotationStyleDelegate.swift in Sources */,
@@ -3660,6 +3686,7 @@
 				0C32CA2625F982300057ED31 /* VectorSourceTests.swift in Sources */,
 				0C5CFCDE25BB951B0001E753 /* BackgroundLayerTests.swift in Sources */,
 				CA99A86F2540CD1900D16C78 /* StyleLoadIntegrationTests.swift in Sources */,
+				CA0C42F22602BF2D0054D9D0 /* LayerPositionTests.swift in Sources */,
 				0C32C9DD25F979800057ED31 /* RasterDemSourceIntegrationTests.swift in Sources */,
 				CA548F22251C3D7200F829A3 /* GestureManagerTests.swift in Sources */,
 				0C5CFD4025BBA06D0001E753 /* Enums+Fixtures.swift in Sources */,
@@ -3730,6 +3757,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CA0C427F2602BECE0054D9D0 /* LayerPosition.swift in Sources */,
 				C64B6FEB25E0479000C8E07E /* Bundle+MapboxMaps.swift in Sources */,
 				1F4B7D7D2464C39000745F05 /* CameraOptions.swift in Sources */,
 				CA355C08256EEA7C00FD1DB7 /* FlyToInterpolator.swift in Sources */,
@@ -3782,6 +3810,7 @@
 				B51DE64825D7038300A80AC9 /* Comparable+ClampedTests.swift in Sources */,
 				CAC1962025AEAE6600F69FEA /* GlyphsRasterizationOptionsTests.swift in Sources */,
 				A4FE88C2255F366F00FBF117 /* MapboxAnimationGroupTests.swift in Sources */,
+				CA0C42CD2602BF2A0054D9D0 /* LayerPositionTests.swift in Sources */,
 				07DA753225840A4600AD0446 /* MultiLineStringTests.swift in Sources */,
 				07DA754725840A4B00AD0446 /* LineStringTests.swift in Sources */,
 				07DA74F325840A3B00AD0446 /* PointTests.swift in Sources */,
@@ -3990,6 +4019,7 @@
 				0C5CFCF425BB951B0001E753 /* FillLayerTests.swift in Sources */,
 				B54B7F0B25DB192C003FD6CA /* MockCameraManager.swift in Sources */,
 				0C5CFCEB25BB951B0001E753 /* HillshadeLayerTests.swift in Sources */,
+				CA0C43052602BF2D0054D9D0 /* LayerPositionTests.swift in Sources */,
 				0C32CA2425F982300057ED31 /* GeoJsonSourceTests.swift in Sources */,
 				0C2CD9F625D19D75006D068F /* OptionsIntegrationTests.swift in Sources */,
 				0C5CFCF125BB951B0001E753 /* SkyLayerTests.swift in Sources */,

--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -486,6 +486,8 @@
 		CA0B37E725C4C00300B3396E /* HTTPIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB11C982555986F00060963 /* HTTPIntegrationTests.swift */; };
 		CA0B380C25C4C01400B3396E /* MapViewIntegrationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA53616D2537ECA600A8AE38 /* MapViewIntegrationTestCase.swift */; };
 		CA0B380D25C4C01400B3396E /* IntegrationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5361862537EE0600A8AE38 /* IntegrationTestCase.swift */; };
+		CA0C426926028ED30054D9D0 /* AnnotationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C426826028ED30054D9D0 /* AnnotationOptions.swift */; };
+		CA0C426A26028ED30054D9D0 /* AnnotationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C426826028ED30054D9D0 /* AnnotationOptions.swift */; };
 		CA2E4A1B2538D3530096DEDE /* MapViewIntegrationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA53616D2537ECA600A8AE38 /* MapViewIntegrationTestCase.swift */; };
 		CA2E4A1C2538D3530096DEDE /* IntegrationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5361862537EE0600A8AE38 /* IntegrationTestCase.swift */; };
 		CA2E4A1D2538D3530096DEDE /* DidIdleFailureIntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2E498825380B300096DEDE /* DidIdleFailureIntegrationTest.swift */; };
@@ -1134,6 +1136,7 @@
 		C69F017325435C55001AB49B /* LocationProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationProviderMock.swift; sourceTree = "<group>"; };
 		CA05A71E2551C89600ABF902 /* CacheManagerIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheManagerIntegrationTests.swift; sourceTree = "<group>"; };
 		CA0B374325C4BEAE00B3396E /* MapboxMapsHTTPTestsWithHost.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxMapsHTTPTestsWithHost.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CA0C426826028ED30054D9D0 /* AnnotationOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnnotationOptions.swift; sourceTree = "<group>"; };
 		CA2E498825380B300096DEDE /* DidIdleFailureIntegrationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DidIdleFailureIntegrationTest.swift; sourceTree = "<group>"; };
 		CA355C06256EEA7C00FD1DB7 /* FlyToInterpolator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlyToInterpolator.swift; sourceTree = "<group>"; };
 		CA4453C52436E71500477B4F /* MapboxTestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MapboxTestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1502,6 +1505,7 @@
 		07E4FD1924E4A35600D734D1 /* MapboxMapsAnnotations */ = {
 			isa = PBXGroup;
 			children = (
+				CA0C426726028ED30054D9D0 /* Configuration */,
 				074205FE24E4A586000A8932 /* AnnotationManager.swift */,
 				A43D7B5125196D1C00951460 /* Annotation.swift */,
 				0742060124E4A5D0000A8932 /* PointAnnotation.swift */,
@@ -2067,6 +2071,14 @@
 				CA05A71E2551C89600ABF902 /* CacheManagerIntegrationTests.swift */,
 			);
 			path = CacheManager;
+			sourceTree = "<group>";
+		};
+		CA0C426726028ED30054D9D0 /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				CA0C426826028ED30054D9D0 /* AnnotationOptions.swift */,
+			);
+			path = Configuration;
 			sourceTree = "<group>";
 		};
 		CA2E498725380AE10096DEDE /* Integration Tests */ = {
@@ -3446,6 +3458,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CAED66D8252D65F6002A1AED /* Annotation.swift in Sources */,
+				CA0C426A26028ED30054D9D0 /* AnnotationOptions.swift in Sources */,
 				CAED6750252D660B002A1AED /* AnnotationSupportableMap.swift in Sources */,
 				CAED66F0252D65FC002A1AED /* PointAnnotation.swift in Sources */,
 				CAED6768252D660F002A1AED /* AnnotationInteractionDelegate.swift in Sources */,
@@ -3563,6 +3576,7 @@
 				07BA35CE251578DD003E1B55 /* AnnotationInteractionDelegate.swift in Sources */,
 				2B8637E12462F31B00698135 /* MapbxoScaleBarConstants.swift in Sources */,
 				2B8637E62463F36400698135 /* DistanceFormatter.swift in Sources */,
+				CA0C426926028ED30054D9D0 /* AnnotationOptions.swift in Sources */,
 				0C708F2F24EB1EE2003CE791 /* RasterLayer.swift in Sources */,
 				0C35750225DD8D960085D775 /* StyleErrors.swift in Sources */,
 				0CE3D1B425816BD6000585A2 /* MapView+Supportable.swift in Sources */,

--- a/Sources/MapboxMaps/Annotations/AnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationManager.swift
@@ -315,6 +315,11 @@ public class AnnotationManager: Observer {
         }
     }
 
+    /**
+     Returns the underlying layer identifier for the associated annotation type.
+     - Parameter annotationType: Type of annotation, for example, PointAnnotation.self
+     - Returns: Identifier (or nil, if there isn't a layer for that type)
+     */
     public func layerId<T: Annotation>(for annotationType: T.Type) -> String? {
         switch annotationType {
         case is PointAnnotation.Type:

--- a/Sources/MapboxMaps/Annotations/AnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationManager.swift
@@ -89,15 +89,15 @@ public class AnnotationManager: Observer {
     /**
      The default source layer identifier to be used by the `AnnotationManager`.
      */
-    internal let defaultSourceId = "com.mapbox.AnnotationManager.DefaultSourceLayer"
+    internal let defaultSourceId = "com.mapbox.AnnotationManager.DefaultSource"
 
     /**
      The default style layer identifiers to be used by the point, line, and polygon
      style layers managed by this class.
      */
-    internal let defaultSymbolLayerId = "com.mapbox.AnnotationManager.DefaultSymbolStylelayer"
-    internal let defaultLineLayerId = "com.mapbox.AnnotationManager.DefaultLineStylelayer"
-    internal let defaultPolygonLayerId = "com.mapbox.AnnotationManager.DefaultPolygonStylelayer"
+    internal let defaultSymbolLayerId = "com.mapbox.AnnotationManager.DefaultSymbolStyleLayer"
+    internal let defaultLineLayerId = "com.mapbox.AnnotationManager.DefaultLineStyleLayer"
+    internal let defaultPolygonLayerId = "com.mapbox.AnnotationManager.DefaultPolygonStyleLayer"
 
     /**
      The default style layers used to render point, line, and polygon

--- a/Sources/MapboxMaps/Annotations/AnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationManager.swift
@@ -86,10 +86,23 @@ public class AnnotationManager: Observer {
      The source layer used by the annotation manager.
      */
     internal var annotationSource: GeoJSONSource?
+
     /**
-     The default source layer identifier to be used by the `AnnotationManager`.
+     Options used by the annotation manager.
+     */
+    internal var annotationOptions: AnnotationOptions
+
+    /**
+     The default source identifier, which will be used by the `AnnotationManager` by default.
      */
     internal let defaultSourceId = "com.mapbox.AnnotationManager.DefaultSource"
+
+    /**
+     The source identifier used by the `AnnotationManager`.
+     */
+    internal var sourceId: String {
+        return annotationOptions.sourceId ?? defaultSourceId
+    }
 
     /**
      The default style layer identifiers to be used by the point, line, and polygon
@@ -103,9 +116,9 @@ public class AnnotationManager: Observer {
      The default style layers used to render point, line, and polygon
      annotations on the map view.
      */
-    internal var defaultSymbolLayer: SymbolLayer?
-    internal var defaultLineLayer: LineLayer?
-    internal var defaultPolygonLayer: FillLayer?
+    internal var symbolLayer: SymbolLayer?
+    internal var lineLayer: LineLayer?
+    internal var fillLayer: FillLayer?
 
     /**
      The tap gesture recognizer used to respond to tap events.
@@ -136,6 +149,7 @@ public class AnnotationManager: Observer {
         self.mapView = mapView
         self.styleDelegate = styleDelegate
         self.interactionDelegate = interactionDelegate
+        self.annotationOptions = options
         annotations = [:]
         annotationFeatures = FeatureCollection(features: [])
         userInteractionEnabled = true
@@ -145,6 +159,8 @@ public class AnnotationManager: Observer {
     }
 
     internal func updateAnnotationOptions(with newOptions: AnnotationOptions) {
+        self.annotationOptions = newOptions
+        try! Log.warning(forMessage: "Updating annotation manager is not supported at this time.", category: "Annotations")
     }
 
     // MARK: - Public functions
@@ -247,7 +263,7 @@ public class AnnotationManager: Observer {
             return .failure(.removeAnnotationFailed("Failed to parse data from FeatureCollection"))
         }
 
-        let updateSourceExpectation = styleDelegate.updateSourceProperty(id: defaultSourceId,
+        let updateSourceExpectation = styleDelegate.updateSourceProperty(id: sourceId,
                                                                          property: "data",
                                                                          value: geoJSONDictionary)
 
@@ -299,6 +315,23 @@ public class AnnotationManager: Observer {
         }
     }
 
+    public func layerId<T: Annotation>(for annotationType: T.Type) -> String? {
+        switch annotationType {
+        case is PointAnnotation.Type:
+            return symbolLayer?.id
+
+        case is LineAnnotation.Type:
+            return lineLayer?.id
+
+        case is PolygonAnnotation.Type:
+            return fillLayer?.id
+
+        default:
+            try! Log.error(forMessage: "Type should be an annotation", category: "Annotations")
+            return nil
+        }
+    }
+
     // MARK: - Internal functions
 
     /**
@@ -314,7 +347,7 @@ public class AnnotationManager: Observer {
 
         sourceLayer.data = .featureCollection(annotationFeatures)
 
-        let addSourceExpectation = styleDelegate.addSource(source: sourceLayer, identifier: defaultSourceId)
+        let addSourceExpectation = styleDelegate.addSource(source: sourceLayer, identifier: sourceId)
 
         switch addSourceExpectation {
         case .success(let bool):
@@ -391,14 +424,14 @@ public class AnnotationManager: Observer {
      */
     internal func updateLayers(for annotation: Annotation) throws {
         let geoJSONDictionary = try GeoJSONManager.dictionaryFrom(annotationFeatures)
-        try updateSourceLayer(geoJSONDictionary: geoJSONDictionary)
+        try updateSource(geoJSONDictionary: geoJSONDictionary)
         try updateStyleLayer(for: annotation)
     }
 
     /**
      Creates or updates the data source layer for the annotations.
      */
-    internal func updateSourceLayer(geoJSONDictionary: [String: Any]?) throws {
+    internal func updateSource(geoJSONDictionary: [String: Any]?) throws {
         guard let geoJSON = geoJSONDictionary else {
             throw AnnotationError.addAnnotationFailed(nil)
         }
@@ -408,7 +441,7 @@ public class AnnotationManager: Observer {
                 throw AnnotationError.addAnnotationFailed(sourceError)
             }
         } else {
-            let updateSourceExpectation = styleDelegate.updateSourceProperty(id: defaultSourceId,
+            let updateSourceExpectation = styleDelegate.updateSourceProperty(id: sourceId,
                                                                              property: "data",
                                                                              value: geoJSON)
             if case .failure(let sourceError) = updateSourceExpectation {
@@ -452,96 +485,102 @@ public class AnnotationManager: Observer {
         }
 
         // Add the default symbol layer image.
-        if defaultSymbolLayer == nil {
-            // Add the default icon image to the sprite, but only once.
-            if styleDelegate.getStyleImage(with: PointAnnotation.defaultIconImageIdentifier) == nil {
-
-                let expectedDefaultImage = styleDelegate.setStyleImage(image: pointAnnotation.defaultAnnotationImage(),
-                                                                       with: PointAnnotation.defaultIconImageIdentifier,
-                                                                       sdf: false,
-                                                                       stretchX: [],
-                                                                       stretchY: [],
-                                                                       scale: 3.0,
-                                                                       imageContent: nil)
-
-                if case .failure(let imageError) = expectedDefaultImage {
-                    throw AnnotationError.addAnnotationFailed(imageError)
-                }
-            }
-
-            // Make the style layer for the first time.
-            var symbolLayer = SymbolLayer(id: defaultSymbolLayerId)
-            symbolLayer.source = defaultSourceId
-
-            /**
-             Create an expression that will use the `icon-image`
-             property associated with an annotation's `Feature`
-             to set the image.
-             */
-            symbolLayer.layout?.iconImage = .expression(Exp(.get) {
-                "icon-image"
-            })
-
-            /**
-             Since all annotation geometries share the same source,
-             render only the point geometries within the symbol layer.
-             */
-            symbolLayer.filter = Exp(.eq) {
-                "$type"
-                "Point"
-            }
-
-            let expectedLayer = styleDelegate.addLayer(layer: symbolLayer, layerPosition: nil)
-
-            if case .failure(let layerError) = expectedLayer {
-                throw AnnotationError.addAnnotationFailed(layerError)
-            }
-
-            defaultSymbolLayer = symbolLayer
+        guard symbolLayer == nil else {
+            return
         }
+
+        // Add the default icon image to the sprite, but only once.
+        if styleDelegate.getStyleImage(with: PointAnnotation.defaultIconImageIdentifier) == nil {
+
+            let expectedDefaultImage = styleDelegate.setStyleImage(image: pointAnnotation.defaultAnnotationImage(),
+                                                                   with: PointAnnotation.defaultIconImageIdentifier,
+                                                                   sdf: false,
+                                                                   stretchX: [],
+                                                                   stretchY: [],
+                                                                   scale: 3.0,
+                                                                   imageContent: nil)
+
+            if case .failure(let imageError) = expectedDefaultImage {
+                throw AnnotationError.addAnnotationFailed(imageError)
+            }
+        }
+
+        // Make the style layer for the first time.
+        var symbolLayer = SymbolLayer(id: defaultSymbolLayerId)
+        symbolLayer.source = sourceId
+
+        /**
+         Create an expression that will use the `icon-image`
+         property associated with an annotation's `Feature`
+         to set the image.
+         */
+        symbolLayer.layout?.iconImage = .expression(Exp(.get) {
+            "icon-image"
+        })
+
+        /**
+         Since all annotation geometries share the same source,
+         render only the point geometries within the symbol layer.
+         */
+        symbolLayer.filter = Exp(.eq) {
+            "$type"
+            "Point"
+        }
+
+        let expectedLayer = styleDelegate.addLayer(layer: symbolLayer, layerPosition: nil)
+
+        if case .failure(let layerError) = expectedLayer {
+            throw AnnotationError.addAnnotationFailed(layerError)
+        }
+
+        self.symbolLayer = symbolLayer
     }
 
     internal func updateLineStyleLayer() throws {
-        if defaultLineLayer == nil {
-            var lineLayer = LineLayer(id: defaultLineLayerId)
-            lineLayer.source = defaultSourceId
-
-            /**
-             Since all annotation geometries share the same source,
-             render only the line geometries within the line layer.
-             */
-            lineLayer.filter = Exp(.eq) {
-                "$type"
-                "LineString"
-            }
-
-            if case .failure(let layerError) = styleDelegate.addLayer(layer: lineLayer, layerPosition: nil) {
-                throw AnnotationError.addAnnotationFailed(layerError)
-            }
-
-            defaultLineLayer = lineLayer
+        guard lineLayer == nil else {
+            return
         }
+
+        var lineLayer = LineLayer(id: defaultLineLayerId)
+        lineLayer.source = sourceId
+
+        /**
+         Since all annotation geometries share the same source,
+         render only the line geometries within the line layer.
+         */
+        lineLayer.filter = Exp(.eq) {
+            "$type"
+            "LineString"
+        }
+
+        if case .failure(let layerError) = styleDelegate.addLayer(layer: lineLayer, layerPosition: nil) {
+            throw AnnotationError.addAnnotationFailed(layerError)
+        }
+
+        self.lineLayer = lineLayer
     }
 
     internal func updateFillStyleLayer() throws {
-        if defaultPolygonLayer == nil {
-            var fillLayer = FillLayer(id: defaultPolygonLayerId)
-            fillLayer.source = defaultSourceId
-            /**
-             Since all annotation geometries share the same source,
-             render only the polygon geometries within the fill layer.
-             */
-            fillLayer.filter = Exp(.eq) {
-                "$type"
-                "Polygon"
-            }
-
-            if case .failure(let layerError) = styleDelegate.addLayer(layer: fillLayer, layerPosition: nil) {
-                throw AnnotationError.addAnnotationFailed(layerError)
-            }
-
-            defaultPolygonLayer = fillLayer
+        guard fillLayer == nil else {
+            return
         }
+
+        var fillLayer = FillLayer(id: defaultPolygonLayerId)
+        fillLayer.source = sourceId
+        /**
+         Since all annotation geometries share the same source,
+         render only the polygon geometries within the fill layer.
+         */
+        fillLayer.filter = Exp(.eq) {
+            "$type"
+            "Polygon"
+        }
+
+        if case .failure(let layerError) = styleDelegate.addLayer(layer: fillLayer, layerPosition: nil) {
+            throw AnnotationError.addAnnotationFailed(layerError)
+        }
+
+        self.fillLayer = fillLayer
     }
 
     // MARK: - Annotation selection
@@ -629,8 +668,8 @@ public class AnnotationManager: Observer {
         // Reset the annotation source and default layers.
         annotations = [:]
         annotationSource = nil
-        defaultSymbolLayer = nil
-        defaultLineLayer = nil
-        defaultPolygonLayer = nil
+        symbolLayer = nil
+        lineLayer = nil
+        fillLayer = nil
     }
 }

--- a/Sources/MapboxMaps/Annotations/AnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationManager.swift
@@ -532,7 +532,7 @@ public class AnnotationManager: Observer {
             "Point"
         }
 
-        let expectedLayer = styleDelegate.addLayer(layer: symbolLayer, layerPosition: nil)
+        let expectedLayer = styleDelegate.addLayer(layer: symbolLayer, layerPosition: annotationOptions.layerPosition)
 
         if case .failure(let layerError) = expectedLayer {
             throw AnnotationError.addAnnotationFailed(layerError)
@@ -558,7 +558,7 @@ public class AnnotationManager: Observer {
             "LineString"
         }
 
-        if case .failure(let layerError) = styleDelegate.addLayer(layer: lineLayer, layerPosition: nil) {
+        if case .failure(let layerError) = styleDelegate.addLayer(layer: lineLayer, layerPosition: annotationOptions.layerPosition) {
             throw AnnotationError.addAnnotationFailed(layerError)
         }
 
@@ -581,7 +581,7 @@ public class AnnotationManager: Observer {
             "Polygon"
         }
 
-        if case .failure(let layerError) = styleDelegate.addLayer(layer: fillLayer, layerPosition: nil) {
+        if case .failure(let layerError) = styleDelegate.addLayer(layer: fillLayer, layerPosition: annotationOptions.layerPosition) {
             throw AnnotationError.addAnnotationFailed(layerError)
         }
 

--- a/Sources/MapboxMaps/Annotations/AnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationManager.swift
@@ -130,6 +130,7 @@ public class AnnotationManager: Observer {
      */
     internal init(for mapView: AnnotationSupportableMap,
                   with styleDelegate: AnnotationStyleDelegate,
+                  options: AnnotationOptions,
                   interactionDelegate: AnnotationInteractionDelegate? = nil) {
 
         self.mapView = mapView
@@ -141,6 +142,9 @@ public class AnnotationManager: Observer {
 
         configureTapGesture()
         try! mapView.observable?.subscribe(for: self, events: [MapEvents.mapLoadingFinished])
+    }
+
+    internal func updateAnnotationOptions(with newOptions: AnnotationOptions) {
     }
 
     // MARK: - Public functions

--- a/Sources/MapboxMaps/Annotations/Configuration/AnnotationOptions.swift
+++ b/Sources/MapboxMaps/Annotations/Configuration/AnnotationOptions.swift
@@ -9,7 +9,7 @@ public struct AnnotationSourceOptions: Equatable {
 public struct AnnotationOptions: Equatable {
     /// The identifier of the layer above the annotation layers. Default is nil, which will position the layers
     /// above existing layers.
-    public var belowLayerId: String? = nil
+    public var belowLayerId: String?
 
     // TODO: Handle multiple layer Ids
 //    /// The layer identifier for the layer used by the AnnotationManager. Default is nil, meaning a
@@ -18,7 +18,7 @@ public struct AnnotationOptions: Equatable {
 
     /// The source identifier for the layer used by the AnnotationManager. Default is nil, meaning a
     /// default identifier will be used.
-    public var sourceId: String? = nil
+    public var sourceId: String?
 
     /// :nodoc: Source configuration options
     public var sourceOptions: AnnotationSourceOptions = AnnotationSourceOptions()

--- a/Sources/MapboxMaps/Annotations/Configuration/AnnotationOptions.swift
+++ b/Sources/MapboxMaps/Annotations/Configuration/AnnotationOptions.swift
@@ -7,13 +7,14 @@ public struct AnnotationSourceOptions: Equatable {
 
 /// Configuration options for the AnnotationManager
 public struct AnnotationOptions: Equatable {
-    /// The layer position for the AnnotationManager. Default is nil, which will position the layers
+    /// The identifier of the layer above the annotation layers. Default is nil, which will position the layers
     /// above existing layers.
-    public var layerPosition: LayerPosition? = nil
+    public var belowLayerId: String? = nil
 
-    /// The layer identifier for the layer used by the AnnotationManager. Default is nil, meaning a
-    /// default identifier will be used.
-    public var layerId: String? = nil
+    // TODO: Handle multiple layer Ids
+//    /// The layer identifier for the layer used by the AnnotationManager. Default is nil, meaning a
+//    /// default identifier will be used.
+//    public var layerId: String? = nil
 
     /// The source identifier for the layer used by the AnnotationManager. Default is nil, meaning a
     /// default identifier will be used.

--- a/Sources/MapboxMaps/Annotations/Configuration/AnnotationOptions.swift
+++ b/Sources/MapboxMaps/Annotations/Configuration/AnnotationOptions.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// :nodoc:
+public struct AnnotationSourceOptions: Equatable {
+    // TODO: Add source and cluster options
+}
+
+/// Configuration options for the AnnotationManager
+public struct AnnotationOptions: Equatable {
+    /// The layer position for the AnnotationManager. Default is nil, which will position the layers
+    /// above existing layers.
+    public var layerPosition: LayerPosition? = nil
+
+    /// The layer identifier for the layer used by the AnnotationManager. Default is nil, meaning a
+    /// default identifier will be used.
+    public var layerId: String? = nil
+
+    /// The source identifier for the layer used by the AnnotationManager. Default is nil, meaning a
+    /// default identifier will be used.
+    public var sourceId: String? = nil
+
+    /// :nodoc: Source configuration options
+    public var sourceOptions: AnnotationSourceOptions = AnnotationSourceOptions()
+}

--- a/Sources/MapboxMaps/Annotations/Configuration/AnnotationOptions.swift
+++ b/Sources/MapboxMaps/Annotations/Configuration/AnnotationOptions.swift
@@ -7,9 +7,9 @@ public struct AnnotationSourceOptions: Equatable {
 
 /// Configuration options for the AnnotationManager
 public struct AnnotationOptions: Equatable {
-    /// The identifier of the layer above the annotation layers. Default is nil, which will position the layers
-    /// above existing layers.
-    public var belowLayerId: String?
+    /// The `LayerPosition` used to position the underlying style layers. Default will position the
+    /// layers above existing layers.
+    public var layerPosition: LayerPosition = LayerPosition()
 
     // TODO: Handle multiple layer Ids
 //    /// The layer identifier for the layer used by the AnnotationManager. Default is nil, meaning a

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/LayerPosition.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/LayerPosition.swift
@@ -1,0 +1,19 @@
+import MapboxCoreMaps
+
+public extension LayerPosition {
+    /// Layer should be positioned at a specified index in the layers stack
+    var at: UInt32? {
+        return __at?.uint32Value
+    }
+
+    override func isEqual(_ object: Any?) -> Bool {
+        guard let object = object as? LayerPosition else {
+            return false
+        }
+
+        return
+            (above == object.above) &&
+            (below == object.below) &&
+            (at == object.at)
+    }
+}

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/ScreenCoordinate.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/ScreenCoordinate.swift
@@ -17,7 +17,7 @@ public extension ScreenCoordinate {
     }
     // swiftlint:enable identifier_name
 
-    /// Reurns a `CGPoint` representation of an internal `ScreenCoordinate` value.
+    /// Returns a `CGPoint` representation of an internal `ScreenCoordinate` value.
     var point: CGPoint {
         CGPoint(x: x, y: y)
     }

--- a/Sources/MapboxMaps/MapView/Configuration/MapOptions.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/MapOptions.swift
@@ -15,4 +15,6 @@ public struct MapOptions: Equatable {
     public var location: LocationOptions = LocationOptions()
 
     public var render: RenderOptions = RenderOptions()
+
+    public var annotations: AnnotationOptions = AnnotationOptions()
 }

--- a/Sources/MapboxMaps/MapView/MapView+Managers.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Managers.swift
@@ -26,7 +26,7 @@ extension MapView {
         setupUserLocationManager(with: self, options: mapOptions.location)
 
         // Initialize/Configure annotations manager
-        setupAnnotationManager(with: self, and: style)
+        setupAnnotationManager(with: self, and: style, options: mapOptions.annotations)
     }
 
     /// Updates the map with new configuration options. Causes underlying structures to reload configuration synchronously.
@@ -40,6 +40,7 @@ extension MapView {
         updateGestures(with: mapOptions.gestures)
         updateOrnaments(with: mapOptions.ornaments)
         updateUserLocationManager(with: mapOptions.location)
+        updateAnnotationManager(with: mapOptions.annotations)
     }
 
     internal func setupMapView(with renderOptions: RenderOptions) {
@@ -94,8 +95,12 @@ extension MapView {
         locationManager.updateLocationOptions(with: mapOptions.location)
     }
 
-    internal func setupAnnotationManager(with annotationSupportableMap: AnnotationSupportableMap, and style: Style) {
-        annotationManager = AnnotationManager(for: annotationSupportableMap, with: style)
+    internal func setupAnnotationManager(with annotationSupportableMap: AnnotationSupportableMap, and style: Style, options: AnnotationOptions) {
+        annotationManager = AnnotationManager(for: annotationSupportableMap, with: style, options: options)
+    }
+
+    internal func updateAnnotationManager(with newOptions: AnnotationOptions) {
+        annotationManager.updateAnnotationOptions(with: newOptions)
     }
 
     internal func setupStyle(with map: Map) {

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -61,6 +61,36 @@ public class Style {
     }
 
     /**
+     :nodoc:
+     Moves a `layer` to a new layer position in the style.
+     - Parameter layerId: The layer to move
+     - Parameter position: The new position to move the layer to
+     - Throws: `LayerError` on failure, or `NSError` with a _domain of "com.mapbox.bindgen"
+     */
+    public func _moveLayer(with layerId: String, to position: LayerPosition) throws {
+        let expectedProperties = try styleManager.getStyleLayerProperties(forLayerId: layerId)
+        if expectedProperties.isError() {
+            throw LayerError.getStyleLayerFailed(expectedProperties.error as? String)
+        }
+
+        if !(expectedProperties.value is [String: Any]) {
+            assertionFailure("Layer properties are not a valid type")
+        }
+
+        let expectedRemoval = try styleManager.removeStyleLayer(forLayerId: layerId)
+        if expectedRemoval.isError() {
+            throw LayerError.removeStyleLayerFailed(expectedRemoval.error as? String)
+        }
+
+        let expectedAddition = try styleManager.addStyleLayer(forProperties: expectedProperties.value as Any,
+                                                              layerPosition: position)
+
+        if expectedAddition.isError() {
+            throw LayerError.addStyleLayerFailed(expectedAddition.error as? String)
+        }
+    }
+
+    /**
      Gets a `layer` from the map
      - Parameter layerID: The id of the layer to be fetched
      - Parameter type: The type of the layer that will be fetched

--- a/Tests/MapboxMapsTests/Annotations/AnnotationInteractionDelegateTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/AnnotationInteractionDelegateTests.swift
@@ -37,7 +37,8 @@ class AnnotationInteractionDelegateTests: XCTestCase {
     func testProgrammaticAnnotationSelection() {
         // Given
         let annotationManager = AnnotationManager(for: annotationSupportableMapMock,
-                                                  with: annotationSupportableStyleMock)
+                                                  with: annotationSupportableStyleMock,
+                                                  options: AnnotationOptions())
         annotationManager.interactionDelegate = self
         let annotation = PointAnnotation(coordinate: defaultCoordinate)
         _ = annotationManager.addAnnotation(annotation)

--- a/Tests/MapboxMapsTests/Annotations/AnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/AnnotationManagerTests.swift
@@ -23,7 +23,8 @@ class AnnotationManagerTests: XCTestCase {
         annotationSupportableMapMock = AnnotationSupportableMapMock()
         annotationSupportableStyleMock = AnnotationStyleDelegateMock()
         annotationManager = AnnotationManager(for: annotationSupportableMapMock,
-                                              with: annotationSupportableStyleMock)
+                                              with: annotationSupportableStyleMock,
+                                              options: AnnotationOptions())
 
         defaultCoordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
     }
@@ -35,6 +36,13 @@ class AnnotationManagerTests: XCTestCase {
         defaultCoordinate = nil
     }
 
+    // MARK: - Test adding point annotation
+    func testAnnotationOptions() {
+        let a = AnnotationOptions()
+        let b = AnnotationOptions()
+        XCTAssertEqual(a, b)
+    }
+    
     func testAnnotationManagerDefaultInitialization() {
         // Given / When
         let expectedInitialAnnotationsCount = 0

--- a/Tests/MapboxMapsTests/Annotations/AnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/AnnotationManagerTests.swift
@@ -42,7 +42,7 @@ class AnnotationManagerTests: XCTestCase {
         let b = AnnotationOptions()
         XCTAssertEqual(a, b)
     }
-    
+
     func testAnnotationManagerDefaultInitialization() {
         // Given / When
         let expectedInitialAnnotationsCount = 0
@@ -52,9 +52,20 @@ class AnnotationManagerTests: XCTestCase {
         XCTAssertTrue(annotationManager.annotationFeatures.features.isEmpty)
         XCTAssertNotNil(annotationManager.tapGesture)
         XCTAssertNil(annotationManager.annotationSource)
-        XCTAssertNil(annotationManager.defaultSymbolLayer)
-        XCTAssertNil(annotationManager.defaultLineLayer)
-        XCTAssertNil(annotationManager.defaultPolygonLayer)
+        XCTAssertNil(annotationManager.symbolLayer)
+        XCTAssertNil(annotationManager.lineLayer)
+        XCTAssertNil(annotationManager.fillLayer)
+    }
+
+    func testLayerIdentifiers() {
+        let symbolLayerId = annotationManager.layerId(for: PointAnnotation.self)
+        XCTAssertNil(symbolLayerId)
+
+        let lineLayerId = annotationManager.layerId(for: LineAnnotation.self)
+        XCTAssertNil(lineLayerId)
+
+        let fillLayerId = annotationManager.layerId(for: PolygonAnnotation.self)
+        XCTAssertNil(fillLayerId)
     }
 
     func testAnnotationFeatureCollectionIsValid() {
@@ -194,5 +205,27 @@ class AnnotationManagerTests: XCTestCase {
 
         XCTAssertTrue(annotationManager.userInteractionEnabled)
         XCTAssertNotNil(annotationManager.tapGesture)
+    }
+
+    func testLayerIdentifiersAfterAddingAnnotation() {
+        annotationManager.addAnnotation(PointAnnotation(coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0)))
+        let symbolLayerId = annotationManager.layerId(for: PointAnnotation.self)
+        XCTAssertEqual(symbolLayerId, annotationManager.defaultSymbolLayerId)
+
+        annotationManager.addAnnotation(LineAnnotation(coordinates: [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            CLLocationCoordinate2D(latitude: 1, longitude: 1)
+        ]))
+        let lineLayerId = annotationManager.layerId(for: LineAnnotation.self)
+        XCTAssertEqual(lineLayerId, annotationManager.defaultLineLayerId)
+
+        annotationManager.addAnnotation(PolygonAnnotation(coordinates: [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            CLLocationCoordinate2D(latitude: 0, longitude: 1),
+            CLLocationCoordinate2D(latitude: 1, longitude: 1),
+            CLLocationCoordinate2D(latitude: 1, longitude: 0)
+        ]))
+        let fillLayerId = annotationManager.layerId(for: PolygonAnnotation.self)
+        XCTAssertEqual(fillLayerId, annotationManager.defaultPolygonLayerId)
     }
 }

--- a/Tests/MapboxMapsTests/Annotations/AnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/AnnotationManagerTests.swift
@@ -41,6 +41,11 @@ class AnnotationManagerTests: XCTestCase {
         let a = AnnotationOptions()
         let b = AnnotationOptions()
         XCTAssertEqual(a, b)
+
+        // Test ergonomics
+        _ = AnnotationOptions(layerPosition: LayerPosition())
+        _ = AnnotationOptions(sourceId: "test")
+        _ = AnnotationOptions(sourceOptions: AnnotationSourceOptions())
     }
 
     func testAnnotationManagerDefaultInitialization() {

--- a/Tests/MapboxMapsTests/Foundation/Extensions/Core/LayerPositionTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Extensions/Core/LayerPositionTests.swift
@@ -18,9 +18,9 @@ final class LayerPositionTests: XCTestCase {
         XCTAssertEqual(a, b)
         XCTAssertEqual(e, f)
 
-        XCTAssertNotEqual(a,c)
-        XCTAssertNotEqual(c,d)
-        XCTAssertNotEqual(d,e)
+        XCTAssertNotEqual(a, c)
+        XCTAssertNotEqual(c, d)
+        XCTAssertNotEqual(d, e)
 
         XCTAssertEqual(f.at, 3)
     }

--- a/Tests/MapboxMapsTests/Foundation/Extensions/Core/LayerPositionTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Extensions/Core/LayerPositionTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+#if canImport(MapboxMaps)
+@testable import MapboxMaps
+#else
+@testable import MapboxMapsFoundation
+#endif
+
+final class LayerPositionTests: XCTestCase {
+    func testPositionEquality() {
+        let a = LayerPosition(above: nil, below: nil, at: nil)
+        let b = LayerPosition(above: nil, below: nil, at: nil)
+        let c = LayerPosition(above: "above", below: nil, at: nil)
+        let d = LayerPosition(above: "above", below: "below", at: nil)
+        let e = LayerPosition(above: "above", below: "below", at: 3)
+        let f = LayerPosition(above: "above", below: "below", at: 3)
+
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(e, f)
+
+        XCTAssertNotEqual(a,c)
+        XCTAssertNotEqual(c,d)
+        XCTAssertNotEqual(d,e)
+
+        XCTAssertEqual(f.at, 3)
+    }
+}

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
@@ -22,7 +22,9 @@ internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase 
 
             // Given
             let annotation = PointAnnotation(coordinate: mapView.centerCoordinate)
-            let annotationManager = AnnotationManager(for: mapView, with: self)
+            let annotationManager = AnnotationManager(for: mapView,
+                                                      with: self,
+                                                      options: AnnotationOptions())
             annotationManager.addAnnotation(annotation)
 
             // When
@@ -71,7 +73,9 @@ internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase 
 
             // Given
             var annotation = PointAnnotation(coordinate: mapView.centerCoordinate)
-            let annotationManager = AnnotationManager(for: mapView, with: self)
+            let annotationManager = AnnotationManager(for: mapView,
+                                                      with: self,
+                                                      options: AnnotationOptions())
             annotation.userInfo = ["TestKey": true]
             annotationManager.addAnnotation(annotation)
 

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase {
 
-    // MARK: - Test adding point annotation
+    // MARK: - Integration tests
 
     /**
      The purpose of this test is to ensure that the appropriate source and style
@@ -54,7 +54,39 @@ internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase 
         wait(for: expectations, timeout: 5.0)
     }
 
-    // MARK: - Test adding userInfo to annotation still renders annotation
+    internal func testAddAnnotationAtSpecificLayerPosition() {
+        style?.styleURL = .streets
+
+        let styleLoadedExpectation = XCTestExpectation(description: "Wait for map to load style")
+
+        didFinishLoadingStyle = { mapView in
+
+            // Given
+            let annotation = PointAnnotation(coordinate: mapView.centerCoordinate)
+            let requiredIndex = 3
+            let position = LayerPosition(above: nil, below: nil, at: requiredIndex)
+            let annotationManager = AnnotationManager(for: mapView,
+                                                      with: self,
+                                                      options: AnnotationOptions(layerPosition: position))
+            annotationManager.addAnnotation(annotation)
+
+            guard let layerId = annotationManager.layerId(for: PointAnnotation.self) else {
+                XCTFail("Layer should exist")
+                return
+            }
+
+            // Get layer position
+            let layers = try! mapView.style.styleManager.getStyleLayers()
+            let layerIds = layers.map { $0.id }
+            let layerIndex = layerIds.firstIndex(of: layerId)
+            XCTAssertNotNil(layerIndex)
+            XCTAssertEqual(layerIndex, requiredIndex)
+
+            styleLoadedExpectation.fulfill()
+        }
+
+        wait(for: [styleLoadedExpectation], timeout: 5.0)
+    }
 
     /**
      The purpose of this test is to ensure that adding userInfo to the annotation

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -103,8 +103,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                 }
 
                 expectation.fulfill()
-            }
-            catch {
+            } catch {
                 XCTFail("_moveLayer failed with \(error)")
             }
         }

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -60,4 +60,55 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
 
         wait(for: [expectation], timeout: 5.0)
     }
+
+    internal func testMoveStyleLayer() throws {
+        guard
+            let style = style else {
+            XCTFail("There should be valid MapView and Style objects created by setUp.")
+            return
+        }
+
+        let expectation = XCTestExpectation(description: "Move style layer succeeded")
+        expectation.expectedFulfillmentCount = 2
+
+        style.styleURL = .streets
+
+        didFinishLoadingStyle = { _ in
+
+            let layers = try! style.styleManager.getStyleLayers()
+            let newBackgroundLayer = BackgroundLayer(id: "test-id")
+
+            let result = style.addLayer(layer: newBackgroundLayer)
+
+            switch result {
+            case .success:
+                expectation.fulfill()
+            case .failure(let error):
+                XCTFail("Could not add background layer due to error: \(error)")
+            }
+
+            // Move layer, repeatedly
+            do {
+                for step in stride(from: 0, to: layers.count, by: 3) {
+
+                    let newLayerPosition = LayerPosition(above: nil, below: nil, at: step)
+                    try style._moveLayer(with: "test-id", to: newLayerPosition)
+
+                    // Get layer position
+                    let layers = try style.styleManager.getStyleLayers()
+                    let layerIds = layers.map { $0.id }
+
+                    let position = layerIds.firstIndex(of: "test-id")
+                    XCTAssertEqual(position, step)
+                }
+
+                expectation.fulfill()
+            }
+            catch {
+                XCTFail("_moveLayer failed with \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+    }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [ ] ~Include before/after visuals or gifs if this PR includes visual changes.~
 - [X] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] ~Add example if relevant.~
 - [X] Document any changes to public APIs.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [X] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Added function to get layer identifier for an annotation type.</changelog>`.
 - [ ] ~Update the migration guide, API Docs, Markdown files - Readme, Developing, etc~

### Summary of changes

This PR adds a function to get the layer id for a particular annotation type. It also adds a WIP convenience function (`_moveLayer`) to `Style` to allow layers to be moved. These combined give developers a method to move the underlying annotation layer. 

The `_moveLayer` change is marked as `:nodoc:` and should be consider prone to change.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

cc @Neel
