### PR TITLE
Create non-generic versions of getLayer/getSource

### DIFF
--- a/Sources/MapboxMaps/Style/Layers.swift
+++ b/Sources/MapboxMaps/Style/Layers.swift
@@ -71,7 +71,7 @@ public protocol Layer: Codable, StyleEncodable, StyleDecodable {
 public extension Layer {
     /// Initializes a Layer given a JSON dictionary
     /// - Throws: Errors occurring during decoding
-    init(jsonObject: [String : AnyObject]) throws {
+    init(jsonObject: [String: AnyObject]) throws {
         let layerData = try JSONSerialization.data(withJSONObject: jsonObject)
         self = try JSONDecoder().decode(Self.self, from: layerData)
     }

--- a/Sources/MapboxMaps/Style/Layers.swift
+++ b/Sources/MapboxMaps/Style/Layers.swift
@@ -68,6 +68,15 @@ public protocol Layer: Codable, StyleEncodable, StyleDecodable {
     var maxZoom: Double? { get set }
 }
 
+public extension Layer {
+    /// Initializes a Layer given a JSON dictionary
+    /// - Throws: Errors occurring during decoding
+    init(jsonObject: [String : AnyObject]) throws {
+        let layerData = try JSONSerialization.data(withJSONObject: jsonObject)
+        self = try JSONDecoder().decode(Self.self, from: layerData)
+    }
+}
+
 public extension LayerPosition {
     convenience init(above: String? = nil, below: String? = nil, at: Int? = nil) {
         self.init(__above: above, below: below, at: at?.NSNumber)

--- a/Sources/MapboxMaps/Style/Layers.swift
+++ b/Sources/MapboxMaps/Style/Layers.swift
@@ -41,7 +41,7 @@ public enum LayerType: String, Codable {
     case model = "model"
 }
 
-public protocol Layer: Codable, StyleEncodable {
+public protocol Layer: Codable, StyleEncodable, StyleDecodable {
     /// Unique layer name
     var id: String { get set }
 

--- a/Sources/MapboxMaps/Style/Sources.swift
+++ b/Sources/MapboxMaps/Style/Sources.swift
@@ -36,3 +36,14 @@ public enum SourceType: String, Codable {
 }
 
 public protocol Source: Codable, StyleEncodable, StyleDecodable { }
+
+public extension Source {
+    /// Initializes a Source given a JSON dictionary
+    /// - Throws: Errors occurring during decoding
+    init(jsonObject: [String : AnyObject]) throws {
+        let sourceData = try JSONSerialization.data(withJSONObject: jsonObject)
+        self = try JSONDecoder().decode(Self.self, from: sourceData)
+    }
+}
+
+

--- a/Sources/MapboxMaps/Style/Sources.swift
+++ b/Sources/MapboxMaps/Style/Sources.swift
@@ -40,10 +40,8 @@ public protocol Source: Codable, StyleEncodable, StyleDecodable { }
 public extension Source {
     /// Initializes a Source given a JSON dictionary
     /// - Throws: Errors occurring during decoding
-    init(jsonObject: [String : AnyObject]) throws {
+    init(jsonObject: [String: AnyObject]) throws {
         let sourceData = try JSONSerialization.data(withJSONObject: jsonObject)
         self = try JSONDecoder().decode(Self.self, from: sourceData)
     }
 }
-
-

--- a/Sources/MapboxMaps/Style/Sources.swift
+++ b/Sources/MapboxMaps/Style/Sources.swift
@@ -35,4 +35,4 @@ public enum SourceType: String, Codable {
     }
 }
 
-public protocol Source: Codable, StyleEncodable { }
+public protocol Source: Codable, StyleEncodable, StyleDecodable { }

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -3,6 +3,7 @@ import Turf
 import MapboxMapsFoundation
 #endif
 
+//swiftlint:disable file_length
 public class Style {
     public private(set) weak var styleManager: StyleManager!
 

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -102,7 +102,9 @@ public class Style {
         let layerResult = _layer(with: layerID, type: type)
         switch layerResult {
         case .success(let layer):
+            // swiftlint:disable force_cast
             return .success(layer as! T)
+            // swiftlint:enable force_cast
         case .failure(let error):
             return .failure(error)
         }
@@ -251,7 +253,9 @@ public class Style {
         let sourceResult = _source(identifier: identifier, type: type)
         switch sourceResult {
         case .success(let source):
+            // swiftlint:disable force_cast
             return .success(source as! T)
+            // swiftlint:enable force_cast
         case .failure(let error):
             return .failure(error)
         }

--- a/Sources/MapboxMaps/Style/StyleEncodable.swift
+++ b/Sources/MapboxMaps/Style/StyleEncodable.swift
@@ -17,3 +17,21 @@ public extension StyleEncodable where Self: Encodable {
         return jsonObject
     }
 }
+
+public protocol StyleDecodable {
+    init(jsonObject: [String: AnyObject]) throws
+}
+
+public extension StyleDecodable where Self: Layer {
+    init(jsonObject: [String : AnyObject]) throws {
+        let layerData = try JSONSerialization.data(withJSONObject: jsonObject)
+        self = try JSONDecoder().decode(Self.self, from: layerData)
+    }
+}
+
+public extension StyleDecodable where Self: Source {
+    init(jsonObject: [String : AnyObject]) throws {
+        let sourceData = try JSONSerialization.data(withJSONObject: jsonObject)
+        self = try JSONDecoder().decode(Self.self, from: sourceData)
+    }
+}

--- a/Sources/MapboxMaps/Style/StyleEncodable.swift
+++ b/Sources/MapboxMaps/Style/StyleEncodable.swift
@@ -1,8 +1,9 @@
-import Foundation
-import MapboxCoreMaps
-
 public protocol StyleEncodable {
     func jsonObject() throws -> [String: AnyObject]
+}
+
+public protocol StyleDecodable {
+    init(jsonObject: [String: AnyObject]) throws
 }
 
 public extension StyleEncodable where Self: Encodable {
@@ -15,23 +16,5 @@ public extension StyleEncodable where Self: Encodable {
             throw StyleEncodingError.invalidJSONObject
         }
         return jsonObject
-    }
-}
-
-public protocol StyleDecodable {
-    init(jsonObject: [String: AnyObject]) throws
-}
-
-public extension StyleDecodable where Self: Layer {
-    init(jsonObject: [String : AnyObject]) throws {
-        let layerData = try JSONSerialization.data(withJSONObject: jsonObject)
-        self = try JSONDecoder().decode(Self.self, from: layerData)
-    }
-}
-
-public extension StyleDecodable where Self: Source {
-    init(jsonObject: [String : AnyObject]) throws {
-        let sourceData = try JSONSerialization.data(withJSONObject: jsonObject)
-        self = try JSONDecoder().decode(Self.self, from: sourceData)
     }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR adds non-generic versions of `getLayer` and `getSource`: these are currently named `_layer(...)` and `_source(...)`.

This does not update `updateLayer` - in its current guise it may not make sense to have a non-generic version.

Follows on from #231