### PR TITLE
[Camera Animations v2] Fix FlyTo

### DIFF
--- a/Apps/Examples/Examples/All Examples/FlyToExample.swift
+++ b/Apps/Examples/Examples/All Examples/FlyToExample.swift
@@ -15,10 +15,7 @@ public class FlyToExample: UIViewController, ExampleProtocol {
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         view.addSubview(mapView)
 
-        // Center the map over the United States.
-        let centerCoordinate = CLLocationCoordinate2D(latitude: 40.58058466412761,
-                                                      longitude: -97.734375)
-
+        // Center the map over San Francisco.
         mapView.cameraManager.setCamera(centerCoordinate: .sanfrancisco,
                                         zoom: 15)
 
@@ -40,7 +37,7 @@ public class FlyToExample: UIViewController, ExampleProtocol {
                                 pitch: 50)
 
         
-        flyToAnimator = self.mapView.cameraManager.flyTo(to: end) { [weak self] _ in
+        flyToAnimator = self.mapView.cameraManager.fly(to: end) { [weak self] _ in
             print("Camera fly-to finished")
             // The below line is used for internal testing purposes only.
             self?.flyToAnimator = nil

--- a/Apps/Examples/Examples/All Examples/FlyToExample.swift
+++ b/Apps/Examples/Examples/All Examples/FlyToExample.swift
@@ -6,6 +6,7 @@ import MapboxMaps
 public class FlyToExample: UIViewController, ExampleProtocol {
 
     internal var mapView: MapView!
+    internal var flyToAnimator: CameraAnimator?
 
     override public func viewDidLoad() {
         super.viewDidLoad()
@@ -18,8 +19,8 @@ public class FlyToExample: UIViewController, ExampleProtocol {
         let centerCoordinate = CLLocationCoordinate2D(latitude: 40.58058466412761,
                                                       longitude: -97.734375)
 
-        mapView.cameraManager.setCamera(centerCoordinate: centerCoordinate,
-                                        zoom: 3)
+        mapView.cameraManager.setCamera(centerCoordinate: .sanfrancisco,
+                                        zoom: 15)
 
         // Allows the view controller to receive information about map events.
         mapView.on(.mapLoaded) { [weak self] _ in
@@ -31,23 +32,21 @@ public class FlyToExample: UIViewController, ExampleProtocol {
 
     // Wait for the style to load before adding data to it.
     public func setupExample() {
-        let start = CameraOptions(center: .sanfrancisco,
-                                  zoom: 15,
-                                  bearing: 0,
-                                  pitch: 0)
+
 
         let end = CameraOptions(center: .boston,
                                 zoom: 15,
                                 bearing: 180,
                                 pitch: 50)
 
-        mapView.cameraManager.setCamera(to: start) { _ in
-            _ = self.mapView.cameraManager.flyTo(to: end) { [weak self] _ in
-                print("Camera fly-to finished")
-                // The below line is used for internal testing purposes only.
-                self?.finish()
-            }
+        
+        flyToAnimator = self.mapView.cameraManager.flyTo(to: end) { [weak self] _ in
+            print("Camera fly-to finished")
+            // The below line is used for internal testing purposes only.
+            self?.flyToAnimator = nil
+            self?.finish()
         }
+        
     }
 }
 

--- a/Apps/Examples/Examples/All Examples/FlyToExample.swift
+++ b/Apps/Examples/Examples/All Examples/FlyToExample.swift
@@ -30,20 +30,18 @@ public class FlyToExample: UIViewController, ExampleProtocol {
     // Wait for the style to load before adding data to it.
     public func setupExample() {
 
-
         let end = CameraOptions(center: .boston,
                                 zoom: 15,
                                 bearing: 180,
                                 pitch: 50)
 
-        
         flyToAnimator = self.mapView.cameraManager.fly(to: end) { [weak self] _ in
             print("Camera fly-to finished")
             // The below line is used for internal testing purposes only.
             self?.flyToAnimator = nil
             self?.finish()
         }
-        
+
     }
 }
 

--- a/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
@@ -369,6 +369,9 @@ public class CameraManager {
         guard let mapView = mapView else {
             return nil
         }
+        
+        // Stop the `internalCameraAnimator` before beginning a `flyTo`
+        internalCameraAnimator?.stopAnimation()
 
         guard let interpolator = FlyToInterpolator(from: mapView.camera,
                                                    to: camera,

--- a/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
@@ -362,7 +362,7 @@ public class CameraManager {
     ///   - duration: Duration of the animation, measured in seconds. If nil, a suitable calculated duration is used.
     ///   - completion: Completion handler called when the animation stops
     /// - Returns: The optional `CameraAnimator` that will execute the FlyTo animation
-    public func flyTo(to camera: CameraOptions,
+    public func fly(to camera: CameraOptions,
                       duration: TimeInterval? = nil,
                       completion: AnimationCompletion? = nil) -> CameraAnimator? {
 

--- a/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
@@ -363,13 +363,13 @@ public class CameraManager {
     ///   - completion: Completion handler called when the animation stops
     /// - Returns: The optional `CameraAnimator` that will execute the FlyTo animation
     public func fly(to camera: CameraOptions,
-                      duration: TimeInterval? = nil,
-                      completion: AnimationCompletion? = nil) -> CameraAnimator? {
+                    duration: TimeInterval? = nil,
+                    completion: AnimationCompletion? = nil) -> CameraAnimator? {
 
         guard let mapView = mapView else {
             return nil
         }
-        
+
         // Stop the `internalCameraAnimator` before beginning a `flyTo`
         internalCameraAnimator?.stopAnimation()
 

--- a/Sources/MapboxMaps/Foundation/Camera/CameraView.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraView.swift
@@ -205,19 +205,19 @@ internal class CameraView: UIView {
             // Diff the targetCamera with the currentCamera and apply diffed camera properties to map
             let diffedCamera = CameraOptions()
 
-            if targetCamera.zoom != currentCamera.zoom {
+            if targetCamera.zoom != currentCamera.zoom, let targetZoom = targetCamera.zoom, !targetZoom.isNaN {
                 diffedCamera.zoom = targetCamera.zoom
             }
 
-            if targetCamera.bearing != currentCamera.bearing {
+            if targetCamera.bearing != currentCamera.bearing, let targetBearing = targetCamera.bearing, !targetBearing.isNaN {
                 diffedCamera.bearing = targetCamera.bearing
             }
 
-            if targetCamera.pitch != currentCamera.pitch {
+            if targetCamera.pitch != currentCamera.pitch, let targetPitch = targetCamera.pitch, !targetPitch.isNaN {
                 diffedCamera.pitch = targetCamera.pitch
             }
 
-            if targetCamera.center != currentCamera.center {
+            if targetCamera.center != currentCamera.center, let targetCenter = targetCamera.center, !targetCenter.latitude.isNaN, !targetCenter.longitude.isNaN {
                 diffedCamera.center = targetCamera.center
             }
 

--- a/Tests/MapboxMapsTests/Foundation/Camera/MapboxMapsCameraTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Camera/MapboxMapsCameraTests.swift
@@ -97,7 +97,7 @@ class CameraManagerTests: XCTestCase {
         let coordinateBounds = CoordinateBounds(southwest: southwest, northeast: northeast)
 
         let camera = cameraManager.camera(for: coordinateBounds)
-        _ = cameraManager.flyTo(to: camera, completion: nil)
+        _ = cameraManager.fly(to: camera, completion: nil)
 
         XCTAssertNotNil(mapView.cameraView.camera)
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.

### Summary of changes
- Make sure that `internalCameraAnimator` is stopped before embarking on flyTo
- Make sure that the flyToAnimator is kept alive in the `FlyToExample`
- Guard against `NaN` values in `CameraView`
- Rename `flyTo` to match old signature