### PR TITLE
Fix xcparty invocation in CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,7 +344,7 @@ jobs:
           name: "Parsing xcresults for errors"
           command: |
             RESULTS=`find build/testruns -name '*.xcresult'`
-            xargs swift run --package-path scripts/xcparty \<<< "$RESULTS" | tee build/testruns/failures.txt
+            xargs swift run --package-path scripts/xcparty xcparty \<<< "$RESULTS" | tee build/testruns/failures.txt
           when: on_fail
       - run:
           name: Symbolicate crash logs
@@ -405,7 +405,7 @@ jobs:
           name: "Parsing xcresults for errors"
           command: |
             RESULTS=`find "$DERIVED_DATA_PATH/testruns" -name '*.xcresult'`
-            xargs swift run --package-path scripts/xcparty \<<< "$RESULTS" | tee build/testruns/failures.txt
+            xargs swift run --package-path scripts/xcparty xcparty \<<< "$RESULTS" | tee build/testruns/failures.txt
           when: on_fail
       - run:
           name: Symbolicate crash logs


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

Here's the usage for `swift run`:

`USAGE: swift run [options] [executable [arguments ...]]`

We forgot to specify the executable