### PR TITLE
Fix Puck3D Deinitialization

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/MapboxMaps.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/MapboxMaps.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "TOKEN_FILE=~/.mapbox&#10;TOKEN_FILE_2=~/mapbox&#10;TOKEN=&quot;$(cat $TOKEN_FILE 2&gt;/dev/null || cat $TOKEN_FILE_2 2&gt;/dev/null)&quot;&#10;if [ &quot;$TOKEN&quot; ]; then&#10;  MBX_ROOT=$(echo &quot;$WORKSPACE_PATH&quot; | rev | cut -d&apos;/&apos; -f4- | rev)&#10;  echo $TOKEN &gt; &quot;$MBX_ROOT/Tests/MapboxMapsTests/Helpers/MapboxAccessToken&quot;&#10;fi&#10;">
+               scriptText = "TOKEN_FILE=~/.mapbox&#10;TOKEN_FILE_2=~/mapbox&#10;TOKEN=&quot;$(cat $TOKEN_FILE 2&gt;/dev/null || cat $TOKEN_FILE_2 2&gt;/dev/null)&quot;&#10;if [ &quot;$TOKEN&quot; ]; then&#10;  if [ $(basename &quot;$WORKSPACE_PATH&quot;) = &quot;package.xcworkspace&quot; ]; then&#10;    MBX_ROOT=$(echo &quot;$WORKSPACE_PATH&quot; | rev | cut -d&apos;/&apos; -f4- | rev)&#10;  elif [ $(basename &quot;$WORKSPACE_PATH&quot;) = &quot;Apps.xcworkspace&quot; ]; then&#10;    MBX_ROOT=$(echo &quot;$WORKSPACE_PATH&quot; | rev | cut -d&apos;/&apos; -f3- | rev) &#10;  else&#10;    exit 1 # Unknown workspace&#10;  fi&#10;  echo $TOKEN &gt; &quot;$MBX_ROOT/Tests/MapboxMapsTests/Helpers/MapboxAccessToken&quot;&#10;fi&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/Sources/MapboxMaps/Location/Pucks/Puck3D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck3D.swift
@@ -40,7 +40,6 @@ internal class Puck3D: Puck {
     // MARK: Protocol Properties
     internal var puckStyle: PuckStyle
     internal weak var locationSupportableMapView: LocationSupportableMapView?
-    public var style: Style!
 
     // MARK: Initializers
     internal init(puckStyle: PuckStyle, locationSupportableMapView: LocationSupportableMapView, configuration: Puck3DConfiguration) {
@@ -49,7 +48,6 @@ internal class Puck3D: Puck {
         self.configuration = configuration
         modelLayer = ModelLayer(id: "puck-model-layer")
         modelSource = ModelSource()
-        style = locationSupportableMapView.style
         setup()
     }
 
@@ -74,8 +72,10 @@ internal class Puck3D: Puck {
         }
 
         let addStyle = { [weak self] in
-
-            guard let self = self, let style = self.style else { return }
+            guard let self = self,
+                  let style = self.locationSupportableMapView?.style else {
+                return
+            }
             self.removePuck()
             style.addSource(source: self.modelSource, identifier: "puck-model-source")
             style.addLayer(layer: self.modelLayer)
@@ -92,7 +92,7 @@ internal class Puck3D: Puck {
 
     // MARK: Protocol Implementation
     internal func updateLocation(location: Location) {
-        guard let style = style,
+        guard let style = locationSupportableMapView?.style,
               let key = modelSource.models?.keys.first,
               var model = modelSource.models?.values.first else { return }
 
@@ -119,6 +119,9 @@ internal class Puck3D: Puck {
 
     /// This function will remove the puck from `mapView`
     private func removePuck() {
+        guard let style = locationSupportableMapView?.style else {
+            return
+        }
         _ = style.removeStyleLayer(forLayerId: "puck-model-layer")
         try! style.styleManager.removeStyleSource(forSourceId: "puck-model-source")
     }

--- a/Tests/MapboxMapsTests/Helpers/XCTestCase+MapboxAccessToken.swift
+++ b/Tests/MapboxMapsTests/Helpers/XCTestCase+MapboxAccessToken.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+extension XCTestCase {
+    func mapboxAccessToken() throws -> String {
+        func token() throws -> String {
+            // User defaults can override plist
+            if let token = UserDefaults.standard.string(forKey: "MBXAccessToken") {
+                print("Found access token from UserDefaults (command line parameter?)")
+                return token
+            } else if let token = Bundle.mapboxMapsTests.infoDictionary?["MBXAccessToken"] as? String {
+                print("Found access token in Info.plist")
+                return token
+            } else if let url = Bundle.mapboxMapsTests.url(forResource: "MapboxAccessToken", withExtension: nil),
+                      let token = try? String(contentsOf: url) {
+                print("Found access token in MapboxAccessToken")
+                return token
+            } else {
+                throw XCTSkip("Mapbox access token not found")
+            }
+        }
+
+        func validated(token: String) throws -> String {
+            if token.starts(with: "pk.") {
+                return token
+            } else {
+                throw XCTSkip("Mapbox access token is invalid")
+            }
+        }
+
+        return try validated(token: token()).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Tests/MapboxMapsTests/Location/Pucks/Puck3DIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Location/Pucks/Puck3DIntegrationTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import MapboxMaps
+
+final class Puck3DIntegrationTests: XCTestCase {
+
+    var resourceOptions: ResourceOptions!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        resourceOptions = try ResourceOptions(accessToken: mapboxAccessToken())
+    }
+
+    func testPuck3DDeinitializationDoesNotCrash() {
+        autoreleasepool {
+            let mapView = MapView(with: .zero, resourceOptions: resourceOptions)
+            mapView.update { (options) in
+                options.location.puckType = .puck3D(
+                    Puck3DConfiguration(
+                        model: Model()))
+            }
+        }
+        // there is no assertion here because this test is
+        // merely ensuring that Puck3D does not crash when
+        // it gets deinited
+    }
+}

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/IntegrationTestCase.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/IntegrationTestCase.swift
@@ -8,7 +8,7 @@ internal class IntegrationTestCase: XCTestCase {
 
     internal override func setUpWithError() throws {
         try setupScreenAndWindow()
-        try setupAccessToken()
+        accessToken = try mapboxAccessToken()
     }
 
     internal override func invokeTest() {
@@ -43,35 +43,5 @@ internal class IntegrationTestCase: XCTestCase {
 
         XCTAssertNotNil(window)
         XCTAssertNotNil(rootViewController?.view)
-    }
-
-    private func setupAccessToken() throws {
-
-        func token() throws -> String {
-            // User defaults can override plist
-            if let token = UserDefaults.standard.string(forKey: "MBXAccessToken") {
-                print("Found access token from UserDefaults (command line parameter?)")
-                return token
-            } else if let token = Bundle.mapboxMapsTests.infoDictionary?["MBXAccessToken"] as? String {
-                print("Found access token in Info.plist")
-                return token
-            } else if let url = Bundle.mapboxMapsTests.url(forResource: "MapboxAccessToken", withExtension: nil),
-               let token = try? String(contentsOf: url) {
-                print("Found access token in MapboxAccessToken")
-                return token
-            } else {
-                throw XCTSkip("Mapbox access token not found")
-            }
-        }
-
-        func validated(token: String) throws -> String {
-            if token.starts(with: "pk.") {
-                return token
-            } else {
-                throw XCTSkip("Mapbox access token is invalid")
-            }
-        }
-
-        accessToken = try validated(token: token()).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

- Updates the pre-build action in the MapboxMaps scheme to work when using Apps.xcworkspace
- Adds an integration test to exercise deinitialization of a map view configured with a 3D puck
- Extracts `func mapboxAccessToken() throws -> String` into an extension on `XCTestCase`
- Updates `Puck3D` so that it no longer keeps a strong reference to `Style`. This strong reference led to an issue in which the `Style`'s `StyleManager` had been deallocated prior to when `Puck3D.deinit` was invoked. This resulted in a crash because `Puck3D.deinit` invokes `Style.removeStyleLayer(forLayerId:)` which accesses `Style.styleManager` which is a weak, implicitly unwrapped optional (IUO). Since the object to which `styleManager` had referred had already been deallocated, the reference was `nil`, but since the type is an IUO and the call site did not use optional chaining, a crash occurred.

### Future improvements

This change is at best a stop-gap solution. A more thorough fix should be completed in the future which:

* Audits the codebase for weak IUOs and either converts them to `unowned` (if we're really sure) or, more likely, converts them to weak optionals (that are not implicitly unwrapped)
* More generally audits the object ownership and reference graph and performs changes to achieve simpler, less error-prone design