### PR TITLE
Cleaning up StyleTransition to use swift values

### DIFF
--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		B5B55D5F260E4D7B00EBB589 /* CameraAnimatorDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B55D56260E4D7500EBB589 /* CameraAnimatorDelegateMock.swift */; };
 		B5B55D60260E4D7B00EBB589 /* CameraAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B55D55260E4D7500EBB589 /* CameraAnimatorTests.swift */; };
 		B5DDE9602613ACB400998840 /* StyleEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DDE95F2613ACB400998840 /* StyleEncodable.swift */; };
+		C6334944262E28C300D17701 /* StyleTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6334943262E28C300D17701 /* StyleTransitionTests.swift */; };
 		C64994A9258D5ADE0052C21C /* LocationPuckManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64994A5258D5ADD0052C21C /* LocationPuckManager.swift */; };
 		C64994AB258D5ADE0052C21C /* Puck.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64994A6258D5ADE0052C21C /* Puck.swift */; };
 		C64994AD258D5ADE0052C21C /* IndicatorAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C64994A7258D5ADE0052C21C /* IndicatorAssets.xcassets */; };
@@ -618,6 +619,7 @@
 		B5B55D55260E4D7500EBB589 /* CameraAnimatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraAnimatorTests.swift; sourceTree = "<group>"; };
 		B5B55D56260E4D7500EBB589 /* CameraAnimatorDelegateMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraAnimatorDelegateMock.swift; sourceTree = "<group>"; };
 		B5DDE95F2613ACB400998840 /* StyleEncodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleEncodable.swift; sourceTree = "<group>"; };
+		C6334943262E28C300D17701 /* StyleTransitionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleTransitionTests.swift; sourceTree = "<group>"; };
 		C64994A5258D5ADD0052C21C /* LocationPuckManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationPuckManager.swift; sourceTree = "<group>"; };
 		C64994A6258D5ADE0052C21C /* Puck.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Puck.swift; sourceTree = "<group>"; };
 		C64994A7258D5ADE0052C21C /* IndicatorAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = IndicatorAssets.xcassets; sourceTree = "<group>"; };
@@ -1381,6 +1383,7 @@
 		A4519DD92432FF03007CF39A /* MapboxMapsStyleTests */ = {
 			isa = PBXGroup;
 			children = (
+				C6334943262E28C300D17701 /* StyleTransitionTests.swift */,
 				0C59ED2025CC6D5400C72E7A /* ExpressionTests */,
 				0C5CFD1825BB961B0001E753 /* Fixtures */,
 				0C5CFCC425BB951A0001E753 /* Generated */,
@@ -2122,6 +2125,7 @@
 				CAA73A9D256F750B00E14EE0 /* FlyToTests.swift in Sources */,
 				B53B8763260D73D600C86BAA /* Puck3DIntegrationTests.swift in Sources */,
 				CAD7BA0625A368DE00E64C78 /* ExampleIntegrationTest.swift in Sources */,
+				C6334944262E28C300D17701 /* StyleTransitionTests.swift in Sources */,
 				CA99A8702540CD1900D16C78 /* StyleLoadIntegrationTests.swift in Sources */,
 				CA548FF5251C404B00F829A3 /* Fixture.swift in Sources */,
 				0C5CFCD325BB951B0001E753 /* RasterLayerTests.swift in Sources */,

--- a/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
@@ -191,7 +191,7 @@ private extension Puck2D {
             location.coordinate.longitude,
             location.internalLocation.altitude
         ])
-        paint.locationTransition = StyleTransition(duration: 500, delay: 0)
+        paint.locationTransition = StyleTransition(duration: 0.5, delay: 0)
         paint.topImageSize = configuration.resolvedScale
         paint.bearingImageSize = configuration.resolvedScale
         paint.shadowImageSize = configuration.resolvedScale

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -416,6 +416,11 @@ public class Style {
  */
 public struct StyleTransition: Codable {
 
+    public enum CodingKeys: String, CodingKey {
+        case duration
+        case delay
+    }
+
     /// Time allotted for transitions to complete in milliseconds.
     public var duration: TimeInterval = 0
 
@@ -427,8 +432,8 @@ public struct StyleTransition: Codable {
     ///   - duration: Time for transition in milliseconds.
     ///   - delay: Time before transition begins in milliseconds.
     public init(duration: TimeInterval, delay: TimeInterval) {
-        self.duration = duration * 1000
-        self.delay = delay * 1000
+        self.duration = duration
+        self.delay = delay
     }
 
     public init(from decoder: Decoder) throws {
@@ -436,5 +441,10 @@ public struct StyleTransition: Codable {
 
         duration = try container.decode(Double.self, forKey: .duration) * 1000
         delay = try container.decode(Double.self, forKey: .delay) * 1000
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self)
     }
 }

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -416,7 +416,7 @@ public class Style {
  */
 public struct StyleTransition: Codable {
 
-    public enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: String, CodingKey {
         case duration
         case delay
     }
@@ -439,12 +439,14 @@ public struct StyleTransition: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        duration = try container.decode(Double.self, forKey: .duration) * 1000
-        delay = try container.decode(Double.self, forKey: .delay) * 1000
+        duration = try container.decode(Double.self, forKey: .duration) / 1000
+        delay = try container.decode(Double.self, forKey: .delay) / 1000
     }
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        duration = try container.encode(Double.self, forKey: .duration) * 1000
+        delay = try container.encode(Double.self, forKey: .delay) * 1000
     }
 }

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -427,7 +427,14 @@ public struct StyleTransition: Codable {
     ///   - duration: Time for transition in milliseconds.
     ///   - delay: Time before transition begins in milliseconds.
     public init(duration: TimeInterval, delay: TimeInterval) {
-        self.duration = duration
-        self.delay = delay
+        self.duration = duration * 1000
+        self.delay = delay * 1000
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        duration = try container.decode(Double.self, forKey: .duration) * 1000
+        delay = try container.decode(Double.self, forKey: .delay) * 1000
     }
 }

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -421,16 +421,16 @@ public struct StyleTransition: Codable {
         case delay
     }
 
-    /// Time allotted for transitions to complete in milliseconds.
+    /// Time allotted for transitions to complete in seconds.
     public var duration: TimeInterval = 0
 
-    /// Length of time before a transition begins in milliseconds.
+    /// Length of time before a transition begins in seconds.
     public var delay: TimeInterval = 0
 
     /// Initiralizer for `StyleTransition`
     /// - Parameters:
-    ///   - duration: Time for transition in milliseconds.
-    ///   - delay: Time before transition begins in milliseconds.
+    ///   - duration: Time for transition in seconds.
+    ///   - delay: Time before transition begins in seconds.
     public init(duration: TimeInterval, delay: TimeInterval) {
         self.duration = duration
         self.delay = delay
@@ -446,7 +446,7 @@ public struct StyleTransition: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        duration = try container.encode(Double.self, forKey: .duration) * 1000
-        delay = try container.encode(Double.self, forKey: .delay) * 1000
+        try container.encode(duration * 1000, forKey: .duration)
+        try container.encode(delay * 1000, forKey: .delay)
     }
 }

--- a/Tests/MapboxMapsTests/Style/StyleTransitionTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleTransitionTests.swift
@@ -6,8 +6,6 @@ class StyleTransitionTests: XCTestCase {
     let jsonString = "{\"delay\":500,\"duration\":1000}"
 
     func testDecodeHasCorrectConversion() {
-
-
         let jsonData = jsonString.data(using: .utf8)!
         let decodedTransition = try! JSONDecoder().decode(StyleTransition.self, from: jsonData)
         let comparingTransition = StyleTransition(duration: 1.0, delay: 0.5)

--- a/Tests/MapboxMapsTests/Style/StyleTransitionTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleTransitionTests.swift
@@ -8,11 +8,8 @@ class StyleTransitionTests: XCTestCase {
     func testDecodeHasCorrectConversion() {
         let jsonData = jsonString.data(using: .utf8)!
         let decodedTransition = try! JSONDecoder().decode(StyleTransition.self, from: jsonData)
-        let comparingTransition = StyleTransition(duration: 1.0, delay: 0.5)
 
-        XCTAssertEqual(comparingTransition.duration, 1.0, "Duration should be equal to 1.0")
         XCTAssertEqual(decodedTransition.duration, 1.0, "Duration should be equal to 1.0")
-        XCTAssertEqual(comparingTransition.delay, 0.5, "Delay should be equal to 0.5")
         XCTAssertEqual(decodedTransition.delay, 0.5, "Delay should be equal to 0.5")
     }
 

--- a/Tests/MapboxMapsTests/Style/StyleTransitionTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleTransitionTests.swift
@@ -3,14 +3,10 @@ import XCTest
 @testable import MapboxMaps
 
 class StyleTransitionTests: XCTestCase {
+    let jsonString = "{\"delay\":500,\"duration\":1000}"
 
     func testDecodeHasCorrectConversion() {
-        let jsonString = """
-        {
-            "duration": 1000,
-            "delay": 500
-        }
-        """
+
 
         let jsonData = jsonString.data(using: .utf8)!
         let decodedTransition = try! JSONDecoder().decode(StyleTransition.self, from: jsonData)
@@ -25,10 +21,8 @@ class StyleTransitionTests: XCTestCase {
     func testEncodeHasCorrectConversion() {
         let transition = StyleTransition(duration: 1.0, delay: 0.5)
         let encodedTransition = try! JSONEncoder().encode(transition)
+        let dataString = String(data: encodedTransition, encoding: .utf8)
 
-        let decodedTransition = try! JSONDecoder().decode(StyleTransition.self, from: encodedTransition)
-
-        XCTAssertEqual(transition.duration, decodedTransition.duration, "Duration should be equal to 1.0")
-        XCTAssertEqual(transition.delay, decodedTransition.delay, "Delay should be equal to 0.5")
+        XCTAssertEqual(dataString, jsonString)
     }
 }

--- a/Tests/MapboxMapsTests/Style/StyleTransitionTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleTransitionTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+#if canImport(MapboxMaps)
+@testable import MapboxMaps
+#else
+@testable import MapboxMapsStyle
+#endif
+
+//swiftlint:disable explicit_top_level_acl explicit_acl
+class StyleTransitionTests: XCTestCase {
+
+    func testDecodeHasCorrectConversion() {
+        let jsonString = """
+        {
+            "duration": 1000,
+            "delay": 500
+        }
+        """
+
+        if let jsonData = jsonString.data(using: .utf8) {
+            let decodedTransition = try! JSONDecoder().decode(StyleTransition.self, from: jsonData)
+            let comparingTransition = StyleTransition(duration: 1.0, delay: 0.5)
+
+            XCTAssertEqual(comparingTransition.duration, decodedTransition.duration, "Duration should be equal to 1.0")
+            XCTAssertNotEqual(decodedTransition.duration, 1000, "Duration should be equal to 1.0")
+            XCTAssertEqual(comparingTransition.delay, decodedTransition.delay, "Delay should be equal to 0.5")
+            XCTAssertNotEqual(decodedTransition.delay, 500, "Duration should be equal to 1.0")
+        }
+    }
+
+    func testEncodeHasCorrectConversion() {
+        let transition = StyleTransition(duration: 1.0, delay: 0.5)
+        let encodedTransition = try! JSONEncoder().encode(transition)
+
+        let decodedTransition = try! JSONDecoder().decode(StyleTransition.self, from: encodedTransition)
+
+        XCTAssertEqual(transition.duration, decodedTransition.duration, "Duration should be equal to 1.0")
+        XCTAssertEqual(transition.delay, decodedTransition.delay, "Delay should be equal to 0.5")
+    }
+}

--- a/Tests/MapboxMapsTests/Style/StyleTransitionTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleTransitionTests.swift
@@ -1,12 +1,7 @@
 import XCTest
 
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
-//swiftlint:disable explicit_top_level_acl explicit_acl
 class StyleTransitionTests: XCTestCase {
 
     func testDecodeHasCorrectConversion() {
@@ -17,15 +12,14 @@ class StyleTransitionTests: XCTestCase {
         }
         """
 
-        if let jsonData = jsonString.data(using: .utf8) {
-            let decodedTransition = try! JSONDecoder().decode(StyleTransition.self, from: jsonData)
-            let comparingTransition = StyleTransition(duration: 1.0, delay: 0.5)
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedTransition = try! JSONDecoder().decode(StyleTransition.self, from: jsonData)
+        let comparingTransition = StyleTransition(duration: 1.0, delay: 0.5)
 
-            XCTAssertEqual(comparingTransition.duration, decodedTransition.duration, "Duration should be equal to 1.0")
-            XCTAssertNotEqual(decodedTransition.duration, 1000, "Duration should be equal to 1.0")
-            XCTAssertEqual(comparingTransition.delay, decodedTransition.delay, "Delay should be equal to 0.5")
-            XCTAssertNotEqual(decodedTransition.delay, 500, "Duration should be equal to 1.0")
-        }
+        XCTAssertEqual(comparingTransition.duration, 1.0, "Duration should be equal to 1.0")
+        XCTAssertEqual(decodedTransition.duration, 1.0, "Duration should be equal to 1.0")
+        XCTAssertEqual(comparingTransition.delay, 0.5, "Delay should be equal to 0.5")
+        XCTAssertEqual(decodedTransition.delay, 0.5, "Delay should be equal to 0.5")
     }
 
     func testEncodeHasCorrectConversion() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Document any changes to public APIs.

### Summary of changes
Updated the StyleTransition so that swift code will be in seconds and conversions are handled in the SDK, since Core uses milliseconds.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
