### PR TITLE
Fix puck update issue

### DIFF
--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -26,7 +26,7 @@ public class DebugViewController: UIViewController {
 
         mapView = MapView(with: view.bounds, resourceOptions: resourceOptions)
         mapView.update { (mapOptions) in
-            mapOptions.location.showUserLocation = true
+            mapOptions.location.puckType = .puck2D()
         }
 
         view.addSubview(mapView)

--- a/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
@@ -28,8 +28,6 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
     internal func setupExample() {
 
         mapView.update { (mapOptions) in
-            mapOptions.location.showUserLocation = true
-
             // Granularly configure the location puck with a `Puck2DConfiguration`
             let configuration = Puck2DConfiguration(topImage: UIImage(named: "star"))
             mapOptions.location.puckType = .puck2D(configuration)

--- a/Apps/Examples/Examples/All Examples/Custom3DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom3DPuckExample.swift
@@ -28,9 +28,6 @@ public class Custom3DPuckExample: UIViewController, ExampleProtocol {
     internal func setupExample() {
 
         mapView.update { (mapOptions) in
-
-            mapOptions.location.showUserLocation = true
-
             // Fetch the `gltf` asset
             let uri = Bundle.main.url(forResource: "race_car_model",
                                       withExtension: "gltf")

--- a/Apps/Examples/Examples/All Examples/TrackingModeExample.swift
+++ b/Apps/Examples/Examples/All Examples/TrackingModeExample.swift
@@ -21,7 +21,7 @@ public class TrackingModeExample: UIViewController, ExampleProtocol {
 
         // Add user position icon to the map with location indicator layer
         mapView.update { (mapOptions) in
-            mapOptions.location.showUserLocation = true
+            mapOptions.location.puckType = .puck2D()
         }
 
         // Set initial camera settings

--- a/Sources/MapboxMaps/Location/LocationManager.swift
+++ b/Sources/MapboxMaps/Location/LocationManager.swift
@@ -13,7 +13,7 @@ public class LocationManager: NSObject {
     public private(set) var latestLocation: Location?
 
     /// Represents the style of the user location puck
-    internal var currentPuckStyle: PuckStyle = .precise {
+    private var currentPuckStyle: PuckStyle = .precise {
         didSet {
             locationPuckManager?.changePuckStyle(to: currentPuckStyle)
         }
@@ -24,9 +24,6 @@ public class LocationManager: NSObject {
 
     /// Making variable `public private(set)` to have direct access to auth functions
     public private(set) var locationProvider: LocationProvider!
-
-    /// Property that will determine if user location visuals should be displayed or not
-    public private(set) var showUserLocation: Bool = false
 
     /// Property that has a list of items that will consume location events
     /// The location manager holds weak references to these consumers, client code should retain these references
@@ -42,25 +39,24 @@ public class LocationManager: NSObject {
     /// Only created if `showsUserLocation` is `true`
     internal var locationPuckManager: LocationPuckManager?
 
-    internal var locationOptions: LocationOptions!
+    internal var locationOptions: LocationOptions
 
     internal init(locationOptions: LocationOptions,
                   locationSupportableMapView: LocationSupportableMapView) {
-        super.init()
-
-        self.locationOptions = locationOptions
         /// Sets the local options needed to configure the user location puck
-        showUserLocation = locationOptions.showUserLocation
+        self.locationOptions = locationOptions
 
         /// Allows location updates to be reflected on screen using delegate method
         self.locationSupportableMapView = locationSupportableMapView
+
+        super.init()
 
         /// Sets our default `locationProvider`
         locationProvider = AppleLocationProvider()
         locationProvider.setDelegate(self)
         locationProvider.locationProviderOptions = locationOptions
 
-        toggleUserLocationUpdates(showUserLocation: locationOptions.showUserLocation)
+        syncUserLocationUpdating()
     }
 
     public func overrideLocationProvider(with customLocationProvider: LocationProvider) {
@@ -93,21 +89,12 @@ public class LocationManager: NSObject {
         locationOptions = newOptions
         locationProvider.locationProviderOptions = newOptions
 
-        if newOptions.showUserLocation != showUserLocation {
-            showUserLocation = newOptions.showUserLocation
-            toggleUserLocationUpdates(showUserLocation: showUserLocation)
-
-            if !newOptions.showUserLocation {
-                // If we should not show user location, then we should
-                // not try and change source or style below
-                return
-            }
+        if newOptions.puckType != previousOptions.puckType {
+            syncUserLocationUpdating()
         }
 
-        if newOptions.puckType != previousOptions?.puckType {
-            if let locationPuckManager = self.locationPuckManager {
-                locationPuckManager.changePuckType(to: newOptions.puckType)
-            }
+        if let puckType = newOptions.puckType, puckType != previousOptions.puckType {
+            locationPuckManager?.changePuckType(to: puckType)
         }
     }
 
@@ -189,12 +176,9 @@ extension LocationManager: LocationProviderDelegate {
                     self.currentPuckStyle = .precise
                 }
             }
-            showUserLocation = locationOptions.showUserLocation
-        } else {
-            showUserLocation = false
         }
 
-        toggleUserLocationUpdates(showUserLocation: showUserLocation)
+        syncUserLocationUpdating()
 
         if let delegate = self.delegate {
             delegate.locationManager?(self, didChangeAccuracyAuthorization: provider.accuracyAuthorization)
@@ -204,8 +188,8 @@ extension LocationManager: LocationProviderDelegate {
 
 // MARK: Private helper functions that only the Location Manager needs access to
 private extension LocationManager {
-    func toggleUserLocationUpdates(showUserLocation: Bool) {
-        if showUserLocation {
+    func syncUserLocationUpdating() {
+        if let puckType = locationOptions.puckType {
             /// Get permissions if needed
             if locationProvider.authorizationStatus == .notDetermined {
                 requestLocationPermissions()
@@ -214,13 +198,13 @@ private extension LocationManager {
             locationProvider.startUpdatingLocation()
             locationProvider.startUpdatingHeading()
 
-            if let locationPuckManager = self.locationPuckManager {
+            if let locationPuckManager = locationPuckManager {
                 // This serves as a reset and handles the case if permissions were changed for accuracy
                 locationPuckManager.changePuckStyle(to: currentPuckStyle)
             } else {
                 let locationPuckManager = LocationPuckManager(
                     locationSupportableMapView: locationSupportableMapView,
-                    puckType: locationOptions.puckType)
+                    puckType: puckType)
                 consumers.add(locationPuckManager)
                 self.locationPuckManager = locationPuckManager
             }
@@ -228,7 +212,7 @@ private extension LocationManager {
             locationProvider.stopUpdatingLocation()
             locationProvider.stopUpdatingHeading()
 
-            if let locationPuckManager = self.locationPuckManager {
+            if let locationPuckManager = locationPuckManager {
                 consumers.remove(locationPuckManager)
                 self.locationPuckManager = nil
             }

--- a/Sources/MapboxMaps/Location/LocationManager.swift
+++ b/Sources/MapboxMaps/Location/LocationManager.swift
@@ -89,6 +89,7 @@ public class LocationManager: NSObject {
         guard newOptions != locationOptions else { return }
 
         // Update the location options
+        let previousOptions = locationOptions
         locationOptions = newOptions
         locationProvider.locationProviderOptions = newOptions
 
@@ -103,7 +104,7 @@ public class LocationManager: NSObject {
             }
         }
 
-        if newOptions.puckType != locationOptions.puckType {
+        if newOptions.puckType != previousOptions?.puckType {
             if let locationPuckManager = self.locationPuckManager {
                 locationPuckManager.changePuckType(to: newOptions.puckType)
             }

--- a/Sources/MapboxMaps/Location/LocationOptions.swift
+++ b/Sources/MapboxMaps/Location/LocationOptions.swift
@@ -21,11 +21,8 @@ public struct LocationOptions: Equatable {
     /// The default value is `other`.
     public var activityType: CLActivityType = .other
 
-    /// Sets if the location manager should show the user location on screen or not
-    public var showUserLocation: Bool = false
-
     /// Sets the type of puck that should be used
-    public var puckType: PuckType = .puck2D()
+    public var puckType: PuckType?
 
     public init() {}
 

--- a/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
@@ -35,51 +35,40 @@ internal class LocationManagerTests: XCTestCase {
         XCTAssertNotNil(locationManager.consumers)
         XCTAssertNotNil(locationManager.locationSupportableMapView)
         XCTAssertNil(locationManager.delegate)
-        XCTAssertFalse(locationManager.showUserLocation)
-    }
-
-    func testLocationManagerShowUserLocationDefaultIsFalse() {
-        let locationOptions = LocationOptions()
-        XCTAssertFalse(locationOptions.showUserLocation)
     }
 
     func testLocationManagerPuckTypeModified() {
         var locationOptions = LocationOptions()
         locationOptions.puckType = .puck2D(Puck2DConfiguration(scale: .constant(1.0)))
-        locationOptions.showUserLocation = true
         let locationManager = LocationManager(locationOptions: locationOptions,
                                               locationSupportableMapView: locationSupportableMapMock)
 
         var locationOptions2 = LocationOptions()
         locationOptions2.puckType = .puck2D(Puck2DConfiguration(scale: .constant(2.0)))
-        locationOptions2.showUserLocation = true
         locationManager.updateLocationOptions(with: locationOptions2)
         XCTAssertEqual(locationManager.locationPuckManager?.puckType, locationOptions2.puckType)
     }
 
-    func testLocationManagerShowUserLocationIsDisabled() {
+    func testLocationManagerPuckTypeSetToNil() {
         var locationOptions = LocationOptions()
-        locationOptions.puckType = .puck2D(Puck2DConfiguration(scale: .constant(1.0)))
-        locationOptions.showUserLocation = true
+        locationOptions.puckType = .puck2D()
         let locationManager = LocationManager(locationOptions: locationOptions,
                                               locationSupportableMapView: locationSupportableMapMock)
 
         var locationOptions2 = LocationOptions()
-        locationOptions2.showUserLocation = false
+        locationOptions2.puckType = nil
         locationManager.updateLocationOptions(with: locationOptions2)
         XCTAssertNil(locationManager.locationPuckManager)
     }
 
-    func testLocationManagerShowUserLocationIsEnabled() {
+    func testLocationManagerPuckTypeSetToNonNil() {
         var locationOptions = LocationOptions()
-        locationOptions.puckType = .puck2D(Puck2DConfiguration(scale: .constant(1.0)))
-        locationOptions.showUserLocation = false
+        locationOptions.puckType = nil
         let locationManager = LocationManager(locationOptions: locationOptions,
                                               locationSupportableMapView: locationSupportableMapMock)
 
         var locationOptions2 = LocationOptions()
-        locationOptions2.puckType = .puck2D(Puck2DConfiguration(scale: .constant(2.0)))
-        locationOptions2.showUserLocation = true
+        locationOptions2.puckType = .puck2D()
         locationManager.updateLocationOptions(with: locationOptions2)
         XCTAssertNotNil(locationManager.locationPuckManager)
         XCTAssertEqual(locationManager.locationPuckManager?.puckType, locationOptions2.puckType)

--- a/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
@@ -37,4 +37,51 @@ internal class LocationManagerTests: XCTestCase {
         XCTAssertNil(locationManager.delegate)
         XCTAssertFalse(locationManager.showUserLocation)
     }
+
+    func testLocationManagerShowUserLocationDefaultIsFalse() {
+        let locationOptions = LocationOptions()
+        XCTAssertFalse(locationOptions.showUserLocation)
+    }
+
+    func testLocationManagerPuckTypeModified() {
+        var locationOptions = LocationOptions()
+        locationOptions.puckType = .puck2D(Puck2DConfiguration(scale: .constant(1.0)))
+        locationOptions.showUserLocation = true
+        let locationManager = LocationManager(locationOptions: locationOptions,
+                                              locationSupportableMapView: locationSupportableMapMock)
+
+        var locationOptions2 = LocationOptions()
+        locationOptions2.puckType = .puck2D(Puck2DConfiguration(scale: .constant(2.0)))
+        locationOptions2.showUserLocation = true
+        locationManager.updateLocationOptions(with: locationOptions2)
+        XCTAssertEqual(locationManager.locationPuckManager?.puckType, locationOptions2.puckType)
+    }
+
+    func testLocationManagerShowUserLocationIsDisabled() {
+        var locationOptions = LocationOptions()
+        locationOptions.puckType = .puck2D(Puck2DConfiguration(scale: .constant(1.0)))
+        locationOptions.showUserLocation = true
+        let locationManager = LocationManager(locationOptions: locationOptions,
+                                              locationSupportableMapView: locationSupportableMapMock)
+
+        var locationOptions2 = LocationOptions()
+        locationOptions2.showUserLocation = false
+        locationManager.updateLocationOptions(with: locationOptions2)
+        XCTAssertNil(locationManager.locationPuckManager)
+    }
+
+    func testLocationManagerShowUserLocationIsEnabled() {
+        var locationOptions = LocationOptions()
+        locationOptions.puckType = .puck2D(Puck2DConfiguration(scale: .constant(1.0)))
+        locationOptions.showUserLocation = false
+        let locationManager = LocationManager(locationOptions: locationOptions,
+                                              locationSupportableMapView: locationSupportableMapMock)
+
+        var locationOptions2 = LocationOptions()
+        locationOptions2.puckType = .puck2D(Puck2DConfiguration(scale: .constant(2.0)))
+        locationOptions2.showUserLocation = true
+        locationManager.updateLocationOptions(with: locationOptions2)
+        XCTAssertNotNil(locationManager.locationPuckManager)
+        XCTAssertEqual(locationManager.locationPuckManager?.puckType, locationOptions2.puckType)
+    }
 }

--- a/Tests/MapboxMapsTests/Location/LocationOptionsTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationOptionsTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+#if canImport(MapboxMaps)
+@testable import MapboxMaps
+#else
+@testable import MapboxMapsLocation
+import MapboxMapsFoundation
+#endif
+
+final class LocationOptionsTests: XCTestCase {
+    func testLocationOptionsPuckTypeDefaultIsNil() {
+        let locationOptions = LocationOptions()
+        XCTAssertNil(locationOptions.puckType)
+    }
+}

--- a/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
@@ -11,7 +11,7 @@ internal class OptionsIntegrationTest: MapViewIntegrationTestCase {
         }
 
         var newOptions = MapboxMaps.MapOptions()
-        newOptions.location.showUserLocation = false
+        newOptions.location.puckType = nil
         newOptions.location.activityType = .automotiveNavigation
         newOptions.camera.animationDuration = 0.1
         newOptions.gestures.scrollEnabled = false


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes. --> NA
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant. --> NA
 - [ ] Document any changes to public APIs. --> NA
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog' 
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Fix puck update issue</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc --> NA

### Summary of changes
This is a bug fix for puck update issue. With this issue, when puch configuration is updated, puck is not updated.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)
No
<!--
If this PR introduces user-facing changes, please note them here.
-->

### Explanation for the update
- Reason for adding `previousOption`: updated `locationOptions` is used in `toggleUserLocationUpdates`. So needed to add a reference to store previous setting
- Test: test checks if `locationManager.locationPuckManager?.puckType` is correctly updated or not. With the issue, `LocationPuckManager` was not updated and it needs to be tested. Also `showUserLocation` on/off test is added to see the update does not affect  `toggleUserLocationUpdates` behavior.