### PR TITLE
Add dependency version validator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: depsvalidator
+          name: build depsvalidator
+          command: swift build --package-path scripts/depsvalidator
+      - run:
+          name: run depsvalidator
           command: swift run --package-path scripts/depsvalidator depsvalidator
 
   build-sdk:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ workflows:
     jobs:
       - swiftlint:
           xcode: "12.4.0"
+      - depsvalidator:
+          xcode: "12.4.0"
       - build-sdk:
           xcode: "12.4.0"
           matrix:
@@ -58,6 +60,8 @@ workflows:
   steve:
     jobs:
       - swiftlint:
+          xcode: "12.4.0"
+      - depsvalidator:
           xcode: "12.4.0"
       - build-sdk:
           xcode: "12.4.0"
@@ -196,6 +200,14 @@ jobs:
       - checkout
       - run: brew install swiftlint
       - run: swiftlint lint --strict
+
+  depsvalidator:
+    <<: *base-job
+    steps:
+      - checkout
+      - run:
+          name: depsvalidator
+          command: swift run --package-path scripts/depsvalidator depsvalidator
 
   build-sdk:
     <<: *base-job

--- a/.depsvalidator.yml
+++ b/.depsvalidator.yml
@@ -1,0 +1,27 @@
+---
+manifests:
+  - type: Cartfile
+  - type: Cartfile.resolved
+  - type: Package.swift
+    omit_for:
+      - MapboxCommon
+  - type: Package.resolved
+  - type: Package.resolved
+    path: Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
+  - type: Podspec
+    path: MapboxMaps.podspec
+  - type: JSON
+    path: scripts/release/packager/versions.json
+dependencies:
+  - name: MapboxCoreMaps
+    variations:
+      Carthage: MapboxCoreMaps-dynamic
+  - name: MapboxCommon
+    variations:
+      Carthage: MapboxCommon-ios
+  - name: Turf
+    variations:
+      Carthage: turf-swift
+  - name: MapboxMobileEvents
+    variations:
+      Carthage: mapbox-events-ios

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ excluded:
   - Pods
   - Sources/MapboxMaps/Style/Generated
   - Tests/MapboxMapsTests/Style/Generated
+  - scripts/depsvalidator/.build
 disabled_rules:
   - comment_spacing
   - computed_accessors_order

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon-ios.json" ~> 11.0.0
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-core/MapboxCoreMaps-dynamic.json" == 10.0.0-beta.19
 github "mapbox/turf-swift" == 2.0.0-alpha.3
-github "mapbox/mapbox-events-ios" ~> 0.10
+github "mapbox/mapbox-events-ios" == 0.10.8

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |m|
   m.resources = 'Sources/**/*.{xcassets,strings}'
 
   m.dependency 'MapboxCoreMaps', '10.0.0-beta.19'
-  m.dependency 'MapboxCommon', '11.0.0'
+  m.dependency 'MapboxCommon', '~> 11.0'
   m.dependency 'MapboxMobileEvents', '0.10.8'
   m.dependency 'Turf', '2.0.0-alpha.3'
 

--- a/scripts/depsvalidator/.gitignore
+++ b/scripts/depsvalidator/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/

--- a/scripts/depsvalidator/.swiftlint.yml
+++ b/scripts/depsvalidator/.swiftlint.yml
@@ -1,0 +1,3 @@
+---
+disabled_rules:
+  - nesting

--- a/scripts/depsvalidator/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/scripts/depsvalidator/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/scripts/depsvalidator/.swiftpm/xcode/xcshareddata/xcschemes/DepsValidator-Package.xcscheme
+++ b/scripts/depsvalidator/.swiftpm/xcode/xcshareddata/xcschemes/DepsValidator-Package.xcscheme
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DepsValidator_DepsValidatorTests"
+               BuildableName = "DepsValidator_DepsValidatorTests"
+               BlueprintName = "DepsValidator_DepsValidatorTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DepsValidatorLibrary"
+               BuildableName = "DepsValidatorLibrary"
+               BlueprintName = "DepsValidatorLibrary"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "depsvalidator"
+               BuildableName = "depsvalidator"
+               BlueprintName = "depsvalidator"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DepsValidatorTests"
+               BuildableName = "DepsValidatorTests"
+               BlueprintName = "DepsValidatorTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DepsValidatorTests"
+               BuildableName = "DepsValidatorTests"
+               BlueprintName = "DepsValidatorTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "depsvalidator"
+            BuildableName = "depsvalidator"
+            BlueprintName = "depsvalidator"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "depsvalidator"
+            BuildableName = "depsvalidator"
+            BlueprintName = "depsvalidator"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/scripts/depsvalidator/.swiftpm/xcode/xcshareddata/xcschemes/DepsValidatorLibrary.xcscheme
+++ b/scripts/depsvalidator/.swiftpm/xcode/xcshareddata/xcschemes/DepsValidatorLibrary.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DepsValidatorLibrary"
+               BuildableName = "DepsValidatorLibrary"
+               BlueprintName = "DepsValidatorLibrary"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DepsValidatorLibrary"
+            BuildableName = "DepsValidatorLibrary"
+            BlueprintName = "DepsValidatorLibrary"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/scripts/depsvalidator/.swiftpm/xcode/xcshareddata/xcschemes/depsvalidator.xcscheme
+++ b/scripts/depsvalidator/.swiftpm/xcode/xcshareddata/xcschemes/depsvalidator.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "depsvalidator"
+               BuildableName = "depsvalidator"
+               BlueprintName = "depsvalidator"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DepsValidatorTests"
+               BuildableName = "DepsValidatorTests"
+               BlueprintName = "DepsValidatorTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "depsvalidator"
+            BuildableName = "depsvalidator"
+            BlueprintName = "depsvalidator"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "depsvalidator"
+            BuildableName = "depsvalidator"
+            BlueprintName = "depsvalidator"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/scripts/depsvalidator/Package.resolved
+++ b/scripts/depsvalidator/Package.resolved
@@ -1,0 +1,115 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Carthage",
+        "repositoryURL": "https://github.com/Carthage/Carthage",
+        "state": {
+          "branch": null,
+          "revision": "0668de43eb5d323d2e816eaab83677f50a8eeb24",
+          "version": "0.37.0"
+        }
+      },
+      {
+        "package": "Commandant",
+        "repositoryURL": "https://github.com/Carthage/Commandant.git",
+        "state": {
+          "branch": null,
+          "revision": "a1671cf728db837cf5ec1980a80d276bbba748f6",
+          "version": "0.18.0"
+        }
+      },
+      {
+        "package": "Curry",
+        "repositoryURL": "https://github.com/thoughtbot/Curry.git",
+        "state": {
+          "branch": null,
+          "revision": "4331dd50bc1db007db664a23f32e6f3df93d4e1a",
+          "version": "4.0.2"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "7a46a5fc86cb917f69e3daf79fcb045283d8f008",
+          "version": "8.1.2"
+        }
+      },
+      {
+        "package": "PrettyColors",
+        "repositoryURL": "https://github.com/jdhealy/PrettyColors.git",
+        "state": {
+          "branch": null,
+          "revision": "afd4553a4db6f656521cfe9b1f70bece2748c7d8",
+          "version": "5.0.2"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "09b3becb37cb2163919a3842a4c5fa6ec7130792",
+          "version": "2.2.1"
+        }
+      },
+      {
+        "package": "ReactiveSwift",
+        "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "c37950dc5020544c58d4bf47c0d028893686b9e6",
+          "version": "5.0.1"
+        }
+      },
+      {
+        "package": "ReactiveTask",
+        "repositoryURL": "https://github.com/Carthage/ReactiveTask.git",
+        "state": {
+          "branch": null,
+          "revision": "df1bf7625684180b9377a8ba3c076db08d98757e",
+          "version": "0.16.0"
+        }
+      },
+      {
+        "package": "Result",
+        "repositoryURL": "https://github.com/antitypical/Result.git",
+        "state": {
+          "branch": null,
+          "revision": "2ca499ba456795616fbc471561ff1d963e6ae160",
+          "version": "4.1.0"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "831ed5e860a70e745bc1337830af4786b2576881",
+          "version": "0.4.1"
+        }
+      },
+      {
+        "package": "Tentacle",
+        "repositoryURL": "https://github.com/mdiep/Tentacle.git",
+        "state": {
+          "branch": null,
+          "revision": "578edd088b03bc749c49253b15ae2d5aaa9aa7df",
+          "version": "0.13.1"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams",
+        "state": {
+          "branch": null,
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/scripts/depsvalidator/Package.swift
+++ b/scripts/depsvalidator/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "DepsValidator",
+    platforms: [.macOS(.v10_13)],
+    products: [
+        .executable(name: "depsvalidator", targets: ["DepsValidator"]),
+        .library(name: "DepsValidatorLibrary", targets: ["DepsValidatorLibrary"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.4.1"),
+        .package(url: "https://github.com/jpsim/Yams", from: "4.0.6"),
+        .package(url: "https://github.com/Carthage/Carthage", from: "0.37.0"),
+    ],
+    targets: [
+        .target(
+            name: "DepsValidator",
+            dependencies: [
+                .target(name: "DepsValidatorLibrary"),
+            ]),
+        .target(
+            name: "DepsValidatorLibrary",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "Yams", package: "Yams"),
+                .product(name: "CarthageKit", package: "Carthage"),
+            ]),
+        .testTarget(
+            name: "DepsValidatorTests",
+            dependencies: [
+                "DepsValidatorLibrary",
+            ],
+            resources: [
+                .copy("Example Manifests/Package.swift.example"),
+                .copy("Example Manifests/Example.podspec"),
+            ]),
+    ]
+)

--- a/scripts/depsvalidator/README.md
+++ b/scripts/depsvalidator/README.md
@@ -1,0 +1,100 @@
+# DepsValidator
+
+DepsValidator is a command line utility that can ensure that a library is using
+a consistent set of dependency versions across multiple Apple-ecosystem package
+managers.
+
+It can validate dependencies specified according to Semantic Versioning with:
+
+- Swift Package Manager
+- CocoaPods
+- Carthage
+- JSON files containing an object with dependency names as keys and the
+  corresponding pinned versions as values.
+
+## Usage
+
+To use DepsValidator, you need to write a config file that specifies the paths
+to your dependency managers' manifests and lists the dependencencies. By
+default, the `depsvalidator` command will look for the config file at
+`.depsvalidator.yml` in the current directory. You may specify a different file
+using the `--config-file` option.
+
+### Config File Structure
+
+The config file has the following structure:
+
+```yaml
+---
+manifests:
+  - type: [Package.swift, Package.resolved, Podspec, Cartfile, Cartfile.resolved, JSON]
+    path: {path to manifest}
+    omit_for:
+      - {dependency name}
+dependencies:
+  - name: {dependency name}
+    variations:
+      [SPM, CocoaPods, Carthage, JSON]: {name variation}
+```
+
+- `manifests`: An array of manifest declarations.
+  - `type`: The type of manifest. Must be one of the values listed above.
+  - `path`: [optional] The path to the manifest, relative to the path of the
+    config file. By default, depsvalidator will look in the same directory as
+    the config file. The default path for JSON manifests is `versions.json`.
+  - `omit_for`: [optional] An array of dependency names which should not be
+    expected in the manifest. The name must match the name of one of the
+    dependencies listed in this config file.
+- `dependencies`: An array of dependency declarations.
+  - `name`: The name of the dependency.
+  - `variations`: a dictionary that can be used to override the name of the
+    dependency for specific package managers. Keys are one of the values shown
+    above. Values are the correct name for that package manager.
+
+It is permissible for there to be more than one manifest of a given type. For
+example, if your repository hosts a Swift package and an Xcode workspace that
+uses Swift packages, you'll likely have two Package.resolved files (one in the
+repo root, and one at
+`YourWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved`).
+
+### Command Line Invocation
+
+You can build and test DepsValidator using the standard Swift Package Manager
+command line techniques, including `swift build` and `swift test`. You can also
+run it directly using `swift run depsvalidator {subcommand} {arguments}`.
+
+#### Validate Subcommand
+
+`depsvalidator [validate] [--config-file {config_file_path}]`
+
+Runs validation. Exits with 0 on success and non-0 otherwise. This command
+validates:
+
+1. Dependency version requirements are specified equivalently.
+2. Pinned dependency versions are specified equivalently.
+3. The dependency version requirement is satisfied by the corresponding pinned
+   dependency version.
+
+## Developing
+
+DepsValidator itself is built using Swift and Swift Package Manager. It can be
+developed by opening its Package.swift in Xcode. To run the tests, you will need
+to set the `DEPSVALIDATOR_POD_EXECUTABLE_PATH` environment variable on your
+scheme so that DepsValidator can locate your CocoaPods `pod` executable. To run
+from Xcode, specify `--config-file={path_to_config_file}` in the scheme's launch
+arguments. Optionally, specify either the `validate` or `dump` subcommand as
+well.
+
+DepsValidator uses SwiftLint. Install and run it from the command line.
+
+### Ideas
+
+- Replace JSON file support with generic custom manifest support. Allow users to
+  specify a command-line invocation with the dependency name as a wildcard. The
+  command-line invocation should send the version or version requirement to
+  standard out.
+- Add a `dump` subcommand that produces a human-readable dump of the
+  currently-specified dependency requirements and dependency versions. Only
+  dependencies listed in the config file will be included in the output. Add
+  `--by-manifest` and `--by-dependency` options to allow the user to configure
+  how the output should be organized.

--- a/scripts/depsvalidator/README.md
+++ b/scripts/depsvalidator/README.md
@@ -39,10 +39,10 @@ dependencies:
 
 - `manifests`: An array of manifest declarations.
   - `type`: The type of manifest. Must be one of the values listed above.
-  - `path`: [optional] The path to the manifest, relative to the path of the
+  - `path` [optional]: The path to the manifest, relative to the path of the
     config file. By default, depsvalidator will look in the same directory as
     the config file. The default path for JSON manifests is `versions.json`.
-  - `omit_for`: [optional] An array of dependency names which should not be
+  - `omit_for` [optional]: An array of dependency names which should not be
     expected in the manifest. The name must match the name of one of the
     dependencies listed in this config file.
 - `dependencies`: An array of dependency declarations.
@@ -51,7 +51,7 @@ dependencies:
     dependency for specific package managers. Keys are one of the values shown
     above. Values are the correct name for that package manager.
 
-It is permissible for there to be more than one manifest of a given type. For
+It is permissible to have more than one manifest of a given type. For
 example, if your repository hosts a Swift package and an Xcode workspace that
 uses Swift packages, you'll likely have two Package.resolved files (one in the
 repo root, and one at
@@ -75,6 +75,13 @@ validates:
 3. The dependency version requirement is satisfied by the corresponding pinned
    dependency version.
 
+### CI Usage
+
+DepsValidator can be used in CI workflows to help maintain a consistent set of
+versions in a repo's main branch. Configure your CI workflow for pull requests
+to run the validate subcommand. The job should fail if depsvalidator exits with
+a non-0 exit code.
+
 ## Developing
 
 DepsValidator itself is built using Swift and Swift Package Manager. It can be
@@ -85,7 +92,8 @@ from Xcode, specify `--config-file={path_to_config_file}` in the scheme's launch
 arguments. Optionally, specify either the `validate` or `dump` subcommand as
 well.
 
-DepsValidator uses SwiftLint. Install and run it from the command line.
+DepsValidator uses [SwiftLint](https://github.com/realm/SwiftLint). Install and
+run it from the command line.
 
 ### Ideas
 

--- a/scripts/depsvalidator/Sources/DepsValidator/main.swift
+++ b/scripts/depsvalidator/Sources/DepsValidator/main.swift
@@ -1,0 +1,3 @@
+import DepsValidatorLibrary
+
+DepsValidator.main()

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Commands/DepsValidator.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Commands/DepsValidator.swift
@@ -1,0 +1,14 @@
+import ArgumentParser
+
+public struct DepsValidator: ParsableCommand {
+    public static var configuration = CommandConfiguration(
+        abstract: """
+            DepsValidator is a command line utility that can ensure that a library is using a consistent set of \
+            dependency versions across multiple Apple-ecosystem package managers.
+            """,
+        subcommands: [Validate.self],
+        defaultSubcommand: Validate.self)
+
+    public init() {
+    }
+}

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Commands/Validate.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Commands/Validate.swift
@@ -8,56 +8,82 @@ final class Validate: ParsableCommand {
     @Option var configFile: URL = ".depsvalidator.yml"
 
     func run() throws {
+        // Load the config file
         let config = try Config.from(file: configFile)
+
+        // Validate each dependency, keeping track of whether we encounter any errors
         var success = true
         for dependency in config.dependencies {
             print("\(dependency.name):")
             do {
+                // Ensure that all of the semantic version requirements are equivalent.
+                // Skip this step if there are none.
                 let versionRequirements = try Set(config.semanticVersionRequirements(for: dependency))
-                guard versionRequirements.count == 1 else {
-                    success = false
-                    let versionRequirementsString = versionRequirements
-                        .map { "'\($0.description)'" }
-                        .joined(separator: ", ")
-                    print("  Inconsistent version requirements: \(versionRequirementsString)")
-                    let groupedManifests = try config.manifestsGroupedBySemanticVersionRequirement(for: dependency)
-                    for (semanticVersionRequirement, manifests) in groupedManifests {
-                        print("    Manifests with '\(semanticVersionRequirement)':")
-                        for manifest in manifests {
-                            print("      - \(manifest.url.relativePath)")
+                if !versionRequirements.isEmpty {
+                    guard versionRequirements.count == 1 else {
+                        success = false
+
+                        // If there were differing semantic version requirements, print them out
+                        let versionRequirementsString = versionRequirements
+                            .map { "'\($0.description)'" }
+                            .joined(separator: ", ")
+                        print("  Inconsistent version requirements: \(versionRequirementsString)")
+
+                        // Also print out which manifests contained each version requirement
+                        let groupedManifests = try config.manifestsGroupedBySemanticVersionRequirement(for: dependency)
+                        for (semanticVersionRequirement, manifests) in groupedManifests {
+                            print("    Manifests with '\(semanticVersionRequirement)':")
+                            for manifest in manifests {
+                                print("      - \(manifest.url.relativePath)")
+                            }
                         }
+                        continue
                     }
-                    continue
                 }
+                // Ensure that all of the semantic versions are equivalent.
+                // Skip this step if there are none.
                 let versions = try Set(config.semanticVersions(for: dependency))
-                guard versions.count == 1 else {
-                    success = false
-                    let versionsString = versions
-                        .map { "'\($0.description)'" }
-                        .joined(separator: ", ")
-                    print("  Inconsistent pinned versions: \(versionsString)")
-                    let groupedManifests = try config.manifestsGroupedBySemanticVersion(for: dependency)
-                    for (semanticVersion, manifests) in groupedManifests {
-                        print("    Manifests with '\(semanticVersion)':")
-                        for manifest in manifests {
-                            print("      - \(manifest.url.relativePath)")
+                if !versions.isEmpty {
+                    guard versions.count == 1 else {
+                        success = false
+
+                        // If there were differing semantic versions, print them out
+                        let versionsString = versions
+                            .map { "'\($0.description)'" }
+                            .joined(separator: ", ")
+                        print("  Inconsistent pinned versions: \(versionsString)")
+
+                        // Also print out which manifests contained each version
+                        let groupedManifests = try config.manifestsGroupedBySemanticVersion(for: dependency)
+                        for (semanticVersion, manifests) in groupedManifests {
+                            print("    Manifests with '\(semanticVersion)':")
+                            for manifest in manifests {
+                                print("      - \(manifest.url.relativePath)")
+                            }
                         }
+                        continue
                     }
-                    continue
                 }
-                let versionRequirement = versionRequirements.first!
-                let version = versions.first!
-                guard versionRequirement.isSatisfied(by: version) else {
-                    success = false
-                    print("  Pinned version '\(version)' does not satisfy requirement '\(versionRequirement)'")
-                    continue
+                // Ensure that the semantic version requirement is satisfied by the semantic version.
+                // Skip this step if we do not have one of each.
+                if let versionRequirement = versionRequirements.first,
+                   let version = versions.first {
+                    guard versionRequirement.isSatisfied(by: version) else {
+                        success = false
+                        print("  Pinned version '\(version)' does not satisfy requirement '\(versionRequirement)'")
+                        continue
+                    }
                 }
+                // If we made it here, this dependency passed validation
                 print("  OK")
             } catch {
+                // Print any parsing issues
                 success = false
                 print("  Encountered an error while parsing dependency versions: '\(error)'")
             }
         }
+        // After checking each dependency, print success (and implicitly exit 0) or exit with failure and no additional
+        // message
         if success {
             print("Success!")
         } else {

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Commands/Validate.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Commands/Validate.swift
@@ -1,0 +1,79 @@
+import Foundation
+import ArgumentParser
+
+final class Validate: ParsableCommand {
+    static var configuration = CommandConfiguration(
+        abstract: "Validate that the dependency manager manifests are in a valid state.")
+
+    @Option var configFile: URL = ".depsvalidator.yml"
+
+    func run() throws {
+        let config = try Config.from(file: configFile)
+        var success = true
+        for dependency in config.dependencies {
+            print("\(dependency.name):")
+            do {
+                let versionRequirements = try Set(config.semanticVersionRequirements(for: dependency))
+                guard versionRequirements.count == 1 else {
+                    success = false
+                    let versionRequirementsString = versionRequirements
+                        .map { "'\($0.description)'" }
+                        .joined(separator: ", ")
+                    print("  Inconsistent version requirements: \(versionRequirementsString)")
+                    let groupedManifests = try config.manifestsGroupedBySemanticVersionRequirement(for: dependency)
+                    for (semanticVersionRequirement, manifests) in groupedManifests {
+                        print("    Manifests with '\(semanticVersionRequirement)':")
+                        for manifest in manifests {
+                            print("      - \(manifest.url.relativePath)")
+                        }
+                    }
+                    continue
+                }
+                let versions = try Set(config.semanticVersions(for: dependency))
+                guard versions.count == 1 else {
+                    success = false
+                    let versionsString = versions
+                        .map { "'\($0.description)'" }
+                        .joined(separator: ", ")
+                    print("  Inconsistent pinned versions: \(versionsString)")
+                    let groupedManifests = try config.manifestsGroupedBySemanticVersion(for: dependency)
+                    for (semanticVersion, manifests) in groupedManifests {
+                        print("    Manifests with '\(semanticVersion)':")
+                        for manifest in manifests {
+                            print("      - \(manifest.url.relativePath)")
+                        }
+                    }
+                    continue
+                }
+                let versionRequirement = versionRequirements.first!
+                let version = versions.first!
+                guard versionRequirement.isSatisfied(by: version) else {
+                    success = false
+                    print("  Pinned version '\(version)' does not satisfy requirement '\(versionRequirement)'")
+                    continue
+                }
+                print("  OK")
+            } catch {
+                success = false
+                print("  Encountered an error while parsing dependency versions: '\(error)'")
+            }
+        }
+        if success {
+            print("Success!")
+        } else {
+            throw ExitCode.failure
+        }
+    }
+}
+
+extension URL: ExpressibleByArgument {
+    public init?(argument: String) {
+        self = URL(fileURLWithPath: argument)
+    }
+}
+
+extension URL: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self = URL(fileURLWithPath: value)
+    }
+}

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Commands/Validate.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Commands/Validate.swift
@@ -16,70 +16,17 @@ final class Validate: ParsableCommand {
         for dependency in config.dependencies {
             print("\(dependency.name):")
             do {
-                // Ensure that all of the semantic version requirements are equivalent.
-                // Skip this step if there are none.
-                let versionRequirements = try Set(config.semanticVersionRequirements(for: dependency))
-                if !versionRequirements.isEmpty {
-                    guard versionRequirements.count == 1 else {
-                        success = false
-
-                        // If there were differing semantic version requirements, print them out
-                        let versionRequirementsString = versionRequirements
-                            .map { "'\($0.description)'" }
-                            .joined(separator: ", ")
-                        print("  Inconsistent version requirements: \(versionRequirementsString)")
-
-                        // Also print out which manifests contained each version requirement
-                        let groupedManifests = try config.manifestsGroupedBySemanticVersionRequirement(for: dependency)
-                        for (semanticVersionRequirement, manifests) in groupedManifests {
-                            print("    Manifests with '\(semanticVersionRequirement)':")
-                            for manifest in manifests {
-                                print("      - \(manifest.url.relativePath)")
-                            }
-                        }
-                        continue
-                    }
+                if try validateSemanticVersionRequirements(for: dependency, in: config),
+                   try validateSemanticVersions(for: dependency, in: config),
+                   try validateRequirementsSatisfiedByVersions(for: dependency, in: config) {
+                    print("  OK")
+                } else {
+                    success = false
                 }
-                // Ensure that all of the semantic versions are equivalent.
-                // Skip this step if there are none.
-                let versions = try Set(config.semanticVersions(for: dependency))
-                if !versions.isEmpty {
-                    guard versions.count == 1 else {
-                        success = false
-
-                        // If there were differing semantic versions, print them out
-                        let versionsString = versions
-                            .map { "'\($0.description)'" }
-                            .joined(separator: ", ")
-                        print("  Inconsistent pinned versions: \(versionsString)")
-
-                        // Also print out which manifests contained each version
-                        let groupedManifests = try config.manifestsGroupedBySemanticVersion(for: dependency)
-                        for (semanticVersion, manifests) in groupedManifests {
-                            print("    Manifests with '\(semanticVersion)':")
-                            for manifest in manifests {
-                                print("      - \(manifest.url.relativePath)")
-                            }
-                        }
-                        continue
-                    }
-                }
-                // Ensure that the semantic version requirement is satisfied by the semantic version.
-                // Skip this step if we do not have one of each.
-                if let versionRequirement = versionRequirements.first,
-                   let version = versions.first {
-                    guard versionRequirement.isSatisfied(by: version) else {
-                        success = false
-                        print("  Pinned version '\(version)' does not satisfy requirement '\(versionRequirement)'")
-                        continue
-                    }
-                }
-                // If we made it here, this dependency passed validation
-                print("  OK")
             } catch {
                 // Print any parsing issues
-                success = false
                 print("  Encountered an error while parsing dependency versions: '\(error)'")
+                success = false
             }
         }
         // After checking each dependency, print success (and implicitly exit 0) or exit with failure and no additional
@@ -89,6 +36,73 @@ final class Validate: ParsableCommand {
         } else {
             throw ExitCode.failure
         }
+    }
+
+    // Ensure that all of the semantic version requirements are equivalent.
+    // Does nothing if there are none.
+    private func validateSemanticVersionRequirements(for dependency: Config.Dependency,
+                                                     in config: Config) throws -> Bool {
+        let versionRequirements = try Set(config.semanticVersionRequirements(for: dependency))
+        // There's only an error if there's more than 1 version requirement
+        guard versionRequirements.count > 1 else {
+            return true
+        }
+        // If there were differing semantic version requirements, print them out
+        let versionRequirementsString = versionRequirements
+            .map { "'\($0.description)'" }
+            .joined(separator: ", ")
+        print("  Inconsistent version requirements: \(versionRequirementsString)")
+
+        // Also print out which manifests contained each version requirement
+        let groupedManifests = try config.manifestsGroupedBySemanticVersionRequirement(for: dependency)
+        for (semanticVersionRequirement, manifests) in groupedManifests {
+            print("    Manifests with '\(semanticVersionRequirement)':")
+            for manifest in manifests {
+                print("      - \(manifest.url.relativePath)")
+            }
+        }
+        return false
+    }
+
+    // Ensure that all of the semantic versions are equivalent.
+    // Does nothing if there are none.
+    private func validateSemanticVersions(for dependency: Config.Dependency,
+                                          in config: Config) throws -> Bool {
+        let versions = try Set(config.semanticVersions(for: dependency))
+        // There's only an error if there's more than 1 version
+        guard versions.count > 1 else {
+            return true
+        }
+        // If there were differing semantic versions, print them out
+        let versionsString = versions
+            .map { "'\($0.description)'" }
+            .joined(separator: ", ")
+        print("  Inconsistent pinned versions: \(versionsString)")
+
+        // Also print out which manifests contained each version
+        let groupedManifests = try config.manifestsGroupedBySemanticVersion(for: dependency)
+        for (semanticVersion, manifests) in groupedManifests {
+            print("    Manifests with '\(semanticVersion)':")
+            for manifest in manifests {
+                print("      - \(manifest.url.relativePath)")
+            }
+        }
+        return false
+    }
+
+    private func validateRequirementsSatisfiedByVersions(for dependency: Config.Dependency,
+                                                         in config: Config) throws -> Bool {
+        // Ensure that the semantic version requirement is satisfied by the semantic version.
+        // Skip this step if we do not have one of each. A previous validation step ensures that
+        // there is not more than one requirement or more than one version, so that is not
+        // verified here.
+        guard let versionRequirement = try config.semanticVersionRequirements(for: dependency).first,
+              let version = try config.semanticVersions(for: dependency).first,
+              !versionRequirement.isSatisfied(by: version) else {
+            return true
+        }
+        print("  Pinned version '\(version)' does not satisfy requirement '\(versionRequirement)'")
+        return false
     }
 }
 

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/Carthage.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/Carthage.swift
@@ -1,0 +1,62 @@
+import CarthageKit
+import Foundation
+
+enum CarthageError: Swift.Error {
+    case compatibleWithUsedWithPrereleaseVersion
+    case unsupportedCarthageVersionSpecifier(VersionSpecifier)
+}
+
+extension SemanticVersionRequirement {
+    init(_ versionSpecifier: VersionSpecifier) throws {
+        switch versionSpecifier {
+        case .any:
+            self = .any
+        case let .exactly(semanticVersion):
+            self = try .exactly(SemanticVersion(string: semanticVersion.description))
+        case let .compatibleWith(semanticVersion):
+            let fromVersion = try SemanticVersion(string: semanticVersion.description)
+            guard fromVersion.suffix == nil else {
+                throw CarthageError.compatibleWithUsedWithPrereleaseVersion
+            }
+            self = .range(
+                from: fromVersion,
+                to: fromVersion.nextMajor)
+        default:
+            throw CarthageError.unsupportedCarthageVersionSpecifier(versionSpecifier)
+        }
+    }
+}
+
+private let cartfileCache = ManifestCache {
+    try Cartfile.from(file: $0).get()
+}
+
+extension Cartfile: SemanticVersionRequirementProviding {
+    static func from(file fileURL: URL) throws -> Cartfile {
+        try cartfileCache.manifest(for: fileURL)
+    }
+
+    func semanticVersionRequirement(for dependency: Config.Dependency) throws -> SemanticVersionRequirement {
+        try SemanticVersionRequirement(dependencies.first { $0.key.name == dependency.name(for: .carthage) }!.value)
+    }
+}
+
+extension SemanticVersion {
+    init(_ pinnedVersion: PinnedVersion) throws {
+        try self.init(string: pinnedVersion.commitish)
+    }
+}
+
+private let resolvedCartfileCache = ManifestCache {
+    try ResolvedCartfile.from(string: String(contentsOf: $0)).get()
+}
+
+extension ResolvedCartfile: SemanticVersionProviding {
+    static func from(file fileURL: URL) throws -> ResolvedCartfile {
+        try resolvedCartfileCache.manifest(for: fileURL)
+    }
+
+    func semanticVersion(for dependency: Config.Dependency) throws -> SemanticVersion {
+        try SemanticVersion(dependencies.first { $0.key.name == dependency.name(for: .carthage) }!.value)
+    }
+}

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/Config.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/Config.swift
@@ -1,0 +1,256 @@
+import CarthageKit
+import Foundation
+import Yams
+
+struct Config: Decodable {
+    struct Manifest: Decodable {
+        var type: ManifestType
+        var omitFor: [String]?
+        var path: String?
+
+        var resolvedPath: String {
+            path ?? type.defaultPath
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case omitFor = "omit_for"
+            case path
+        }
+    }
+
+    struct Dependency: Decodable {
+        var name: String
+        var variations: [PackageManager: String]
+
+        enum Error: Swift.Error {
+            case invalidPackageManager(String)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case variations
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            name = try container.decode(String.self, forKey: .name)
+            let stringlyTypedVariations = try container.decode([String: String].self, forKey: .variations)
+            variations = [:]
+            try stringlyTypedVariations.forEach { (key, value) in
+                guard let newKey = PackageManager(rawValue: key) else {
+                    throw Error.invalidPackageManager(key)
+                }
+                variations[newKey] = value
+            }
+        }
+
+        func name(for packageManager: PackageManager) -> String {
+            variations[packageManager] ?? name
+        }
+    }
+
+    var root: URL
+    var manifests: [Manifest]
+    var dependencies: [Dependency]
+
+    static func from(file fileURL: URL) throws -> Self {
+        let data = try Data(contentsOf: fileURL)
+        return try YAMLDecoder()
+            .decode(Config.self, from: data, userInfo: [CodingUserInfoKey(rawValue: "root")!: fileURL])
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case manifests
+        case dependencies
+    }
+
+    init(from decoder: Decoder) throws {
+        // swiftlint:disable:next force_cast
+        root = decoder.userInfo[CodingUserInfoKey(rawValue: "root")!] as! URL
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        manifests = try container.decode([Manifest].self, forKey: .manifests)
+        dependencies = try container.decode([Dependency].self, forKey: .dependencies)
+    }
+
+    // MARK: - SemanticVersionRequirement
+
+    // swiftlint:disable:next type_name
+    struct SemanticVersionRequirementProvidingManifest {
+        var type: SemanticVersionRequirementProvidingManifestType
+        var omitFor: [String]
+        var url: URL
+
+        init?(manifest: Manifest, root: URL) {
+            guard let type = SemanticVersionRequirementProvidingManifestType(manifestType: manifest.type) else {
+                return nil
+            }
+            self.type = type
+            self.omitFor = manifest.omitFor ?? []
+            self.url = URL(fileURLWithPath: manifest.resolvedPath, relativeTo: root)
+        }
+
+        func semanticVersionRequirement(for dependency: Dependency) throws -> SemanticVersionRequirement {
+            try type.providerType
+                .from(file: url)
+                .semanticVersionRequirement(for: dependency)
+        }
+    }
+
+    var semanticVersionRequirementProvidingManifests: [SemanticVersionRequirementProvidingManifest] {
+        manifests.compactMap { SemanticVersionRequirementProvidingManifest.init(manifest: $0, root: root) }
+    }
+
+    private func semanticVersionRequirementProvidingManifests(for dependency: Dependency) -> [SemanticVersionRequirementProvidingManifest] {
+        semanticVersionRequirementProvidingManifests
+            .filter { !$0.omitFor.contains(dependency.name) }
+    }
+
+    func semanticVersionRequirements(for dependency: Dependency) throws -> [SemanticVersionRequirement] {
+        try semanticVersionRequirementProvidingManifests(for: dependency)
+            .map { try $0.semanticVersionRequirement(for: dependency) }
+    }
+
+    func manifestsGroupedBySemanticVersionRequirement(for dependency: Dependency) throws -> [SemanticVersionRequirement: [SemanticVersionRequirementProvidingManifest]] {
+        try Dictionary(grouping: semanticVersionRequirementProvidingManifests(for: dependency)) {
+            try $0.semanticVersionRequirement(for: dependency)
+        }
+    }
+
+    // MARK: - SemanticVersion
+
+    struct SemanticVersionProvidingManifest {
+        var type: SemanticVersionProvidingManifestType
+        var omitFor: [String]
+        var url: URL
+
+        init?(manifest: Manifest, root: URL) {
+            guard let type = SemanticVersionProvidingManifestType(manifestType: manifest.type) else {
+                return nil
+            }
+            self.type = type
+            self.omitFor = manifest.omitFor ?? []
+            self.url = URL(fileURLWithPath: manifest.resolvedPath, relativeTo: root)
+        }
+
+        func semanticVersion(for dependency: Dependency, root: URL) throws -> SemanticVersion {
+            try type.providerType
+                .from(file: url)
+                .semanticVersion(for: dependency)
+        }
+    }
+
+    var semanticVersionProvidingManifests: [SemanticVersionProvidingManifest] {
+        manifests.compactMap { SemanticVersionProvidingManifest.init(manifest: $0, root: root) }
+    }
+
+    private func semanticVersionProvidingManifests(for dependency: Dependency) -> [SemanticVersionProvidingManifest] {
+        semanticVersionProvidingManifests
+            .filter { !$0.omitFor.contains(dependency.name) }
+    }
+
+    func semanticVersions(for dependency: Dependency) throws -> [SemanticVersion] {
+        try semanticVersionProvidingManifests(for: dependency)
+            .map { try $0.semanticVersion(for: dependency, root: root) }
+    }
+
+    func manifestsGroupedBySemanticVersion(for dependency: Dependency) throws -> [SemanticVersion: [SemanticVersionProvidingManifest]] {
+        try Dictionary(grouping: semanticVersionProvidingManifests(for: dependency)) {
+            try $0.semanticVersion(for: dependency, root: root)
+        }
+    }
+}
+
+enum ManifestType: String, Decodable {
+    case package = "Package.swift"
+    case resolvedPackage = "Package.resolved"
+    case podspec = "Podspec"
+    case cartfile = "Cartfile"
+    case resolvedCartfile = "Cartfile.resolved"
+    case json = "JSON"
+
+    var defaultPath: String {
+        switch self {
+        case .package:
+            return "Package.swift"
+        case .resolvedPackage:
+            return "Package.resolved"
+        case .podspec:
+            return "*.podspec"
+        case .cartfile:
+            return "Cartfile"
+        case .resolvedCartfile:
+            return "Cartfile.resolved"
+        case .json:
+            return "versions.json"
+        }
+    }
+}
+
+// swiftlint:disable:next type_name
+enum SemanticVersionRequirementProvidingManifestType {
+    case package
+    case podspec
+    case cartfile
+
+    init?(manifestType: ManifestType) {
+        switch manifestType {
+        case .package:
+            self = .package
+        case .podspec:
+            self = .podspec
+        case .cartfile:
+            self = .cartfile
+        default:
+            return nil
+        }
+    }
+
+    var providerType: SemanticVersionRequirementProviding.Type {
+        switch self {
+        case .package:
+            return Package.self
+        case .podspec:
+            return Podspec.self
+        case .cartfile:
+            return Cartfile.self
+        }
+    }
+}
+
+enum SemanticVersionProvidingManifestType {
+    case resolvedPackage
+    case resolvedCartfile
+    case json
+
+    init?(manifestType: ManifestType) {
+        switch manifestType {
+        case .resolvedPackage:
+            self = .resolvedPackage
+        case .resolvedCartfile:
+            self = .resolvedCartfile
+        case .json:
+            self = .json
+        default:
+            return nil
+        }
+    }
+
+    var providerType: SemanticVersionProviding.Type {
+        switch self {
+        case .resolvedPackage:
+            return ResolvedPackage.self
+        case .resolvedCartfile:
+            return ResolvedCartfile.self
+        case .json:
+            return JSONManifest.self
+        }
+    }
+}
+
+enum PackageManager: String, Decodable {
+    case spm = "SPM"
+    case cocoapods = "CocoaPods"
+    case carthage = "Carthage"
+    case json = "JSON"
+}

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/JSONManifest.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/JSONManifest.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct JSONManifest: SemanticVersionProviding {
+    private static let cache = ManifestCache { (url) -> Self in
+        let data = try Data(contentsOf: url)
+        let dependencies = try JSONDecoder().decode([String: SemanticVersion].self, from: data)
+        return JSONManifest(dependencies: dependencies)
+    }
+
+    static func from(file fileURL: URL) throws -> Self {
+        try cache.manifest(for: fileURL)
+    }
+
+    var dependencies: [String: SemanticVersion]
+
+    func semanticVersion(for dependency: Config.Dependency) -> SemanticVersion {
+        dependencies[dependency.name(for: .json)]!
+    }
+}

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/ManifestCache.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/ManifestCache.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+final class ManifestCache<T> {
+
+    private let manifestProvider: (URL) throws -> T
+    private var cache = [URL: T]()
+
+    init(manifestProvider: @escaping (URL) throws -> T) {
+        self.manifestProvider = manifestProvider
+    }
+
+    func manifest(for url: URL) throws -> T {
+        let manifest = try cache[url] ?? manifestProvider(url)
+        cache[url] = manifest
+        return manifest
+    }
+}

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/Package.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/Package.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+struct Package: Decodable, SemanticVersionRequirementProviding {
+    enum Error: Swift.Error {
+        case unsupportedVersionRequirements(String)
+    }
+
+    private static let cache = ManifestCache { (url) -> Self in
+        let data = Process
+            .shell("swift package --package-path \(url.deletingLastPathComponent().path) dump-package")
+            .output
+        return try JSONDecoder().decode(Self.self, from: data)
+    }
+
+    static func from(file fileURL: URL) throws -> Self {
+        try cache.manifest(for: fileURL)
+    }
+
+    var dependencies: [Dependency]
+
+    struct Dependency: Decodable, Equatable {
+        var name: String
+        var requirement: Requirement
+
+        enum Requirement: Decodable, Equatable {
+            enum Error: Swift.Error {
+                case unrecognizedRequirementValue
+            }
+
+            case range(lowerBound: SemanticVersion, upperBound: SemanticVersion)
+            case branch(String)
+            case exact(SemanticVersion)
+            case revision(String)
+
+            enum CodingKeys: String, CodingKey {
+                case range
+                case branch
+                case exact
+                case revision
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                if let range = try container.decodeIfPresent([[String: String]].self, forKey: .range),
+                   range.count == 1,
+                   let dict = range.first,
+                   dict.count == 2,
+                   let lowerBound = dict["lowerBound"],
+                   let upperBound = dict["upperBound"] {
+                    self = try .range(
+                        lowerBound: SemanticVersion(string: lowerBound),
+                        upperBound: SemanticVersion(string: upperBound))
+                } else if let branch = try container.decodeIfPresent([String].self, forKey: .branch),
+                          branch.count == 1,
+                          let branchString = branch.first {
+                    self = .branch(branchString)
+                } else if let exact = try container.decodeIfPresent([String].self, forKey: .exact),
+                          exact.count == 1,
+                          let exactString = exact.first {
+                    self = try .exact(SemanticVersion(string: exactString))
+                } else if let revision = try container.decodeIfPresent([String].self, forKey: .revision),
+                          revision.count == 1,
+                          let revisionString = revision.first {
+                    self = .revision(revisionString)
+                } else {
+                    throw Error.unrecognizedRequirementValue
+                }
+            }
+        }
+    }
+
+    func semanticVersionRequirement(for dependency: Config.Dependency) throws -> SemanticVersionRequirement {
+        try SemanticVersionRequirement(dependencies.first { $0.name == dependency.name(for: .spm) }!.requirement)
+    }
+}
+
+extension SemanticVersionRequirement {
+    init(_ packageDependencyRequirement: Package.Dependency.Requirement) throws {
+        switch packageDependencyRequirement {
+        case let .range(lowerBound, upperBound):
+            self = .range(from: lowerBound, to: upperBound)
+        case let .exact(version):
+            self = .exactly(version)
+        default:
+            throw Package.Error.unsupportedVersionRequirements("\(packageDependencyRequirement) is unsupported")
+        }
+    }
+}

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/Podspec.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/Podspec.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+struct Podspec: Decodable, SemanticVersionRequirementProviding {
+    enum Error: Swift.Error {
+        case unsupportedDependencyRequirement(DependencyRequirement)
+    }
+
+    private static let cache = ManifestCache { (url) -> Self in
+        let podExecutable = ProcessInfo.processInfo.environment["DEPSVALIDATOR_POD_EXECUTABLE_PATH"] ?? "pod"
+        let data = Process.shell("LANG=en_US.UTF-8 \(podExecutable) ipc spec \(url.path)").output
+        return try JSONDecoder().decode(Self.self, from: data)
+    }
+
+    static func from(file fileURL: URL) throws -> Self {
+        try cache.manifest(for: fileURL)
+    }
+
+    enum DependencyRequirement: Decodable, Equatable {
+        enum Error: Swift.Error {
+            case invalidDependencyVersionRequirements([String])
+        }
+
+        case any
+        case exactly(SemanticVersion)
+        case greaterThan(SemanticVersion)
+        case greaterThanOrEqualTo(SemanticVersion)
+        case lessThan(SemanticVersion)
+        case lessThanOrEqualTo(SemanticVersion)
+        case range(from: SemanticVersion, to: SemanticVersion)
+
+        // swiftlint:disable:next cyclomatic_complexity
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let requirements = try container.decode([String].self)
+            if requirements.count == 0 {
+                self = .any
+            } else if requirements.count == 1, let requirement = requirements.first {
+                let components = requirement.components(separatedBy: .whitespacesAndNewlines)
+                if components.count == 1, let versionString = components.first {
+                    self = try .exactly(SemanticVersion(string: versionString))
+                } else if components.count == 2,
+                          let op = components.first,
+                          let versionString = components.last {
+                    let version = try SemanticVersion(string: versionString)
+                    switch op {
+                    case "=":
+                        self = .exactly(version)
+                    case ">":
+                        self = .greaterThan(version)
+                    case ">=":
+                        self = .greaterThanOrEqualTo(version)
+                    case "<":
+                        self = .lessThan(version)
+                    case "<=":
+                        self = .lessThanOrEqualTo(version)
+                    case "~>":
+                        // In CocoaPods, the range is based on the last component specified.
+                        // See https://guides.cocoapods.org/syntax/podfile.html#pod
+                        self = .range(from: version, to: version.patch == nil ? version.nextMajor : version.nextMinor)
+                    default:
+                        throw Error.invalidDependencyVersionRequirements([requirement])
+                    }
+                } else {
+                    throw Error.invalidDependencyVersionRequirements([requirement])
+                }
+            } else {
+                throw Error.invalidDependencyVersionRequirements(requirements)
+            }
+        }
+    }
+
+    var dependencies: [String: DependencyRequirement]
+
+    func semanticVersionRequirement(for dependency: Config.Dependency) throws -> SemanticVersionRequirement {
+        try SemanticVersionRequirement(dependencies[dependency.name(for: .cocoapods)]!)
+    }
+}
+
+extension SemanticVersionRequirement {
+    init(_ podspecDependencyRequirement: Podspec.DependencyRequirement) throws {
+        switch podspecDependencyRequirement {
+        case .any:
+            self = .any
+        case let .exactly(version):
+            self = .exactly(version)
+        case let .range(fromVersion, toVersion):
+            self = .range(from: fromVersion, to: toVersion)
+        default:
+            throw Podspec.Error.unsupportedDependencyRequirement(podspecDependencyRequirement)
+        }
+    }
+}

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/Process+Shell.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/Process+Shell.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension Process {
+    static func shell(_ command: String) -> Self {
+        let process = Self()
+        process.launchPath = "/bin/bash"
+        process.arguments = ["-c", command]
+        return process
+    }
+
+    var outputString: String {
+        return String(data: output, encoding: .utf8)!
+    }
+
+    var output: Data {
+        let outputPipe = Pipe()
+        standardOutput = outputPipe
+        launch()
+        return outputPipe.fileHandleForReading.readDataToEndOfFile()
+    }
+}

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/ResolvedPackage.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/ResolvedPackage.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct ResolvedPackage: Decodable, SemanticVersionProviding {
+    enum Error: Swift.Error {
+        case unsupportedPin(ResolvedPackageObject.Pin)
+    }
+
+    private static let cache = ManifestCache { (url) -> Self in
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(Self.self, from: data)
+    }
+
+    static func from(file fileURL: URL) throws -> Self {
+        try cache.manifest(for: fileURL)
+    }
+
+    var object: ResolvedPackageObject
+
+    struct ResolvedPackageObject: Decodable {
+        var pins: [Pin]
+
+        struct Pin: Decodable {
+            var package: String
+            var state: State
+
+            struct State: Decodable {
+                var branch: String?
+                var revision: String
+                var version: String?
+            }
+        }
+    }
+
+    func semanticVersion(for dependency: Config.Dependency) throws -> SemanticVersion {
+        try SemanticVersion(object.pins.first { $0.package == dependency.name(for: .spm) }!)
+    }
+}
+
+extension SemanticVersion {
+    init(_ pin: ResolvedPackage.ResolvedPackageObject.Pin) throws {
+        if let version = pin.state.version {
+            self = try SemanticVersion(string: version)
+        } else {
+            throw ResolvedPackage.Error.unsupportedPin(pin)
+        }
+    }
+}

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/SemanticVersion.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/SemanticVersion.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+struct SemanticVersion: Hashable, Comparable, CustomStringConvertible, Decodable {
+
+    enum Error: Swift.Error, Equatable {
+        case notASemanticVersion(String)
+    }
+
+    // swiftlint:disable:next force_try
+    private static let regex = try! NSRegularExpression(
+        pattern: "^v?(?<major>[0-9]+).(?<minor>[0-9]+)(?:.(?<patch>[0-9]+)(?<suffix>.*)?)?$", options: [])
+
+    init(string: String) throws {
+        let nsString = NSString(string: string)
+        let matches = Self.regex.matches(in: string, options: [], range: NSRange(location: 0, length: nsString.length))
+        guard matches.count == 1, let match = matches.first else {
+            throw Error.notASemanticVersion(string)
+        }
+        major = Int(nsString.substring(with: match.range(withName: "major")))!
+        minor = Int(nsString.substring(with: match.range(withName: "minor")))!
+
+        let patchRange = match.range(withName: "patch")
+        if patchRange.location != NSNotFound {
+            patch = Int(nsString.substring(with: patchRange))
+        }
+
+        let suffixRange = match.range(withName: "suffix")
+        if suffixRange.location != NSNotFound, suffixRange.length > 0 {
+            suffix = nsString.substring(with: suffixRange)
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let string = try container.decode(String.self)
+        self = try SemanticVersion(string: string)
+    }
+
+    var description: String {
+        let versionComponent = components.map { $0.description }.joined(separator: ".")
+        return "v\(versionComponent)\(suffix ?? "")"
+    }
+
+    var major: Int
+
+    var minor: Int
+
+    var patch: Int?
+
+    var suffix: String?
+
+    var nextMajor: SemanticVersion {
+        var result = self
+        result.major += 1
+        result.minor = 0
+        result.patch = nil
+        result.suffix = nil
+        return result
+    }
+
+    var nextMinor: SemanticVersion {
+        var result = self
+        result.minor += 1
+        result.patch = nil
+        result.suffix = nil
+        return result
+    }
+
+    var components: [Int] {
+        [major, minor, patch].compactMap { $0 }
+    }
+
+    static func == (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        lhs.major == rhs.major
+            && lhs.minor == rhs.minor
+            && (lhs.patch ?? 0) == (rhs.patch ?? 0)
+            && lhs.suffix == rhs.suffix
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(major)
+        hasher.combine(minor)
+        hasher.combine(patch ?? 0)
+        hasher.combine(suffix)
+    }
+
+    static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        lhs.components.lexicographicallyPrecedes(rhs.components)
+    }
+}

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/SemanticVersionProviding.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/SemanticVersionProviding.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol SemanticVersionProviding {
+    static func from(file url: URL) throws -> Self
+    func semanticVersion(for dependency: Config.Dependency) throws -> SemanticVersion
+}

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/SemanticVersionRequirement.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/SemanticVersionRequirement.swift
@@ -1,0 +1,27 @@
+enum SemanticVersionRequirement: CustomStringConvertible, Hashable {
+    case any
+    case exactly(SemanticVersion)
+    case range(from: SemanticVersion, to: SemanticVersion)
+
+    func isSatisfied(by version: SemanticVersion) -> Bool {
+        switch self {
+        case .any:
+            return true
+        case let .exactly(v):
+            return v == version
+        case let .range(fromVersion, toVersion):
+            return version >= fromVersion && version < toVersion
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .any:
+            return "any"
+        case let .exactly(v):
+            return "exactly \(v)"
+        case let .range(fromVersion, toVersion):
+            return "from \(fromVersion) up to \(toVersion)"
+        }
+    }
+}

--- a/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/VersionRequirementProviding.swift
+++ b/scripts/depsvalidator/Sources/DepsValidatorLibrary/Models/VersionRequirementProviding.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol SemanticVersionRequirementProviding {
+    static func from(file url: URL) throws -> Self
+    func semanticVersionRequirement(for dependency: Config.Dependency) throws -> SemanticVersionRequirement
+}

--- a/scripts/depsvalidator/Tests/DepsValidatorTests/Example Manifests/Example.podspec
+++ b/scripts/depsvalidator/Tests/DepsValidatorTests/Example Manifests/Example.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |m|
+
+  m.dependency 'a', '1.0'
+  m.dependency 'b', '= 1.0'
+  m.dependency 'c', '> 1.0'
+  m.dependency 'd', '>= 1.0'
+  m.dependency 'e', '< 1.0'
+  m.dependency 'f', '<= 1.0'
+  m.dependency 'g', '~> 1.0'
+  m.dependency 'h', '~> 1.0.0'
+  m.dependency 'i', '~> 1.0.0-beta.1'
+  m.dependency 'j'
+
+end

--- a/scripts/depsvalidator/Tests/DepsValidatorTests/Example Manifests/Package.swift.example
+++ b/scripts/depsvalidator/Tests/DepsValidatorTests/Example Manifests/Package.swift.example
@@ -1,0 +1,27 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "MyLibrary",
+    products: [
+        .library(
+            name: "MyLibrary",
+            targets: ["MyLibrary"]),
+    ],
+    dependencies: [
+        .package(name: "A", url: "https://github.com/mapbox/a.git", from: "1.0.0"),
+        .package(name: "B", url: "https://github.com/mapbox/b.git", .branch("abranch")),
+        .package(name: "C", url: "https://github.com/mapbox/c.git", .exact("1.2.0")),
+        .package(name: "D", url: "https://github.com/mapbox/d.git", .revision("abcdef")),
+        .package(name: "E", url: "https://github.com/mapbox/e.git", .upToNextMajor(from: "1.2.0")),
+        .package(name: "F", url: "https://github.com/mapbox/f.git", .upToNextMinor(from: "1.2.0")),
+    ],
+    targets: [
+        .target(
+            name: "MyLibrary",
+            dependencies: []),
+        .testTarget(
+            name: "MyLibraryTests",
+            dependencies: ["MyLibrary"]),
+    ]
+)

--- a/scripts/depsvalidator/Tests/DepsValidatorTests/PackageTests.swift
+++ b/scripts/depsvalidator/Tests/DepsValidatorTests/PackageTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import DepsValidatorLibrary
+
+private typealias Dependency = Package.Dependency
+
+final class PackageTests: XCTestCase {
+    func testInitialization() throws {
+        let url = Bundle.module.url(forResource: "Package.swift", withExtension: "example")!
+
+        let packageDir = FileManager.default.temporaryDirectory.appendingPathComponent("MyLibrary")
+        try FileManager.default.removeItem(at: packageDir)
+        try FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true, attributes: nil)
+        let packageURL = packageDir.appendingPathComponent("Package.swift")
+        try FileManager.default.copyItem(at: url, to: packageURL)
+
+        let package = try Package.from(file: packageURL)
+
+        try XCTAssertEqual(package.dependencies, [
+            Dependency(name: "A", requirement: .range(lowerBound: SemanticVersion(string: "1.0.0"),
+                                                      upperBound: SemanticVersion(string: "2.0.0"))),
+            Dependency(name: "B", requirement: .branch("abranch")),
+            Dependency(name: "C", requirement: .exact(SemanticVersion(string: "1.2.0"))),
+            Dependency(name: "D", requirement: .revision("abcdef")),
+            Dependency(name: "E", requirement: .range(lowerBound: SemanticVersion(string: "1.2.0"),
+                                                      upperBound: SemanticVersion(string: "2.0.0"))),
+            Dependency(name: "F", requirement: .range(lowerBound: SemanticVersion(string: "1.2.0"),
+                                                      upperBound: SemanticVersion(string: "1.3.0"))),
+        ])
+    }
+}

--- a/scripts/depsvalidator/Tests/DepsValidatorTests/PodspecTests.swift
+++ b/scripts/depsvalidator/Tests/DepsValidatorTests/PodspecTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import DepsValidatorLibrary
+
+final class PodspecTests: XCTestCase {
+    func testInitialization() throws {
+        let url = Bundle.module.url(forResource: "Example", withExtension: "podspec")!
+
+        let podspec = try Podspec.from(file: url)
+
+        try XCTAssertEqual(podspec.dependencies, [
+            "a": .exactly(SemanticVersion(string: "1.0")),
+            "b": .exactly(SemanticVersion(string: "1.0")),
+            "c": .greaterThan(SemanticVersion(string: "1.0")),
+            "d": .greaterThanOrEqualTo(SemanticVersion(string: "1.0")),
+            "e": .lessThan(SemanticVersion(string: "1.0")),
+            "f": .lessThanOrEqualTo(SemanticVersion(string: "1.0")),
+            "g": .range(from: SemanticVersion(string: "1.0"), to: SemanticVersion(string: "2.0")),
+            "h": .range(from: SemanticVersion(string: "1.0.0"), to: SemanticVersion(string: "1.1")),
+            "i": .range(from: SemanticVersion(string: "1.0.0-beta.1"), to: SemanticVersion(string: "1.1")),
+            "j": .any,
+        ])
+    }
+}

--- a/scripts/depsvalidator/Tests/DepsValidatorTests/SemanticVersionRequirementTests.swift
+++ b/scripts/depsvalidator/Tests/DepsValidatorTests/SemanticVersionRequirementTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import DepsValidatorLibrary
+
+final class SemanticVersionRequirementTests: XCTestCase {
+    func testIsSatisfiedBy() throws {
+        try XCTAssertTrue(SemanticVersionRequirement.any.isSatisfied(by: SemanticVersion(string: "1.2.0")))
+
+        let exactly = try SemanticVersionRequirement.exactly(SemanticVersion(string: "v1.2.0"))
+        try XCTAssertTrue(exactly.isSatisfied(by: SemanticVersion(string: "v1.2.0")))
+        try XCTAssertTrue(exactly.isSatisfied(by: SemanticVersion(string: "1.2.0")))
+        try XCTAssertTrue(exactly.isSatisfied(by: SemanticVersion(string: "1.2")))
+
+        let range = try SemanticVersionRequirement.range(
+            from: SemanticVersion(string: "v1.2.0"),
+            to: SemanticVersion(string: "v2.0"))
+        try XCTAssertTrue(range.isSatisfied(by: SemanticVersion(string: "v1.2.0")))
+        try XCTAssertTrue(range.isSatisfied(by: SemanticVersion(string: "v1.999999.123123123")))
+        try XCTAssertFalse(range.isSatisfied(by: SemanticVersion(string: "v2.0")))
+
+        // Suffixes are ignored during comparison
+        let suffixRange = try SemanticVersionRequirement.range(
+            from: SemanticVersion(string: "v1.2.0-beta1"),
+            to: SemanticVersion(string: "v1.2.0-beta10"))
+        try XCTAssertFalse(suffixRange.isSatisfied(by: SemanticVersion(string: "v1.2.0")))
+        try XCTAssertFalse(suffixRange.isSatisfied(by: SemanticVersion(string: "v1.2.0-beta0")))
+        try XCTAssertFalse(suffixRange.isSatisfied(by: SemanticVersion(string: "v1.2.0-beta1")))
+        try XCTAssertFalse(suffixRange.isSatisfied(by: SemanticVersion(string: "v1.2.0-beta2")))
+        try XCTAssertFalse(suffixRange.isSatisfied(by: SemanticVersion(string: "v1.2.0-beta10")))
+        try XCTAssertFalse(suffixRange.isSatisfied(by: SemanticVersion(string: "v1.2.0-beta11")))
+
+        // Suffixes are ignored during comparison
+        let suffixRange2 = try SemanticVersionRequirement.range(
+            from: SemanticVersion(string: "v1.2.0-beta4"),
+            to: SemanticVersion(string: "v1.2.1"))
+        try XCTAssertTrue(suffixRange2.isSatisfied(by: SemanticVersion(string: "v1.2.0")))
+        try XCTAssertTrue(suffixRange2.isSatisfied(by: SemanticVersion(string: "v1.2.0-beta0")))
+        try XCTAssertTrue(suffixRange2.isSatisfied(by: SemanticVersion(string: "v1.2.0-beta1")))
+        try XCTAssertTrue(suffixRange2.isSatisfied(by: SemanticVersion(string: "v1.2.0-beta2")))
+        try XCTAssertTrue(suffixRange2.isSatisfied(by: SemanticVersion(string: "v1.2.0-beta10")))
+        try XCTAssertTrue(suffixRange2.isSatisfied(by: SemanticVersion(string: "v1.2.0-beta11")))
+    }
+}

--- a/scripts/depsvalidator/Tests/DepsValidatorTests/SemanticVersionTests.swift
+++ b/scripts/depsvalidator/Tests/DepsValidatorTests/SemanticVersionTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+import CarthageKit
+@testable import struct DepsValidatorLibrary.SemanticVersion
+
+final class SemanticVersionTests: XCTestCase {
+
+    func testInitWithString() throws {
+        let version = try SemanticVersion(string: "v1.2.3")
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 2)
+        XCTAssertEqual(version.patch, 3)
+        XCTAssertNil(version.suffix)
+    }
+
+    func testInitWithStringNoV() throws {
+        let version = try SemanticVersion(string: "1.2.3")
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 2)
+        XCTAssertEqual(version.patch, 3)
+        XCTAssertNil(version.suffix)
+    }
+
+    func testInitWithStringWithSuffix() throws {
+        let version = try SemanticVersion(string: "v1.2.3-beta.17")
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 2)
+        XCTAssertEqual(version.patch, 3)
+        XCTAssertEqual(version.suffix, "-beta.17")
+    }
+
+    func testInitWithStringNoPatch() throws {
+        let version = try SemanticVersion(string: "v1.2")
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 2)
+        XCTAssertNil(version.patch)
+        XCTAssertNil(version.suffix)
+    }
+
+    func verifyInitWithStringsThatAreNotSemvers(_ versionString: String, line: UInt = #line) {
+        XCTAssertThrowsError(try SemanticVersion(string: versionString), line: line) { (error) in
+            XCTAssertEqual(error as? SemanticVersion.Error, .notASemanticVersion(versionString))
+        }
+    }
+
+    func testInitWithStringsThatAreNotSemvers() {
+        verifyInitWithStringsThatAreNotSemvers("")
+        verifyInitWithStringsThatAreNotSemvers("v")
+        verifyInitWithStringsThatAreNotSemvers("1")
+        verifyInitWithStringsThatAreNotSemvers("v1")
+        verifyInitWithStringsThatAreNotSemvers("v1.x")
+        verifyInitWithStringsThatAreNotSemvers("v10.0-beta.1")
+    }
+
+    func verifyDescription(withVersionString versionString: String, line: UInt = #line) throws {
+        try XCTAssertEqual(SemanticVersion(string: versionString).description, versionString)
+    }
+
+    func verifyDescriptionPrependsV(withVersionString versionString: String, line: UInt = #line) throws {
+        try XCTAssertEqual(SemanticVersion(string: versionString).description, "v" + versionString)
+    }
+
+    func testDescription() throws {
+        try verifyDescription(withVersionString: "v1.2.3-beta.1")
+        try verifyDescription(withVersionString: "v1.2.3")
+        try verifyDescription(withVersionString: "v1.2")
+        try verifyDescriptionPrependsV(withVersionString: "1.2.3-beta.1")
+        try verifyDescriptionPrependsV(withVersionString: "1.2.3")
+        try verifyDescriptionPrependsV(withVersionString: "1.2")
+    }
+
+    func verifyNextMajor(of version: String, is nextVersion: String, line: UInt = #line) throws {
+        let version = try SemanticVersion(string: version)
+        let expected = try SemanticVersion(string: nextVersion)
+
+        let actual = version.nextMajor
+
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testNextMajor() throws {
+        try verifyNextMajor(of: "v1.2.0-beta", is: "v2.0")
+        try verifyNextMajor(of: "v1.2.0", is: "v2.0")
+        try verifyNextMajor(of: "v1.2", is: "v2.0")
+    }
+
+    func verifyNextMinor(of version: String, is nextVersion: String, line: UInt = #line) throws {
+        let version = try SemanticVersion(string: version)
+        let expected = try SemanticVersion(string: nextVersion)
+
+        let actual = version.nextMinor
+
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testNextMinor() throws {
+        try verifyNextMinor(of: "v1.2.0-beta", is: "v1.3")
+        try verifyNextMinor(of: "v1.2.0", is: "v1.3")
+        try verifyNextMinor(of: "v1.2", is: "v1.3")
+    }
+
+    func testComponents() throws {
+        try XCTAssertEqual(SemanticVersion(string: "v1.2.0-beta").components, [1, 2, 0])
+        try XCTAssertEqual(SemanticVersion(string: "1.2.0-beta").components, [1, 2, 0])
+        try XCTAssertEqual(SemanticVersion(string: "v1.2.0").components, [1, 2, 0])
+        try XCTAssertEqual(SemanticVersion(string: "1.2.0").components, [1, 2, 0])
+        try XCTAssertEqual(SemanticVersion(string: "v1.2").components, [1, 2])
+        try XCTAssertEqual(SemanticVersion(string: "1.2").components, [1, 2])
+    }
+
+    func testEquals() throws {
+        try XCTAssertEqual(SemanticVersion(string: "v1.2.0"), SemanticVersion(string: "1.2.0"))
+        try XCTAssertEqual(SemanticVersion(string: "v1.2.0-beta"), SemanticVersion(string: "1.2.0-beta"))
+        try XCTAssertEqual(SemanticVersion(string: "v1.2"), SemanticVersion(string: "1.2.0"))
+        try XCTAssertEqual(SemanticVersion(string: "v1.2"), SemanticVersion(string: "1.2"))
+        try XCTAssertNotEqual(SemanticVersion(string: "v1.2.0"), SemanticVersion(string: "v1.2.0-beta"))
+        try XCTAssertNotEqual(SemanticVersion(string: "v1.2"), SemanticVersion(string: "v1.2.1"))
+        try XCTAssertNotEqual(SemanticVersion(string: "v1.2.1"), SemanticVersion(string: "v1.2.2"))
+        try XCTAssertNotEqual(SemanticVersion(string: "v1.2"), SemanticVersion(string: "v1.3"))
+        try XCTAssertNotEqual(SemanticVersion(string: "v2.0"), SemanticVersion(string: "v1.0"))
+    }
+
+    func testLessThan() throws {
+        try XCTAssertLessThan(SemanticVersion(string: "1.0"), SemanticVersion(string: "1.0.1"))
+        try XCTAssertLessThan(SemanticVersion(string: "1.0"), SemanticVersion(string: "1.1.0"))
+        try XCTAssertLessThan(SemanticVersion(string: "1.0"), SemanticVersion(string: "1.1"))
+        try XCTAssertLessThan(SemanticVersion(string: "1.0"), SemanticVersion(string: "2.0"))
+
+        try XCTAssertLessThan(SemanticVersion(string: "1.0.0"), SemanticVersion(string: "1.0.1"))
+        try XCTAssertLessThan(SemanticVersion(string: "1.0.0"), SemanticVersion(string: "1.1.0"))
+        try XCTAssertLessThan(SemanticVersion(string: "1.0.0"), SemanticVersion(string: "1.1"))
+        try XCTAssertLessThan(SemanticVersion(string: "1.0.0"), SemanticVersion(string: "2.0"))
+
+        try XCTAssertLessThan(SemanticVersion(string: "1.0.0-beta1"), SemanticVersion(string: "1.0.1-beta0"))
+        try XCTAssertLessThan(SemanticVersion(string: "1.0.0-beta1"), SemanticVersion(string: "1.1.0-beta0"))
+        try XCTAssertLessThan(SemanticVersion(string: "1.0.0-beta1"), SemanticVersion(string: "1.1"))
+        try XCTAssertLessThan(SemanticVersion(string: "1.0.0-beta1"), SemanticVersion(string: "2.0"))
+
+        try XCTAssertFalse(SemanticVersion(string: "1.0.0-beta1") < SemanticVersion(string: "1.0.0-beta2"))
+        try XCTAssertFalse(SemanticVersion(string: "1.0.0-beta2") < SemanticVersion(string: "1.0.0-beta1"))
+        try XCTAssertFalse(SemanticVersion(string: "1.0.0-beta2") == SemanticVersion(string: "1.0.0-beta1"))
+    }
+}


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

- Adds a new dependency validation tool for use in CI. See `scripts/depsvalidator/README.md` for details.

Sample output (from the CI run for the initial commit of this PR):

```
MapboxCoreMaps:
  OK
MapboxCommon:
  Inconsistent version requirements: 'exactly v11.0.0', 'from v11.0.0 up to v12.0'
    Manifests with 'from v11.0.0 up to v12.0':
      - Cartfile
    Manifests with 'exactly v11.0.0':
      - MapboxMaps.podspec
Turf:
  OK
MapboxMobileEvents:
  OK
```