### PR TITLE
Make LocationManager.locationOptions getter public

### DIFF
--- a/Sources/MapboxMaps/Location/LocationManager.swift
+++ b/Sources/MapboxMaps/Location/LocationManager.swift
@@ -39,7 +39,7 @@ public class LocationManager: NSObject {
     /// Only created if `showsUserLocation` is `true`
     internal var locationPuckManager: LocationPuckManager?
 
-    internal var locationOptions: LocationOptions
+    public private(set) var locationOptions: LocationOptions
 
     internal init(locationOptions: LocationOptions,
                   locationSupportableMapView: LocationSupportableMapView) {

--- a/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
@@ -9,68 +9,83 @@ import MapboxMapsFoundation
 
 internal class LocationManagerTests: XCTestCase {
 
-    var locationSupportableMapMock: LocationSupportableMapViewMock!
-    var locationProviderOptionsMock: LocationOptions!
-    var locationConsumerMock: LocationConsumerMock!
+    var locationSupportableMapView: LocationSupportableMapViewMock!
 
     override func setUp() {
-        locationSupportableMapMock = LocationSupportableMapViewMock()
-        locationProviderOptionsMock = LocationOptions()
-        locationConsumerMock = LocationConsumerMock()
+        locationSupportableMapView = LocationSupportableMapViewMock()
         super.setUp()
     }
 
     override func tearDown() {
-        locationSupportableMapMock = nil
-        locationProviderOptionsMock = nil
-        locationConsumerMock = nil
+        locationSupportableMapView = nil
         super.tearDown()
     }
 
     func testLocationManagerDefaultInitialization() {
-        let locationManager = LocationManager(locationOptions: locationProviderOptionsMock,
-                                              locationSupportableMapView: locationSupportableMapMock)
-        locationManager.addLocationConsumer(newConsumer: locationConsumerMock)
+        let locationOptions = LocationOptions()
 
-        XCTAssertNotNil(locationManager.consumers)
-        XCTAssertNotNil(locationManager.locationSupportableMapView)
+        let locationManager = LocationManager(
+            locationOptions: locationOptions,
+            locationSupportableMapView: locationSupportableMapView)
+
+        XCTAssertEqual(locationManager.locationOptions, locationOptions)
+        XCTAssertTrue(locationManager.locationSupportableMapView === locationSupportableMapView)
         XCTAssertNil(locationManager.delegate)
     }
 
-    func testLocationManagerPuckTypeModified() {
+    func testAddLocationConsumer() {
+        let locationManager = LocationManager(
+            locationOptions: LocationOptions(),
+            locationSupportableMapView: locationSupportableMapView)
+        let locationConsumer = LocationConsumerMock()
+
+        locationManager.addLocationConsumer(newConsumer: locationConsumer)
+
+        XCTAssertTrue(locationManager.consumers.contains(locationConsumer))
+    }
+
+    func testUpdateLocationOptionsWithModifiedPuckType() {
         var locationOptions = LocationOptions()
         locationOptions.puckType = .puck2D(Puck2DConfiguration(scale: .constant(1.0)))
-        let locationManager = LocationManager(locationOptions: locationOptions,
-                                              locationSupportableMapView: locationSupportableMapMock)
+        let locationManager = LocationManager(
+            locationOptions: locationOptions,
+            locationSupportableMapView: locationSupportableMapView)
 
         var locationOptions2 = LocationOptions()
         locationOptions2.puckType = .puck2D(Puck2DConfiguration(scale: .constant(2.0)))
         locationManager.updateLocationOptions(with: locationOptions2)
+
+        XCTAssertEqual(locationManager.locationOptions, locationOptions2)
         XCTAssertEqual(locationManager.locationPuckManager?.puckType, locationOptions2.puckType)
     }
 
-    func testLocationManagerPuckTypeSetToNil() {
+    func testUpdateLocationOptionsWithPuckTypeSetToNil() {
         var locationOptions = LocationOptions()
         locationOptions.puckType = .puck2D()
-        let locationManager = LocationManager(locationOptions: locationOptions,
-                                              locationSupportableMapView: locationSupportableMapMock)
+        let locationManager = LocationManager(
+            locationOptions: locationOptions,
+            locationSupportableMapView: locationSupportableMapView)
 
         var locationOptions2 = LocationOptions()
         locationOptions2.puckType = nil
         locationManager.updateLocationOptions(with: locationOptions2)
+
+        XCTAssertEqual(locationManager.locationOptions, locationOptions2)
         XCTAssertNil(locationManager.locationPuckManager)
     }
 
-    func testLocationManagerPuckTypeSetToNonNil() {
+    func testUpdateLocationOptionsWithPuckTypeSetToNonNil() {
         var locationOptions = LocationOptions()
         locationOptions.puckType = nil
-        let locationManager = LocationManager(locationOptions: locationOptions,
-                                              locationSupportableMapView: locationSupportableMapMock)
+        let locationManager = LocationManager(
+            locationOptions: locationOptions,
+            locationSupportableMapView: locationSupportableMapView)
 
         var locationOptions2 = LocationOptions()
         locationOptions2.puckType = .puck2D()
         locationManager.updateLocationOptions(with: locationOptions2)
-        XCTAssertNotNil(locationManager.locationPuckManager)
+
+        XCTAssertEqual(locationManager.locationOptions, locationOptions2)
         XCTAssertEqual(locationManager.locationPuckManager?.puckType, locationOptions2.puckType)
     }
 }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>The getter for LocationManager.locationOptions is now public</changelog>`.

### Summary of changes

- The getter for LocationManager.locationOptions is now public. This compensates for the removal of `LocationManager.showUserLocation` in #199 & #203 