### PR TITLE
Make PropertyAnimator non optional

### DIFF
--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -82,12 +82,6 @@ public class DebugViewController: UIViewController {
 
             let initialCenter = CLLocationCoordinate2D(latitude: 39.01305735102963, longitude: -77.01570412528032)
             self.mapView.cameraManager.setCamera(centerCoordinate: initialCenter, zoom: 12)
-
-            self.runningAnimator = self.mapView.cameraManager.makeCameraAnimator(duration: 10, curve: .linear) {
-                self.mapView.cameraManager.setCamera(centerCoordinate: CLLocationCoordinate2D(latitude: 36.0893334370578, longitude: -78.06549948618996), zoom: 12)
-            }
-
-            self.runningAnimator!.startAnimation(afterDelay: 2)
         }
 
         /**

--- a/Sources/MapboxMaps/Foundation/Camera/CameraAnimator.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraAnimator.swift
@@ -6,7 +6,7 @@ public class CameraAnimator: NSObject {
     // MARK: Stored Properties
 
     /// Instance of the property animator that will run animations.
-    private var propertyAnimator: UIViewPropertyAnimator?
+    private var propertyAnimator: UIViewPropertyAnimator
 
     /// Delegate that conforms to `CameraAnimatorDelegate`.
     private weak var delegate: CameraAnimatorDelegate?
@@ -17,24 +17,24 @@ public class CameraAnimator: NSObject {
     // MARK: Computed Properties
 
     /// The state from of the animator.
-    public var state: UIViewAnimatingState? { return propertyAnimator?.state }
+    public var state: UIViewAnimatingState { return propertyAnimator.state }
 
     /// Boolean that represents if the animation is running or not.
-    public var isRunning: Bool? { return propertyAnimator?.isRunning }
+    public var isRunning: Bool { return propertyAnimator.isRunning }
 
     /// Boolean that represents if the animation is running normally or in reverse.
-    public var isReversed: Bool? { return propertyAnimator?.isReversed }
+    public var isReversed: Bool { return propertyAnimator.isReversed }
 
     /// A Boolean value that indicates whether a completed animation remains in the active state.
-    public var pausesOnCompletion: Bool? {
-        get { return propertyAnimator?.pausesOnCompletion}
-        set { propertyAnimator?.pausesOnCompletion = newValue ?? false }
+    public var pausesOnCompletion: Bool {
+        get { return propertyAnimator.pausesOnCompletion}
+        set { propertyAnimator.pausesOnCompletion = newValue }
     }
 
     /// Value that represents what percentage of the animation has been completed.
-    public var fractionComplete: CGFloat? {
-        get { return propertyAnimator?.fractionComplete }
-        set { propertyAnimator?.fractionComplete = newValue ?? 0 }
+    public var fractionComplete: CGFloat {
+        get { return propertyAnimator.fractionComplete }
+        set { propertyAnimator.fractionComplete = newValue }
     }
 
     // MARK: Initializer
@@ -47,56 +47,55 @@ public class CameraAnimator: NSObject {
     }
 
     deinit {
-        if propertyAnimator?.state == .active {
-            propertyAnimator?.stopAnimation(false)
-            propertyAnimator?.finishAnimation(at: .current)
-        }
-        propertyAnimator = nil
+        print("about to deinit animator")
+        propertyAnimator.stopAnimation(false)
+        propertyAnimator.finishAnimation(at: .current)
     }
 
     // MARK: Functions
 
     /// Starts the animation.
     public func startAnimation() {
-        propertyAnimator?.startAnimation()
+        propertyAnimator.startAnimation()
     }
 
     /// Starts the animation after a `delay` which is of type `TimeInterval`.
     public func startAnimation(afterDelay delay: TimeInterval) {
-        propertyAnimator?.startAnimation(afterDelay: delay)
+        propertyAnimator.startAnimation(afterDelay: delay)
     }
 
     /// Pauses the animation.
     public func pauseAnimation() {
-        propertyAnimator?.pauseAnimation()
+        propertyAnimator.pauseAnimation()
     }
 
     /// Stops the animation.
     public func stopAnimation() {
-        propertyAnimator?.stopAnimation(false)
-        propertyAnimator?.finishAnimation(at: .current)
+        propertyAnimator.stopAnimation(false)
+        propertyAnimator.finishAnimation(at: .current)
     }
 
     /// Add animations block to the animator with a `delayFactor`.
     public func addAnimations(_ animations: @escaping () -> Void, delayFactor: CGFloat) {
-        // if this cameraAnimator is not in the list of CameraAnimators held by the `CameraManager` then add it to that list??
-        propertyAnimator?.addAnimations(animations, delayFactor: delayFactor)
+        // if this cameraAnimator is not in the list of CameraAnimators held by the `CameraManager` then add it to that list
+        propertyAnimator.addAnimations(animations, delayFactor: delayFactor)
     }
 
     /// Add animations block to the animator.
     public func addAnimations(_ animations: @escaping () -> Void) {
-        propertyAnimator?.addAnimations(animations)
+        propertyAnimator.addAnimations(animations)
     }
 
     /// Add a completion block to the animator. 
     public func addCompletion(_ completion: @escaping AnimationCompletion) {
-        propertyAnimator?.addCompletion({ animatingPosition in
+        propertyAnimator.addCompletion({ [weak self] animatingPosition in
+            guard let self = self else { return }
             self.delegate?.schedulePendingCompletion(forAnimator: self, completion: completion, animatingPosition: animatingPosition)
         })
     }
 
     /// Continue the animation with a timing parameter (`UITimingCurveProvider`) and duration factor (`CGFloat`).
     public func continueAnimation(withTimingParameters parameters: UITimingCurveProvider?, durationFactor: CGFloat) {
-        propertyAnimator?.continueAnimation(withTimingParameters: parameters, durationFactor: durationFactor)
+        propertyAnimator.continueAnimation(withTimingParameters: parameters, durationFactor: durationFactor)
     }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.

### Summary of changes

This PR makes the `propertyAnimator` held by a `CameraAnimator` non-optional but ensures that the `propertyAnimator` is stopped before deinitializing the CameraAnimator.