### PR TITLE
Add style integration test for style.getLayer(with:)

### DIFF
--- a/Sources/MapboxMaps/Style/Layers.swift
+++ b/Sources/MapboxMaps/Style/Layers.swift
@@ -39,6 +39,36 @@ public enum LayerType: String, Codable {
 
     /// Layer used for a 3D model
     case model = "model"
+
+    /// The associated Swift struct type
+    public var layerType: Layer.Type {
+        switch self {
+        case .fill:
+            return FillLayer.self
+        case .line:
+            return LineLayer.self
+        case .symbol:
+            return SymbolLayer.self
+        case .circle:
+            return CircleLayer.self
+        case .heatmap:
+            return HeatmapLayer.self
+        case .fillExtrusion:
+            return FillExtrusionLayer.self
+        case .raster:
+            return RasterLayer.self
+        case .hillshade:
+            return HillshadeLayer.self
+        case .background:
+            return BackgroundLayer.self
+        case .locationIndicator:
+            return LocationIndicatorLayer.self
+        case .sky:
+            return SkyLayer.self
+        case .model:
+            return ModelLayer.self
+        }
+    }
 }
 
 public protocol Layer: Codable, StyleEncodable, StyleDecodable {

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -141,12 +141,10 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                         switch result {
                         case .success:
                             let layerProperties = try! mapView.__map.getStyleLayerProperties(forLayerId: layer.id)
-                            print("Success: \(layerProperties.value)")
                             expectation.fulfill()
                         default:
-                            failures.append(result)
                             let layerProperties = try! mapView.__map.getStyleLayerProperties(forLayerId: layer.id)
-                            print("Failed: \(layerProperties.value)")
+                            failures.append(layerProperties.value)
                             XCTFail("Failed to get symbol layer with id \(layer.id), error \(result)")
                         } // getting 6 failures
                     case .fill:

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -119,7 +119,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
         }
 
         let expectation = XCTestExpectation(description: "Getting style layers succeeded")
-        expectation.expectedFulfillmentCount = 111
+        expectation.expectedFulfillmentCount = 111 // The current number of layers
         didFinishLoadingStyle = { _ in
             let layers = try! mapView.__map.getStyleLayers()
             do {
@@ -133,7 +133,6 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                         default:
                             XCTFail("Failed to get layer with id \(layer.id), error \(result)")
                         }
-                     }
                      case "symbol":
                         let result = style.getLayer(with: layer.id, type: SymbolLayer.self)
                         switch result {

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -111,9 +111,8 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
         wait(for: [expectation], timeout: 5.0)
     }
 
-    func testGetLayers() {
-        guard
-            let mapView = mapView, let style = style else {
+    func testDecodingOfAllLayersInStreetsv11() {
+        guard let mapView = mapView, let style = style else {
             XCTFail("There should be valid MapView and Style objects created by setUp.")
             return
         }

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -121,10 +121,8 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
         expectation.expectedFulfillmentCount = 111 // The current number of layers
 
         didFinishLoadingStyle = { _ in
-            try! self.mapView?.__map.setStyleLayerPropertyForLayerId("settlement-label", property: "text-field", value: "OOPS")
             let layers = try! mapView.__map.getStyleLayers()
             do {
-                var failures : [Any] = []
                 for layer in layers {
                     let type = LayerType(rawValue: layer.type)
                     switch type {
@@ -140,11 +138,8 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                         let result = style.getLayer(with: layer.id, type: SymbolLayer.self)
                         switch result {
                         case .success:
-                            let layerProperties = try! mapView.__map.getStyleLayerProperties(forLayerId: layer.id)
                             expectation.fulfill()
                         default:
-                            let layerProperties = try! mapView.__map.getStyleLayerProperties(forLayerId: layer.id)
-                            failures.append(layerProperties.value)
                             XCTFail("Failed to get symbol layer with id \(layer.id), error \(result)")
                         } // getting 6 failures
                     case .fill:
@@ -167,7 +162,6 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                          print("Unable to match type for layer of type \(layer.type)")
                      }
                 }
-                print(failures)
             }
         }
         wait(for: [expectation], timeout: 5.0)

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -126,22 +126,23 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             expectation.expectedFulfillmentCount = layers.count
             do {
                 for layer in layers {
-                    var layerType : Layer.Type
-                    switch layer.type {
-                    case "line":
-                        layerType = LineLayer.self
-                    case "symbol":
-                        layerType = SymbolLayer.self
-                    case "fill":
-                        layerType = FillLayer.self
-                    case "background":
-                        layerType = BackgroundLayer.self
-                    default:
-                        print("Unable to match type for layer of type \(layer.type)")
-                    }
+//                    var layerType : Layer
+//                    switch layer.type {
+//                    case "line":
+//                        layerType = LineLayer.self as! Layer
+//                    case "symbol":
+//                        layerType = SymbolLayer.self as! Layer
+//                    case "fill":
+//                        layerType = FillLayer.self as! Layer
+//                    case "background":
+//                        layerType = BackgroundLayer.self as! Layer
+//                    default:
+//                        print("Unable to match type for layer of type \(layer.type)")
+//                    }
 //
-                    let layerResponse = style.getLayer(with: layer.id, type: layerType.self)
+                    let layerResponse = style.getLayer(with: layer.id, type: getLayerClass(type: layer.type).self) // Cannot convert value of type 'Layer' to expected argument type 'T.Type'
 
+                    // let layerResponse = style.getLayer(with: layer.id, type: getLayerClass(type: layer.type).self as! T.Type) // Cannot find type 'T' in scope
                     switch layerResponse {
                     case .success:
                         expectation.fulfill()
@@ -175,5 +176,20 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             }
         }
         wait(for: [expectation], timeout: 5.0)
+    }
+
+    func getLayerClass(type: String) -> Layer {
+        switch type {
+        case "line":
+            return LineLayer as! Layer
+        case "symbol":
+            return SymbolLayer.self as! Layer
+        case "fill":
+            return FillLayer.self as! Layer
+        case "background":
+            return BackgroundLayer.self as! Layer
+        default:
+            XCTFail("Could not convert \(type)to Layer")
+        }
     }
 }

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -141,7 +141,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                             expectation.fulfill()
                         default:
                             XCTFail("Failed to get symbol layer with id \(layer.id), error \(result)")
-                        } // getting 6 failures
+                        }
                     case .fill:
                         let result = style.getLayer(with: layer.id, type: FillLayer.self)
                         switch result {

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -118,10 +118,11 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             return
         }
 
+        var expectation: XCTestExpectation
         didFinishLoadingStyle = { _ in
             let layers = try! mapView.__map.getStyleLayers()
 
-            let expectation = XCTestExpectation(description: "Getting style layers succeeded")
+            expectation = XCTestExpectation(description: "Getting style layers succeeded")
             expectation.expectedFulfillmentCount = layers.count
             do {
                 for layer in layers {
@@ -140,8 +141,14 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                     }
 //
                     let layerResponse = style.getLayer(with: layer.id, type: layerType.self)
-                    XCTAssert(layerResponse == .success, "Failed to retrieve layer with id \(layer.id)")
 
+                    switch layerResponse {
+                    case .success:
+                        expectation.fulfill()
+                    default:
+                        XCTFail("Failed to get layer with id \(layer.id)")
+                    }
+                    
 //                     var result : Any
 //                     switch layer.type {
 //                     case "line":
@@ -166,9 +173,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             } catch {
                 XCTFail("Failed to get layer")
             }
-
         }
         wait(for: [expectation], timeout: 5.0)
     }
-
 }

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -117,45 +117,46 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             XCTFail("There should be valid MapView and Style objects created by setUp.")
             return
         }
-
         let expectation = XCTestExpectation(description: "Getting style layers succeeded")
         expectation.expectedFulfillmentCount = 111 // The current number of layers
+
         didFinishLoadingStyle = { _ in
             let layers = try! mapView.__map.getStyleLayers()
             do {
                 for layer in layers {
-                     switch layer.type {
-                     case "line":
+                    let type = LayerType(rawValue: layer.type)
+                    switch type {
+                    case .line:
                         let result = style.getLayer(with: layer.id, type: LineLayer.self)
                         switch result {
                         case .success:
                             expectation.fulfill()
                         default:
-                            XCTFail("Failed to get layer with id \(layer.id), error \(result)")
+                            XCTFail("Failed to get line layer with id \(layer.id), error \(result)")
                         }
-                     case "symbol":
+                    case .symbol:
                         let result = style.getLayer(with: layer.id, type: SymbolLayer.self)
                         switch result {
                         case .success:
                             expectation.fulfill()
                         default:
-                            XCTFail("Failed to get layer with id \(layer.id), error \(result)")
+                            XCTFail("Failed to get symbol layer with id \(layer.id), error \(result)")
                         } // getting 17 failures
-                     case "fill":
+                    case .fill:
                         let result = style.getLayer(with: layer.id, type: FillLayer.self)
                         switch result {
                         case .success:
                             expectation.fulfill()
                         default:
-                            XCTFail("Failed to get layer with id \(layer.id)")
+                            XCTFail("Failed to get fill layer with id \(layer.id)")
                         }
-                     case "background":
+                    case .background:
                         let result = style.getLayer(with: layer.id, type: BackgroundLayer.self)
                         switch result {
                         case .success:
                             expectation.fulfill()
                         default:
-                            XCTFail("Failed to get layer with id \(layer.id), error \(result)")
+                            XCTFail("Failed to get background layer with id \(layer.id), error \(result)")
                         }
                      default:
                          print("Unable to match type for layer of type \(layer.type)")

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -111,56 +111,33 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
         wait(for: [expectation], timeout: 5.0)
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     func testDecodingOfAllLayersInStreetsv11() {
         guard let mapView = mapView, let style = style else {
             XCTFail("There should be valid MapView and Style objects created by setUp.")
             return
         }
+        let expectedLayerCount = 111 // The current number of layers
+
         let expectation = XCTestExpectation(description: "Getting style layers succeeded")
-        expectation.expectedFulfillmentCount = 111 // The current number of layers
+        expectation.expectedFulfillmentCount = expectedLayerCount
 
         didFinishLoadingStyle = { _ in
             let layers = try! mapView.__map.getStyleLayers()
-            do {
-                for layer in layers {
-                    let type = LayerType(rawValue: layer.type)
-                    switch type {
-                    case .line:
-                        let result = style.getLayer(with: layer.id, type: LineLayer.self)
-                        switch result {
-                        case .success:
-                            expectation.fulfill()
-                        default:
-                            XCTFail("Failed to get line layer with id \(layer.id), error \(result)")
-                        }
-                    case .symbol:
-                        let result = style.getLayer(with: layer.id, type: SymbolLayer.self)
-                        switch result {
-                        case .success:
-                            expectation.fulfill()
-                        default:
-                            XCTFail("Failed to get symbol layer with id \(layer.id), error \(result)")
-                        }
-                    case .fill:
-                        let result = style.getLayer(with: layer.id, type: FillLayer.self)
-                        switch result {
-                        case .success:
-                            expectation.fulfill()
-                        default:
-                            XCTFail("Failed to get fill layer with id \(layer.id)")
-                        }
-                    case .background:
-                        let result = style.getLayer(with: layer.id, type: BackgroundLayer.self)
-                        switch result {
-                        case .success:
-                            expectation.fulfill()
-                        default:
-                            XCTFail("Failed to get background layer with id \(layer.id), error \(result)")
-                        }
-                    default:
-                        print("Unable to match type for layer of type \(layer.type)")
-                    }
+            XCTAssertEqual(layers.count, expectedLayerCount)
+
+            for layer in layers {
+                guard let type = LayerType(rawValue: layer.type) else {
+                    XCTFail("Failed to create LayerType from \(layer.type)")
+                    continue
+                }
+
+                let result = style._layer(with: layer.id, type: type.layerType)
+
+                switch result {
+                case .success:
+                    expectation.fulfill()
+                default:
+                    XCTFail("Failed to get line layer with id \(layer.id), error \(result)")
                 }
             }
         }

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -121,8 +121,10 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
         expectation.expectedFulfillmentCount = 111 // The current number of layers
 
         didFinishLoadingStyle = { _ in
+            try! self.mapView?.__map.setStyleLayerPropertyForLayerId("settlement-label", property: "text-field", value: "OOPS")
             let layers = try! mapView.__map.getStyleLayers()
             do {
+                var failures : [Any] = []
                 for layer in layers {
                     let type = LayerType(rawValue: layer.type)
                     switch type {
@@ -138,8 +140,13 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                         let result = style.getLayer(with: layer.id, type: SymbolLayer.self)
                         switch result {
                         case .success:
+                            let layerProperties = try! mapView.__map.getStyleLayerProperties(forLayerId: layer.id)
+                            print("Success: \(layerProperties.value)")
                             expectation.fulfill()
                         default:
+                            failures.append(result)
+                            let layerProperties = try! mapView.__map.getStyleLayerProperties(forLayerId: layer.id)
+                            print("Failed: \(layerProperties.value)")
                             XCTFail("Failed to get symbol layer with id \(layer.id), error \(result)")
                         } // getting 17 failures
                     case .fill:
@@ -162,6 +169,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                          print("Unable to match type for layer of type \(layer.type)")
                      }
                 }
+                print(failures)
             }
         }
         wait(for: [expectation], timeout: 5.0)

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -118,78 +118,52 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             return
         }
 
-        var expectation: XCTestExpectation
+        let expectation = XCTestExpectation(description: "Getting style layers succeeded")
+        expectation.expectedFulfillmentCount = 111
         didFinishLoadingStyle = { _ in
             let layers = try! mapView.__map.getStyleLayers()
-
-            expectation = XCTestExpectation(description: "Getting style layers succeeded")
-            expectation.expectedFulfillmentCount = layers.count
             do {
                 for layer in layers {
-//                    var layerType : Layer
-//                    switch layer.type {
-//                    case "line":
-//                        layerType = LineLayer.self as! Layer
-//                    case "symbol":
-//                        layerType = SymbolLayer.self as! Layer
-//                    case "fill":
-//                        layerType = FillLayer.self as! Layer
-//                    case "background":
-//                        layerType = BackgroundLayer.self as! Layer
-//                    default:
-//                        print("Unable to match type for layer of type \(layer.type)")
-//                    }
-//
-                    let layerResponse = style.getLayer(with: layer.id, type: getLayerClass(type: layer.type).self) // Cannot convert value of type 'Layer' to expected argument type 'T.Type'
-
-                    // let layerResponse = style.getLayer(with: layer.id, type: getLayerClass(type: layer.type).self as! T.Type) // Cannot find type 'T' in scope
-                    switch layerResponse {
-                    case .success:
-                        expectation.fulfill()
-                    default:
-                        XCTFail("Failed to get layer with id \(layer.id)")
-                    }
-                    
-//                     var result : Any
-//                     switch layer.type {
-//                     case "line":
-//                         result = style.getLayer(with: layer.id, type: LineLayer.self)
-//                     case "symbol":
-//                         result = style.getLayer(with: layer.id, type: SymbolLayer.self)
-//                     case "fill":
-//                         result = style.getLayer(with: layer.id, type: FillLayer.self)
-//                     case "background":
-//                         result = style.getLayer(with: layer.id, type: BackgroundLayer.self)
-//                     default:
-//                         print("Unable to match type for layer of type \(layer.type)")
-//                     }
-//                     switch result as! Result{
-//                     case .success:
-//                         expectation.fulfill()
-//                     default:
-//                         XCTFail("Failed to get layer with id \(layer.id)")
-//                     }
-
+                     switch layer.type {
+                     case "line":
+                        let result = style.getLayer(with: layer.id, type: LineLayer.self)
+                        switch result {
+                        case .success:
+                            expectation.fulfill()
+                        default:
+                            XCTFail("Failed to get layer with id \(layer.id), error \(result)")
+                        }
+                     }
+                     case "symbol":
+                        let result = style.getLayer(with: layer.id, type: SymbolLayer.self)
+                        switch result {
+                        case .success:
+                            expectation.fulfill()
+                        default:
+                            XCTFail("Failed to get layer with id \(layer.id), error \(result)")
+                        } // getting 17 failures
+                     case "fill":
+                        let result = style.getLayer(with: layer.id, type: FillLayer.self)
+                        switch result {
+                        case .success:
+                            expectation.fulfill()
+                        default:
+                            XCTFail("Failed to get layer with id \(layer.id)")
+                        }
+                     case "background":
+                        let result = style.getLayer(with: layer.id, type: BackgroundLayer.self)
+                        switch result {
+                        case .success:
+                            expectation.fulfill()
+                        default:
+                            XCTFail("Failed to get layer with id \(layer.id), error \(result)")
+                        }
+                     default:
+                         print("Unable to match type for layer of type \(layer.type)")
+                     }
                 }
-            } catch {
-                XCTFail("Failed to get layer")
             }
         }
         wait(for: [expectation], timeout: 5.0)
-    }
-
-    func getLayerClass(type: String) -> Layer {
-        switch type {
-        case "line":
-            return LineLayer as! Layer
-        case "symbol":
-            return SymbolLayer.self as! Layer
-        case "fill":
-            return FillLayer.self as! Layer
-        case "background":
-            return BackgroundLayer.self as! Layer
-        default:
-            XCTFail("Could not convert \(type)to Layer")
-        }
     }
 }

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -110,4 +110,65 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
 
         wait(for: [expectation], timeout: 5.0)
     }
+
+    func testGetLayers() {
+        guard
+            let mapView = mapView, let style = style else {
+            XCTFail("There should be valid MapView and Style objects created by setUp.")
+            return
+        }
+
+        didFinishLoadingStyle = { _ in
+            let layers = try! mapView.__map.getStyleLayers()
+
+            let expectation = XCTestExpectation(description: "Getting style layers succeeded")
+            expectation.expectedFulfillmentCount = layers.count
+            do {
+                for layer in layers {
+                    var layerType : Layer.Type
+                    switch layer.type {
+                    case "line":
+                        layerType = LineLayer.self
+                    case "symbol":
+                        layerType = SymbolLayer.self
+                    case "fill":
+                        layerType = FillLayer.self
+                    case "background":
+                        layerType = BackgroundLayer.self
+                    default:
+                        print("Unable to match type for layer of type \(layer.type)")
+                    }
+//
+                    let layerResponse = style.getLayer(with: layer.id, type: layerType.self)
+                    XCTAssert(layerResponse == .success, "Failed to retrieve layer with id \(layer.id)")
+
+//                     var result : Any
+//                     switch layer.type {
+//                     case "line":
+//                         result = style.getLayer(with: layer.id, type: LineLayer.self)
+//                     case "symbol":
+//                         result = style.getLayer(with: layer.id, type: SymbolLayer.self)
+//                     case "fill":
+//                         result = style.getLayer(with: layer.id, type: FillLayer.self)
+//                     case "background":
+//                         result = style.getLayer(with: layer.id, type: BackgroundLayer.self)
+//                     default:
+//                         print("Unable to match type for layer of type \(layer.type)")
+//                     }
+//                     switch result as! Result{
+//                     case .success:
+//                         expectation.fulfill()
+//                     default:
+//                         XCTFail("Failed to get layer with id \(layer.id)")
+//                     }
+
+                }
+            } catch {
+                XCTFail("Failed to get layer")
+            }
+
+        }
+        wait(for: [expectation], timeout: 5.0)
+    }
+
 }

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -148,7 +148,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                             let layerProperties = try! mapView.__map.getStyleLayerProperties(forLayerId: layer.id)
                             print("Failed: \(layerProperties.value)")
                             XCTFail("Failed to get symbol layer with id \(layer.id), error \(result)")
-                        } // getting 17 failures
+                        } // getting 6 failures
                     case .fill:
                         let result = style.getLayer(with: layer.id, type: FillLayer.self)
                         switch result {

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -124,6 +124,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             do {
                 for layer in layers {
                     let type = LayerType(rawValue: layer.type)
+                    // swiftlint:disable:next cyclomatic_complexity
                     switch type {
                     case .line:
                         let result = style.getLayer(with: layer.id, type: LineLayer.self)
@@ -157,9 +158,9 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                         default:
                             XCTFail("Failed to get background layer with id \(layer.id), error \(result)")
                         }
-                     default:
-                         print("Unable to match type for layer of type \(layer.type)")
-                     }
+                    default:
+                        print("Unable to match type for layer of type \(layer.type)")
+                    }
                 }
             }
         }

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -111,6 +111,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
         wait(for: [expectation], timeout: 5.0)
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     func testDecodingOfAllLayersInStreetsv11() {
         guard let mapView = mapView, let style = style else {
             XCTFail("There should be valid MapView and Style objects created by setUp.")
@@ -124,7 +125,6 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             do {
                 for layer in layers {
                     let type = LayerType(rawValue: layer.type)
-                    // swiftlint:disable:next cyclomatic_complexity
                     switch type {
                     case .line:
                         let result = style.getLayer(with: layer.id, type: LineLayer.self)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: n/a

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.

### Summary of changes

This PR adds a test to `StyleIntegrationTests` that:
- Retrieves style layers from the `mapView.__map`.
- Attempts to retrieve each layer from `mapView.style` using the layer ID and type.
- Tests should fail if one layer cannot be retrieved.

Note that currently the number of layers is hardcoded. 
