### PR TITLE
[Draft] Add expressible by literal conformances to Value

### DIFF
--- a/Apps/Examples/Examples/All Examples/AnimateLayerExample.swift
+++ b/Apps/Examples/Examples/All Examples/AnimateLayerExample.swift
@@ -73,7 +73,7 @@ public class AnimateLayerExample: UIViewController, ExampleProtocol {
         var lineLayer = LineLayer(id: "line-layer")
         lineLayer.source = airplaneRoute.identifier
         lineLayer.paint?.lineColor = .constant(ColorRepresentable(color: UIColor.red))
-        lineLayer.paint?.lineWidth = .constant(3.0)
+        lineLayer.paint?.lineWidth = 3.0
         lineLayer.layout?.lineCap = .constant(.round)
 
         // Define the source data and style layer for the airplane symbol.
@@ -84,8 +84,8 @@ public class AnimateLayerExample: UIViewController, ExampleProtocol {
         // "airport-15" is the name the image that belongs in the style's sprite by default.
         airplaneSymbolLayer.layout?.iconImage = .constant(.name("airport-15"))
         airplaneSymbolLayer.layout?.iconRotationAlignment = .constant(.map)
-        airplaneSymbolLayer.layout?.iconAllowOverlap = .constant(true)
-        airplaneSymbolLayer.layout?.iconIgnorePlacement = .constant(true)
+        airplaneSymbolLayer.layout?.iconAllowOverlap = true
+        airplaneSymbolLayer.layout?.iconIgnorePlacement = true
         // Get the "bearing" property from the point's feature dictionary,
         // and use that value to determine the rotation angle of the airplane icon.
         airplaneSymbolLayer.layout?.iconRotate = .expression(Exp(.get) {

--- a/Apps/Examples/Examples/All Examples/BuildingExtrusionsExample.swift
+++ b/Apps/Examples/Examples/All Examples/BuildingExtrusionsExample.swift
@@ -41,7 +41,7 @@ public class BuildingExtrusionsExample: UIViewController, ExampleProtocol {
         layer.minZoom                     = 15
         layer.sourceLayer                 = "building"
         layer.paint?.fillExtrusionColor   = .constant(ColorRepresentable(color: .lightGray))
-        layer.paint?.fillExtrusionOpacity = .constant(0.6)
+        layer.paint?.fillExtrusionOpacity = 0.6
 
         layer.filter = Exp(.eq) {
             Exp(.get) {

--- a/Apps/Examples/Examples/All Examples/ExternalVectorSourceExample.swift
+++ b/Apps/Examples/Examples/All Examples/ExternalVectorSourceExample.swift
@@ -40,8 +40,8 @@ public class ExternalVectorSourceExample: UIViewController, ExampleProtocol {
         lineLayer.sourceLayer = "mapillary-sequences"
         let lineColor = ColorRepresentable(color: UIColor(red: 0.21, green: 0.69, blue: 0.43, alpha: 1.00))
         lineLayer.paint?.lineColor = .constant(lineColor)
-        lineLayer.paint?.lineOpacity = .constant(0.6)
-        lineLayer.paint?.lineWidth = .constant(2.0)
+        lineLayer.paint?.lineOpacity = 0.6
+        lineLayer.paint?.lineWidth = 2.0
         lineLayer.layout?.lineCap = .constant(.round)
 
         let addSourceResult = mapView.style.addSource(source: vectorSource, identifier: sourceIdentifier)

--- a/Apps/Examples/Examples/All Examples/FeaturesAtPointExample.swift
+++ b/Apps/Examples/Examples/All Examples/FeaturesAtPointExample.swift
@@ -47,7 +47,7 @@ public class FeaturesAtPointExample: UIViewController, ExampleProtocol {
 
         // Apply basic styling to the fill layer.
         fillLayer.paint?.fillColor = .constant(ColorRepresentable(color: UIColor.blue))
-        fillLayer.paint?.fillOpacity = .constant(0.3)
+        fillLayer.paint?.fillOpacity = 0.3
         fillLayer.paint?.fillOutlineColor = .constant(ColorRepresentable(color: UIColor.black))
 
         // Add the data source and style layer to the map.

--- a/Apps/Examples/Examples/All Examples/FitCameraToGeometryExample.swift
+++ b/Apps/Examples/Examples/All Examples/FitCameraToGeometryExample.swift
@@ -44,7 +44,7 @@ public class FitCameraToGeometryExample: UIViewController, ExampleProtocol {
         source.data = .feature(polygonFeature)
 
         var polygonLayer = FillLayer(id: "triangle-style")
-        polygonLayer.paint?.fillOpacity = .constant(0.5)
+        polygonLayer.paint?.fillOpacity = 0.5
         polygonLayer.paint?.fillColor = .constant(ColorRepresentable(color: .gray))
         polygonLayer.source = sourceIdentifier
 

--- a/Apps/Examples/Examples/All Examples/GeoJSONSourceExample.swift
+++ b/Apps/Examples/Examples/All Examples/GeoJSONSourceExample.swift
@@ -68,8 +68,8 @@ public class GeoJSONSourceExample: UIViewController, ExampleProtocol {
         }
         circleLayer.source = geoJSONDataSourceIdentifier
         circleLayer.paint?.circleColor = .constant(ColorRepresentable(color: UIColor.yellow))
-        circleLayer.paint?.circleOpacity = .constant(0.6)
-        circleLayer.paint?.circleRadius = .constant(8.0)
+        circleLayer.paint?.circleOpacity = 0.6
+        circleLayer.paint?.circleRadius = 8.0
         // Follow the same steps to create a line layer
         var lineLayer = LineLayer(id: "line-layer")
         lineLayer.filter = Exp(.eq) {
@@ -78,7 +78,7 @@ public class GeoJSONSourceExample: UIViewController, ExampleProtocol {
         }
         lineLayer.source = geoJSONDataSourceIdentifier
         lineLayer.paint?.lineColor = .constant(ColorRepresentable(color: UIColor.red))
-        lineLayer.paint?.lineWidth = .constant(1.4)
+        lineLayer.paint?.lineWidth = 1.4
         // Follow the same steps to create a polygon (fill) layer
         var polygonLayer = FillLayer(id: "fill-layer")
         polygonLayer.filter = Exp(.eq) {
@@ -87,7 +87,7 @@ public class GeoJSONSourceExample: UIViewController, ExampleProtocol {
         }
         polygonLayer.source = geoJSONDataSourceIdentifier
         polygonLayer.paint?.fillColor = .constant(ColorRepresentable(color: UIColor.green))
-        polygonLayer.paint?.fillOpacity = .constant(0.3)
+        polygonLayer.paint?.fillOpacity = 0.3
         polygonLayer.paint?.fillOutlineColor = .constant(ColorRepresentable(color: UIColor.purple))
         // Add the source and style layers to the map style.
         _ = mapView.style.addSource(source: geoJSONSource, identifier: geoJSONDataSourceIdentifier)

--- a/Apps/Examples/Examples/All Examples/SceneKitExample.swift
+++ b/Apps/Examples/Examples/All Examples/SceneKitExample.swift
@@ -58,7 +58,7 @@ public class SceneKitExample: UIViewController, ExampleProtocol, CustomLayerHost
         var skyLayer = SkyLayer(id: "sky-layer")
         skyLayer.paint?.skyType = .constant(.atmosphere)
         skyLayer.paint?.skyAtmosphereSun = .constant([0, 0])
-        skyLayer.paint?.skyAtmosphereSunIntensity = .constant(15.0)
+        skyLayer.paint?.skyAtmosphereSunIntensity = 15.0
 
         _ = self.mapView.style.addLayer(layer: skyLayer)
 

--- a/Apps/Examples/Examples/All Examples/TerrainExample.swift
+++ b/Apps/Examples/Examples/All Examples/TerrainExample.swift
@@ -41,14 +41,14 @@ public class TerrainExample: UIViewController, ExampleProtocol {
         _ = mapView.style.addSource(source: demSource, identifier: "mapbox-dem")
 
         var terrain = Terrain(sourceId: "mapbox-dem")
-        terrain.exaggeration = .constant(1.5)
+        terrain.exaggeration = 1.5
 
         _ = mapView.style.setTerrain(terrain)
 
         var skyLayer = SkyLayer(id: "sky-layer")
         skyLayer.paint?.skyType = .constant(.atmosphere)
         skyLayer.paint?.skyAtmosphereSun = .constant([0.0, 0.0])
-        skyLayer.paint?.skyAtmosphereSunIntensity = .constant(15.0)
+        skyLayer.paint?.skyAtmosphereSunIntensity = 15.0
 
         _ = mapView.style.addLayer(layer: skyLayer)
     }

--- a/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
@@ -43,7 +43,7 @@ public struct Puck2DConfiguration: Equatable {
     }
 
     internal var resolvedScale: Value<Double> {
-        scale ?? .constant(1.0)
+        scale ?? 1.0
     }
 }
 

--- a/Sources/MapboxMaps/Style/Types/Value.swift
+++ b/Sources/MapboxMaps/Style/Types/Value.swift
@@ -35,5 +35,36 @@ public enum Value<T: Codable>: Codable {
 }
 
 extension Value: Equatable where T: Equatable {
+}
 
+extension Value: ExpressibleByFloatLiteral where T == FloatLiteralType {
+    public init(floatLiteral value: FloatLiteralType) {
+        self = .constant(value)
+    }
+}
+
+extension Value: ExpressibleByStringLiteral, ExpressibleByExtendedGraphemeClusterLiteral, ExpressibleByUnicodeScalarLiteral where T == StringLiteralType {
+    public init(stringLiteral value: StringLiteralType) {
+        self = .constant(value)
+    }
+
+    public init(extendedGraphemeClusterLiteral value: StringLiteralType) {
+        self = .constant(String(value))
+    }
+
+    public init(unicodeScalarLiteral value: StringLiteralType) {
+        self = .constant(String(value))
+    }
+}
+
+extension Value: ExpressibleByIntegerLiteral where T == IntegerLiteralType {
+    public init(integerLiteral value: IntegerLiteralType) {
+        self = .constant(value)
+    }
+}
+
+extension Value: ExpressibleByBooleanLiteral where T == BooleanLiteralType {
+    public init(booleanLiteral value: BooleanLiteralType) {
+        self = .constant(value)
+    }
 }

--- a/Tests/MapboxMapsTests/Location/PuckTypeTests.swift
+++ b/Tests/MapboxMapsTests/Location/PuckTypeTests.swift
@@ -28,10 +28,10 @@ internal class PuckTypeTests: XCTestCase {
 
     func testPuck2DEqual() throws {
 
-        let config1 = Puck2DConfiguration(topImage: image, scale: .constant(10))
+        let config1 = Puck2DConfiguration(topImage: image, scale: 10)
         let puck1 = PuckType.puck2D(config1)
 
-        let config2 = Puck2DConfiguration(topImage: image, scale: .constant(10))
+        let config2 = Puck2DConfiguration(topImage: image, scale: 10)
         let puck2 = PuckType.puck2D(config2)
 
         XCTAssertEqual(puck1, puck2)
@@ -39,10 +39,10 @@ internal class PuckTypeTests: XCTestCase {
 
     func testPuck2DNotEqual() throws {
 
-        let config1 = Puck2DConfiguration(topImage: image, scale: .constant(12))
+        let config1 = Puck2DConfiguration(topImage: image, scale: 12)
         let puck1 = PuckType.puck2D(config1)
 
-        let config2 = Puck2DConfiguration(topImage: image, scale: .constant(10))
+        let config2 = Puck2DConfiguration(topImage: image, scale: 10)
         let puck2 = PuckType.puck2D(config2)
 
         XCTAssertNotEqual(puck1, puck2)

--- a/Tests/MapboxMapsTests/Style/Fixtures/Value+Fixtures.swift
+++ b/Tests/MapboxMapsTests/Style/Fixtures/Value+Fixtures.swift
@@ -7,7 +7,7 @@ import UIKit
 
 internal extension Value where T == Double {
     static func testConstantValue() -> Value<Double> {
-        return .constant(1.0)
+        return 1.0
     }
 }
 
@@ -19,7 +19,7 @@ internal extension Value where T == [Double] {
 
 internal extension Value where T == String {
     static func testConstantValue() -> Value<String> {
-        return .constant("some string")
+        return "some string"
     }
 }
 
@@ -43,7 +43,7 @@ internal extension Value where T == ColorRepresentable {
 
 internal extension Value where T == Bool {
     static func testConstantValue() -> Value<Bool> {
-        return .constant(true)
+        return true
     }
 }
 


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Value.constant can now be expressed as a float, integer, string, or boolean literal.</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

- Adds several expressible by literal conformances to Value so that it can be expressed as a float, integer, string, or boolean literal.