### PR TITLE
Fix an issue where updating compass visibility doesn't take effect

### DIFF
--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -21,13 +21,15 @@ public class DebugViewController: UIViewController {
             mapOptions.location.puckType = .puck2D()
         }
 
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        mapView.addGestureRecognizer(tap)
         view.addSubview(mapView)
 
         /**
          The closure is called when style data has been loaded. This is called
          multiple times. Use the event data to determine what kind of style data
          has been loaded.
-         
+
          When the type is `style` this event most closely matches
          `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]` in SDK versions
          prior to v10.
@@ -88,6 +90,18 @@ public class DebugViewController: UIViewController {
             }
 
             print("The map failed to load.. \(type) = \(message)")
+        }
+    }
+
+    @objc func handleTap() {
+        mapView.update {
+            let visibility = $0.ornaments.scaleBarVisibility
+            if visibility == .adaptive || visibility == .hidden {
+                $0.ornaments.scaleBarVisibility = .visible
+            } else {
+                $0.ornaments.scaleBarVisibility = .hidden
+            }
+
         }
     }
 }

--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -21,15 +21,13 @@ public class DebugViewController: UIViewController {
             mapOptions.location.puckType = .puck2D()
         }
 
-        let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
-        mapView.addGestureRecognizer(tap)
         view.addSubview(mapView)
 
         /**
          The closure is called when style data has been loaded. This is called
          multiple times. Use the event data to determine what kind of style data
          has been loaded.
-
+         
          When the type is `style` this event most closely matches
          `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]` in SDK versions
          prior to v10.
@@ -90,18 +88,6 @@ public class DebugViewController: UIViewController {
             }
 
             print("The map failed to load.. \(type) = \(message)")
-        }
-    }
-
-    @objc func handleTap() {
-        mapView.update {
-            let visibility = $0.ornaments.scaleBarVisibility
-            if visibility == .adaptive || visibility == .hidden {
-                $0.ornaments.scaleBarVisibility = .visible
-            } else {
-                $0.ornaments.scaleBarVisibility = .hidden
-            }
-
         }
     }
 }

--- a/Sources/MapboxMaps/MapView/Configuration/OrnamentOptions.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/OrnamentOptions.swift
@@ -13,7 +13,7 @@ public struct OrnamentOptions: Equatable {
     /// Compass options
     public var compassViewPosition: OrnamentPosition = .topRight
     public var compassViewMargins: CGPoint = defaultOrnamentsMargin
-    public var compassVisiblity: OrnamentVisibility = .adaptive
+    public var compassVisibility: OrnamentVisibility = .adaptive
 
     /// Logo view options
     public var _showsLogoView: Bool = true
@@ -35,12 +35,13 @@ public struct OrnamentOptions: Equatable {
         if scaleBarVisibility != .hidden {
             supportedOrnaments[.mapboxScaleBar] = scaleBarPosition
             supportedOrnamentMargins[.mapboxScaleBar] = scaleBarMargins
+            ornamentVisibility[.mapboxScaleBar] = scaleBarVisibility
         }
 
-        if compassVisiblity != .hidden {
+        if compassVisibility != .hidden {
             supportedOrnaments[.compass] = compassViewPosition
             supportedOrnamentMargins[.compass] = compassViewMargins
-            ornamentVisibility[.compass] = compassVisiblity
+            ornamentVisibility[.compass] = compassVisibility
         }
 
         if _showsLogoView {

--- a/Sources/MapboxMaps/Ornaments/Compass/MapboxCompassOrnamentView.swift
+++ b/Sources/MapboxMaps/Ornaments/Compass/MapboxCompassOrnamentView.swift
@@ -27,9 +27,11 @@ internal class MapboxCompassOrnamentView: UIButton {
     /// Should be in range [-pi; pi]
     internal var currentBearing: CLLocationDirection = 0 {
         didSet {
-            let adjustedBearing = currentBearing.truncatingRemainder(dividingBy: 360)
-            updateVisibility()
-            self.transform = CGAffineTransform(rotationAngle: -adjustedBearing.toRadians())
+            if oldValue != currentBearing {
+                let adjustedBearing = currentBearing.truncatingRemainder(dividingBy: 360)
+                updateVisibility()
+                self.transform = CGAffineTransform(rotationAngle: -adjustedBearing.toRadians())
+            }
         }
     }
 

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -193,7 +193,7 @@ internal class OrnamentsManager: NSObject {
                 }
                 if $0.type == .mapboxScaleBar {
                     let scaleBar = view.subviews.filter { $0.isKind(of: MapboxScaleBarOrnamentView.self) }.first as? MapboxScaleBarOrnamentView
-                    scaleBar?.visibility = .hidden
+                    scaleBar?.isHidden = true
                     $0.view = scaleBar
                 }
             }

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -199,7 +199,6 @@ internal class OrnamentsManager: NSObject {
             }
 
             removeFromView(ornament: $0)
-
         }
     }
 
@@ -266,7 +265,6 @@ internal class OrnamentsManager: NSObject {
                 ornamentView.heightAnchor.constraint(equalTo: ornamentView.widthAnchor, multiplier: 0.25)
             ])
         }
-
         if let compassView = ornamentView as? MapboxCompassOrnamentView {
             compassView.visibility = ornament.visibility
         }

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -185,7 +185,21 @@ internal class OrnamentsManager: NSObject {
 
     private func removeFromView(ornaments: [Ornament]) {
         ornaments.forEach {
+            if $0.view == nil {
+                if $0.type == .compass {
+                    let compass = view.subviews.filter { $0.isKind(of: MapboxCompassOrnamentView.self) }.first as? MapboxCompassOrnamentView
+                    compass?.visibility = .hidden
+                    $0.view = compass
+                }
+                if $0.type == .mapboxScaleBar {
+                    let scaleBar = view.subviews.filter { $0.isKind(of: MapboxScaleBarOrnamentView.self) }.first as? MapboxScaleBarOrnamentView
+                    scaleBar?.visibility = .hidden
+                    $0.view = scaleBar
+                }
+            }
+
             removeFromView(ornament: $0)
+
         }
     }
 
@@ -253,6 +267,9 @@ internal class OrnamentsManager: NSObject {
             ])
         }
 
+        if let compassView = ornamentView as? MapboxCompassOrnamentView {
+            compassView.visibility = ornament.visibility
+        }
         NSLayoutConstraint.activate(constraints)
     }
 

--- a/Sources/MapboxMaps/Ornaments/ScaleBar/MapboxScaleBarOrnamentView.swift
+++ b/Sources/MapboxMaps/Ornaments/ScaleBar/MapboxScaleBarOrnamentView.swift
@@ -11,12 +11,6 @@ internal class MapboxScaleBarOrnamentView: UIView {
 
     // MARK: - Properties
 
-    internal var visibility: OrnamentVisibility = .adaptive {
-        didSet {
-            updateVisibility()
-        }
-    }
-
     internal var metersPerPoint: CLLocationDistance = 1 {
         didSet {
             guard metersPerPoint != oldValue else {
@@ -349,9 +343,7 @@ internal class MapboxScaleBarOrnamentView: UIView {
     }
 
     private func updateVisibility() {
-        if visibility == .hidden {
-            self.alpha = 0
-        } else {
+        if !isHidden {
             let maximumDistance: CLLocationDistance = Double(maximumWidth) * unitsPerPoint
             let allowedDistance = isMetricLocale ?
                                   Constants.metricTable.last!.distance : Constants.imperialTable.last!.distance

--- a/Sources/MapboxMaps/Ornaments/ScaleBar/MapboxScaleBarOrnamentView.swift
+++ b/Sources/MapboxMaps/Ornaments/ScaleBar/MapboxScaleBarOrnamentView.swift
@@ -11,6 +11,12 @@ internal class MapboxScaleBarOrnamentView: UIView {
 
     // MARK: - Properties
 
+    internal var visibility: OrnamentVisibility = .adaptive {
+        didSet {
+            updateVisibility()
+        }
+    }
+
     internal var metersPerPoint: CLLocationDistance = 1 {
         didSet {
             guard metersPerPoint != oldValue else {
@@ -343,19 +349,27 @@ internal class MapboxScaleBarOrnamentView: UIView {
     }
 
     private func updateVisibility() {
-        let maximumDistance: CLLocationDistance = Double(maximumWidth) * unitsPerPoint
-        let allowedDistance = isMetricLocale ?
-                              Constants.metricTable.last!.distance : Constants.imperialTable.last!.distance
-        let alpha: CGFloat = maximumDistance > allowedDistance ? 0 : 1
+        switch visibility {
+//        case .visible:
+//            self.alpha = 1
+        case .hidden:
+            self.alpha = 0
+        default:
+            let maximumDistance: CLLocationDistance = Double(maximumWidth) * unitsPerPoint
+            let allowedDistance = isMetricLocale ?
+                                  Constants.metricTable.last!.distance : Constants.imperialTable.last!.distance
+            let alpha: CGFloat = maximumDistance > allowedDistance ? 0 : 1
 
-        if alpha != self.alpha {
-            UIView.animate(withDuration: 0.2,
-                           delay: 0,
-                           options: .beginFromCurrentState,
-                           animations: {
-                            self.alpha = alpha
-            },
-                           completion: nil)
+            if alpha != self.alpha {
+                UIView.animate(withDuration: 0.2,
+                               delay: 0,
+                               options: .beginFromCurrentState,
+                               animations: {
+                                self.alpha = alpha
+                },
+                               completion: nil)
+            }
         }
+
     }
 }

--- a/Sources/MapboxMaps/Ornaments/ScaleBar/MapboxScaleBarOrnamentView.swift
+++ b/Sources/MapboxMaps/Ornaments/ScaleBar/MapboxScaleBarOrnamentView.swift
@@ -349,12 +349,9 @@ internal class MapboxScaleBarOrnamentView: UIView {
     }
 
     private func updateVisibility() {
-        switch visibility {
-//        case .visible:
-//            self.alpha = 1
-        case .hidden:
+        if visibility == .hidden {
             self.alpha = 0
-        default:
+        } else {
             let maximumDistance: CLLocationDistance = Double(maximumWidth) * unitsPerPoint
             let allowedDistance = isMetricLocale ?
                                   Constants.metricTable.last!.distance : Constants.imperialTable.last!.distance
@@ -370,6 +367,5 @@ internal class MapboxScaleBarOrnamentView: UIView {
                                completion: nil)
             }
         }
-
     }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR:
- Renames `OrnamentOptions.compassVisiblity` to `OrnamentOptions.compassVisibility`.
- Fixes an issue where updating the visibility of the compass doesn't take effect. 
   - This seems to have been because the compass' view property was `nil` when we tried to remove it from its superview. My current approach is to check whether the map view contains a scale bar or compass subview, then set that as the ornament's view.  
- Allows scale bar visibility to be updated. 
- `MapboxCompassOrnamentView.currentBearing`, only update compass visibility if the old value is different from the new value.
### User impact (optional)

- The rename of `OrnamentOptions.compassVisibility` impacts users currently using that property.