### PR TITLE
Prevent ambigous Polygon usage when Turf is imported externally

### DIFF
--- a/Sources/MapboxMaps/Annotations/AnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationManager.swift
@@ -386,7 +386,7 @@ public class AnnotationManager {
         case let line as LineAnnotation:
             feature = Feature(LineString(line.coordinates))
         case let polygon as PolygonAnnotation:
-            var turfPolygon: Polygon
+            var turfPolygon: Turf.Polygon
 
             if let holes = polygon.interiorPolygons {
                 let outerRing = Ring(coordinates: polygon.coordinates)

--- a/Sources/MapboxMaps/Foundation/Extensions/Turf/Feature.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Turf/Feature.swift
@@ -45,7 +45,7 @@ extension Feature {
 
     /// Initialize a `Turf.Feature` with a `Polygon`.
     /// - Parameter polygon: The `Polygon` to use to create the `Turf.Feature`.
-    public init(_ polygon: Polygon) {
+    public init(_ polygon: Turf.Polygon) {
         self.init(geometry: Geometry.polygon(polygon))
     }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: Compiler may detect Ambiguous references to Polygon when Turf is imported into a project along with Mapbox Maps.

## Pull request checklist:
 - [ X ] Briefly describe the changes in this PR.
 - [N/A] Include before/after visuals or gifs if this PR includes visual changes.
 - [N/A] Write tests for all new functionality. If tests were not written, please explain why.
 - [N/A] Add example if relevant.
 - [N/A] Document any changes to public APIs.
 - [bug :beetle:] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ X ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Prevent ambiguous references to Polygon by explicitly referencing Turf</changelog>`.
 - [N/A] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

Explicitly reference the Turf library when referring to Polygons.

### User impact (optional)
No Visual Changes
<!--
If this PR introduces user-facing changes, please note them here.
-->
