### PR TITLE
[Camera Animators v2] Update gestures to use drag API

### DIFF
--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -80,13 +80,14 @@ public class DebugViewController: UIViewController {
         mapView.on(.mapLoaded) { (event) in
             print("The map has finished loading... Event = \(event)")
             
-//            let initialCenter = CLLocationCoordinate2D(latitude: 39.01305735102963, longitude: -77.01570412528032)
-//            self.mapView.cameraManager.setCamera(centerCoordinate: initialCenter, zoom: 12)
-//            
-//            self.runningAnimator = self.mapView.cameraManager.makeRunningCameraAnimator(duration: 10, delay: 2, animations: {
-//                
-//                self.mapView.cameraManager.setCamera(centerCoordinate: CLLocationCoordinate2D(latitude: 36.0893334370578, longitude: -78.06549948618996), zoom: 12)
-//            })
+            let initialCenter = CLLocationCoordinate2D(latitude: 39.01305735102963, longitude: -77.01570412528032)
+            self.mapView.cameraManager.setCamera(centerCoordinate: initialCenter, zoom: 12)
+            
+            self.runningAnimator = self.mapView.cameraManager.makeCameraAnimator(duration: 10, curve: .linear) {
+                self.mapView.cameraManager.setCamera(centerCoordinate: CLLocationCoordinate2D(latitude: 36.0893334370578, longitude: -78.06549948618996), zoom: 12)
+            }
+            
+            self.runningAnimator!.startAnimation(afterDelay: 2)
         }
 
         /**

--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -79,14 +79,14 @@ public class DebugViewController: UIViewController {
          */
         mapView.on(.mapLoaded) { (event) in
             print("The map has finished loading... Event = \(event)")
-            
+
             let initialCenter = CLLocationCoordinate2D(latitude: 39.01305735102963, longitude: -77.01570412528032)
             self.mapView.cameraManager.setCamera(centerCoordinate: initialCenter, zoom: 12)
-            
+
             self.runningAnimator = self.mapView.cameraManager.makeCameraAnimator(duration: 10, curve: .linear) {
                 self.mapView.cameraManager.setCamera(centerCoordinate: CLLocationCoordinate2D(latitude: 36.0893334370578, longitude: -78.06549948618996), zoom: 12)
             }
-            
+
             self.runningAnimator!.startAnimation(afterDelay: 2)
         }
 

--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -11,6 +11,7 @@ import Turf
 public class DebugViewController: UIViewController {
 
     internal var mapView: MapView!
+    internal var runningAnimator: CameraAnimator?
 
     var resourceOptions: ResourceOptions {
         guard let accessToken = AccountManager.shared.accessToken else {
@@ -78,31 +79,14 @@ public class DebugViewController: UIViewController {
          */
         mapView.on(.mapLoaded) { (event) in
             print("The map has finished loading... Event = \(event)")
-
-            let coordinate = CLLocationCoordinate2D(latitude: 39.085006, longitude: -77.150925)
-            self.mapView.cameraManager.setCamera(centerCoordinate: coordinate,
-                                                 zoom: 12)
-
-            UIViewPropertyAnimator.runningPropertyAnimator(withDuration: 10, delay: 2, options: .curveLinear) {
-
-                let coordinate2 = CLLocationCoordinate2D(latitude: 39.085006, longitude: -78.12)
-                self.mapView.cameraManager.setCamera(centerCoordinate: coordinate2, zoom: 16)
-
-            } completion: { (_) in
-                print("Camera animation complete!!!")
-            }
-        }
-
-        /**
-         The closure is called whenever the map view is entering an idle state,
-         and no more drawing will be necessary until new data is loaded or there
-         is some interaction with the map.
-
-         - All currently requested tiles have been rendered
-         - All fade/transition animations have completed
-         */
-        mapView.on(.mapIdle) { (event) in
-            print("The map is idle... Event = \(event)")
+            
+//            let initialCenter = CLLocationCoordinate2D(latitude: 39.01305735102963, longitude: -77.01570412528032)
+//            self.mapView.cameraManager.setCamera(centerCoordinate: initialCenter, zoom: 12)
+//            
+//            self.runningAnimator = self.mapView.cameraManager.makeRunningCameraAnimator(duration: 10, delay: 2, animations: {
+//                
+//                self.mapView.cameraManager.setCamera(centerCoordinate: CLLocationCoordinate2D(latitude: 36.0893334370578, longitude: -78.06549948618996), zoom: 12)
+//            })
         }
 
         /**

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,0 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon-ios.json" "10.0.2"
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-core/MapboxCoreMaps-dynamic.json" "10.0.0-beta.17"
-github "mapbox/mapbox-events-ios" "v0.10.8"
-github "mapbox/turf-swift" "v2.0.0-alpha.3"

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -433,7 +433,7 @@ open class BaseMapView: UIView, MapClient, MBMMetalViewProvider, CameraViewDeleg
         metalView.layer.isOpaque = isOpaque
         metalView.isPaused = true
         metalView.enableSetNeedsDisplay = true
-        metalView.presentsWithTransaction = true
+        metalView.presentsWithTransaction = false
 
         insertSubview(metalView, at: 0)
         self.metalView = metalView

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -433,7 +433,7 @@ open class BaseMapView: UIView, MapClient, MBMMetalViewProvider, CameraViewDeleg
         metalView.layer.isOpaque = isOpaque
         metalView.isPaused = true
         metalView.enableSetNeedsDisplay = true
-        metalView.presentsWithTransaction = false
+        metalView.presentsWithTransaction = true
 
         insertSubview(metalView, at: 0)
         self.metalView = metalView

--- a/Sources/MapboxMaps/Foundation/Camera/CameraAnimationDelegate.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraAnimationDelegate.swift
@@ -16,12 +16,4 @@ internal protocol CameraAnimatorDelegate: class {
     func schedulePendingCompletion(forAnimator animator: CameraAnimator,
                                    completion: @escaping AnimationCompletion,
                                    animatingPosition: UIViewAnimatingPosition)
-
-    /**
-    This delegate function notifies that the animation is finished
-
-    - Parameter animator: The current animator that this delegate function is being called from
-    */
-    func animatorIsFinished(forAnimator animator: CameraAnimator)
-
 }

--- a/Sources/MapboxMaps/Foundation/Camera/CameraAnimator.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraAnimator.swift
@@ -45,7 +45,7 @@ public class CameraAnimator: NSObject {
         self.propertyAnimator = propertyAnimator
         self.owner = owner
     }
-    
+
     deinit {
         if propertyAnimator?.state == .active {
             propertyAnimator?.stopAnimation(false)

--- a/Sources/MapboxMaps/Foundation/Camera/CameraAnimator.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraAnimator.swift
@@ -67,11 +67,11 @@ public class CameraAnimator: NSObject {
     public func stopAnimation() {
         propertyAnimator.stopAnimation(false)
         propertyAnimator.finishAnimation(at: .current)
-        delegate?.animatorIsFinished(forAnimator: self)
     }
 
     /// Add animations block to the animator with a `delayFactor`.
     public func addAnimations(_ animations: @escaping () -> Void, delayFactor: CGFloat) {
+        // if this cameraAnimator is not in the list of CameraAnimators held by the `CameraManager` then add it to that list??
         propertyAnimator.addAnimations(animations, delayFactor: delayFactor)
     }
 

--- a/Sources/MapboxMaps/Foundation/Camera/CameraAnimator.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraAnimator.swift
@@ -6,7 +6,7 @@ public class CameraAnimator: NSObject {
     // MARK: Stored Properties
 
     /// Instance of the property animator that will run animations.
-    private let propertyAnimator: UIViewPropertyAnimator
+    private var propertyAnimator: UIViewPropertyAnimator?
 
     /// Delegate that conforms to `CameraAnimatorDelegate`.
     private weak var delegate: CameraAnimatorDelegate?
@@ -17,24 +17,24 @@ public class CameraAnimator: NSObject {
     // MARK: Computed Properties
 
     /// The state from of the animator.
-    public var state: UIViewAnimatingState { return propertyAnimator.state }
+    public var state: UIViewAnimatingState? { return propertyAnimator?.state }
 
     /// Boolean that represents if the animation is running or not.
-    public var isRunning: Bool { return propertyAnimator.isRunning }
+    public var isRunning: Bool? { return propertyAnimator?.isRunning }
 
     /// Boolean that represents if the animation is running normally or in reverse.
-    public var isReversed: Bool { return propertyAnimator.isReversed }
+    public var isReversed: Bool? { return propertyAnimator?.isReversed }
 
     /// A Boolean value that indicates whether a completed animation remains in the active state.
-    public var pausesOnCompletion: Bool {
-        get { return propertyAnimator.pausesOnCompletion}
-        set { propertyAnimator.pausesOnCompletion = newValue }
+    public var pausesOnCompletion: Bool? {
+        get { return propertyAnimator?.pausesOnCompletion}
+        set { propertyAnimator?.pausesOnCompletion = newValue ?? false }
     }
 
     /// Value that represents what percentage of the animation has been completed.
-    public var fractionComplete: CGFloat {
-        get { return propertyAnimator.fractionComplete }
-        set { propertyAnimator.fractionComplete = newValue }
+    public var fractionComplete: CGFloat? {
+        get { return propertyAnimator?.fractionComplete }
+        set { propertyAnimator?.fractionComplete = newValue ?? 0 }
     }
 
     // MARK: Initializer
@@ -45,50 +45,58 @@ public class CameraAnimator: NSObject {
         self.propertyAnimator = propertyAnimator
         self.owner = owner
     }
+    
+    deinit {
+        if propertyAnimator?.state == .active {
+            propertyAnimator?.stopAnimation(false)
+            propertyAnimator?.finishAnimation(at: .current)
+        }
+        propertyAnimator = nil
+    }
 
     // MARK: Functions
 
     /// Starts the animation.
     public func startAnimation() {
-        propertyAnimator.startAnimation()
+        propertyAnimator?.startAnimation()
     }
 
     /// Starts the animation after a `delay` which is of type `TimeInterval`.
     public func startAnimation(afterDelay delay: TimeInterval) {
-        propertyAnimator.startAnimation(afterDelay: delay)
+        propertyAnimator?.startAnimation(afterDelay: delay)
     }
 
     /// Pauses the animation.
     public func pauseAnimation() {
-        propertyAnimator.pauseAnimation()
+        propertyAnimator?.pauseAnimation()
     }
 
     /// Stops the animation.
     public func stopAnimation() {
-        propertyAnimator.stopAnimation(false)
-        propertyAnimator.finishAnimation(at: .current)
+        propertyAnimator?.stopAnimation(false)
+        propertyAnimator?.finishAnimation(at: .current)
     }
 
     /// Add animations block to the animator with a `delayFactor`.
     public func addAnimations(_ animations: @escaping () -> Void, delayFactor: CGFloat) {
         // if this cameraAnimator is not in the list of CameraAnimators held by the `CameraManager` then add it to that list??
-        propertyAnimator.addAnimations(animations, delayFactor: delayFactor)
+        propertyAnimator?.addAnimations(animations, delayFactor: delayFactor)
     }
 
     /// Add animations block to the animator.
     public func addAnimations(_ animations: @escaping () -> Void) {
-        propertyAnimator.addAnimations(animations)
+        propertyAnimator?.addAnimations(animations)
     }
 
     /// Add a completion block to the animator. 
     public func addCompletion(_ completion: @escaping AnimationCompletion) {
-        propertyAnimator.addCompletion({ animatingPosition in
+        propertyAnimator?.addCompletion({ animatingPosition in
             self.delegate?.schedulePendingCompletion(forAnimator: self, completion: completion, animatingPosition: animatingPosition)
         })
     }
 
     /// Continue the animation with a timing parameter (`UITimingCurveProvider`) and duration factor (`CGFloat`).
     public func continueAnimation(withTimingParameters parameters: UITimingCurveProvider?, durationFactor: CGFloat) {
-        propertyAnimator.continueAnimation(withTimingParameters: parameters, durationFactor: durationFactor)
+        propertyAnimator?.continueAnimation(withTimingParameters: parameters, durationFactor: durationFactor)
     }
 }

--- a/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
@@ -3,7 +3,6 @@ import UIKit
 import Turf
 
 /// An object that manages a camera's view lifecycle.
-// swiftlint:disable type_body_length
 public class CameraManager {
 
     /// Used to set up camera specific configuration

--- a/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
@@ -153,12 +153,11 @@ public class CameraManager {
         guard mapView.camera != clampedCamera else {
             return
         }
-        
-        
+
         let transitionBlock = {
             mapView.camera = clampedCamera
         }
-        
+
         if animated && duration > 0 {
             performCameraAnimation(duration: duration, animation: transitionBlock, completion: completion)
         } else {
@@ -195,7 +194,7 @@ public class CameraManager {
                                       zoom: zoom,
                                       bearing: bearing,
                                       pitch: pitch)
-        
+
         setCamera(to: newCamera, animated: animated, duration: duration, completion: completion)
     }
     // swiftlint:enable function_parameter_count
@@ -216,18 +215,15 @@ public class CameraManager {
      */
     fileprivate func performCameraAnimation(duration: TimeInterval, animation: @escaping () -> Void, completion: ((UIViewAnimatingPosition) -> Void)? = nil) {
         var animator: CameraAnimator?
-        
+
         animator = makeCameraAnimator(duration: duration, curve: .easeOut)
         animator?.addAnimations(animation)
-        
+
         animator?.addCompletion({ (position) in
-            if let validCompletion = completion, let validAnimator = animator {
-                self.schedulePendingCompletion(forAnimator: validAnimator, completion: validCompletion, animatingPosition: position)
-            }
-            
+            completion?(position)
             animator = nil
         })
-        
+
         animator?.startAnimation()
     }
 
@@ -355,8 +351,7 @@ public class CameraManager {
                                                                     padding: padding,
                                                                     bearing: NSNumber(value: Float(bearing)),
                                                                     pitch: NSNumber(value: Float(pitch)))
-        
-        
+
         setCamera(to: cameraOptions, animated: animated, duration: duration, completion: completion)
     }
 
@@ -386,7 +381,7 @@ public class CameraManager {
 
         // If there was no duration specified, use a default
         let time: TimeInterval = duration ?? interpolator.duration()
-        
+
         // TODO: Consider timesteps based on the flyTo curve, for example, it would be beneficial to have a higher
         // density of time steps at towards the start and end of the animation to avoid jiggling.
         let timeSteps = stride(from: 0.0, through: 1.0, by: 0.025)

--- a/Sources/MapboxMaps/Foundation/Camera/CameraView.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraView.swift
@@ -234,9 +234,8 @@ public class CameraView: UIView {
     }
 }
 
-
 fileprivate extension CameraOptions {
-    
+
     func wrap() -> CameraOptions {
         return CameraOptions(center: self.center?.wrap(),
                              padding: self.padding,
@@ -244,6 +243,6 @@ fileprivate extension CameraOptions {
                              zoom: self.zoom,
                              bearing: self.bearing,
                              pitch: self.pitch)
-        
+
     }
 }

--- a/Sources/MapboxMaps/Foundation/Camera/CameraView.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraView.swift
@@ -218,9 +218,7 @@ public class CameraView: UIView {
             }
 
             if targetCamera.center != currentCamera.center {
-                
                 diffedCamera.center = targetCamera.center
-//                print("** currentCamera center: \(currentCamera.center) interpolated center: \(targetCamera.center!)")
             }
 
             if targetCamera.anchor != currentCamera.anchor {

--- a/Sources/MapboxMaps/Foundation/Camera/CameraView.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraView.swift
@@ -197,7 +197,7 @@ public class CameraView: UIView {
         let currentCamera = delegate.camera
 
         // Get the latest interpolated values of the camera properties (if they exist)
-        let targetCamera = localCamera
+        let targetCamera = localCamera.wrap()
 
         // Apply targetCamera options only if they are different from currentCamera options
         if currentCamera != targetCamera {
@@ -218,7 +218,9 @@ public class CameraView: UIView {
             }
 
             if targetCamera.center != currentCamera.center {
+                
                 diffedCamera.center = targetCamera.center
+//                print("** currentCamera center: \(currentCamera.center) interpolated center: \(targetCamera.center!)")
             }
 
             if targetCamera.anchor != currentCamera.anchor {
@@ -231,5 +233,19 @@ public class CameraView: UIView {
 
             delegate.jumpTo(camera: diffedCamera)
         }
+    }
+}
+
+
+fileprivate extension CameraOptions {
+    
+    func wrap() -> CameraOptions {
+        return CameraOptions(center: self.center?.wrap(),
+                             padding: self.padding,
+                             anchor: self.anchor,
+                             zoom: self.zoom,
+                             bearing: self.bearing,
+                             pitch: self.pitch)
+        
     }
 }

--- a/Sources/MapboxMaps/Foundation/Extensions/CoreLocation.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/CoreLocation.swift
@@ -11,7 +11,7 @@ public extension CLLocationCoordinate2D {
         CLLocation(latitude: latitude, longitude: longitude)
     }
 
-    /// Returns a new `CLLocationCoordinate` value with a new latitude constrained within 360 degrees.
+    /// Returns a new `CLLocationCoordinate` value with a new longitude constrained to [-180, +180] degrees.
     func wrap() -> CLLocationCoordinate2D {
         /**
          mbgl::geo.hpp equivalent:

--- a/Sources/MapboxMaps/Gestures/GestureHandlerDelegate.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlerDelegate.swift
@@ -6,7 +6,7 @@ internal protocol GestureHandlerDelegate: class {
 
     // View has been tapped with a number of taps and number of finger touches
     func tapped(numberOfTaps: Int, numberOfTouches: Int)
-    
+
     func panBegan(at point: CGPoint)
 
     // View has been panned
@@ -59,7 +59,7 @@ internal protocol GestureHandlerDelegate: class {
 internal extension GestureHandlerDelegate {
 
     func tapped(numberOfTaps: Int, numberOfTouches: Int) {}
-    
+
     func panBegan(at point: CGPoint) {}
 
     // View has been panned

--- a/Sources/MapboxMaps/Gestures/GestureHandlerDelegate.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlerDelegate.swift
@@ -6,12 +6,14 @@ internal protocol GestureHandlerDelegate: class {
 
     // View has been tapped with a number of taps and number of finger touches
     func tapped(numberOfTaps: Int, numberOfTouches: Int)
+    
+    func panBegan(at point: CGPoint)
 
     // View has been panned
-    func panned(by displacement: CGPoint)
+    func panned(from startPoint: CGPoint, to: CGPoint)
 
     // Pan on the view has ended with a residual offset
-    func panEnded(with offset: CGPoint)
+    func panEnded(at endPoint: CGPoint, shouldDriftTo driftEndPoint: CGPoint)
 
     // Cancel any gesture transitions that are happening
     func cancelGestureTransitions()
@@ -57,10 +59,14 @@ internal protocol GestureHandlerDelegate: class {
 internal extension GestureHandlerDelegate {
 
     func tapped(numberOfTaps: Int, numberOfTouches: Int) {}
+    
+    func panBegan(at point: CGPoint) {}
 
-    func panned(by displacement: CGPoint) {}
+    // View has been panned
+    func panned(from startPoint: CGPoint, to endPoint: CGPoint) {}
 
-    func panEnded(with offset: CGPoint) {}
+    // Pan on the view has ended (with a potential drift)
+    func panEnded(at endPoint: CGPoint, shouldDriftTo driftEndPoint: CGPoint) {}
 
     func cancelGestureTransitions() {}
 

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PanGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PanGestureHandler.swift
@@ -22,26 +22,38 @@ internal class PanGestureHandler: GestureHandler {
     @objc internal func handlePan(_ pan: UIPanGestureRecognizer) {
         switch pan.state {
         case .began:
+            
+            let point = pan.location(in: pan.view)
+            delegate.panBegan(at: point)
             delegate.gestureBegan(for: .pan)
+            
         case .changed:
+            let start = pan.location(in: pan.view)
             let delta = pan.translation(in: pan.view).applyPanScrollingMode(panScrollingMode: scrollMode)
-            delegate.panned(by: delta)
+            let end = CGPoint(x: start.x + delta.x, y: start.y + delta.y)
+            delegate.panned(from: start, to: end)
             pan.setTranslation(.zero, in: pan.view)
+            
         case .ended, .cancelled:
+            let endPoint = pan.location(in: pan.view)
             var velocity = pan.velocity(in: pan.view)
             let velocityHypot = sqrt(pow(velocity.x, 2) + pow(velocity.y, 2))
 
             if decelerationRate == 0.0 || velocityHypot < 1000 {
                 velocity = CGPoint.zero
             }
-
+            
+            var driftOffset = CGPoint.zero
             if velocity != CGPoint.zero { // There is a potential drift after the gesture has ended
-                let offset = CGPoint(x: velocity.x * decelerationRate / 4,
+                driftOffset = CGPoint(x: velocity.x * decelerationRate / 4,
                                      y: velocity.y * decelerationRate / 4)
                                     .applyPanScrollingMode(panScrollingMode: scrollMode)
-
-                delegate.panEnded(with: offset)
             }
+            
+            let driftEndPoint = CGPoint(x: endPoint.x + driftOffset.x,
+                                        y: endPoint.y + driftOffset.y)
+            
+            delegate.panEnded(at: endPoint, shouldDriftTo: driftEndPoint)
         default:
             break
         }

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PanGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PanGestureHandler.swift
@@ -22,18 +22,18 @@ internal class PanGestureHandler: GestureHandler {
     @objc internal func handlePan(_ pan: UIPanGestureRecognizer) {
         switch pan.state {
         case .began:
-            
+
             let point = pan.location(in: pan.view)
             delegate.panBegan(at: point)
             delegate.gestureBegan(for: .pan)
-            
+
         case .changed:
             let start = pan.location(in: pan.view)
             let delta = pan.translation(in: pan.view).applyPanScrollingMode(panScrollingMode: scrollMode)
             let end = CGPoint(x: start.x + delta.x, y: start.y + delta.y)
             delegate.panned(from: start, to: end)
             pan.setTranslation(.zero, in: pan.view)
-            
+
         case .ended, .cancelled:
             let endPoint = pan.location(in: pan.view)
             var velocity = pan.velocity(in: pan.view)
@@ -42,17 +42,17 @@ internal class PanGestureHandler: GestureHandler {
             if decelerationRate == 0.0 || velocityHypot < 1000 {
                 velocity = CGPoint.zero
             }
-            
+
             var driftOffset = CGPoint.zero
             if velocity != CGPoint.zero { // There is a potential drift after the gesture has ended
                 driftOffset = CGPoint(x: velocity.x * decelerationRate / 4,
                                      y: velocity.y * decelerationRate / 4)
                                     .applyPanScrollingMode(panScrollingMode: scrollMode)
             }
-            
+
             let driftEndPoint = CGPoint(x: endPoint.x + driftOffset.x,
                                         y: endPoint.y + driftOffset.y)
-            
+
             delegate.panEnded(at: endPoint, shouldDriftTo: driftEndPoint)
         default:
             break

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/TapGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/TapGestureHandler.swift
@@ -22,6 +22,7 @@ internal class TapGestureHandler: GestureHandler {
 
     // Calls view to process the tap gesture
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {
+        delegate.gestureBegan(for: .tap(numberOfTaps: tap.numberOfTapsRequired, numberOfTouches: tap.numberOfTouchesRequired))
         delegate.tapped(numberOfTaps: tap.numberOfTapsRequired, numberOfTouches: tap.numberOfTouchesRequired)
     }
 }

--- a/Sources/MapboxMaps/Gestures/GestureManager+GestureHandlerDelegate.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager+GestureHandlerDelegate.swift
@@ -26,30 +26,30 @@ extension GestureManager: GestureHandlerDelegate {
                                     completion: nil)
         }
     }
-    
+
     internal func panBegan(at point: CGPoint) {
         try! cameraManager.mapView?.__map.dragStart(forPoint: point.screenCoordinate)
     }
 
     // MapView has been panned
     internal func panned(from startPoint: CGPoint, to endPoint: CGPoint) {
-        
+
         if let cameraOptions = try! cameraManager.mapView?.__map.getDragCameraOptionsFor(fromPoint: startPoint.screenCoordinate, toPoint: endPoint.screenCoordinate) {
-            
+
             cameraManager.setCamera(to: cameraOptions,
                                     animated: false,
                                     duration: 0,
                                     completion: nil)
-            
+
         }
     }
 
     // Pan has ended on the MapView with a residual `offset`
     func panEnded(at endPoint: CGPoint, shouldDriftTo driftEndPoint: CGPoint) {
-    
+
         if endPoint != driftEndPoint,
            let driftCameraOptions = try! cameraManager.mapView?.__map.getDragCameraOptionsFor(fromPoint: endPoint.screenCoordinate, toPoint: driftEndPoint.screenCoordinate) {
-            
+
             cameraManager.setCamera(to: driftCameraOptions,
                                     animated: true,
                                     duration: Double(UIScrollView.DecelerationRate.normal.rawValue),

--- a/Sources/MapboxMaps/Gestures/GestureManager+GestureHandlerDelegate.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager+GestureHandlerDelegate.swift
@@ -1,0 +1,186 @@
+import UIKit
+import MapboxCommon
+import MapboxCoreMaps
+
+extension GestureManager: GestureHandlerDelegate {
+    // MapView has been tapped a certain number of times
+    internal func tapped(numberOfTaps: Int, numberOfTouches: Int) {
+
+        guard let mapView = cameraManager.mapView else {
+            return
+        }
+
+        // Single tapping twice with one finger will cause the map to zoom in
+        if numberOfTaps == 2 && numberOfTouches == 1 {
+            cameraManager.setCamera(to: CameraOptions(zoom: mapView.zoom + 1.0),
+                                    animated: true,
+                                    duration: 0.3,
+                                    completion: nil)
+        }
+
+        // Double tapping twice with two fingers will cause the map to zoom out
+        if numberOfTaps == 2 && numberOfTouches == 2 {
+            cameraManager.setCamera(to: CameraOptions(zoom: mapView.zoom - 1.0),
+                                    animated: true,
+                                    duration: 0.3,
+                                    completion: nil)
+        }
+    }
+    
+    internal func panBegan(at point: CGPoint) {
+        try! cameraManager.mapView?.__map.dragStart(forPoint: point.screenCoordinate)
+    }
+
+    // MapView has been panned
+    internal func panned(from startPoint: CGPoint, to endPoint: CGPoint) {
+        
+        if let cameraOptions = try! cameraManager.mapView?.__map.getDragCameraOptionsFor(fromPoint: startPoint.screenCoordinate, toPoint: endPoint.screenCoordinate) {
+            
+            cameraManager.setCamera(to: cameraOptions,
+                                    animated: false,
+                                    duration: 0,
+                                    completion: nil)
+            
+        }
+    }
+
+    // Pan has ended on the MapView with a residual `offset`
+    func panEnded(at endPoint: CGPoint, shouldDriftTo driftEndPoint: CGPoint) {
+    
+        if endPoint != driftEndPoint,
+           let driftCameraOptions = try! cameraManager.mapView?.__map.getDragCameraOptionsFor(fromPoint: endPoint.screenCoordinate, toPoint: driftEndPoint.screenCoordinate) {
+            
+            cameraManager.setCamera(to: driftCameraOptions,
+                                    animated: true,
+                                    duration: Double(UIScrollView.DecelerationRate.normal.rawValue),
+                                    completion: nil)
+        }
+        try! cameraManager.mapView?.__map.dragEnd()
+    }
+
+    internal func cancelGestureTransitions() {
+        cameraManager.cancelTransitions()
+    }
+
+    internal func gestureBegan(for gestureType: GestureType) {
+        cameraManager.cancelTransitions()
+        delegate?.gestureBegan(for: gestureType)
+    }
+
+    internal func scaleForZoom() -> CGFloat {
+        cameraManager.mapView?.zoom ?? 0
+    }
+
+    internal func pinchScaleChanged(with newScale: CGFloat, andAnchor anchor: CGPoint) {
+        cameraManager.setCamera(to: CameraOptions(anchor: anchor, zoom: newScale),
+                                animated: false,
+                                duration: 0,
+                                completion: nil)
+    }
+
+    internal func pinchEnded(with finalScale: CGFloat, andDrift possibleDrift: Bool, andAnchor anchor: CGPoint) {
+        cameraManager.setCamera(to: CameraOptions(anchor: anchor, zoom: finalScale),
+                                animated: false,
+                                duration: 0,
+                                completion: nil)
+        unrotateIfNeededForGesture(with: .ended)
+    }
+
+    internal func quickZoomChanged(with newScale: CGFloat, and anchor: CGPoint) {
+        let zoom = max(newScale, cameraManager.mapCameraOptions.minimumZoomLevel)
+        cameraManager.setCamera(to: CameraOptions(anchor: anchor, zoom: zoom),
+                                animated: false,
+                                duration: 0,
+                                completion: nil)
+    }
+
+    internal func quickZoomEnded() {
+        unrotateIfNeededForGesture(with: .ended)
+    }
+    internal func isRotationAllowed() -> Bool {
+        guard let mapView = cameraManager.mapView else {
+            return false
+        }
+
+        return mapView.cameraView.zoom >= cameraManager.mapCameraOptions.minimumZoomLevel
+    }
+
+    internal func rotationStartAngle() -> CGFloat {
+        guard let mapView = cameraManager.mapView else {
+            return 0
+        }
+        return (mapView.cameraView.bearing * .pi) / 180.0 * -1
+    }
+
+    internal func rotationChanged(with changedAngle: CGFloat, and anchor: CGPoint, and pinchScale: CGFloat) {
+
+        var changedAngleInDegrees = changedAngle * 180.0 / .pi * -1
+        changedAngleInDegrees = changedAngleInDegrees.truncatingRemainder(dividingBy: 360.0)
+
+        // Constraining `changedAngleInDegrees` to -30.0 to +30.0 degrees
+        if isRotationAllowed() == false && abs(pinchScale) < 10 {
+            changedAngleInDegrees = changedAngleInDegrees < -30.0 ? -30.0 : changedAngleInDegrees
+            changedAngleInDegrees = changedAngleInDegrees > 30.0 ? 30.0 : changedAngleInDegrees
+        }
+
+        cameraManager.setCamera(to: CameraOptions(bearing: CLLocationDirection(changedAngleInDegrees)),
+                                animated: false,
+                                duration: 0,
+                                completion: nil)
+    }
+
+    internal func rotationEnded(with finalAngle: CGFloat, and anchor: CGPoint, with pinchState: UIGestureRecognizer.State) {
+        var finalAngleInDegrees = finalAngle * 180.0 / .pi * -1
+        finalAngleInDegrees = finalAngleInDegrees.truncatingRemainder(dividingBy: 360.0)
+        cameraManager.setCamera(to: CameraOptions(bearing: CLLocationDirection(finalAngleInDegrees)),
+                                animated: false,
+                                duration: 0,
+                                completion: nil)
+    }
+
+    internal func unrotateIfNeededForGesture(with pinchState: UIGestureRecognizer.State) {
+        guard let mapView = cameraManager.mapView else {
+            return
+        }
+
+        // Avoid contention with in-progress gestures
+        // let toleranceForSnappingToNorth: CGFloat = 7.0
+        if mapView.cameraView.bearing != 0.0
+            && pinchState != .began
+            && pinchState != .changed {
+            if mapView.cameraView.bearing != 0.0 && isRotationAllowed() == false {
+                cameraManager.setCamera(to: CameraOptions(bearing: 0),
+                                        animated: false,
+                                        duration: 0,
+                                        completion: nil)
+            }
+
+            // TODO: Add snapping behavior to "north" if bearing is less than some tolerance
+            // else if abs(self.mapView.cameraView.bearing) < toleranceForSnappingToNorth
+            //            || abs(self.mapView.cameraView.bearing) > 360.0 - toleranceForSnappingToNorth {
+            //    self.transitionBearing(to: 0.0, animated: true)
+            //}
+        }
+    }
+
+    internal func initialPitch() -> CGFloat {
+        guard let mapView = cameraManager.mapView else {
+            return 0
+        }
+        return mapView.cameraView.pitch
+    }
+
+    internal func horizontalPitchTiltTolerance() -> Double {
+        return 45.0
+    }
+
+    internal func pitchChanged(newPitch: CGFloat) {
+        cameraManager.setCamera(to: CameraOptions(pitch: newPitch),
+                                animated: false,
+                                duration: 0,
+                                completion: nil)
+    }
+
+    internal func pitchEnded() {
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureManager+GestureHandlerDelegate.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager+GestureHandlerDelegate.swift
@@ -52,7 +52,7 @@ extension GestureManager: GestureHandlerDelegate {
 
             cameraManager.setCamera(to: driftCameraOptions,
                                     animated: true,
-                                    duration: Double(UIScrollView.DecelerationRate.normal.rawValue),
+                                    duration: Double(cameraManager.mapCameraOptions.decelerationRate),
                                     completion: nil)
         }
         try! cameraManager.mapView?.__map.dragEnd()

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -5,8 +5,6 @@ import CoreLocation
 import MapboxMapsFoundation
 #endif
 
-// swiftlint:disable file_length
-
 public enum GestureType: Hashable {
     /// The pan gesture type
     case pan

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -117,21 +117,12 @@ internal protocol CameraManagerProtocol: AnyObject {
     func setCamera(to camera: CameraOptions,
                    animated: Bool,
                    duration: TimeInterval,
-                   completion: ((Bool) -> Void)?)
-
-    //swiftlint:disable function_parameter_count
-    func moveCamera(by offset: CGPoint?,
-                    rotation: CGFloat?,
-                    pitch: CGFloat?,
-                    zoom: CGFloat?,
-                    animated: Bool,
-                    pitchedDrift: Bool)
+                   completion: ((UIViewAnimatingPosition) -> Void)?)
 
     func cancelTransitions()
 }
 
-extension CameraManager: CameraManagerProtocol {
-}
+extension CameraManager: CameraManagerProtocol { }
 
 public final class GestureManager: NSObject {
 
@@ -145,7 +136,7 @@ public final class GestureManager: NSObject {
     private weak var view: UIView?
 
     /// The camera manager that responds to gestures.
-    private let cameraManager: CameraManagerProtocol
+    internal let cameraManager: CameraManagerProtocol
 
     public weak var delegate: GestureManagerDelegate?
 
@@ -281,167 +272,5 @@ extension GestureManager: GestureContextProvider {
     internal func requireGestureToFail(allowedGesture: GestureHandler, failableGesture: GestureHandler) {
         guard let failableGesture = failableGesture.gestureRecognizer else { return }
         allowedGesture.gestureRecognizer?.require(toFail: failableGesture)
-    }
-}
-
-extension GestureManager: GestureHandlerDelegate {
-    // MapView has been tapped a certain number of times
-    internal func tapped(numberOfTaps: Int, numberOfTouches: Int) {
-
-        guard let mapView = cameraManager.mapView else {
-            return
-        }
-
-        // Single tapping twice with one finger will cause the map to zoom in
-        if numberOfTaps == 2 && numberOfTouches == 1 {
-            cameraManager.setCamera(to: CameraOptions(zoom: mapView.cameraView.zoom + 1.0),
-                                    animated: false,
-                                    duration: 0,
-                                    completion: nil)
-        }
-
-        // Double tapping twice with two fingers will cause the map to zoom out
-        if numberOfTaps == 2 && numberOfTouches == 2 {
-            cameraManager.setCamera(to: CameraOptions(zoom: mapView.cameraView.zoom - 1.0),
-                                    animated: false,
-                                    duration: 0,
-                                    completion: nil)
-        }
-    }
-
-    // MapView has been panned
-    internal func panned(by displacement: CGPoint) {
-        cameraManager.moveCamera(by: displacement, rotation: nil, pitch: nil, zoom: nil, animated: false, pitchedDrift: false)
-    }
-
-    // Pan has ended on the MapView with a residual `offset`
-    internal func panEnded(with offset: CGPoint) {
-        cameraManager.moveCamera(by: offset, rotation: nil, pitch: nil, zoom: nil, animated: true, pitchedDrift: true)
-    }
-
-    internal func cancelGestureTransitions() {
-        cameraManager.cancelTransitions()
-    }
-
-    internal func gestureBegan(for gestureType: GestureType) {
-        cameraManager.cancelTransitions()
-        delegate?.gestureBegan(for: gestureType)
-    }
-
-    internal func scaleForZoom() -> CGFloat {
-        cameraManager.mapView?.zoom ?? 0
-    }
-
-    internal func pinchScaleChanged(with newScale: CGFloat, andAnchor anchor: CGPoint) {
-        cameraManager.setCamera(to: CameraOptions(anchor: anchor, zoom: newScale),
-                                animated: false,
-                                duration: 0,
-                                completion: nil)
-    }
-
-    internal func pinchEnded(with finalScale: CGFloat, andDrift possibleDrift: Bool, andAnchor anchor: CGPoint) {
-        cameraManager.setCamera(to: CameraOptions(anchor: anchor, zoom: finalScale),
-                                animated: false,
-                                duration: 0,
-                                completion: nil)
-        unrotateIfNeededForGesture(with: .ended)
-    }
-
-    internal func quickZoomChanged(with newScale: CGFloat, and anchor: CGPoint) {
-        let zoom = max(newScale, cameraManager.mapCameraOptions.minimumZoomLevel)
-        cameraManager.setCamera(to: CameraOptions(anchor: anchor, zoom: zoom),
-                                animated: false,
-                                duration: 0,
-                                completion: nil)
-    }
-
-    internal func quickZoomEnded() {
-        unrotateIfNeededForGesture(with: .ended)
-    }
-    internal func isRotationAllowed() -> Bool {
-        guard let mapView = cameraManager.mapView else {
-            return false
-        }
-
-        return mapView.cameraView.zoom >= cameraManager.mapCameraOptions.minimumZoomLevel
-    }
-
-    internal func rotationStartAngle() -> CGFloat {
-        guard let mapView = cameraManager.mapView else {
-            return 0
-        }
-        return (mapView.cameraView.bearing * .pi) / 180.0 * -1
-    }
-
-    internal func rotationChanged(with changedAngle: CGFloat, and anchor: CGPoint, and pinchScale: CGFloat) {
-
-        var changedAngleInDegrees = changedAngle * 180.0 / .pi * -1
-        changedAngleInDegrees = changedAngleInDegrees.truncatingRemainder(dividingBy: 360.0)
-
-        // Constraining `changedAngleInDegrees` to -30.0 to +30.0 degrees
-        if isRotationAllowed() == false && abs(pinchScale) < 10 {
-            changedAngleInDegrees = changedAngleInDegrees < -30.0 ? -30.0 : changedAngleInDegrees
-            changedAngleInDegrees = changedAngleInDegrees > 30.0 ? 30.0 : changedAngleInDegrees
-        }
-
-        cameraManager.setCamera(to: CameraOptions(bearing: CLLocationDirection(changedAngleInDegrees)),
-                                animated: false,
-                                duration: 0,
-                                completion: nil)
-    }
-
-    internal func rotationEnded(with finalAngle: CGFloat, and anchor: CGPoint, with pinchState: UIGestureRecognizer.State) {
-        var finalAngleInDegrees = finalAngle * 180.0 / .pi * -1
-        finalAngleInDegrees = finalAngleInDegrees.truncatingRemainder(dividingBy: 360.0)
-        cameraManager.setCamera(to: CameraOptions(bearing: CLLocationDirection(finalAngleInDegrees)),
-                                animated: false,
-                                duration: 0,
-                                completion: nil)
-    }
-
-    internal func unrotateIfNeededForGesture(with pinchState: UIGestureRecognizer.State) {
-        guard let mapView = cameraManager.mapView else {
-            return
-        }
-
-        // Avoid contention with in-progress gestures
-        // let toleranceForSnappingToNorth: CGFloat = 7.0
-        if mapView.cameraView.bearing != 0.0
-            && pinchState != .began
-            && pinchState != .changed {
-            if mapView.cameraView.bearing != 0.0 && isRotationAllowed() == false {
-                cameraManager.setCamera(to: CameraOptions(bearing: 0),
-                                        animated: false,
-                                        duration: 0,
-                                        completion: nil)
-            }
-
-            // TODO: Add snapping behavior to "north" if bearing is less than some tolerance
-            // else if abs(self.mapView.cameraView.bearing) < toleranceForSnappingToNorth
-            //            || abs(self.mapView.cameraView.bearing) > 360.0 - toleranceForSnappingToNorth {
-            //    self.transitionBearing(to: 0.0, animated: true)
-            //}
-        }
-    }
-
-    internal func initialPitch() -> CGFloat {
-        guard let mapView = cameraManager.mapView else {
-            return 0
-        }
-        return mapView.cameraView.pitch
-    }
-
-    internal func horizontalPitchTiltTolerance() -> Double {
-        return 45.0
-    }
-
-    internal func pitchChanged(newPitch: CGFloat) {
-        cameraManager.setCamera(to: CameraOptions(pitch: newPitch),
-                                animated: false,
-                                duration: 0,
-                                completion: nil)
-    }
-
-    internal func pitchEnded() {
     }
 }

--- a/Tests/MapboxMapsTests/Foundation/Camera/CameraAnimatorTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Camera/CameraAnimatorTests.swift
@@ -19,11 +19,6 @@ internal class CameraAnimatorTests: XCTestCase {
                                         owner: .unspecified)
     }
 
-    func testStopAnimationCallsDelegate() {
-        cameraAnimator.stopAnimation()
-        XCTAssertEqual(delegate.cameraAnimatorStub.invocations.count, 1)
-    }
-
     func testAddCompletionSchedulesACompletion() {
         cameraAnimator.addCompletion({ _ in
             XCTAssertEqual(self.delegate.cameraAnimatorStub.invocations.count, 1)

--- a/Tests/MapboxMapsTests/Foundation/Camera/MapboxMapsCameraTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Camera/MapboxMapsCameraTests.swift
@@ -7,7 +7,6 @@ import MetalKit
 @testable import MapboxMapsFoundation
 #endif
 
-// swiftlint:disable:next type_body_length
 class CameraManagerTests: XCTestCase {
 
     var mapView: BaseMapView!

--- a/Tests/MapboxMapsTests/Foundation/Camera/MapboxMapsCameraTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Camera/MapboxMapsCameraTests.swift
@@ -294,68 +294,6 @@ class CameraManagerTests: XCTestCase {
         XCTAssertEqual(optimizedBearing, 200)
     }
 
-    func verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing bearing: CLLocationDirection,
-                                                                               offset: CGPoint,
-                                                                               line: UInt = #line) {
-        cameraManager.setCamera(centerCoordinate: CLLocationCoordinate2D(latitude: 0,
-                                                                         longitude: 179.999),
-                                zoom: 0,
-                                bearing: bearing,
-                                animated: false)
-
-        let shiftedCenterCoordinate = cameraManager.shiftCenterCoordinate(by: offset, pitchedDrift: false)
-
-        XCTAssertGreaterThan(shiftedCenterCoordinate.longitude, 180, line: line)
-    }
-
-    func verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing bearing: CLLocationDirection,
-                                                                               offset: CGPoint,
-                                                                               line: UInt = #line) {
-        cameraManager.setCamera(centerCoordinate: CLLocationCoordinate2D(latitude: 0,
-                                                                         longitude: -179.999),
-                                zoom: 0,
-                                bearing: bearing,
-                                animated: false)
-
-        let shiftedCenterCoordinate = cameraManager.shiftCenterCoordinate(by: offset, pitchedDrift: false)
-
-        XCTAssertLessThan(shiftedCenterCoordinate.longitude, -180, line: line)
-    }
-
-    func testShiftCenterCoordinateHandlesAntimeridianCrossingWhileHeadingEast() {
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: 0, offset: CGPoint(x: -10, y: 0))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: 45, offset: CGPoint(x: -10, y: 0))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: 135, offset: CGPoint(x: 10, y: 0))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: 180, offset: CGPoint(x: 10, y: 0))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: -180, offset: CGPoint(x: 10, y: 0))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: -135, offset: CGPoint(x: 10, y: 0))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: -45, offset: CGPoint(x: -10, y: 0))
-
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: 45, offset: CGPoint(x: 0, y: 10))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: 90, offset: CGPoint(x: 0, y: 10))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: 135, offset: CGPoint(x: 0, y: 10))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: -135, offset: CGPoint(x: 0, y: -10))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: -90, offset: CGPoint(x: 0, y: -10))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingEast(forBearing: -45, offset: CGPoint(x: 0, y: -10))
-    }
-
-    func testShiftCenterCoordinateHandlesAntimeridianCrossingWhileHeadingWest() {
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: 0, offset: CGPoint(x: 10, y: 0))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: 45, offset: CGPoint(x: 10, y: 0))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: 135, offset: CGPoint(x: -10, y: 0))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: 180, offset: CGPoint(x: -10, y: 0))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: -180, offset: CGPoint(x: -10, y: 0))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: -135, offset: CGPoint(x: -10, y: 0))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: -45, offset: CGPoint(x: 10, y: 0))
-
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: 45, offset: CGPoint(x: 0, y: -10))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: 90, offset: CGPoint(x: 0, y: -10))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: 135, offset: CGPoint(x: 0, y: -10))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: -135, offset: CGPoint(x: 0, y: 10))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: -90, offset: CGPoint(x: 0, y: 10))
-        verifyShiftCenterCoordinateHandlesAntimeridianCrossingWhenHeadingWest(forBearing: -45, offset: CGPoint(x: 0, y: 10))
-    }
-
     // MARK: MakeCameraAnimator Tests
 
     func testAddCameraAnimators() {

--- a/Tests/MapboxMapsTests/Foundation/Camera/MapboxMapsCameraTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Camera/MapboxMapsCameraTests.swift
@@ -224,24 +224,6 @@ class CameraManagerTests: XCTestCase {
         XCTAssertEqual(mapView.cameraView.localPitch, cameraManager.mapCameraOptions.maximumPitch, accuracy: 0.000001)
     }
 
-    func testMoveCamera() {
-        mapView.zoom = 0.0
-        let initialCamera = mapView.camera
-        cameraManager.moveCamera(rotation: 10)
-
-        XCTAssertNotEqual(initialCamera.bearing, mapView.cameraView.localBearing)
-        XCTAssertEqual(mapView.cameraView.localBearing, -212.957, accuracy: 0.001, "Check that the new bearing matches the expected value.")
-        XCTAssertEqual(mapView.cameraView.localCenterCoordinate, CLLocationCoordinate2D(latitude: 0, longitude: 0))
-
-        cameraManager.moveCamera(by: .zero, pitch: 10, zoom: 10.0)
-        XCTAssertEqual(mapView.cameraView.localPitch, -10)
-        XCTAssertEqual(mapView.cameraView.localZoom, 10.0, accuracy: 0.001, "The value for zoom should be 10.0")
-
-        cameraManager.moveCamera(by: CGPoint(x: -10, y: 10))
-        XCTAssertEqual(mapView.cameraView.localCenterCoordinate.latitude, 7.013668, accuracy: 0.0001, "The new latitude should be approximately 7.013668")
-        XCTAssertEqual(mapView.cameraView.localCenterCoordinate.longitude, -352.96875, accuracy: 0.0001, "The new longitude should be approximately -352.96875")
-    }
-
     func testOptimizeBearingClockwise() {
         let startBearing = 0.0
         let endBearing = 90.0
@@ -376,19 +358,14 @@ class CameraManagerTests: XCTestCase {
 
     // MARK: MakeCameraAnimator Tests
 
-    func testAddAndRemoveCameraAnimators() {
+    func testAddCameraAnimators() {
         let firstAnimator = cameraManager.makeCameraAnimator(duration: 5.0, curve: .linear)
         let secondAnimator = cameraManager.makeCameraAnimator(duration: 5.0, dampingRatio: 1.0)
         let thirdAnimator = cameraManager.makeCameraAnimator(duration: 5.0, curve: .linear)
         let fourthAnimator = cameraManager.makeCameraAnimator(duration: 5.0, controlPoint1: CGPoint(x: 0.0, y: 1.0), controlPoint2: CGPoint(x: 1.0, y: 0.0))
-        XCTAssertEqual(cameraManager.cameraAnimators.count, 4)
-
-        firstAnimator.stopAnimation()
-        XCTAssertEqual(cameraManager.cameraAnimators.count, 3)
-
-        secondAnimator.stopAnimation()
-        thirdAnimator.stopAnimation()
-        fourthAnimator.stopAnimation()
-        XCTAssertEqual(cameraManager.cameraAnimators.count, 0)
+        XCTAssertTrue(cameraManager.cameraAnimators.contains(firstAnimator))
+        XCTAssertTrue(cameraManager.cameraAnimators.contains(secondAnimator))
+        XCTAssertTrue(cameraManager.cameraAnimators.contains(thirdAnimator))
+        XCTAssertTrue(cameraManager.cameraAnimators.contains(fourthAnimator))
     }
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureSupportableViewMock.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureSupportableViewMock.swift
@@ -35,8 +35,8 @@ class GestureHandlerDelegateMock: GestureHandlerDelegate {
         tapCalledWithNumberOfTaps = numberOfTaps
         tapCalledWithNumberOfTouches = numberOfTouches
     }
-
-    public func panned(by displacement: CGPoint) {
+    
+    public func panned(from startPoint: CGPoint, to endPoint: CGPoint) {
         pannedCalled = true
     }
 

--- a/Tests/MapboxMapsTests/Gestures/GestureSupportableViewMock.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureSupportableViewMock.swift
@@ -35,7 +35,7 @@ class GestureHandlerDelegateMock: GestureHandlerDelegate {
         tapCalledWithNumberOfTaps = numberOfTaps
         tapCalledWithNumberOfTouches = numberOfTouches
     }
-    
+
     public func panned(from startPoint: CGPoint, to endPoint: CGPoint) {
         pannedCalled = true
     }

--- a/Tests/MapboxMapsTests/Gestures/MockCameraManager.swift
+++ b/Tests/MapboxMapsTests/Gestures/MockCameraManager.swift
@@ -16,29 +16,22 @@ final class MockCameraManager: CameraManagerProtocol {
         var camera: CameraOptions
         var animated: Bool
         var duration: TimeInterval
-        var completion: ((Bool) -> Void)?
+        var completion: ((UIViewAnimatingPosition) -> Void)?
     }
+    
     let setCameraStub = Stub<SetCameraParameters, Void>()
+    
     func setCamera(to camera: CameraOptions,
                    animated: Bool,
                    duration: TimeInterval,
-                   completion: ((Bool) -> Void)?) {
+                   completion: ((UIViewAnimatingPosition) -> Void)?) {
         setCameraStub.call(
             with: SetCameraParameters(camera: camera,
                                       animated: animated,
                                       duration: duration,
                                       completion: completion))
     }
-
-    //swiftlint:disable function_parameter_count
-    func moveCamera(by offset: CGPoint?,
-                    rotation: CGFloat?,
-                    pitch: CGFloat?,
-                    zoom: CGFloat?,
-                    animated: Bool,
-                    pitchedDrift: Bool) {
-    }
-
+    
     func cancelTransitions() {
     }
 }

--- a/Tests/MapboxMapsTests/Gestures/MockCameraManager.swift
+++ b/Tests/MapboxMapsTests/Gestures/MockCameraManager.swift
@@ -18,9 +18,9 @@ final class MockCameraManager: CameraManagerProtocol {
         var duration: TimeInterval
         var completion: ((UIViewAnimatingPosition) -> Void)?
     }
-    
+
     let setCameraStub = Stub<SetCameraParameters, Void>()
-    
+
     func setCamera(to camera: CameraOptions,
                    animated: Bool,
                    duration: TimeInterval,
@@ -31,7 +31,7 @@ final class MockCameraManager: CameraManagerProtocol {
                                       duration: duration,
                                       completion: completion))
     }
-    
+
     func cancelTransitions() {
     }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Document any changes to public APIs.

### Summary of changes

- Makes the `GestureManager` call into the drag API when the map is panned.
- Deletes the now unused `moveBy` and `shiftCenterCoordinate` methods
- Makes the `propertyAnimator` held by `CameraAnimator` optional -- and makes it so that a `deinit` of a `CameraAnimator` 
   results in the `propertyAnimator` being nil'ed out.
- Deletes unused `TransitionState` and associated notification
- Ensures that gestures call into `cancelTransition` when invoked
- Reworks `cancelTransitions` to operate on list of `cameraAnimators`
- Ensures that the `cameraView` wraps center coordinate longitudes to within [-180, +180] range before calling `jumpTo`.
- Ensuring that internal infrastructure never removes a `CameraAnimator` from the list of `cameraAnimators` directly -- instead we rely on ARC to clean up the `cameraAnimators` hashTable for us.


https://user-images.githubusercontent.com/6844889/112365244-d07cc200-8cad-11eb-9691-0b9acccd7180.mov

