### PR TITLE
Add enum for layer position

### DIFF
--- a/Apps/Examples/Examples/All Examples/CustomLayerExample.swift
+++ b/Apps/Examples/Examples/All Examples/CustomLayerExample.swift
@@ -30,12 +30,10 @@ public class CustomLayerExample: UIViewController, ExampleProtocol {
 
     internal func addCustomLayer() {
         // Position the custom layer above the water layer and below all other layers.
-        let layerPosition = LayerPosition(above: "water", below: nil, at: nil)
-
         try! mapView.style.addCustomLayer(
             withId: "Custom",
             layerHost: self,
-            layerPosition: layerPosition)
+            layerPosition: .above("water"))
     }
 }
 

--- a/Apps/Examples/Examples/All Examples/ExternalVectorSourceExample.swift
+++ b/Apps/Examples/Examples/All Examples/ExternalVectorSourceExample.swift
@@ -51,10 +51,8 @@ public class ExternalVectorSourceExample: UIViewController, ExampleProtocol {
 
         // Define the layer's positioning within the layer stack so
         // that it doesn't obscure other important labels.
-        let layerPosition = LayerPosition(above: nil, below: "waterway-label", at: nil)
-
         do {
-            try mapView.style.addLayer(lineLayer, layerPosition: layerPosition)
+            try mapView.style.addLayer(lineLayer, layerPosition: .below("waterway-label"))
         } catch let layerError {
             displayAlert(message: layerError.localizedDescription)
         }

--- a/Apps/Examples/Examples/All Examples/LayerBelowExample.swift
+++ b/Apps/Examples/Examples/All Examples/LayerBelowExample.swift
@@ -45,7 +45,7 @@ public class LayerBelowExample: UIViewController, ExampleProtocol {
         // Add the data source to the map
         try! mapView.style.addSource(source, id: sourceIdentifier)
         // Add the layer to the map below the "settlement-label" layer
-        try! mapView.style.addLayer(layer, layerPosition: LayerPosition(below: "settlement-label"))
+        try! mapView.style.addLayer(layer, layerPosition: .below("settlement-label"))
 
         // The below line is used for internal testing purposes only.
         finish()

--- a/Apps/Examples/Examples/All Examples/LayerPositionExample.swift
+++ b/Apps/Examples/Examples/All Examples/LayerPositionExample.swift
@@ -60,14 +60,14 @@ public class LayerPositionExample: UIViewController, ExampleProtocol {
             guard let self = self else { return }
             try? self.mapView.style.removeLayer(withId: self.layer.id)
             try? self.mapView.style.addLayer(self.layer,
-                                             layerPosition: LayerPosition(above: "state-label"))
+                                             layerPosition: .above("state-label"))
         }))
 
         alert.addAction(UIAlertAction(title: "Below state label", style: .default, handler: { [weak self] _ in
             guard let self = self else { return }
             try? self.mapView.style.removeLayer(withId: self.layer.id)
             try? self.mapView.style.addLayer(self.layer,
-                                             layerPosition: LayerPosition(below: "state-label"))
+                                             layerPosition: .below("state-label"))
         }))
 
         alert.addAction(UIAlertAction(title: "Above all", style: .default, handler: { [weak self] _ in
@@ -81,7 +81,7 @@ public class LayerPositionExample: UIViewController, ExampleProtocol {
             guard let self = self else { return }
             try? self.mapView.style.removeLayer(withId: self.layer.id)
             try? self.mapView.style.addLayer(self.layer,
-                                             layerPosition: LayerPosition(at: 0))
+                                             layerPosition: .at(0))
         }))
 
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))

--- a/Apps/Examples/Examples/All Examples/SceneKitExample.swift
+++ b/Apps/Examples/Examples/All Examples/SceneKitExample.swift
@@ -42,7 +42,7 @@ public class SceneKitExample: UIViewController, ExampleProtocol, CustomLayerHost
         try! mapView.style.addCustomLayer(
             withId: "Custom",
             layerHost: self,
-            layerPosition: LayerPosition(above: nil, below: "waterway-label", at: nil))
+            layerPosition: .below("waterway-label"))
 
         var demSource = RasterDemSource()
         demSource.url = "mapbox://mapbox.mapbox-terrain-dem-v1"
@@ -69,9 +69,7 @@ public class SceneKitExample: UIViewController, ExampleProtocol, CustomLayerHost
             "hillshade-illumination-anchor": "map"
         ] as [ String: Any ]
 
-        mapView.mapboxMap.__map.addStyleLayer(
-            forProperties: properties,
-            layerPosition: LayerPosition(above: nil, below: "water", at: nil))
+        try! mapView.style.addLayer(with: properties, layerPosition: .below("water"))
     }
 
     public func renderingWillStart(_ metalDevice: MTLDevice, colorPixelFormat: UInt, depthStencilPixelFormat: UInt) {

--- a/Sources/MapboxMaps/Annotations/AnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationManager.swift
@@ -93,7 +93,7 @@ public class AnnotationManager {
     /**
      Options used by the annotation manager.
      */
-    public var options = AnnotationOptions() {
+    public var options: AnnotationOptions {
         didSet {
             Log.warning(forMessage: "Updating annotation manager options is not supported at this time.", category: "Annotations")
         }
@@ -150,12 +150,15 @@ public class AnnotationManager {
     internal init(for mapView: AnnotationSupportableMap,
                   mapEventsObservable: MapEventsObservable,
                   with styleDelegate: AnnotationStyleDelegate,
-                  interactionDelegate: AnnotationInteractionDelegate? = nil) {
+                  interactionDelegate: AnnotationInteractionDelegate? = nil,
+                  options: AnnotationOptions = AnnotationOptions()) {
 
         self.mapView = mapView
         self.mapEventsObservable = mapEventsObservable
         self.styleDelegate = styleDelegate
         self.interactionDelegate = interactionDelegate
+        self.options = options
+        
         annotations = [:]
         annotationFeatures = FeatureCollection(features: [])
         userInteractionEnabled = true

--- a/Sources/MapboxMaps/Annotations/AnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationManager.swift
@@ -158,7 +158,7 @@ public class AnnotationManager {
         self.styleDelegate = styleDelegate
         self.interactionDelegate = interactionDelegate
         self.options = options
-        
+
         annotations = [:]
         annotationFeatures = FeatureCollection(features: [])
         userInteractionEnabled = true

--- a/Sources/MapboxMaps/Annotations/Configuration/AnnotationOptions.swift
+++ b/Sources/MapboxMaps/Annotations/Configuration/AnnotationOptions.swift
@@ -9,7 +9,7 @@ public struct AnnotationSourceOptions: Equatable {
 public struct AnnotationOptions: Equatable {
     /// The `LayerPosition` used to position the underlying style layers. Default will position the
     /// layers above existing layers.
-    public var layerPosition: LayerPosition = LayerPosition()
+    public var layerPosition: LayerPosition?
 
     // TODO: Handle multiple layer Ids
 //    /// The layer identifier for the layer used by the AnnotationManager. Default is nil, meaning a

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/LayerPosition.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/LayerPosition.swift
@@ -1,12 +1,38 @@
 import MapboxCoreMaps
 
-extension LayerPosition {
+/// Specifies the position at which a layer will be added when using
+/// `Style.addLayer`.
+public enum LayerPosition: Equatable {
+    /// Default behavior; add to the top of the layers stack.
+    case `default`
 
-    /// Convenience initializer for LayerPosition
-    /// - Parameters:
-    ///   - above: Layer should be positioned above specified layer id
-    ///   - below: Layer should be positioned below specified layer id
-    ///   - at: Layer should be positioned at specified index in a layers stack
+    /// Layer should be positioned above the specified layer id.
+    case above(String)
+
+    /// Layer should be positioned below the specified layer id.
+    case below(String)
+
+    /// Layer should be positioned at the specified index in the layers stack.
+    case at(Int)
+
+    internal var corePosition: MapboxCoreMaps.LayerPosition {
+        switch self {
+        case .default:
+            return MapboxCoreMaps.LayerPosition()
+        case .above(let layerId):
+            return MapboxCoreMaps.LayerPosition(above: layerId)
+        case .below(let layerId):
+            return MapboxCoreMaps.LayerPosition(below: layerId)
+        case .at(let index):
+            return MapboxCoreMaps.LayerPosition(at: index)
+        }
+    }
+}
+
+// MARK: - MapboxCoreMaps.LayerPosition conveniences
+
+extension MapboxCoreMaps.LayerPosition {
+
     public convenience init(above: String? = nil, below: String? = nil, at: Int? = nil) {
         self.init(__above: above, below: below, at: at?.NSNumber)
     }
@@ -17,7 +43,7 @@ extension LayerPosition {
     }
 
     public override func isEqual(_ object: Any?) -> Bool {
-        guard let object = object as? LayerPosition else {
+        guard let object = object as? MapboxCoreMaps.LayerPosition else {
             return false
         }
 

--- a/Sources/MapboxMaps/Style/Layers.swift
+++ b/Sources/MapboxMaps/Style/Layers.swift
@@ -101,16 +101,16 @@ public protocol Layer: Codable, StyleEncodable, StyleDecodable {
 /// Information about a layer
 public struct LayerInfo {
     /// The identifier of the layer
-    var id: String
+    public var id: String
 
     /// The type of the layer
-    var type: LayerType
+    public var type: LayerType
 }
 
-public extension Layer {
+extension Layer {
     /// Initializes a Layer given a JSON dictionary
     /// - Throws: Errors occurring during decoding
-    init(jsonObject: [String: Any]) throws {
+    public init(jsonObject: [String: Any]) throws {
         let layerData = try JSONSerialization.data(withJSONObject: jsonObject)
         self = try JSONDecoder().decode(Self.self, from: layerData)
     }

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -311,13 +311,13 @@ extension Style: StyleManagerProtocol {
 
     public func addLayer(with properties: [String: Any], layerPosition: LayerPosition?) throws {
         return try handleExpected {
-            return styleManager.addStyleLayer(forProperties: properties, layerPosition: layerPosition)
+            return styleManager.addStyleLayer(forProperties: properties, layerPosition: layerPosition?.corePosition)
         }
     }
 
     public func addCustomLayer(withId id: String, layerHost: CustomLayerHost, layerPosition: LayerPosition?) throws {
         return try handleExpected {
-            return styleManager.addStyleCustomLayer(forLayerId: id, layerHost: layerHost, layerPosition: layerPosition)
+            return styleManager.addStyleCustomLayer(forLayerId: id, layerHost: layerHost, layerPosition: layerPosition?.corePosition)
         }
     }
 

--- a/Tests/MapboxMapsTests/Annotations/AnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/AnnotationManagerTests.swift
@@ -37,7 +37,7 @@ final class AnnotationManagerTests: XCTestCase {
         XCTAssertEqual(a, b)
 
         // Test ergonomics
-        _ = AnnotationOptions(layerPosition: LayerPosition())
+        _ = AnnotationOptions(layerPosition: .above("line-layer"))
         _ = AnnotationOptions(sourceId: "test")
         _ = AnnotationOptions(sourceOptions: AnnotationSourceOptions())
     }

--- a/Tests/MapboxMapsTests/Foundation/Extensions/Core/LayerPositionTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Extensions/Core/LayerPositionTests.swift
@@ -7,13 +7,32 @@ import XCTest
 #endif
 
 final class LayerPositionTests: XCTestCase {
-    func testPositionEquality() {
-        let a = LayerPosition(above: nil, below: nil, at: nil)
-        let b = LayerPosition(above: nil, below: nil, at: nil)
-        let c = LayerPosition(above: "above", below: nil, at: nil)
-        let d = LayerPosition(above: "above", below: "below", at: nil)
-        let e = LayerPosition(above: "above", below: "below", at: 3)
-        let f = LayerPosition(above: "above", below: "below", at: 3)
+
+    func testPositionEnumEquality() {
+        let a = LayerPosition.default
+        let b = LayerPosition.default
+        let c = LayerPosition.above("something")
+        let d = LayerPosition.above("something-else")
+        let e = LayerPosition.below("something")
+        let f = LayerPosition.below("something-else")
+        let g = LayerPosition.at(3)
+        let h = LayerPosition.at(4)
+
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(c, d)
+        XCTAssertNotEqual(c, e)
+        XCTAssertNotEqual(d, f)
+        XCTAssertNotEqual(e, f)
+        XCTAssertNotEqual(g, h)
+    }
+
+    func testCoreMapsPositionEquality() {
+        let a = MapboxCoreMaps.LayerPosition(above: nil, below: nil, at: nil)
+        let b = MapboxCoreMaps.LayerPosition(above: nil, below: nil, at: nil)
+        let c = MapboxCoreMaps.LayerPosition(above: "above", below: nil, at: nil)
+        let d = MapboxCoreMaps.LayerPosition(above: "above", below: "below", at: nil)
+        let e = MapboxCoreMaps.LayerPosition(above: "above", below: "below", at: 3)
+        let f = MapboxCoreMaps.LayerPosition(above: "above", below: "below", at: 3)
 
         XCTAssertEqual(a, b)
         XCTAssertEqual(e, f)

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
@@ -61,7 +61,6 @@ internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase 
             // Given
             let annotation = PointAnnotation(coordinate: mapView.cameraState.center)
             let requiredIndex = 3
-            let position = LayerPosition.at(requiredIndex)
             let annotationManager = AnnotationManager(for: mapView,
                                                       mapEventsObservable: mapView.mapboxMap,
                                                       with: self)

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
@@ -61,7 +61,7 @@ internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase 
             // Given
             let annotation = PointAnnotation(coordinate: mapView.cameraState.center)
             let requiredIndex = 3
-            let position = LayerPosition(above: nil, below: nil, at: requiredIndex)
+            let position = LayerPosition.at(requiredIndex)
             let annotationManager = AnnotationManager(for: mapView,
                                                       mapEventsObservable: mapView.mapboxMap,
                                                       with: self)

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
@@ -63,7 +63,8 @@ internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase 
             let requiredIndex = 3
             let annotationManager = AnnotationManager(for: mapView,
                                                       mapEventsObservable: mapView.mapboxMap,
-                                                      with: self)
+                                                      with: self,
+                                                      options: AnnotationOptions(layerPosition: .at(requiredIndex)))
             annotationManager.addAnnotation(annotation)
 
             guard let layerId = annotationManager.layerId(for: PointAnnotation.self) else {

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -82,8 +82,8 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             do {
                 for step in stride(from: 0, to: layers.count, by: 3) {
 
-                    let newLayerPosition = LayerPosition(above: nil, below: nil, at: step)
-                    try style._moveLayer(withId: "test-id", to: newLayerPosition)
+                    let newLayerPosition: LayerPosition = .at(step)
+                    try style._moveLayer(with: "test-id", to: newLayerPosition)
 
                     // Get layer position
                     let layers = style.styleManager.getStyleLayers()

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -82,8 +82,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             do {
                 for step in stride(from: 0, to: layers.count, by: 3) {
 
-                    let newLayerPosition: LayerPosition = .at(step)
-                    try style._moveLayer(with: "test-id", to: newLayerPosition)
+                    try style._moveLayer(with: "test-id", to: .at(step))
 
                     // Get layer position
                     let layers = style.styleManager.getStyleLayers()

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -82,7 +82,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             do {
                 for step in stride(from: 0, to: layers.count, by: 3) {
 
-                    try style._moveLayer(with: "test-id", to: .at(step))
+                    try style._moveLayer(withId: "test-id", to: .at(step))
 
                     // Get layer position
                     let layers = style.styleManager.getStyleLayers()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Added new LayerPosition enum which improves Swift ergonomics.</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR adds a `LayerPosition` enum that shadows the underlying `MapboxCoreMaps.LayerPosition` struct to improve the Swift ergonomics of function calls.

For example, the layerPosition parameter in the following function call

```swift
mapView.style.addCustomLayer(
    withId: "Custom",
    layerHost: self,
    layerPosition: LayerPosition(above: nil, below: "waterway-label", at: nil))
```

becomes

```swift
layerPosition: .below("waterway-label"))
```


