### PR TITLE
Encapsulate MapboxCoreMaps protocol conformances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Mapbox welcomes participation and contributions from everyone.
 
 - #### Foundation
   * `AccountManager` has been removed. A new `CredentialsManager` replaces it. You can use `CredentialsManager.default` to set a global access token.
+  * MapboxCoreMaps protocol conformances have been encapsulated. ([#265](https://github.com/mapbox/mapbox-maps-ios/pull/265))
+      * `ObserverConcrete` has been removed.
+      * `BaseMapView` no longer conforms to `MapClient` or `MBMMetalViewProvider`, and the methods they required are now internal.
+      * The setter for `BaseMapView.__map` is now private
+      * `Snapshotter` no longer conforms to `Observer`, and the method it required is now internal.
 
 ## 10.0.0-beta.17 - April 13, 2021
 

--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 		B5A6921D262754DF00A03412 /* MockDelegatingObserverDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A69218262754DF00A03412 /* MockDelegatingObserverDelegate.swift */; };
 		B5A6921E262754DF00A03412 /* DelegatingMapClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A69219262754DF00A03412 /* DelegatingMapClientTests.swift */; };
 		B5A6921F262754DF00A03412 /* CredentialsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A6921A262754DF00A03412 /* CredentialsManagerTests.swift */; };
+		B5A6922B2627566A00A03412 /* MapInitOptionsTests.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5A6922A2627566A00A03412 /* MapInitOptionsTests.xib */; };
 		B5B55D44260E4D1500EBB589 /* CameraAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B55D40260E4D1500EBB589 /* CameraAnimator.swift */; };
 		B5B55D45260E4D1500EBB589 /* AnimationOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B55D41260E4D1500EBB589 /* AnimationOwner.swift */; };
 		B5B55D46260E4D1500EBB589 /* CameraAnimationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B55D42260E4D1500EBB589 /* CameraAnimationDelegate.swift */; };
@@ -607,6 +608,7 @@
 		B5A69218262754DF00A03412 /* MockDelegatingObserverDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDelegatingObserverDelegate.swift; sourceTree = "<group>"; };
 		B5A69219262754DF00A03412 /* DelegatingMapClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegatingMapClientTests.swift; sourceTree = "<group>"; };
 		B5A6921A262754DF00A03412 /* CredentialsManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialsManagerTests.swift; sourceTree = "<group>"; };
+		B5A6922A2627566A00A03412 /* MapInitOptionsTests.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MapInitOptionsTests.xib; sourceTree = "<group>"; };
 		B5B55D40260E4D1500EBB589 /* CameraAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraAnimator.swift; sourceTree = "<group>"; };
 		B5B55D41260E4D1500EBB589 /* AnimationOwner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationOwner.swift; sourceTree = "<group>"; };
 		B5B55D42260E4D1500EBB589 /* CameraAnimationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraAnimationDelegate.swift; sourceTree = "<group>"; };
@@ -1257,6 +1259,7 @@
 				A4519DD92432FF03007CF39A /* MapboxMapsStyleTests */,
 				CA4453C62436E71500477B4F /* MapboxTestHost */,
 				CA9481542554AA3D00D93C3C /* TestHelpers */,
+				B5A692292627566A00A03412 /* Resources */,
 				1FEE78C42421884000337895 /* Products */,
 				1FEE79BC2421AC7C00337895 /* Frameworks */,
 			);
@@ -1409,6 +1412,15 @@
 				B53B8761260D73D600C86BAA /* Puck3DIntegrationTests.swift */,
 			);
 			path = Pucks;
+			sourceTree = "<group>";
+		};
+		B5A692292627566A00A03412 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				B5A6922A2627566A00A03412 /* MapInitOptionsTests.xib */,
+			);
+			name = Resources;
+			path = ../Tests/MapboxMapsTests/Resources;
 			sourceTree = "<group>";
 		};
 		C69F017225435BAE001AB49B /* Mocks */ = {
@@ -1747,6 +1759,7 @@
 				CA549006251C404B00F829A3 /* polygon.geojson in Resources */,
 				CA549007251C404B00F829A3 /* point.geojson in Resources */,
 				CA549008251C404B00F829A3 /* multipoint.geojson in Resources */,
+				B5A6922B2627566A00A03412 /* MapInitOptionsTests.xib in Resources */,
 				CA549009251C404B00F829A3 /* multiline.geojson in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -166,6 +166,9 @@
 		B51DE65B25D7038900A80AC9 /* Comparable+Clamped.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51DE62125D7032C00A80AC9 /* Comparable+Clamped.swift */; };
 		B51DE68125D7039700A80AC9 /* Comparable+ClampedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51DE64725D7038300A80AC9 /* Comparable+ClampedTests.swift */; };
 		B52050A8260538240003E5BB /* ModelLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52050A7260538240003E5BB /* ModelLayer.swift */; };
+		B529341C2624E9D6003B181C /* PreferredFPS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52934192624E9D6003B181C /* PreferredFPS.swift */; };
+		B529341D2624E9D6003B181C /* DelegatingMapClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B529341A2624E9D6003B181C /* DelegatingMapClient.swift */; };
+		B529341E2624E9D6003B181C /* DelegatingObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B529341B2624E9D6003B181C /* DelegatingObserver.swift */; };
 		B53A685B25E033AF008CB2AF /* OrnamentsLocalizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = B53A685E25E033AF008CB2AF /* OrnamentsLocalizable.strings */; };
 		B53B8622260D717700C86BAA /* XCTestCase+MapboxAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B8620260D717700C86BAA /* XCTestCase+MapboxAccessToken.swift */; };
 		B53B8623260D717700C86BAA /* XCTestCase+MapboxAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B8620260D717700C86BAA /* XCTestCase+MapboxAccessToken.swift */; };
@@ -175,6 +178,11 @@
 		B53B8763260D73D600C86BAA /* Puck3DIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B8761260D73D600C86BAA /* Puck3DIntegrationTests.swift */; };
 		B54B7F0B25DB192C003FD6CA /* MockCameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F0925DB192C003FD6CA /* MockCameraManager.swift */; };
 		B54B7F2125DB1ABA003FD6CA /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B7F1F25DB1ABA003FD6CA /* Stub.swift */; };
+		B5A6921B262754DF00A03412 /* DelegatingObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A69216262754DF00A03412 /* DelegatingObserverTests.swift */; };
+		B5A6921C262754DF00A03412 /* MockDelegatingMapClientDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A69217262754DF00A03412 /* MockDelegatingMapClientDelegate.swift */; };
+		B5A6921D262754DF00A03412 /* MockDelegatingObserverDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A69218262754DF00A03412 /* MockDelegatingObserverDelegate.swift */; };
+		B5A6921E262754DF00A03412 /* DelegatingMapClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A69219262754DF00A03412 /* DelegatingMapClientTests.swift */; };
+		B5A6921F262754DF00A03412 /* CredentialsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A6921A262754DF00A03412 /* CredentialsManagerTests.swift */; };
 		B5B55D44260E4D1500EBB589 /* CameraAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B55D40260E4D1500EBB589 /* CameraAnimator.swift */; };
 		B5B55D45260E4D1500EBB589 /* AnimationOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B55D41260E4D1500EBB589 /* AnimationOwner.swift */; };
 		B5B55D46260E4D1500EBB589 /* CameraAnimationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B55D42260E4D1500EBB589 /* CameraAnimationDelegate.swift */; };
@@ -585,12 +593,20 @@
 		B51DE62125D7032C00A80AC9 /* Comparable+Clamped.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comparable+Clamped.swift"; sourceTree = "<group>"; };
 		B51DE64725D7038300A80AC9 /* Comparable+ClampedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comparable+ClampedTests.swift"; sourceTree = "<group>"; };
 		B52050A7260538240003E5BB /* ModelLayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelLayer.swift; sourceTree = "<group>"; };
+		B52934192624E9D6003B181C /* PreferredFPS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferredFPS.swift; sourceTree = "<group>"; };
+		B529341A2624E9D6003B181C /* DelegatingMapClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegatingMapClient.swift; sourceTree = "<group>"; };
+		B529341B2624E9D6003B181C /* DelegatingObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegatingObserver.swift; sourceTree = "<group>"; };
 		B53A685D25E033AF008CB2AF /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/OrnamentsLocalizable.strings; sourceTree = "<group>"; };
 		B53B8620260D717700C86BAA /* XCTestCase+MapboxAccessToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MapboxAccessToken.swift"; sourceTree = "<group>"; };
 		B53B86D8260D735B00C86BAA /* LocationOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationOptionsTests.swift; sourceTree = "<group>"; };
 		B53B8761260D73D600C86BAA /* Puck3DIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Puck3DIntegrationTests.swift; sourceTree = "<group>"; };
 		B54B7F0925DB192C003FD6CA /* MockCameraManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCameraManager.swift; sourceTree = "<group>"; };
 		B54B7F1F25DB1ABA003FD6CA /* Stub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stub.swift; sourceTree = "<group>"; };
+		B5A69216262754DF00A03412 /* DelegatingObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegatingObserverTests.swift; sourceTree = "<group>"; };
+		B5A69217262754DF00A03412 /* MockDelegatingMapClientDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDelegatingMapClientDelegate.swift; sourceTree = "<group>"; };
+		B5A69218262754DF00A03412 /* MockDelegatingObserverDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDelegatingObserverDelegate.swift; sourceTree = "<group>"; };
+		B5A69219262754DF00A03412 /* DelegatingMapClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegatingMapClientTests.swift; sourceTree = "<group>"; };
+		B5A6921A262754DF00A03412 /* CredentialsManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialsManagerTests.swift; sourceTree = "<group>"; };
 		B5B55D40260E4D1500EBB589 /* CameraAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraAnimator.swift; sourceTree = "<group>"; };
 		B5B55D41260E4D1500EBB589 /* AnimationOwner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationOwner.swift; sourceTree = "<group>"; };
 		B5B55D42260E4D1500EBB589 /* CameraAnimationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraAnimationDelegate.swift; sourceTree = "<group>"; };
@@ -1127,6 +1143,9 @@
 		1F11C1102421B05600F8397B /* MapboxMapsFoundation */ = {
 			isa = PBXGroup;
 			children = (
+				B529341A2624E9D6003B181C /* DelegatingMapClient.swift */,
+				B529341B2624E9D6003B181C /* DelegatingObserver.swift */,
+				B52934192624E9D6003B181C /* PreferredFPS.swift */,
 				C6F256EE261FB99C0093D353 /* LogoView.swift */,
 				1F11C1112421B05600F8397B /* MapboxMapsFoundation.h */,
 				1F11C1122421B05600F8397B /* Info.plist */,
@@ -1144,6 +1163,11 @@
 		1F11C11B2421B05600F8397B /* MapboxMapsFoundationTests */ = {
 			isa = PBXGroup;
 			children = (
+				B5A6921A262754DF00A03412 /* CredentialsManagerTests.swift */,
+				B5A69219262754DF00A03412 /* DelegatingMapClientTests.swift */,
+				B5A69216262754DF00A03412 /* DelegatingObserverTests.swift */,
+				B5A69217262754DF00A03412 /* MockDelegatingMapClientDelegate.swift */,
+				B5A69218262754DF00A03412 /* MockDelegatingObserverDelegate.swift */,
 				CA0C42922602BF000054D9D0 /* Extensions */,
 				CAC1961E25AEAE2800F69FEA /* Glyphs */,
 				07DA743A258409AF00AD0446 /* GeoJSON */,
@@ -1872,6 +1896,7 @@
 				0CD62F0724588501006421D1 /* PinchGestureHandler.swift in Sources */,
 				0782B17B258C236B00D5FCE5 /* MBXGeometry.swift in Sources */,
 				0CD62F26245887D5006421D1 /* OrnamentConfig.swift in Sources */,
+				B529341D2624E9D6003B181C /* DelegatingMapClient.swift in Sources */,
 				0C3B1E9224DDADD000CC29E8 /* MapboxMobileEvents+TelemetryProtocol.swift in Sources */,
 				0C9640E12531056700CABD3E /* LocationConsumer.swift in Sources */,
 				0C708F4D24EB23C7003CE791 /* RasterDemSource.swift in Sources */,
@@ -1929,6 +1954,7 @@
 				0CD62F1924588661006421D1 /* MapCameraOptions.swift in Sources */,
 				0CD62F15245885B6006421D1 /* MapView.swift in Sources */,
 				0C3B1E8E24DDADD000CC29E8 /* EventsStringTokens.swift in Sources */,
+				B529341E2624E9D6003B181C /* DelegatingObserver.swift in Sources */,
 				0CD62F2024588737006421D1 /* AppleLocationProvider.swift in Sources */,
 				0782B010258C051900D5FCE5 /* ScreenCoordinate.swift in Sources */,
 				CABCDF372620E03A00D61635 /* CredentialsManager.swift in Sources */,
@@ -1944,6 +1970,7 @@
 				0C88F22624F04D1600FC35F3 /* ExpressionBuilder.swift in Sources */,
 				1FECC9E02474519D00B63910 /* Expression.swift in Sources */,
 				B52050A8260538240003E5BB /* ModelLayer.swift in Sources */,
+				B529341C2624E9D6003B181C /* PreferredFPS.swift in Sources */,
 				0CD62F1124588532006421D1 /* GestureHandlerDelegate.swift in Sources */,
 				0782B061258C16B200D5FCE5 /* Utils.swift in Sources */,
 				0CD62F2C24588937006421D1 /* Style.swift in Sources */,
@@ -2032,6 +2059,7 @@
 				CA548FE4251C404B00F829A3 /* GestureManagerTests.swift in Sources */,
 				CA4AE123252D656600183075 /* MockAnnotationStyleDelegate.swift in Sources */,
 				0C5CFD4125BBA06D0001E753 /* Enums+Fixtures.swift in Sources */,
+				B5A6921B262754DF00A03412 /* DelegatingObserverTests.swift in Sources */,
 				CA548FE6251C404B00F829A3 /* GestureSupportableViewMock.swift in Sources */,
 				0CC6EF2C25C3263400BFB153 /* RasterLayerIntegrationTests.swift in Sources */,
 				0C5CFCE825BB951B0001E753 /* LineLayerTests.swift in Sources */,
@@ -2050,6 +2078,7 @@
 				0C32C9B025F979680057ED31 /* RasterDemSourceIntegrationTests.swift in Sources */,
 				0C5CFD1B25BB963A0001E753 /* Value+Fixtures.swift in Sources */,
 				CA548FEA251C404B00F829A3 /* AnnotationManagerTests.swift in Sources */,
+				B5A6921F262754DF00A03412 /* CredentialsManagerTests.swift in Sources */,
 				CAEDA0B0258E8188003CCEFE /* MapViewIntegrationTests.swift in Sources */,
 				0C5CFCE225BB951B0001E753 /* SymbolLayerTests.swift in Sources */,
 				CA57257E2568D15E005ED95E /* ObservableIntegrationTests.swift in Sources */,
@@ -2058,6 +2087,7 @@
 				0CC6EF2625C3263400BFB153 /* HillshadeLayerIntegrationTests.swift in Sources */,
 				CA548FEB251C404B00F829A3 /* MapboxMapsFoundationTests.swift in Sources */,
 				CA548FEC251C404B00F829A3 /* MultiPolygonTests.swift in Sources */,
+				B5A6921C262754DF00A03412 /* MockDelegatingMapClientDelegate.swift in Sources */,
 				CA548FED251C404B00F829A3 /* Geometry+MBXGeometryTests.swift in Sources */,
 				0C5CFDD525BE29BC0001E753 /* SouceProperties+Fixtures.swift in Sources */,
 				CA4AE07B252D655000183075 /* PolygonAnnotationTests.swift in Sources */,
@@ -2069,6 +2099,7 @@
 				CA548FF1251C404B00F829A3 /* RotateGestureHandlerTests.swift in Sources */,
 				CA4AE033252D654800183075 /* LineAnnotationTests.swift in Sources */,
 				0C37B1E425CB05F000DCDD3D /* ColorTests.swift in Sources */,
+				B5A6921D262754DF00A03412 /* MockDelegatingObserverDelegate.swift in Sources */,
 				CADC7AD3251C51070082BA0A /* MockAnnotationSupportableMap.swift in Sources */,
 				0C32CA2125F982300057ED31 /* RasterDemSourceTests.swift in Sources */,
 				CA548FF4251C404B00F829A3 /* DistanceFormatterTests.swift in Sources */,
@@ -2089,6 +2120,7 @@
 				CA548FF7251C404B00F829A3 /* UIImage+CGColor.swift in Sources */,
 				0CC6EF2025C3263400BFB153 /* FillLayerIntegrationTests.swift in Sources */,
 				C64ED307253F7CF500ADADFB /* LocationSupportableMapViewMock.swift in Sources */,
+				B5A6921E262754DF00A03412 /* DelegatingMapClientTests.swift in Sources */,
 				CA548FFA251C404B00F829A3 /* CompassDirectionFormatterTests.swift in Sources */,
 				0CDFEB0D25A7745A008BC505 /* UtilsTests.swift in Sources */,
 				CA548FFB251C404B00F829A3 /* StyleURITests.swift in Sources */,

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -3,7 +3,7 @@
 import UIKit
 import Turf
 
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable file_length
 
 internal typealias PendingAnimationCompletion = (completion: AnimationCompletion, animatingPosition: UIViewAnimatingPosition)
 

--- a/Sources/MapboxMaps/Foundation/DelegatingMapClient.swift
+++ b/Sources/MapboxMaps/Foundation/DelegatingMapClient.swift
@@ -1,0 +1,23 @@
+import MapboxCoreMaps
+
+internal protocol DelegatingMapClientDelegate: AnyObject {
+    func scheduleRepaint()
+    func scheduleTask(forTask task: @escaping Task)
+    func getMetalView(for metalDevice: MTLDevice?) -> MTKView?
+}
+
+internal final class DelegatingMapClient: MapClient, MBMMetalViewProvider {
+    internal weak var delegate: DelegatingMapClientDelegate?
+
+    internal func scheduleRepaint() {
+        delegate?.scheduleRepaint()
+    }
+
+    internal func scheduleTask(forTask task: @escaping Task) {
+        delegate?.scheduleTask(forTask: task)
+    }
+
+    internal func getMetalView(for metalDevice: MTLDevice?) -> MTKView? {
+        return delegate?.getMetalView(for: metalDevice)
+    }
+}

--- a/Sources/MapboxMaps/Foundation/DelegatingObserver.swift
+++ b/Sources/MapboxMaps/Foundation/DelegatingObserver.swift
@@ -1,0 +1,13 @@
+import MapboxCoreMaps
+
+internal protocol DelegatingObserverDelegate: AnyObject {
+    func notify(for event: MapboxCoreMaps.Event)
+}
+
+internal final class DelegatingObserver: Observer {
+    internal weak var delegate: DelegatingObserverDelegate?
+
+    internal func notify(for event: MapboxCoreMaps.Event) {
+        delegate?.notify(for: event)
+    }
+}

--- a/Sources/MapboxMaps/Foundation/PreferredFPS.swift
+++ b/Sources/MapboxMaps/Foundation/PreferredFPS.swift
@@ -1,0 +1,50 @@
+public enum PreferredFPS: RawRepresentable, Equatable {
+
+    /**
+     Create a `PreferredFPS` value from an `Int`.
+     - Parameter rawValue: The `Int` value to use as the preferred frames per second.
+     */
+    public init?(rawValue: Int) {
+        switch rawValue {
+        case Self.lowPower.rawValue:
+            self = .lowPower
+        case Self.normal.rawValue:
+            self = .normal
+        case Self.maximum.rawValue:
+            self = .maximum
+        default:
+            self = .custom(fps: rawValue)
+        }
+    }
+
+    public typealias RawValue = Int
+
+    /// The default frame rate. This can be either 30 FPS or 60 FPS, depending on
+    /// device capabilities.
+    case normal
+
+    /// A conservative frame rate; typically 30 FPS.
+    case lowPower
+
+    /// The maximum supported frame rate; typically 60 FPS.
+    case maximum
+
+    /// A custom frame rate. The default value is 30 FPS.
+    case custom(fps: Int)
+
+    /// The preferred frames per second as an `Int` value.
+    public var rawValue: Int {
+        switch self {
+        case .lowPower:
+            return 30
+        case .normal:
+            return -1
+        case .maximum:
+            return 0
+        case .custom(let fps):
+            // TODO: Check that value is a valid FPS value.
+            return fps
+        }
+    }
+
+}

--- a/Tests/MapboxMapsTests/Foundation/DelegatingMapClientTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/DelegatingMapClientTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import MapboxMaps
+
+final class DelegatingMapClientTests: XCTestCase {
+
+    var delegatingMapClient: DelegatingMapClient!
+    // swiftlint:disable:next weak_delegate
+    var delegate: MockDelegatingMapClientDelegate!
+
+    override func setUp() {
+        super.setUp()
+        delegatingMapClient = DelegatingMapClient()
+        delegate = MockDelegatingMapClientDelegate()
+        delegatingMapClient.delegate = delegate
+    }
+
+    override func tearDown() {
+        delegate = nil
+        delegatingMapClient = nil
+        super.tearDown()
+    }
+
+    func testScheduleRepaintForwardsToDelegate() {
+        delegatingMapClient.scheduleRepaint()
+
+        XCTAssertEqual(delegate.scheduleRepaintStub.invocations.count, 1)
+    }
+
+    func testScheduleTaskForwardsToDelegate() {
+        var invoked = false
+
+        delegatingMapClient.scheduleTask {
+            invoked = true
+        }
+        delegate.scheduleTaskStub.parameters.first?()
+
+        XCTAssertEqual(delegate.scheduleTaskStub.invocations.count, 1)
+        XCTAssertTrue(invoked)
+    }
+
+    func testGetMetalViewForwardsToDelegate() {
+        let expectedDevice = MTLCreateSystemDefaultDevice()
+        let expectedView = MTKView()
+        delegate.getMetalViewStub.defaultReturnValue = expectedView
+
+        let actualView = delegatingMapClient.getMetalView(for: expectedDevice)
+
+        XCTAssertEqual(delegate.getMetalViewStub.invocations.count, 1)
+        guard let actualDevice = delegate.getMetalViewStub.parameters.first else {
+            return
+        }
+        if case let .some(actual) = actualDevice,
+           let expected = expectedDevice {
+            XCTAssertTrue(actual === expected)
+        } else {
+            XCTAssertNil(actualDevice)
+            XCTAssertNil(expectedDevice)
+        }
+        XCTAssertEqual(actualView, expectedView)
+    }
+}

--- a/Tests/MapboxMapsTests/Foundation/DelegatingObserverTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/DelegatingObserverTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import MapboxMaps
+
+final class DelegatingObserverTests: XCTestCase {
+
+    var delegatingObserver: DelegatingObserver!
+    // swiftlint:disable:next weak_delegate
+    var delegate: MockDelegatingObserverDelegate!
+
+    override func setUp() {
+        super.setUp()
+        delegatingObserver = DelegatingObserver()
+        delegate = MockDelegatingObserverDelegate()
+        delegatingObserver.delegate = delegate
+    }
+
+    override func tearDown() {
+        delegate = nil
+        delegatingObserver = nil
+        super.tearDown()
+    }
+
+    func testNotifyForwardsToDelegate() {
+        let expectedEvent = Event()
+
+        delegatingObserver.notify(for: expectedEvent)
+
+        XCTAssertEqual(delegate.notifyStub.invocations.count, 1)
+        XCTAssertEqual(delegate.notifyStub.parameters.first, expectedEvent)
+    }
+}

--- a/Tests/MapboxMapsTests/Foundation/MockDelegatingMapClientDelegate.swift
+++ b/Tests/MapboxMapsTests/Foundation/MockDelegatingMapClientDelegate.swift
@@ -1,0 +1,18 @@
+@testable import MapboxMaps
+
+final class MockDelegatingMapClientDelegate: DelegatingMapClientDelegate {
+    let scheduleRepaintStub = Stub<Void, Void>()
+    func scheduleRepaint() {
+        scheduleRepaintStub.call()
+    }
+
+    let scheduleTaskStub = Stub<Task, Void>()
+    func scheduleTask(forTask task: @escaping Task) {
+        scheduleTaskStub.call(with: task)
+    }
+
+    let getMetalViewStub = Stub<MTLDevice?, MTKView?>(defaultReturnValue: nil)
+    func getMetalView(for metalDevice: MTLDevice?) -> MTKView? {
+        return getMetalViewStub.call(with: metalDevice)
+    }
+}

--- a/Tests/MapboxMapsTests/Foundation/MockDelegatingObserverDelegate.swift
+++ b/Tests/MapboxMapsTests/Foundation/MockDelegatingObserverDelegate.swift
@@ -1,0 +1,8 @@
+@testable import MapboxMaps
+
+final class MockDelegatingObserverDelegate: DelegatingObserverDelegate {
+    let notifyStub = Stub<Event, Void>()
+    func notify(for event: Event) {
+        notifyStub.call(with: event)
+    }
+}

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/Map/MapViewIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/Map/MapViewIntegrationTests.swift
@@ -76,7 +76,7 @@ class MapViewIntegrationTests: IntegrationTestCase {
 
         mapView.pendingAnimatorCompletionBlocks.append(firstCompletion)
         mapView.pendingAnimatorCompletionBlocks.append(secondCompletion)
-        mapView.needsDisplayRefresh = true
+        mapView.scheduleRepaint()
         XCTAssertEqual(mapView.pendingAnimatorCompletionBlocks.count, 2)
 
         mapView.updateFromDisplayLink(displayLink: CADisplayLink())


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Update changelog

### Summary of changes

Implement Core interfaces via delegation

- [breaking] BaseMapView no longer conforms to MapClient or MBMMetalViewProvider.
  Instead, it owns and acts as the delegate for a DelegatingMapClient
  which implements the protocols instead. This allows the required
  methods to be internal instead of public.
- [breaking] Snapshotter no longer conforms to Observer
- ObserverConcrete was refactored into DelegatingObserver and is now
  used by both BaseMapView and Snapshotter.

Misc ACL Changes

- BaseMapView setters for __map, metalView, resourceOptions,
  mapInitOptionsDataSource, and cameraView are now private
- BaseMapView properties needsDisplayRefresh, dormant, displayCallback,
  and styleURI__ are now private
- Snapshotter.eventHandlers is now private

Other Refactoring

- The metal support checks in BaseMapView.commonInit were factored out
  into a separate helper method to avoid the need for a local variable
- In awakeFromNib(), the default styleURI is accessed via StyleURI
  rather than via a string literal.
- PreferredFPS moved to separate file
- Adds test xib to Xcode project