### PR TITLE
Switch to using _layer in test

### DIFF
--- a/Sources/MapboxMaps/Style/Layers.swift
+++ b/Sources/MapboxMaps/Style/Layers.swift
@@ -41,7 +41,7 @@ public enum LayerType: String, Codable {
     case model = "model"
 
     /// The associated Swift struct type
-    public var type: Layer.Type {
+    public var layerType: Layer.Type {
         switch self {
         case .fill:
             return FillLayer.self

--- a/Sources/MapboxMaps/Style/Layers.swift
+++ b/Sources/MapboxMaps/Style/Layers.swift
@@ -39,6 +39,36 @@ public enum LayerType: String, Codable {
 
     /// Layer used for a 3D model
     case model = "model"
+
+    /// The associated Swift struct type
+    public var type: Layer.Type {
+        switch self {
+        case .fill:
+            return FillLayer.self
+        case .line:
+            return LineLayer.self
+        case .symbol:
+            return SymbolLayer.self
+        case .circle:
+            return CircleLayer.self
+        case .heatmap:
+            return HeatmapLayer.self
+        case .fillExtrusion:
+            return FillExtrusionLayer.self
+        case .raster:
+            return RasterLayer.self
+        case .hillshade:
+            return HillshadeLayer.self
+        case .background:
+            return BackgroundLayer.self
+        case .locationIndicator:
+            return LocationIndicatorLayer.self
+        case .sky:
+            return SkyLayer.self
+        case .model:
+            return ModelLayer.self
+        }
+    }
 }
 
 public protocol Layer: Codable, StyleEncodable, StyleDecodable {

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -131,7 +131,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                     continue
                 }
 
-                let result = style._layer(with: layer.id, type: type.type)
+                let result = style._layer(with: layer.id, type: type.layerType)
 
                 switch result {
                 case .success:

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -111,7 +111,6 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
         wait(for: [expectation], timeout: 5.0)
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     func testDecodingOfAllLayersInStreetsv11() {
         guard let mapView = mapView, let style = style else {
             XCTFail("There should be valid MapView and Style objects created by setUp.")

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -117,50 +117,28 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             XCTFail("There should be valid MapView and Style objects created by setUp.")
             return
         }
+        let expectedLayerCount = 111 // The current number of layers
+
         let expectation = XCTestExpectation(description: "Getting style layers succeeded")
-        expectation.expectedFulfillmentCount = 111 // The current number of layers
+        expectation.expectedFulfillmentCount = expectedLayerCount
 
         didFinishLoadingStyle = { _ in
             let layers = try! mapView.__map.getStyleLayers()
-            do {
-                for layer in layers {
-                    let type = LayerType(rawValue: layer.type)
-                    switch type {
-                    case .line:
-                        let result = style.getLayer(with: layer.id, type: LineLayer.self)
-                        switch result {
-                        case .success:
-                            expectation.fulfill()
-                        default:
-                            XCTFail("Failed to get line layer with id \(layer.id), error \(result)")
-                        }
-                    case .symbol:
-                        let result = style.getLayer(with: layer.id, type: SymbolLayer.self)
-                        switch result {
-                        case .success:
-                            expectation.fulfill()
-                        default:
-                            XCTFail("Failed to get symbol layer with id \(layer.id), error \(result)")
-                        }
-                    case .fill:
-                        let result = style.getLayer(with: layer.id, type: FillLayer.self)
-                        switch result {
-                        case .success:
-                            expectation.fulfill()
-                        default:
-                            XCTFail("Failed to get fill layer with id \(layer.id)")
-                        }
-                    case .background:
-                        let result = style.getLayer(with: layer.id, type: BackgroundLayer.self)
-                        switch result {
-                        case .success:
-                            expectation.fulfill()
-                        default:
-                            XCTFail("Failed to get background layer with id \(layer.id), error \(result)")
-                        }
-                    default:
-                        print("Unable to match type for layer of type \(layer.type)")
-                    }
+            XCTAssertEqual(layers.count, expectedLayerCount)
+
+            for layer in layers {
+                guard let type = LayerType(rawValue: layer.type) else {
+                    XCTFail("Failed to create LayerType from \(layer.type)")
+                    continue
+                }
+
+                let result = style._layer(with: layer.id, type: type.type)
+
+                switch result {
+                case .success:
+                    expectation.fulfill()
+                default:
+                    XCTFail("Failed to get line layer with id \(layer.id), error \(result)")
                 }
             }
         }


### PR DESCRIPTION
PR adds a `type` property to `LayerType` and updates the layer test to use `_layer` accordingly.