### PR TITLE
[Camera Animations v2] Fix optimize bearing

### DIFF
--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -79,9 +79,10 @@ public class DebugViewController: UIViewController {
          */
         mapView.on(.mapLoaded) { (event) in
             print("The map has finished loading... Event = \(event)")
-
-            let initialCenter = CLLocationCoordinate2D(latitude: 39.01305735102963, longitude: -77.01570412528032)
-            self.mapView.cameraManager.setCamera(centerCoordinate: initialCenter, zoom: 12)
+            
+            
+            
+            self.runTest()
         }
 
         /**
@@ -100,6 +101,45 @@ public class DebugViewController: UIViewController {
             }
 
             print("The map failed to load.. \(type) = \(message)")
+        }
+    }
+    
+    static var counter = 0
+    
+    func runTest() {
+        let bearings: [(Double, Double)] = [
+            (330.7222595214844, 344.0169982910156),
+            (332.0651550292969, 357.12646484375),
+            (334.2096252441406, 359.3537292480469),
+            (336.25244140625, -0.0),
+            (337.7581481933594, 347.4563903808594),
+            (339.7362365722656, 355.0942077636719),
+            (339.7362365722656, -0.0),
+            (339.7362365722656, 358.5126037597656),
+            (339.7362365722656, -0.0),
+            (339.7362365722656, 359.1885986328125),
+            (339.7362365722656, 359.3114929199219),
+            (339.7362365722656, 359.5973205566406),
+            (339.2138671875, 359.5579833984375),
+            (336.46484375, 358.6362609863281),
+            (335.15325927734375, -0.0),
+            (332.86944580078125, 359.4662170410156)
+        ]
+        
+        let initialCenter = CLLocationCoordinate2D(latitude: 39.01305735102963, longitude: -77.01570412528032)
+        let co1 = CameraOptions(center: initialCenter, zoom: 16, bearing: bearings[Self.counter].0, pitch: 30)
+        self.mapView.cameraManager.setCamera(to: co1)
+        
+        Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] (timer) in
+            let co = CameraOptions(center: initialCenter, zoom: 16, bearing: bearings[Self.counter].0, pitch: 30)
+            if Self.counter == bearings.count - 1 {
+                Self.counter = 0
+            } else {
+                Self.counter += 1
+            }
+            
+            self?.mapView.cameraManager.setCamera(to: co, animated: true, duration: 1)
+            print("newbearing = \(co.bearing!), currentMapBearing = \(self!.mapView.bearing)")
         }
     }
 }

--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -79,10 +79,6 @@ public class DebugViewController: UIViewController {
          */
         mapView.on(.mapLoaded) { (event) in
             print("The map has finished loading... Event = \(event)")
-            
-            
-            
-            self.runTest()
         }
 
         /**
@@ -101,45 +97,6 @@ public class DebugViewController: UIViewController {
             }
 
             print("The map failed to load.. \(type) = \(message)")
-        }
-    }
-    
-    static var counter = 0
-    
-    func runTest() {
-        let bearings: [(Double, Double)] = [
-            (330.7222595214844, 344.0169982910156),
-            (332.0651550292969, 357.12646484375),
-            (334.2096252441406, 359.3537292480469),
-            (336.25244140625, -0.0),
-            (337.7581481933594, 347.4563903808594),
-            (339.7362365722656, 355.0942077636719),
-            (339.7362365722656, -0.0),
-            (339.7362365722656, 358.5126037597656),
-            (339.7362365722656, -0.0),
-            (339.7362365722656, 359.1885986328125),
-            (339.7362365722656, 359.3114929199219),
-            (339.7362365722656, 359.5973205566406),
-            (339.2138671875, 359.5579833984375),
-            (336.46484375, 358.6362609863281),
-            (335.15325927734375, -0.0),
-            (332.86944580078125, 359.4662170410156)
-        ]
-        
-        let initialCenter = CLLocationCoordinate2D(latitude: 39.01305735102963, longitude: -77.01570412528032)
-        let co1 = CameraOptions(center: initialCenter, zoom: 16, bearing: bearings[Self.counter].0, pitch: 30)
-        self.mapView.cameraManager.setCamera(to: co1)
-        
-        Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] (timer) in
-            let co = CameraOptions(center: initialCenter, zoom: 16, bearing: bearings[Self.counter].0, pitch: 30)
-            if Self.counter == bearings.count - 1 {
-                Self.counter = 0
-            } else {
-                Self.counter += 1
-            }
-            
-            self?.mapView.cameraManager.setCamera(to: co, animated: true, duration: 1)
-            print("newbearing = \(co.bearing!), currentMapBearing = \(self!.mapView.bearing)")
         }
     }
 }

--- a/Apps/Examples/Examples/All Examples/CameraAnimatorsExample.swift
+++ b/Apps/Examples/Examples/All Examples/CameraAnimatorsExample.swift
@@ -14,7 +14,7 @@ public class CameraAnimatorsExample: UIViewController, ExampleProtocol {
         }
 
         animator.addCompletion { [unowned self] (_) in
-            self.pitchAnimator.startAnimation()
+//            self.pitchAnimator.startAnimation()
         }
 
         return animator
@@ -58,12 +58,17 @@ public class CameraAnimatorsExample: UIViewController, ExampleProtocol {
 
         // Center the map over New York City.
         let newYork = CLLocationCoordinate2D(latitude: 40.7128, longitude: -74.0060)
-        mapView.cameraManager.setCamera(centerCoordinate: newYork)
+        mapView.zoom = 15
+        mapView.cameraManager.setCamera(centerCoordinate: newYork, bearing: 358.0316467285156)
+
 
         // Allows the delegate to receive information about map events.
         mapView.on(.mapLoaded) { [weak self] _ in
             guard let self = self else { return }
-            self.zoomAnimator.startAnimation(afterDelay: 1)
+            let cameraOptions = CameraOptions(center: newYork, bearing: CLLocationDirection(0.7362971305847168))
+            self.mapView.cameraManager.setCamera(to: cameraOptions, animated: true, duration: 0.5, completion: nil)
+            
+            
             self.finish()
         }
     }

--- a/Apps/Examples/Examples/All Examples/CameraAnimatorsExample.swift
+++ b/Apps/Examples/Examples/All Examples/CameraAnimatorsExample.swift
@@ -14,7 +14,7 @@ public class CameraAnimatorsExample: UIViewController, ExampleProtocol {
         }
 
         animator.addCompletion { [unowned self] (_) in
-//            self.pitchAnimator.startAnimation()
+            self.pitchAnimator.startAnimation()
         }
 
         return animator
@@ -58,17 +58,12 @@ public class CameraAnimatorsExample: UIViewController, ExampleProtocol {
 
         // Center the map over New York City.
         let newYork = CLLocationCoordinate2D(latitude: 40.7128, longitude: -74.0060)
-        mapView.zoom = 15
-        mapView.cameraManager.setCamera(centerCoordinate: newYork, bearing: 358.0316467285156)
-
+        mapView.cameraManager.setCamera(centerCoordinate: newYork)
 
         // Allows the delegate to receive information about map events.
         mapView.on(.mapLoaded) { [weak self] _ in
             guard let self = self else { return }
-            let cameraOptions = CameraOptions(center: newYork, bearing: CLLocationDirection(0.7362971305847168))
-            self.mapView.cameraManager.setCamera(to: cameraOptions, animated: true, duration: 0.5, completion: nil)
-            
-            
+            self.zoomAnimator.startAnimation(afterDelay: 1)
             self.finish()
         }
     }

--- a/Sources/MapboxMaps/Foundation/Camera/CameraManager+CameraAnimatorDelegate.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraManager+CameraAnimatorDelegate.swift
@@ -1,0 +1,104 @@
+import UIKit
+
+// MARK: Camera Animation
+extension CameraManager: CameraAnimatorDelegate {
+    
+    // MARK: Animator Functions
+
+    /// Convenience to create a `CameraAnimator` and will add it to a List of `CameraAnimators` to track the lifecycle of that animation.
+    ///
+    /// NOTE: Keep in mind the lifecycle of a `CameraAnimator`. If a `CameraAnimator` is destroyed, before the animation is finished,
+    /// the animation will be interrupted and completion handlers will be called.
+    ///
+    /// - Parameters:
+    ///   - duration: The duration of the animation, in seconds.
+    ///   - timingParameters: The object providing the timing information. This object must adopt the `UITimingCurveProvider` protocol.
+    ///   - animationOwner: Property that conforms to `AnimationOwnerProtocol` to represent who owns that animation.
+    /// - Returns: A class that represents an animator with the provided configuration.
+    public func makeCameraAnimator(duration: TimeInterval,
+                                   timingParameters parameters: UITimingCurveProvider,
+                                   animationOwner: AnimationOwner = .unspecified) -> CameraAnimator {
+        let propertyAnimator = UIViewPropertyAnimator(duration: duration, timingParameters: parameters)
+        let cameraAnimator = CameraAnimator(delegate: self, propertyAnimator: propertyAnimator, owner: animationOwner)
+        cameraAnimators.add(cameraAnimator)
+        return cameraAnimator
+    }
+
+    /// Convenience to create a `CameraAnimator` and will add it to a List of `CameraAnimators` to track the lifecycle of that animation.
+    ///
+    /// NOTE: Keep in mind the lifecycle of a `CameraAnimator`. If a `CameraAnimator` is destroyed, before the animation is finished,
+    /// the animation will be interrupted and completion handlers will be called.
+    ///
+    /// - Parameters:
+    ///   - duration: The duration of the animation, in seconds.
+    ///   - curve: The UIKit timing curve to apply to the animation.
+    ///   - animationOwner: Property that conforms to `AnimationOwnerProtocol` to represent who owns that animation.
+    ///   - animations: The block containing the animations. This block has no return value and takes no parameters.
+    ///                 Use this block to modify any animatable view properties. When you start the animations,
+    ///                 those properties are animated from their current values to the new values using the specified animation parameters.
+    /// - Returns: A class that represents an animator with the provided configuration.
+    public func makeCameraAnimator(duration: TimeInterval,
+                                   curve: UIView.AnimationCurve,
+                                   animationOwner: AnimationOwner = .unspecified,
+                                   animations: (() -> Void)? = nil) -> CameraAnimator {
+        let propertyAnimator = UIViewPropertyAnimator(duration: duration, curve: curve, animations: animations)
+        let cameraAnimator = CameraAnimator(delegate: self, propertyAnimator: propertyAnimator, owner: animationOwner)
+        cameraAnimators.add(cameraAnimator)
+        return cameraAnimator
+    }
+
+    /// Convenience to create a `CameraAnimator` and will add it to a List of `CameraAnimators` to track the lifecycle of that animation.
+    ///
+    /// NOTE: Keep in mind the lifecycle of a `CameraAnimator`. If a `CameraAnimator` is destroyed, before the animation is finished,
+    /// the animation will be interrupted and completion handlers will be called.
+    ///
+    /// - Parameters:
+    ///   - duration: The duration of the animation, in seconds.
+    ///   - controlPoint1: The first control point for the cubic Bézier timing curve.
+    ///   - controlPoint2: The second control point for the cubic Bézier timing curve.
+    ///   - animationOwner: Property that conforms to `AnimationOwnerProtocol` to represent who owns that animation.
+    ///   - animations: The block containing the animations. This block has no return value and takes no parameters.
+    ///                 Use this block to modify any animatable view properties. When you start the animations,
+    ///                 those properties are animated from their current values to the new values using the specified animation parameters.
+    /// - Returns: A class that represents an animator with the provided configuration.
+    public func makeCameraAnimator(duration: TimeInterval,
+                                   controlPoint1 point1: CGPoint,
+                                   controlPoint2 point2: CGPoint,
+                                   animationOwner: AnimationOwner = .unspecified,
+                                   animations: (() -> Void)? = nil) -> CameraAnimator {
+        let propertyAnimator = UIViewPropertyAnimator(duration: duration, controlPoint1: point1, controlPoint2: point2, animations: animations)
+        let cameraAnimator = CameraAnimator(delegate: self, propertyAnimator: propertyAnimator, owner: animationOwner)
+        cameraAnimators.add(cameraAnimator)
+        return cameraAnimator
+    }
+
+    /// Convenience to create a `CameraAnimator` and will add it to a List of `CameraAnimators` to track the lifecycle of that animation.
+    ///
+    /// NOTE: Keep in mind the lifecycle of a `CameraAnimator`. If a `CameraAnimator` is destroyed, before the animation is finished,
+    /// the animation will be interrupted and completion handlers will be called.
+    ///
+    /// - Parameters:
+    ///   - duration: The duration of the animation, in seconds.
+    ///   - dampingRatio: The damping ratio to apply to the initial acceleration and oscillation. To smoothly decelerate the animation without oscillation, specify a value of 1.
+    ///                   Specify values closer to 0 to create less damping and more oscillation.
+    ///   - animationOwner: Property that conforms to `AnimationOwnerProtocol` to represent who owns that animation.
+    ///   - animations: The block containing the animations. This block has no return value and takes no parameters.
+    ///                 Use this block to modify any animatable view properties. When you start the animations,
+    ///                 those properties are animated from their current values to the new values using the specified animation parameters.
+    /// - Returns: A class that represents an animator with the provided configuration.
+    public func makeCameraAnimator(duration: TimeInterval,
+                                   dampingRatio ratio: CGFloat,
+                                   animationOwner: AnimationOwner = .unspecified,
+                                   animations: (() -> Void)? = nil) -> CameraAnimator {
+        let propertyAnimator = UIViewPropertyAnimator(duration: duration, dampingRatio: ratio, animations: animations)
+        let cameraAnimator = CameraAnimator(delegate: self, propertyAnimator: propertyAnimator, owner: animationOwner)
+        cameraAnimators.add(cameraAnimator)
+        return cameraAnimator
+    }
+
+    // MARK: CameraAnimatorDelegate functions
+    func schedulePendingCompletion(forAnimator animator: CameraAnimator, completion: @escaping AnimationCompletion, animatingPosition: UIViewAnimatingPosition) {
+        guard let mapView = mapView else { return }
+        mapView.pendingAnimatorCompletionBlocks.append((completion, animatingPosition))
+    }
+}

--- a/Sources/MapboxMaps/Foundation/Camera/CameraManager+CameraAnimatorDelegate.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraManager+CameraAnimatorDelegate.swift
@@ -2,10 +2,10 @@ import UIKit
 
 // MARK: Camera Animation
 extension CameraManager: CameraAnimatorDelegate {
-    
+
     // MARK: Animator Functions
 
-    /// Convenience to create a `CameraAnimator` and will add it to a List of `CameraAnimators` to track the lifecycle of that animation.
+    /// Convenience to create a `CameraAnimator` and will add it to a list of `CameraAnimators` to track the lifecycle of that animation.
     ///
     /// NOTE: Keep in mind the lifecycle of a `CameraAnimator`. If a `CameraAnimator` is destroyed, before the animation is finished,
     /// the animation will be interrupted and completion handlers will be called.
@@ -24,7 +24,7 @@ extension CameraManager: CameraAnimatorDelegate {
         return cameraAnimator
     }
 
-    /// Convenience to create a `CameraAnimator` and will add it to a List of `CameraAnimators` to track the lifecycle of that animation.
+    /// Convenience to create a `CameraAnimator` and will add it to a list of `CameraAnimators` to track the lifecycle of that animation.
     ///
     /// NOTE: Keep in mind the lifecycle of a `CameraAnimator`. If a `CameraAnimator` is destroyed, before the animation is finished,
     /// the animation will be interrupted and completion handlers will be called.
@@ -47,7 +47,7 @@ extension CameraManager: CameraAnimatorDelegate {
         return cameraAnimator
     }
 
-    /// Convenience to create a `CameraAnimator` and will add it to a List of `CameraAnimators` to track the lifecycle of that animation.
+    /// Convenience to create a `CameraAnimator` and will add it to a list of `CameraAnimators` to track the lifecycle of that animation.
     ///
     /// NOTE: Keep in mind the lifecycle of a `CameraAnimator`. If a `CameraAnimator` is destroyed, before the animation is finished,
     /// the animation will be interrupted and completion handlers will be called.
@@ -72,7 +72,7 @@ extension CameraManager: CameraAnimatorDelegate {
         return cameraAnimator
     }
 
-    /// Convenience to create a `CameraAnimator` and will add it to a List of `CameraAnimators` to track the lifecycle of that animation.
+    /// Convenience to create a `CameraAnimator` and will add it to a list of `CameraAnimators` to track the lifecycle of that animation.
     ///
     /// NOTE: Keep in mind the lifecycle of a `CameraAnimator`. If a `CameraAnimator` is destroyed, before the animation is finished,
     /// the animation will be interrupted and completion handlers will be called.

--- a/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
@@ -21,7 +21,7 @@ public class CameraManager {
 
     /// Pointer HashTable for holding camera animators
     public internal(set) var cameraAnimators = NSHashTable<CameraAnimator>.weakObjects()
-    
+
     /// Internal camera animator used for animated transition
     internal var internalCameraAnimator: CameraAnimator?
 
@@ -206,16 +206,16 @@ public class CameraManager {
     ///   - animation: closure to perform
     ///   - completion: animation block called on completion
     fileprivate func performCameraAnimation(duration: TimeInterval, animation: @escaping () -> Void, completion: ((UIViewAnimatingPosition) -> Void)? = nil) {
-        
+
         // Stop previously running animations
         internalCameraAnimator?.stopAnimation()
-        
+
         // Make a new camera animator for the new properties
         internalCameraAnimator = makeCameraAnimator(duration: duration,
                                       curve: .easeOut,
                                       animationOwner: .custom(id: "com.mapbox.maps.cameraManager"),
                                       animations: animation)
-        
+
         // Add completion
         internalCameraAnimator?.addCompletion({ [weak self] (position) in
             completion?(position)

--- a/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
@@ -196,6 +196,19 @@ public class CameraManager {
             animator.stopAnimation()
         }
     }
+    
+    fileprivate func cancelAnimators(withID id: String) {
+        for animator in cameraAnimators.allObjects {
+            switch animator.owner {
+            case .custom(let customId):
+                if customId == id {
+                    animator.stopAnimation()
+                }
+            default:
+                print("")
+            }
+        }
+    }
 
     /// Private func to perform camera animation
     /// - Parameters:
@@ -203,11 +216,12 @@ public class CameraManager {
     ///   - animation: closure to perform
     ///   - completion: animation block called on completion
     fileprivate func performCameraAnimation(duration: TimeInterval, animation: @escaping () -> Void, completion: ((UIViewAnimatingPosition) -> Void)? = nil) {
+        cancelAnimators(withID: "internal-set-camera")
         var animator: CameraAnimator?
-
-        animator = makeCameraAnimator(duration: duration, curve: .easeOut)
-        animator?.addAnimations(animation)
-
+        animator = makeCameraAnimator(duration: duration,
+                                      curve: .easeOut,
+                                      animationOwner: .custom(id: "internal-set-camera"),
+                                      animations: animation)
         animator?.addCompletion({ (position) in
             completion?(position)
             animator = nil

--- a/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
@@ -21,6 +21,9 @@ public class CameraManager {
 
     /// Pointer HashTable for holding camera animators
     public internal(set) var cameraAnimators = NSHashTable<CameraAnimator>.weakObjects()
+    
+    /// Internal camera animator used for animated transition
+    internal var internalCameraAnimator: CameraAnimator?
 
     /// May want to convert to an enum.
     fileprivate let northBearing: CGFloat = 0
@@ -196,38 +199,31 @@ public class CameraManager {
             animator.stopAnimation()
         }
     }
-    
-    fileprivate func cancelAnimators(withID id: String) {
-        for animator in cameraAnimators.allObjects {
-            switch animator.owner {
-            case .custom(let customId):
-                if customId == id {
-                    animator.stopAnimation()
-                }
-            default:
-                print("")
-            }
-        }
-    }
 
-    /// Private func to perform camera animation
+    /// Private function to perform camera animation
     /// - Parameters:
     ///   - duration: If animated, how long the animation takes
     ///   - animation: closure to perform
     ///   - completion: animation block called on completion
     fileprivate func performCameraAnimation(duration: TimeInterval, animation: @escaping () -> Void, completion: ((UIViewAnimatingPosition) -> Void)? = nil) {
-        cancelAnimators(withID: "internal-set-camera")
-        var animator: CameraAnimator?
-        animator = makeCameraAnimator(duration: duration,
+        
+        // Stop previously running animations
+        internalCameraAnimator?.stopAnimation()
+        
+        // Make a new camera animator for the new properties
+        internalCameraAnimator = makeCameraAnimator(duration: duration,
                                       curve: .easeOut,
-                                      animationOwner: .custom(id: "internal-set-camera"),
+                                      animationOwner: .custom(id: "com.mapbox.maps.cameraManager"),
                                       animations: animation)
-        animator?.addCompletion({ (position) in
+        
+        // Add completion
+        internalCameraAnimator?.addCompletion({ [weak self] (position) in
             completion?(position)
-            animator = nil
+            self?.internalCameraAnimator = nil
         })
 
-        animator?.startAnimation()
+        // Start animation
+        internalCameraAnimator?.startAnimation()
     }
 
     /// Reset the map's camera to the default style camera.
@@ -357,7 +353,8 @@ public class CameraManager {
     /// It seamlessly incorporates zooming and panning to help
     /// the user find his or her bearings even after traversing a great distance.
     ///
-    /// NOTE: Keep in mind the lifecycle of a `CameraAnimator`. If a `CameraAnimator` is destroyed, before the animation is finished,
+    /// NOTE: Keep in mind the lifecycle of the `CameraAnimator` returned by this method.
+    /// If a `CameraAnimator` is destroyed, before the animation is finished,
     /// the animation will be interrupted and completion handlers will be called.
     ///
     /// - Parameters:
@@ -442,108 +439,6 @@ public class CameraManager {
         }
 
         return endBearing
-    }
-}
-
-// MARK: Camera Animation
-extension CameraManager: CameraAnimatorDelegate {
-    // MARK: Animator Functions
-
-    /// Convenience to create a `CameraAnimator` and will add it to a List of `CameraAnimators` to track the lifecycle of that animation.
-    ///
-    /// NOTE: Keep in mind the lifecycle of a `CameraAnimator`. If a `CameraAnimator` is destroyed, before the animation is finished,
-    /// the animation will be interrupted and completion handlers will be called.
-    ///
-    /// - Parameters:
-    ///   - duration: The duration of the animation, in seconds.
-    ///   - timingParameters: The object providing the timing information. This object must adopt the `UITimingCurveProvider` protocol.
-    ///   - animationOwner: Property that conforms to `AnimationOwnerProtocol` to represent who owns that animation.
-    /// - Returns: A class that represents an animator with the provided configuration.
-    public func makeCameraAnimator(duration: TimeInterval,
-                                   timingParameters parameters: UITimingCurveProvider,
-                                   animationOwner: AnimationOwner = .unspecified) -> CameraAnimator {
-        let propertyAnimator = UIViewPropertyAnimator(duration: duration, timingParameters: parameters)
-        let cameraAnimator = CameraAnimator(delegate: self, propertyAnimator: propertyAnimator, owner: animationOwner)
-        cameraAnimators.add(cameraAnimator)
-        return cameraAnimator
-    }
-
-    /// Convenience to create a `CameraAnimator` and will add it to a List of `CameraAnimators` to track the lifecycle of that animation.
-    ///
-    /// NOTE: Keep in mind the lifecycle of a `CameraAnimator`. If a `CameraAnimator` is destroyed, before the animation is finished,
-    /// the animation will be interrupted and completion handlers will be called.
-    ///
-    /// - Parameters:
-    ///   - duration: The duration of the animation, in seconds.
-    ///   - curve: The UIKit timing curve to apply to the animation.
-    ///   - animationOwner: Property that conforms to `AnimationOwnerProtocol` to represent who owns that animation.
-    ///   - animations: The block containing the animations. This block has no return value and takes no parameters.
-    ///                 Use this block to modify any animatable view properties. When you start the animations,
-    ///                 those properties are animated from their current values to the new values using the specified animation parameters.
-    /// - Returns: A class that represents an animator with the provided configuration.
-    public func makeCameraAnimator(duration: TimeInterval,
-                                   curve: UIView.AnimationCurve,
-                                   animationOwner: AnimationOwner = .unspecified,
-                                   animations: (() -> Void)? = nil) -> CameraAnimator {
-        let propertyAnimator = UIViewPropertyAnimator(duration: duration, curve: curve, animations: animations)
-        let cameraAnimator = CameraAnimator(delegate: self, propertyAnimator: propertyAnimator, owner: animationOwner)
-        cameraAnimators.add(cameraAnimator)
-        return cameraAnimator
-    }
-
-    /// Convenience to create a `CameraAnimator` and will add it to a List of `CameraAnimators` to track the lifecycle of that animation.
-    ///
-    /// NOTE: Keep in mind the lifecycle of a `CameraAnimator`. If a `CameraAnimator` is destroyed, before the animation is finished,
-    /// the animation will be interrupted and completion handlers will be called.
-    ///
-    /// - Parameters:
-    ///   - duration: The duration of the animation, in seconds.
-    ///   - controlPoint1: The first control point for the cubic Bézier timing curve.
-    ///   - controlPoint2: The second control point for the cubic Bézier timing curve.
-    ///   - animationOwner: Property that conforms to `AnimationOwnerProtocol` to represent who owns that animation.
-    ///   - animations: The block containing the animations. This block has no return value and takes no parameters.
-    ///                 Use this block to modify any animatable view properties. When you start the animations,
-    ///                 those properties are animated from their current values to the new values using the specified animation parameters.
-    /// - Returns: A class that represents an animator with the provided configuration.
-    public func makeCameraAnimator(duration: TimeInterval,
-                                   controlPoint1 point1: CGPoint,
-                                   controlPoint2 point2: CGPoint,
-                                   animationOwner: AnimationOwner = .unspecified,
-                                   animations: (() -> Void)? = nil) -> CameraAnimator {
-        let propertyAnimator = UIViewPropertyAnimator(duration: duration, controlPoint1: point1, controlPoint2: point2, animations: animations)
-        let cameraAnimator = CameraAnimator(delegate: self, propertyAnimator: propertyAnimator, owner: animationOwner)
-        cameraAnimators.add(cameraAnimator)
-        return cameraAnimator
-    }
-
-    /// Convenience to create a `CameraAnimator` and will add it to a List of `CameraAnimators` to track the lifecycle of that animation.
-    ///
-    /// NOTE: Keep in mind the lifecycle of a `CameraAnimator`. If a `CameraAnimator` is destroyed, before the animation is finished,
-    /// the animation will be interrupted and completion handlers will be called.
-    ///
-    /// - Parameters:
-    ///   - duration: The duration of the animation, in seconds.
-    ///   - dampingRatio: The damping ratio to apply to the initial acceleration and oscillation. To smoothly decelerate the animation without oscillation, specify a value of 1.
-    ///                   Specify values closer to 0 to create less damping and more oscillation.
-    ///   - animationOwner: Property that conforms to `AnimationOwnerProtocol` to represent who owns that animation.
-    ///   - animations: The block containing the animations. This block has no return value and takes no parameters.
-    ///                 Use this block to modify any animatable view properties. When you start the animations,
-    ///                 those properties are animated from their current values to the new values using the specified animation parameters.
-    /// - Returns: A class that represents an animator with the provided configuration.
-    public func makeCameraAnimator(duration: TimeInterval,
-                                   dampingRatio ratio: CGFloat,
-                                   animationOwner: AnimationOwner = .unspecified,
-                                   animations: (() -> Void)? = nil) -> CameraAnimator {
-        let propertyAnimator = UIViewPropertyAnimator(duration: duration, dampingRatio: ratio, animations: animations)
-        let cameraAnimator = CameraAnimator(delegate: self, propertyAnimator: propertyAnimator, owner: animationOwner)
-        cameraAnimators.add(cameraAnimator)
-        return cameraAnimator
-    }
-
-    // MARK: CameraAnimatorDelegate functions
-    func schedulePendingCompletion(forAnimator animator: CameraAnimator, completion: @escaping AnimationCompletion, animatingPosition: UIViewAnimatingPosition) {
-        guard let mapView = mapView else { return }
-        mapView.pendingAnimatorCompletionBlocks.append((completion, animatingPosition))
     }
 }
 

--- a/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
@@ -140,7 +140,7 @@ public class CameraManager {
                                           padding: targetCamera.padding,
                                           anchor: targetCamera.anchor,
                                           zoom: targetCamera.zoom?.clamped(to: mapCameraOptions.minimumZoomLevel...mapCameraOptions.maximumZoomLevel),
-                                          bearing: optimizeBearing(startBearing: mapView.bearing, endBearing: targetCamera.bearing),
+                                          bearing: optimizeBearing(startBearing: mapView.cameraView.localBearing, endBearing: targetCamera.bearing),
                                           pitch: targetCamera.pitch?.clamped(to: mapCameraOptions.minimumPitch...mapCameraOptions.maximumPitch))
 
         // Return early if the cameraView's camera is already at `clampedCamera`

--- a/Sources/MapboxMaps/MapView/Configuration/RenderOptions.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/RenderOptions.swift
@@ -22,4 +22,15 @@ public struct RenderOptions: Equatable {
     ///
     ///  The default value of this property is `true`.
     public var prefetchesTiles: Bool = true
+    
+    /// A Boolean value that indicates whether the underlying `CAMetalLayer` of the `MapView`
+    /// presents its content using a CoreAnimation transaction
+    ///
+    /// By default, this is `false` resulting in the output of a rendering pass being displayed on
+    /// the `CAMetalLayer` as quickly as possible (and asynchronously). This typically results
+    /// in the fastest rendering performance.
+    ///
+    /// If, however, the `MapView` is overlaid with a `UIKit` element which must be pinned to a
+    /// particular lat-long, then setting this to `true` will result in better synchronization and less jitter.
+    public var presentsWithTransaction: Bool = true
 }

--- a/Sources/MapboxMaps/MapView/Configuration/RenderOptions.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/RenderOptions.swift
@@ -22,7 +22,7 @@ public struct RenderOptions: Equatable {
     ///
     ///  The default value of this property is `true`.
     public var prefetchesTiles: Bool = true
-    
+
     /// A Boolean value that indicates whether the underlying `CAMetalLayer` of the `MapView`
     /// presents its content using a CoreAnimation transaction
     ///

--- a/Sources/MapboxMaps/MapView/MapView+Managers.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Managers.swift
@@ -49,6 +49,7 @@ extension MapView {
         let defaultPrefetchZoomDelta: UInt8 = 4
         try! self.__map.setPrefetchZoomDeltaForDelta(renderOptions.prefetchesTiles ? defaultPrefetchZoomDelta : 0)
         self.preferredFPS = renderOptions.preferredFramesPerSecond
+        metalView?.presentsWithTransaction = renderOptions.presentsWithTransaction
     }
 
     internal func updateMapView(with newOptions: RenderOptions) {
@@ -56,6 +57,7 @@ extension MapView {
         let defaultPrefetchZoomDelta: UInt8 = 4
         try! self.__map.setPrefetchZoomDeltaForDelta(newOptions.prefetchesTiles ? defaultPrefetchZoomDelta : 0)
         self.preferredFPS = newOptions.preferredFramesPerSecond
+        metalView?.presentsWithTransaction = newOptions.presentsWithTransaction
     }
 
     internal func setupGestures(with view: UIView, options: GestureOptions, cameraManager: CameraManager) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.

### Summary of changes

This PR fixes the setCamera call to `optimizeBearing` to be with the correct argument for startBearing -- it should be the latest interpolated value instead of the latest retrieval from the renderer.