### PR TITLE
Make addLayer/addSource not generic.

### DIFF
--- a/Sources/MapboxMaps/Annotations/AnnotationStyleDelegate.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationStyleDelegate.swift
@@ -20,14 +20,14 @@ public protocol AnnotationStyleDelegate {
 
     func getStyleImage(with identifier: String) -> Image?
 
-    func addSource<T: Source>(source: T,
-                              identifier: String) -> Result<Bool, SourceError>
+    func addSource(source: Source,
+                   identifier: String) -> Result<Bool, SourceError>
 
     // swiftlint:disable identifier_name
     func updateSourceProperty(id: String,
                               property: String,
                               value: [String: Any]) -> Result<Bool, SourceError>
 
-    func addLayer<T: Layer>(layer: T,
-                            layerPosition: LayerPosition?) -> Result<Bool, LayerError>
+    func addLayer(layer: Layer,
+                  layerPosition: LayerPosition?) -> Result<Bool, LayerError>
 }

--- a/Sources/MapboxMaps/Style/Layers.swift
+++ b/Sources/MapboxMaps/Style/Layers.swift
@@ -41,7 +41,7 @@ public enum LayerType: String, Codable {
     case model = "model"
 }
 
-public protocol Layer: Codable {
+public protocol Layer: Codable, StyleEncodable {
     /// Unique layer name
     var id: String { get set }
 

--- a/Sources/MapboxMaps/Style/Sources.swift
+++ b/Sources/MapboxMaps/Style/Sources.swift
@@ -35,4 +35,4 @@ public enum SourceType: String, Codable {
     }
 }
 
-public protocol Source: Codable { }
+public protocol Source: Codable, StyleEncodable { }

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -366,8 +366,7 @@ public class Style {
         update(&validLayer)
 
         do {
-            let data = try JSONEncoder().encode(validLayer)
-            let value = try JSONSerialization.jsonObject(with: data, options: [])
+            let value = try validLayer.jsonObject()
 
             // Apply the changes to the layer properties to the style
             try styleManager.setStyleLayerPropertiesForLayerId(id, properties: value)

--- a/Sources/MapboxMaps/Style/StyleEncodable.swift
+++ b/Sources/MapboxMaps/Style/StyleEncodable.swift
@@ -1,0 +1,19 @@
+import Foundation
+import MapboxCoreMaps
+
+public protocol StyleEncodable {
+    func jsonObject() throws -> [String: AnyObject]
+}
+
+public extension StyleEncodable where Self: Encodable {
+    /// Given an Encodable object return the JSON dictionary representation
+    /// - Throws: Errors occurring during encoding, or `StyleEncodingError.invalidJSONObject`
+    /// - Returns: A JSON dictionary representing the object.
+    func jsonObject() throws -> [String: AnyObject] {
+        let data = try JSONEncoder().encode(self)
+        guard let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: AnyObject] else {
+            throw StyleEncodingError.invalidJSONObject
+        }
+        return jsonObject
+    }
+}

--- a/Sources/MapboxMaps/Style/StyleErrors.swift
+++ b/Sources/MapboxMaps/Style/StyleErrors.swift
@@ -2,6 +2,10 @@ import Foundation
 
 // MARK: - Style error types
 
+public enum StyleEncodingError: Error {
+    case invalidJSONObject
+}
+
 /// All source related errors
 public enum SourceError: Error {
     /// The source could not be encoded to JSON
@@ -26,7 +30,7 @@ public enum SourceError: Error {
 /// Error enum for all layer-related errors
 public enum LayerError: Error {
     /// The layer provided to the map in `addLayer()` could not be encoded
-    case layerEncodingFailed(Error)
+    case layerEncodingFailed(Error?)
 
     /// The layer retrieved from the map could not be decoded.
     case layerDecodingFailed(Error)

--- a/Tests/MapboxMapsTests/Annotations/AnnotationStyleDelegateMock.swift
+++ b/Tests/MapboxMapsTests/Annotations/AnnotationStyleDelegateMock.swift
@@ -25,7 +25,7 @@ class AnnotationStyleDelegateMock: AnnotationStyleDelegate {
         return Image(uiImage: UIImage())
     }
 
-    func addSource<T>(source: T, identifier: String) -> Result<Bool, SourceError> where T: Source {
+    func addSource(source: Source, identifier: String) -> Result<Bool, SourceError> {
         return .success(true)
     }
 
@@ -34,7 +34,7 @@ class AnnotationStyleDelegateMock: AnnotationStyleDelegate {
         return .success(true)
     }
 
-    func addLayer<T>(layer: T, layerPosition: LayerPosition?) -> Result<Bool, LayerError> where T: Layer {
+    func addLayer(layer: Layer, layerPosition: LayerPosition?) -> Result<Bool, LayerError> {
         return .success(true)
     }
 }

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
@@ -172,7 +172,7 @@ extension AnnotationManagerIntegrationTestCase: AnnotationStyleDelegate {
         return style.getStyleImage(with: identifier)
     }
 
-    func addSource<T>(source: T, identifier: String) -> Result<Bool, SourceError> where T: Source {
+    func addSource(source: Source, identifier: String) -> Result<Bool, SourceError> {
         guard let style = style else {
             XCTFail("No style available")
             return .failure(.addSourceFailed(nil))
@@ -190,7 +190,7 @@ extension AnnotationManagerIntegrationTestCase: AnnotationStyleDelegate {
         return style.updateSourceProperty(id: id, property: property, value: value)
     }
 
-    func addLayer<T>(layer: T, layerPosition: LayerPosition?) -> Result<Bool, LayerError> where T: Layer {
+    func addLayer(layer: Layer, layerPosition: LayerPosition?) -> Result<Bool, LayerError> {
         guard let style = style else {
             XCTFail("No style available")
             return .failure(.addStyleLayerFailed(nil))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

This PR removes the generic parameter from `addLayer` and `addSource`, instead moving the functionality to a new `StyleEncodable`.

I have not done the same for `getLayer/getSource`, but a similar approach (and a `StyleDecodable`) would work here (though this may be something we don't want to do).

### User impact (optional)

Although these functions have been made non-generic, there is no change to user code.
