### PR TITLE
Remove a hardcoded value for scale factor

### DIFF
--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -181,8 +181,9 @@ public class Style {
             return .failure(.convertingImageFailed(nil))
         }
 
+        let screenScale = Float(UIScreen.main.scale)
         let expected = styleManager.addStyleImage(forImageId: identifier,
-                                                  scale: 3.0,
+                                                  scale: screenScale,
                                                   image: mbxImage,
                                                   sdf: sdf,
                                                   stretchX: stretchX,

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -181,9 +181,8 @@ public class Style {
             return .failure(.convertingImageFailed(nil))
         }
 
-        let screenScale = Float(UIScreen.main.scale)
         let expected = styleManager.addStyleImage(forImageId: identifier,
-                                                  scale: screenScale,
+                                                  scale: image.scale,
                                                   image: mbxImage,
                                                   sdf: sdf,
                                                   stretchX: stretchX,

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -182,7 +182,7 @@ public class Style {
         }
 
         let expected = styleManager.addStyleImage(forImageId: identifier,
-                                                  scale: image.scale,
+                                                  scale: Float(image.scale),
                                                   image: mbxImage,
                                                   sdf: sdf,
                                                   stretchX: stretchX,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: #251

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Fixed an issue where the scale for a style image didn't provided image scale.</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR removes a hardcoded value for scaling the size of style images. 
### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
