### PR TITLE
[bug] Fix puck animation transition

### DIFF
--- a/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
@@ -191,7 +191,7 @@ private extension Puck2D {
             location.coordinate.longitude,
             location.internalLocation.altitude
         ])
-        paint.locationTransition = StyleTransition(duration: 0, delay: 0)
+        paint.locationTransition = StyleTransition(duration: 500, delay: 0)
         paint.topImageSize = configuration.resolvedScale
         paint.bearingImageSize = configuration.resolvedScale
         paint.shadowImageSize = configuration.resolvedScale

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -423,12 +423,16 @@ public class Style {
  */
 public struct StyleTransition: Codable {
 
-    /// Time allotted for transitions to complete.
+    /// Time allotted for transitions to complete in milliseconds.
     public var duration: TimeInterval = 0
 
-    /// Length of time before a transition begins.
+    /// Length of time before a transition begins in milliseconds.
     public var delay: TimeInterval = 0
 
+    /// Initiralizer for `StyleTransition`
+    /// - Parameters:
+    ///   - duration: Time for transition in milliseconds.
+    ///   - delay: Time before transition begins in milliseconds.
     public init(duration: TimeInterval, delay: TimeInterval) {
         self.duration = duration
         self.delay = delay


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Bug fix for location puck not transition/animating smoothly on location updates. </changelog>`.

### Summary of changes
This PR updates the `locationTransition` layer property in the 2D puck to use a `StyleTransition`. It is discovered in the documentation that Transitions use milliseconds, and therefore we needed to provide an appropriate duration value to see a smooth animation.

Please see the gif below. 

<img width="300px" src="https://user-images.githubusercontent.com/5885209/114437584-bccdc880-9b94-11eb-8380-e12f831f0d3b.gif">
