### PR TITLE
Remove the `manager` suffix from the MapView's manager properties

### DIFF
--- a/Apps/Examples/Examples/All Examples/AnimateGeoJSONLineExample.swift
+++ b/Apps/Examples/Examples/All Examples/AnimateGeoJSONLineExample.swift
@@ -21,7 +21,7 @@ public class AnimateGeoJSONLineExample: UIViewController, ExampleProtocol {
 
         let centerCoordinate = CLLocationCoordinate2D(latitude: 45.5076, longitude: -122.6736)
 
-        mapView.cameraManager.setCamera(to: CameraOptions(center: centerCoordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: centerCoordinate,
                                                           zoom: 11.0))
 
         // Wait for the map to load its style before adding data.

--- a/Apps/Examples/Examples/All Examples/AnimateLayerExample.swift
+++ b/Apps/Examples/Examples/All Examples/AnimateLayerExample.swift
@@ -23,7 +23,7 @@ public class AnimateLayerExample: UIViewController, ExampleProtocol {
         let centerCoordinate = CLLocationCoordinate2D(latitude: 37.8,
                                                       longitude: -96)
 
-        mapView.cameraManager.setCamera(to: CameraOptions(center: centerCoordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: centerCoordinate,
                                                           zoom: 2))
 
         // Allows the view controller to receive information about map events.

--- a/Apps/Examples/Examples/All Examples/BuildingExtrusionsExample.swift
+++ b/Apps/Examples/Examples/All Examples/BuildingExtrusionsExample.swift
@@ -25,7 +25,7 @@ public class BuildingExtrusionsExample: UIViewController, ExampleProtocol {
                                           zoom: 15.5,
                                           bearing: -17.6,
                                           pitch: 45)
-        mapView.cameraManager.setCamera(to: cameraOptions)
+        mapView.camera.setCamera(to: cameraOptions)
 
         // The below lines are used for internal testing purposes only.
         DispatchQueue.main.asyncAfter(deadline: .now()+5.0) {

--- a/Apps/Examples/Examples/All Examples/CameraAnimationExample.swift
+++ b/Apps/Examples/Examples/All Examples/CameraAnimationExample.swift
@@ -29,7 +29,7 @@ public class CameraAnimationExample: UIViewController, ExampleProtocol {
                                           bearing: 180.0,
                                           pitch: 15.0)
 
-            self.mapView.cameraManager.setCamera(to: newCamera,
+            self.mapView.camera.setCamera(to: newCamera,
                                                  animated: true,
                                                  duration: 5.0) { _ in
                 // The below line is used for internal testing purposes only.

--- a/Apps/Examples/Examples/All Examples/CameraAnimatorsExample.swift
+++ b/Apps/Examples/Examples/All Examples/CameraAnimatorsExample.swift
@@ -9,7 +9,7 @@ public class CameraAnimatorsExample: UIViewController, ExampleProtocol {
 
     // Store the CameraAnimators so that the do not fall out of scope.
     lazy var zoomAnimator: CameraAnimator = {
-        let animator = mapView.cameraManager.makeCameraAnimator(duration: 4, curve: .easeInOut) { [unowned self] in
+        let animator = mapView.camera.makeCameraAnimator(duration: 4, curve: .easeInOut) { [unowned self] in
             self.mapView.zoom = 14
         }
 
@@ -21,7 +21,7 @@ public class CameraAnimatorsExample: UIViewController, ExampleProtocol {
     }()
 
     lazy var pitchAnimator: CameraAnimator = {
-        let animator = mapView.cameraManager.makeCameraAnimator(duration: 2, curve: .easeInOut) { [unowned self] in
+        let animator = mapView.camera.makeCameraAnimator(duration: 2, curve: .easeInOut) { [unowned self] in
             self.mapView.pitch = 55
         }
 
@@ -33,7 +33,7 @@ public class CameraAnimatorsExample: UIViewController, ExampleProtocol {
     }()
 
     lazy var bearingAnimator: CameraAnimator = {
-        let animator = mapView.cameraManager.makeCameraAnimator(duration: 4, curve: .easeInOut) { [unowned self] in
+        let animator = mapView.camera.makeCameraAnimator(duration: 4, curve: .easeInOut) { [unowned self] in
             self.mapView.bearing = -45
         }
 
@@ -53,7 +53,7 @@ public class CameraAnimatorsExample: UIViewController, ExampleProtocol {
 
         // Center the map over New York City.
         let newYork = CLLocationCoordinate2D(latitude: 40.7128, longitude: -74.0060)
-        mapView.cameraManager.setCamera(to: CameraOptions(center: newYork))
+        mapView.camera.setCamera(to: CameraOptions(center: newYork))
 
         // Allows the delegate to receive information about map events.
         mapView.on(.mapLoaded) { [weak self] _ in

--- a/Apps/Examples/Examples/All Examples/ColorExpressionExample.swift
+++ b/Apps/Examples/Examples/All Examples/ColorExpressionExample.swift
@@ -18,7 +18,7 @@ public class ColorExpressionExample: UIViewController, ExampleProtocol {
         let centerCoordinate = CLLocationCoordinate2D(latitude: 40.58058466412761,
                                                       longitude: -97.734375)
 
-        mapView.cameraManager.setCamera(to: CameraOptions(center: centerCoordinate, zoom: 3))
+        mapView.camera.setCamera(to: CameraOptions(center: centerCoordinate, zoom: 3))
 
         // Allows the view controller to receive information about map events.
         mapView.on(.mapLoaded) { [weak self] _ in

--- a/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
@@ -34,7 +34,7 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
         }
 
         let coordinate = CLLocationCoordinate2D(latitude: 39.085006, longitude: -77.150925)
-        mapView.cameraManager.setCamera(to: CameraOptions(center: coordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: coordinate,
                                                           zoom: 14,
                                                           pitch: 0))
     }

--- a/Apps/Examples/Examples/All Examples/Custom3DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom3DPuckExample.swift
@@ -72,7 +72,7 @@ public class Custom3DPuckExample: UIViewController, ExampleProtocol {
         }
 
         let coordinate = CLLocationCoordinate2D(latitude: 39.085006, longitude: -77.150925)
-        mapView.cameraManager.setCamera(to: CameraOptions(center: coordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: coordinate,
                                                           zoom: 14,
                                                           pitch: 80))
     }

--- a/Apps/Examples/Examples/All Examples/CustomPointAnnotationExample.swift
+++ b/Apps/Examples/Examples/All Examples/CustomPointAnnotationExample.swift
@@ -17,7 +17,7 @@ public class CustomPointAnnotationExample: UIViewController, ExampleProtocol {
         // Center the map camera over New York City
         let centerCoordinate = CLLocationCoordinate2D(latitude: 40.7128, longitude: -74.0060)
 
-        mapView.cameraManager.setCamera(to: CameraOptions(center: centerCoordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: centerCoordinate,
                                                           zoom: 9.0))
 
         // Allows the delegate to receive information about map events.
@@ -34,7 +34,7 @@ public class CustomPointAnnotationExample: UIViewController, ExampleProtocol {
                                                         image: UIImage(named: "star"))
 
             // Add the annotation to the map.
-            self.mapView.annotationManager.addAnnotation(customPointAnnotation)
+            self.mapView.annotations.addAnnotation(customPointAnnotation)
 
             // The below line is used for internal testing purposes only.
             self.finish()

--- a/Apps/Examples/Examples/All Examples/DataDrivenSymbolsExample.swift
+++ b/Apps/Examples/Examples/All Examples/DataDrivenSymbolsExample.swift
@@ -17,7 +17,7 @@ public class DataDrivenSymbolsExample: UIViewController, ExampleProtocol {
         // Set center location
         let centerCoordinate = CLLocationCoordinate2D(latitude: 37.761, longitude: -119.624)
 
-        mapView.cameraManager.setCamera(to: CameraOptions(center: centerCoordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: centerCoordinate,
                                                           zoom: 10.0))
 
         // Allows the delegate to receive information about map events.

--- a/Apps/Examples/Examples/All Examples/ExternalVectorSourceExample.swift
+++ b/Apps/Examples/Examples/All Examples/ExternalVectorSourceExample.swift
@@ -12,7 +12,7 @@ public class ExternalVectorSourceExample: UIViewController, ExampleProtocol {
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.style.uri = .light
         let centerCoordinate = CLLocationCoordinate2D(latitude: 41.878781, longitude: -87.622088)
-        mapView.cameraManager.setCamera(to: CameraOptions(center: centerCoordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: centerCoordinate,
                                                           zoom: 12))
         view.addSubview(mapView)
 

--- a/Apps/Examples/Examples/All Examples/FeaturesAtPointExample.swift
+++ b/Apps/Examples/Examples/All Examples/FeaturesAtPointExample.swift
@@ -18,7 +18,7 @@ public class FeaturesAtPointExample: UIViewController, ExampleProtocol {
         let centerCoordinate = CLLocationCoordinate2D(latitude: 39.368279,
                                                       longitude: -97.646484)
 
-        mapView.cameraManager.setCamera(to: CameraOptions(center: centerCoordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: centerCoordinate,
                                                           zoom: 2.4))
 
         // Allows the view controller to receive information about map events.

--- a/Apps/Examples/Examples/All Examples/FitCameraToGeometryExample.swift
+++ b/Apps/Examples/Examples/All Examples/FitCameraToGeometryExample.swift
@@ -54,8 +54,8 @@ public class FitCameraToGeometryExample: UIViewController, ExampleProtocol {
             displayAlert(message: layerError.localizedDescription)
         }
 
-        let newCamera = mapView.cameraManager.camera(fitting: polygon)
-        mapView.cameraManager.setCamera(to: newCamera) { _ in
+        let newCamera = mapView.camera.camera(fitting: polygon)
+        mapView.camera.setCamera(to: newCamera) { _ in
             // The below line is used for internal testing purposes only.
             self.finish()
         }

--- a/Apps/Examples/Examples/All Examples/FlyToExample.swift
+++ b/Apps/Examples/Examples/All Examples/FlyToExample.swift
@@ -16,7 +16,7 @@ public class FlyToExample: UIViewController, ExampleProtocol {
         view.addSubview(mapView)
 
         // Center the map over San Francisco.
-        mapView.cameraManager.setCamera(to: CameraOptions(center: .sanfrancisco,
+        mapView.camera.setCamera(to: CameraOptions(center: .sanfrancisco,
                                                           zoom: 15))
 
         // Allows the view controller to receive information about map events.
@@ -35,7 +35,7 @@ public class FlyToExample: UIViewController, ExampleProtocol {
                                 bearing: 180,
                                 pitch: 50)
 
-        flyToAnimator = self.mapView.cameraManager.fly(to: end) { [weak self] _ in
+        flyToAnimator = self.mapView.camera.fly(to: end) { [weak self] _ in
             print("Camera fly-to finished")
             // The below line is used for internal testing purposes only.
             self?.flyToAnimator = nil

--- a/Apps/Examples/Examples/All Examples/LayerBelowExample.swift
+++ b/Apps/Examples/Examples/All Examples/LayerBelowExample.swift
@@ -18,7 +18,7 @@ public class LayerBelowExample: UIViewController, ExampleProtocol {
                                                       longitude: -88.137343)
 
         // Zoom to cover the whole Atlanta urban area
-        mapView.cameraManager.setCamera(to: CameraOptions(center: centerCoordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: centerCoordinate,
                                                           zoom: 4))
 
         // Allows the view controller to receive information about map events

--- a/Apps/Examples/Examples/All Examples/LayerPositionExample.swift
+++ b/Apps/Examples/Examples/All Examples/LayerPositionExample.swift
@@ -21,7 +21,7 @@ public class LayerPositionExample: UIViewController, ExampleProtocol {
         let centerCoordinate = CLLocationCoordinate2D(latitude: 40.58058466412761,
                                                       longitude: -97.734375)
 
-        mapView.cameraManager.setCamera(to: CameraOptions(center: centerCoordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: centerCoordinate,
                                                           zoom: 3))
 
         // Allows the view controller to receive information about map events.

--- a/Apps/Examples/Examples/All Examples/LineAnnotationExample.swift
+++ b/Apps/Examples/Examples/All Examples/LineAnnotationExample.swift
@@ -16,7 +16,7 @@ public class LineAnnotationExample: UIViewController, ExampleProtocol {
 
         let centerCoordinate = CLLocationCoordinate2D(latitude: 39.7128, longitude: -75.0060)
 
-        mapView.cameraManager.setCamera(to: CameraOptions(center: centerCoordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: centerCoordinate,
                                                           zoom: 5.0))
 
         // Allows the delegate to receive information about map events.
@@ -34,7 +34,7 @@ public class LineAnnotationExample: UIViewController, ExampleProtocol {
             let lineAnnotation = LineAnnotation(coordinates: lineCoordinates)
 
             // Add the annotation to the map.
-            self.mapView.annotationManager.addAnnotation(lineAnnotation)
+            self.mapView.annotations.addAnnotation(lineAnnotation)
 
             // The below line is used for internal testing purposes only.
             self.finish()

--- a/Apps/Examples/Examples/All Examples/LineGradientExample.swift
+++ b/Apps/Examples/Examples/All Examples/LineGradientExample.swift
@@ -21,7 +21,7 @@ public class LineGradientExample: UIViewController, ExampleProtocol {
             // Set the center coordinate and zoom level.
             let centerCoordinate = CLLocationCoordinate2D(latitude: 38.875, longitude: -77.035)
             let camera = CameraOptions(center: centerCoordinate, zoom: 12.0)
-            self?.mapView.cameraManager.setCamera(to: camera, animated: true, duration: 0, completion: nil)
+            self?.mapView.camera.setCamera(to: camera, animated: true, duration: 0, completion: nil)
         }
     }
 

--- a/Apps/Examples/Examples/All Examples/PointAnnotationExample.swift
+++ b/Apps/Examples/Examples/All Examples/PointAnnotationExample.swift
@@ -17,7 +17,7 @@ public class PointAnnotationExample: UIViewController, ExampleProtocol {
         // Center the map camera over Copenhagen.
         let centerCoordinate = CLLocationCoordinate2D(latitude: 55.665957, longitude: 12.550343)
 
-        mapView.cameraManager.setCamera(to: CameraOptions(center: centerCoordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: centerCoordinate,
                                                           zoom: 8.0))
 
         // Allows the delegate to receive information about map events.
@@ -30,7 +30,7 @@ public class PointAnnotationExample: UIViewController, ExampleProtocol {
             let pointAnnotation = PointAnnotation(coordinate: centerCoordinate)
 
             // Add the annotation to the map.
-            self.mapView.annotationManager.addAnnotation(pointAnnotation)
+            self.mapView.annotations.addAnnotation(pointAnnotation)
 
             // The below line is used for internal testing purposes only.
             self.finish()

--- a/Apps/Examples/Examples/All Examples/PolygonAnnotationExample.swift
+++ b/Apps/Examples/Examples/All Examples/PolygonAnnotationExample.swift
@@ -15,7 +15,7 @@ public class PolygonAnnotationExample: UIViewController, ExampleProtocol {
 
         let centerCoordinate = CLLocationCoordinate2D(latitude: 25.04579, longitude: -88.90136)
 
-        mapView.cameraManager.setCamera(to: CameraOptions(center: centerCoordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: centerCoordinate,
                                                           zoom: 5.0))
 
         // Allows the delegate to receive information about map events.
@@ -49,7 +49,7 @@ public class PolygonAnnotationExample: UIViewController, ExampleProtocol {
         let polygon = PolygonAnnotation(coordinates: polygonCoords, interiorPolygons: [polygonHole])
 
         // Add the annotation to the map.
-        mapView.annotationManager.addAnnotation(polygon)
+        mapView.annotations.addAnnotation(polygon)
 
         // The below line is used for internal testing purposes only.
         finish()

--- a/Apps/Examples/Examples/All Examples/RestrictCoordinateBoundsExample.swift
+++ b/Apps/Examples/Examples/All Examples/RestrictCoordinateBoundsExample.swift
@@ -15,9 +15,9 @@ public class RestrictCoordinateBoundsExample: UIViewController, ExampleProtocol 
 
         let bounds = CoordinateBounds(southwest: CLLocationCoordinate2D(latitude: 63.33, longitude: -25.52),
                                       northeast: CLLocationCoordinate2D(latitude: 66.61, longitude: -13.47))
-        let camera = mapView.cameraManager.camera(for: bounds)
+        let camera = mapView.camera.camera(for: bounds)
         // Set the camera's center coordinate.
-        mapView.cameraManager.setCamera(to: camera, completion: nil)
+        mapView.camera.setCamera(to: camera, completion: nil)
 
         mapView.update { (mapOptions) in
             mapOptions.camera.restrictedCoordinateBounds = bounds

--- a/Apps/Examples/Examples/All Examples/SceneKitExample.swift
+++ b/Apps/Examples/Examples/All Examples/SceneKitExample.swift
@@ -27,7 +27,7 @@ public class SceneKitExample: UIViewController, ExampleProtocol, CustomLayerHost
                                    zoom: 18,
                                    bearing: 180,
                                    pitch: 60)
-        mapView.cameraManager.setCamera(to: camera)
+        mapView.camera.setCamera(to: camera)
 
         self.mapView.on(.styleLoaded) { [weak self] _ in
             self?.addModelAndTerrain()

--- a/Apps/Examples/Examples/All Examples/SelectAnnotationExample.swift
+++ b/Apps/Examples/Examples/All Examples/SelectAnnotationExample.swift
@@ -30,7 +30,7 @@ public class SelectAnnotationExample: UIViewController, ExampleProtocol {
         let centerCoordinate = CLLocationCoordinate2D(latitude: 63.982738,
                                                       longitude: -16.741790)
 
-        mapView.cameraManager.setCamera(to: CameraOptions(center: centerCoordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: centerCoordinate,
                                                           zoom: 12.0))
 
         // Allow the view controller to receive information about map events.
@@ -63,10 +63,10 @@ public class SelectAnnotationExample: UIViewController, ExampleProtocol {
         let pointAnnotation = PointAnnotation(coordinate: coordinate)
 
         // Allow the view controller to accept annotation selection events.
-        mapView.annotationManager.interactionDelegate = self
+        mapView.annotations.interactionDelegate = self
 
         // Add the annotation to the map.
-        mapView.annotationManager.addAnnotation(pointAnnotation)
+        mapView.annotations.addAnnotation(pointAnnotation)
 
         // The below line is used for internal testing purposes only.
         finish()

--- a/Apps/Examples/Examples/All Examples/SnapshotterExample.swift
+++ b/Apps/Examples/Examples/All Examples/SnapshotterExample.swift
@@ -23,7 +23,7 @@ public class SnapshotterExample: UIViewController, ExampleProtocol {
         mapView = MapView(frame: testRect, mapInitOptions: mapInitOptions)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.style.uri = .dark
-        mapView.cameraManager.setCamera(to: CameraOptions(center: CLLocationCoordinate2D(latitude: 37.858, longitude: 138.472),
+        mapView.camera.setCamera(to: CameraOptions(center: CLLocationCoordinate2D(latitude: 37.858, longitude: 138.472),
                                                           zoom: 3.5))
 
         // Add the `MapViewController`'s view to the stack view as a
@@ -44,7 +44,7 @@ public class SnapshotterExample: UIViewController, ExampleProtocol {
                                          resourceOptions: mapInitOptions.resourceOptions)
         snapshotter = Snapshotter(options: options)
         snapshotter.style.uri = .light
-        snapshotter.camera = mapView.camera
+        snapshotter.camera = mapView.cameraOptions
 
         snapshotter.on(.styleLoaded) { [weak self] _ in
             self?.startSnapshot()

--- a/Apps/Examples/Examples/All Examples/SwiftUIExample.swift
+++ b/Apps/Examples/Examples/All Examples/SwiftUIExample.swift
@@ -89,7 +89,7 @@ internal struct SwiftUIMapView: UIViewRepresentable {
     /// If your `SwiftUIMapView` is reconfigured externally, SwiftUI will invoke `updateUIView(_:context:)`
     /// to give you an opportunity to re-sync the state of the underlying map view.
     func updateUIView(_ mapView: MapView, context: Context) {
-        mapView.cameraManager.setCamera(to: CameraOptions(center: camera.center, zoom: camera.zoom),
+        mapView.camera.setCamera(to: CameraOptions(center: camera.center, zoom: camera.zoom),
                                         animated: false)
         /// Since changing the style causes annotations to be removed from the map
         /// we only call the setter if the value has changed.
@@ -171,19 +171,19 @@ internal class SwiftUIMapViewCoordinator {
         }
         let annotationsByIdentifier = Dictionary(uniqueKeysWithValues: annotations.map { ($0.identifier, $0) })
 
-        let oldAnnotationIds = Set(mapView.annotationManager.annotations.values.map(\.identifier))
+        let oldAnnotationIds = Set(mapView.annotations.annotations.values.map(\.identifier))
         let newAnnotationIds = Set(annotationsByIdentifier.values.map(\.identifier))
 
         let idsForAnnotationsToRemove = oldAnnotationIds.subtracting(newAnnotationIds)
-        let annotationsToRemove = idsForAnnotationsToRemove.compactMap { mapView.annotationManager.annotations[$0] }
+        let annotationsToRemove = idsForAnnotationsToRemove.compactMap { mapView.annotations.annotations[$0] }
         if !annotationsToRemove.isEmpty {
-            mapView.annotationManager.removeAnnotations(annotationsToRemove)
+            mapView.annotations.removeAnnotations(annotationsToRemove)
         }
 
         let idsForAnnotationsToAdd = newAnnotationIds.subtracting(oldAnnotationIds)
         let annotationsToAdd = idsForAnnotationsToAdd.compactMap { annotationsByIdentifier[$0] }
         if !annotationsToAdd.isEmpty {
-            mapView.annotationManager.addAnnotations(annotationsToAdd)
+            mapView.annotations.addAnnotations(annotationsToAdd)
         }
     }
 }

--- a/Apps/Examples/Examples/All Examples/TerrainExample.swift
+++ b/Apps/Examples/Examples/All Examples/TerrainExample.swift
@@ -16,7 +16,7 @@ public class TerrainExample: UIViewController, ExampleProtocol {
         view.addSubview(mapView)
 
         let centerCoordinate = CLLocationCoordinate2D(latitude: 32.6141, longitude: -114.34411)
-        mapView.cameraManager.setCamera(to: CameraOptions(center: centerCoordinate,
+        mapView.camera.setCamera(to: CameraOptions(center: centerCoordinate,
                                                           zoom: 13.1,
                                                           bearing: 80,
                                                           pitch: 85))

--- a/Apps/Examples/Examples/All Examples/TrackingModeExample.swift
+++ b/Apps/Examples/Examples/All Examples/TrackingModeExample.swift
@@ -23,7 +23,7 @@ public class TrackingModeExample: UIViewController, ExampleProtocol {
         }
 
         // Set initial camera settings
-        mapView.cameraManager.setCamera(to: CameraOptions(zoom: 15.0))
+        mapView.camera.setCamera(to: CameraOptions(zoom: 15.0))
 
         // Allows the delegate to receive information about map events.
         mapView.on(.mapLoaded) { [weak self] _ in
@@ -47,7 +47,7 @@ public class CameraLocationConsumer: LocationConsumer {
     }
 
     public func locationUpdate(newLocation: Location) {
-        mapView?.cameraManager.setCamera(to: CameraOptions(center: newLocation.coordinate, zoom: 15),
+        mapView?.camera.setCamera(to: CameraOptions(center: newLocation.coordinate, zoom: 15),
                                          animated: true,
                                          duration: 1.3)
     }

--- a/Apps/Examples/Examples/All Examples/TrackingModeExample.swift
+++ b/Apps/Examples/Examples/All Examples/TrackingModeExample.swift
@@ -31,7 +31,7 @@ public class TrackingModeExample: UIViewController, ExampleProtocol {
 
             // Register the location consumer with the map
             // Note that the location manager holds weak references to consumers, which should be retained
-            self.mapView.locationManager.addLocationConsumer(newConsumer: self.cameraLocationConsumer)
+            self.mapView.location.addLocationConsumer(newConsumer: self.cameraLocationConsumer)
 
             self.finish() // Needed for internal testing purposes.
         }

--- a/Apps/Examples/Examples/All Examples/UpdatePointAnnotationPositionExample.swift
+++ b/Apps/Examples/Examples/All Examples/UpdatePointAnnotationPositionExample.swift
@@ -14,7 +14,7 @@ public class UpdatePointAnnotationPositionExample: UIViewController, ExampleProt
 
         mapView = MapView(frame: view.bounds)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        mapView.cameraManager.setCamera(to: CameraOptions(center: CLLocationCoordinate2D(latitude: 59.3, longitude: 8.06),
+        mapView.camera.setCamera(to: CameraOptions(center: CLLocationCoordinate2D(latitude: 59.3, longitude: 8.06),
                                                           zoom: 12))
         view.addSubview(mapView)
 
@@ -30,7 +30,7 @@ public class UpdatePointAnnotationPositionExample: UIViewController, ExampleProt
 
     public func addPointAnnotation() {
         pointAnnotation = PointAnnotation(coordinate: mapView.centerCoordinate)
-        mapView.annotationManager.addAnnotation(pointAnnotation)
+        mapView.annotations.addAnnotation(pointAnnotation)
         mapView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(updatePosition)))
     }
 
@@ -39,7 +39,7 @@ public class UpdatePointAnnotationPositionExample: UIViewController, ExampleProt
         pointAnnotation.coordinate = newCoordinate
 
         do {
-            try mapView.annotationManager.updateAnnotation(pointAnnotation)
+            try mapView.annotations.updateAnnotation(pointAnnotation)
         } catch let error {
             displayAlert(message: error.localizedDescription)
         }

--- a/Apps/StressTest/StressTest/ViewController.swift
+++ b/Apps/StressTest/StressTest/ViewController.swift
@@ -193,21 +193,21 @@ class ViewController: UIViewController {
     }
 
     func flyTo(end: CLLocationCoordinate2D, completion: @escaping () -> Void) {
-        let startOptions = mapView.camera
+        let startOptions = mapView.cameraOptions
         let start = startOptions.center!
 
         let lineAnnotation = LineAnnotation(coordinates: [start, end])
 
         // Add the annotation to the map.
         print("Adding line annotation")
-        mapView.annotationManager.addAnnotation(lineAnnotation)
+        mapView.annotations.addAnnotation(lineAnnotation)
 
         let endOptions = CameraOptions(center: end, zoom: 17)
 
         var animator: CameraAnimator?
-        animator = mapView.cameraManager.fly(to: endOptions) { _ in
+        animator = mapView.camera.fly(to: endOptions) { _ in
             print("Removing line annotation for animator \(String(describing: animator))")
-            self.mapView.annotationManager.removeAnnotation(lineAnnotation)
+            self.mapView.annotations.removeAnnotation(lineAnnotation)
             animator = nil
             completion()
         }
@@ -215,7 +215,7 @@ class ViewController: UIViewController {
 
     func removeAnnotations() {
         print("Removing \(annotations.count) annotations")
-        mapView.annotationManager.removeAnnotations(annotations)
+        mapView.annotations.removeAnnotations(annotations)
         annotations = []
     }
 
@@ -228,7 +228,7 @@ class ViewController: UIViewController {
         }
 
         print("Adding \(annotations.count) annotations")
-        mapView.annotationManager.addAnnotations(annotations)
+        mapView.annotations.addAnnotations(annotations)
     }
 
     func pushColorExpression() {
@@ -290,7 +290,7 @@ class ViewController: UIViewController {
         print("Creating snapshotter")
         let snapshotter = Snapshotter(options: options)
         snapshotter.style.uri = .light
-        snapshotter.camera = mapView.camera
+        snapshotter.camera = mapView.cameraOptions
 
         snapshotter.on(.styleLoaded) { [weak self] _ in
             guard let snapshotter = self?.snapshotter else {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Mapbox welcomes participation and contributions from everyone.
   * `MapOptions` has been renamed `MapConfig`. A new `MapOptions` has been introduced; its properties are required to initialize the underlying map object.
   * A `MapInitOptions` configuration struct has been introduced. It currently wraps both `ResourceOptions` and `MapOptions` and is used when initializing a `MapView`.
   * `baseURL` and `accessToken` can no longer be set from a nib or storyboard. Instead a new `MapInitOptionsProvider` protocol and an `IBOutlet` on `MapView` has been introduced to allow a customer `MapInitOptions` to be provided to the `MapView`. This provider is not used when initializing a `MapView` programmatically.
+  * The `Manager` suffix has been removed from `MapView.gesturesManager`, `MapView.ornamentsManager`, `MapView.cameraManager`, `MapView.locationManager`, and `MapView.annotationsManager`.
+  * `BaseMapView.camera` has been renamed to `BaseMapView.cameraOptions`.
 
 - #### Foundation
   * `AccountManager` has been removed. A new `CredentialsManager` replaces it. You can use `CredentialsManager.default` to set a global access token.
@@ -34,7 +36,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 - #### Ornaments
     * `LayoutPosition` has been deprecated in favor of `OrnamentPosition`.
-    * `LayoutVisibility` has been depracted in favor of `OrnamentVisibility`.
+    * `LayoutVisibility` has been deprecated in favor of `OrnamentVisibility`.
     * `showsLogoView` has been renamed to `_showsLogoView`.
     * `showsCompass` and `showsScale` have been deprecated. Visibility properties can be used to set how the Compass and Scale Bar should be shown.
 

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -48,7 +48,7 @@ open class BaseMapView: UIView, CameraViewDelegate {
     internal private(set) var cameraView: CameraView!
 
     /// The map's current camera
-    public var camera: CameraOptions {
+    public var cameraOptions: CameraOptions {
         get {
             return __map.getCameraOptions(forPadding: nil)
         } set {
@@ -59,7 +59,7 @@ open class BaseMapView: UIView, CameraViewDelegate {
     /// The map's current center coordinate.
     public var centerCoordinate: CLLocationCoordinate2D {
         get {
-            guard let center = camera.center else {
+            guard let center = cameraOptions.center else {
                 fatalError("Center is nil in camera options")
             }
             return center
@@ -71,7 +71,7 @@ open class BaseMapView: UIView, CameraViewDelegate {
     /// The map's  zoom level.
     public var zoom: CGFloat {
         get {
-            guard let zoom = camera.zoom else {
+            guard let zoom = cameraOptions.zoom else {
                 fatalError("Zoom is nil in camera options")
             }
             return CGFloat(zoom)
@@ -83,7 +83,7 @@ open class BaseMapView: UIView, CameraViewDelegate {
     /// The map's bearing, measured clockwise from 0° north.
     public var bearing: CLLocationDirection {
         get {
-            guard let bearing = camera.bearing else {
+            guard let bearing = cameraOptions.bearing else {
                 fatalError("Bearing is nil in camera options")
             }
             return CLLocationDirection(bearing)
@@ -95,7 +95,7 @@ open class BaseMapView: UIView, CameraViewDelegate {
     /// The map's pitch, falling within a range of 0 to 60.
     public var pitch: CGFloat {
         get {
-            guard let pitch = camera.pitch else {
+            guard let pitch = cameraOptions.pitch else {
                 fatalError("Pitch is nil in camera options")
             }
 
@@ -108,7 +108,7 @@ open class BaseMapView: UIView, CameraViewDelegate {
     /// The map's camera padding
     public var padding: UIEdgeInsets {
         get {
-            return camera.padding ?? .zero
+            return cameraOptions.padding ?? .zero
         } set {
             cameraView.padding = newValue
         }

--- a/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraManager.swift
@@ -154,12 +154,12 @@ public class CameraManager {
                                           pitch: targetCamera.pitch?.clamped(to: mapCameraOptions.minimumPitch...mapCameraOptions.maximumPitch))
 
         // Return early if the cameraView's camera is already at `clampedCamera`
-        guard mapView.camera != clampedCamera else {
+        guard mapView.cameraOptions != clampedCamera else {
             return
         }
 
         let transitionBlock = {
-            mapView.camera = clampedCamera
+            mapView.cameraOptions = clampedCamera
         }
 
         if animated && duration > 0 {
@@ -226,7 +226,7 @@ public class CameraManager {
         // Stop the `internalCameraAnimator` before beginning a `flyTo`
         internalCameraAnimator?.stopAnimation()
 
-        guard let interpolator = FlyToInterpolator(from: mapView.camera,
+        guard let interpolator = FlyToInterpolator(from: mapView.cameraOptions,
                                                    to: camera,
                                                    size: mapView.bounds.size) else {
             return nil

--- a/Sources/MapboxMaps/Foundation/Camera/CameraView.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraView.swift
@@ -3,7 +3,7 @@ import UIKit
 /// Internal protocol that provides needed information / methods for the `CameraView`
 internal protocol CameraViewDelegate: class {
     /// The map's current camera
-    var camera: CameraOptions { get }
+    var cameraOptions: CameraOptions { get }
 
     /// The map's current center coordinate.
     var centerCoordinate: CLLocationCoordinate2D { get }
@@ -32,7 +32,7 @@ internal class CameraView: UIView {
 
     internal var camera: CameraOptions {
         get {
-            return delegate.camera
+            return delegate.cameraOptions
         }
         set {
             if let newZoom = newValue.zoom {
@@ -194,7 +194,7 @@ internal class CameraView: UIView {
     internal func update() {
 
         // Retrieve currently rendered camera
-        let currentCamera = delegate.camera
+        let currentCamera = delegate.cameraOptions
 
         // Get the latest interpolated values of the camera properties (if they exist)
         let targetCamera = localCamera.wrap()

--- a/Sources/MapboxMaps/MapView/MapView+Managers.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Managers.swift
@@ -17,7 +17,7 @@ extension MapView {
         setupStyle(with: __map)
 
         // Initialize/Configure gesture manager
-        setupGestures(with: self, options: mapConfig.gestures, cameraManager: cameraManager)
+        setupGestures(with: self, options: mapConfig.gestures, cameraManager: camera)
 
         // Initialize/Configure ornaments manager
         setupOrnaments(with: self, options: mapConfig.ornaments)
@@ -69,11 +69,11 @@ extension MapView {
     }
 
     internal func setupCamera(for view: MapView, options: MapCameraOptions) {
-        cameraManager = CameraManager(for: view, with: mapConfig.camera)
+        camera = CameraManager(for: view, with: mapConfig.camera)
     }
 
     internal func updateCamera(with newOptions: MapCameraOptions) {
-        cameraManager.updateMapCameraOptions(newOptions: newOptions)
+        camera.updateMapCameraOptions(newOptions: newOptions)
     }
 
     internal func setupOrnaments(with view: OrnamentSupportableView, options: OrnamentOptions) {
@@ -96,11 +96,11 @@ extension MapView {
     }
 
     internal func setupAnnotationManager(with annotationSupportableMap: AnnotationSupportableMap, and style: Style, options: AnnotationOptions) {
-        annotationManager = AnnotationManager(for: annotationSupportableMap, with: style, options: options)
+        annotations = AnnotationManager(for: annotationSupportableMap, with: style, options: options)
     }
 
     internal func updateAnnotationManager(with newOptions: AnnotationOptions) {
-        annotationManager.updateAnnotationOptions(with: newOptions)
+        annotations.updateAnnotationOptions(with: newOptions)
     }
 
     internal func setupStyle(with map: Map) {

--- a/Sources/MapboxMaps/MapView/MapView+Managers.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Managers.swift
@@ -87,12 +87,12 @@ extension MapView {
 
     internal func setupUserLocationManager(with locationSupportableMapView: LocationSupportableMapView, options: LocationOptions) {
 
-        locationManager = LocationManager(locationOptions: options,
+        location = LocationManager(locationOptions: options,
                                           locationSupportableMapView: locationSupportableMapView)
     }
 
     internal func updateUserLocationManager(with options: LocationOptions) {
-        locationManager.updateLocationOptions(with: mapConfig.location)
+        location.updateLocationOptions(with: mapConfig.location)
     }
 
     internal func setupAnnotationManager(with annotationSupportableMap: AnnotationSupportableMap, and style: Style, options: AnnotationOptions) {

--- a/Sources/MapboxMaps/MapView/MapView+Managers.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Managers.swift
@@ -61,11 +61,11 @@ extension MapView {
     }
 
     internal func setupGestures(with view: UIView, options: GestureOptions, cameraManager: CameraManager) {
-        gestureManager = GestureManager(for: view, options: options, cameraManager: cameraManager)
+        gestures = GestureManager(for: view, options: options, cameraManager: cameraManager)
     }
 
     internal func updateGestures(with newOptions: GestureOptions) {
-        gestureManager.updateGestureOptions(with: newOptions)
+        gestures.updateGestureOptions(with: newOptions)
     }
 
     internal func setupCamera(for view: MapView, options: MapCameraOptions) {

--- a/Sources/MapboxMaps/MapView/MapView+Managers.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Managers.swift
@@ -77,12 +77,12 @@ extension MapView {
     }
 
     internal func setupOrnaments(with view: OrnamentSupportableView, options: OrnamentOptions) {
-        ornamentsManager = OrnamentsManager(for: view,
+        ornaments = OrnamentsManager(for: view,
                                             withConfig: options.makeConfig())
     }
 
     internal func updateOrnaments(with newOptions: OrnamentOptions) {
-        ornamentsManager.ornamentConfig = newOptions.makeConfig()
+        ornaments.ornamentConfig = newOptions.makeConfig()
     }
 
     internal func setupUserLocationManager(with locationSupportableMapView: LocationSupportableMapView, options: LocationOptions) {

--- a/Sources/MapboxMaps/MapView/MapView.swift
+++ b/Sources/MapboxMaps/MapView/MapView.swift
@@ -11,8 +11,8 @@ open class MapView: BaseMapView {
     /// The `gestures` property will be responsible for all gestures on the map
     public internal(set) var gestures: GestureManager!
 
-    /// The `ornamentsManager` will be responsible for all ornaments on the map
-    internal var ornamentsManager: OrnamentsManager!
+    /// The `ornaments` property will be responsible for all ornaments on the map
+    internal var ornaments: OrnamentsManager!
 
     /// The `cameraManager` that manages a camera's view lifecycle.
     public internal(set) var cameraManager: CameraManager!

--- a/Sources/MapboxMaps/MapView/MapView.swift
+++ b/Sources/MapboxMaps/MapView/MapView.swift
@@ -8,8 +8,8 @@ open class MapView: BaseMapView {
     /// To synchronously update the `mapOptions` please call `updateMapOptions(with newOptions: MapOptions)`
     internal var mapConfig: MapConfig = MapConfig()
 
-    /// The `gestureManager` will be responsible for all gestures on the map
-    public internal(set) var gestureManager: GestureManager!
+    /// The `gestures` property will be responsible for all gestures on the map
+    public internal(set) var gestures: GestureManager!
 
     /// The `ornamentsManager` will be responsible for all ornaments on the map
     internal var ornamentsManager: OrnamentsManager!

--- a/Sources/MapboxMaps/MapView/MapView.swift
+++ b/Sources/MapboxMaps/MapView/MapView.swift
@@ -8,23 +8,23 @@ open class MapView: BaseMapView {
     /// To synchronously update the `mapOptions` please call `updateMapOptions(with newOptions: MapOptions)`
     internal var mapConfig: MapConfig = MapConfig()
 
-    /// The `gestures` property will be responsible for all gestures on the map.
+    /// The `gestures` object will be responsible for all gestures on the map.
     public internal(set) var gestures: GestureManager!
 
-    /// The `ornaments` property will be responsible for all ornaments on the map.
+    /// The `ornaments`object will be responsible for all ornaments on the map.
     internal var ornaments: OrnamentsManager!
 
-    /// The `cameraManager` that manages a camera's view lifecycle..
-    public internal(set) var cameraManager: CameraManager!
+    /// The `camera` object manages a camera's view lifecycle..
+    public internal(set) var camera: CameraManager!
 
-    /// The `location` property handles location events of the map.
+    /// The `location`object handles location events of the map.
     public internal(set) var location: LocationManager!
 
     /// The `style` object supports run time styling.
     public internal(set) var style: Style!
 
     /// Controls the addition/removal of annotations to the map.
-    public internal(set) var annotationManager: AnnotationManager!
+    public internal(set) var annotations: AnnotationManager!
 
     /// A reference to the `EventsManager` used for dispatching telemetry.
     internal var eventsListener: EventsListener!

--- a/Sources/MapboxMaps/MapView/MapView.swift
+++ b/Sources/MapboxMaps/MapView/MapView.swift
@@ -8,19 +8,19 @@ open class MapView: BaseMapView {
     /// To synchronously update the `mapOptions` please call `updateMapOptions(with newOptions: MapOptions)`
     internal var mapConfig: MapConfig = MapConfig()
 
-    /// The `gestures` property will be responsible for all gestures on the map
+    /// The `gestures` property will be responsible for all gestures on the map.
     public internal(set) var gestures: GestureManager!
 
-    /// The `ornaments` property will be responsible for all ornaments on the map
+    /// The `ornaments` property will be responsible for all ornaments on the map.
     internal var ornaments: OrnamentsManager!
 
-    /// The `cameraManager` that manages a camera's view lifecycle.
+    /// The `cameraManager` that manages a camera's view lifecycle..
     public internal(set) var cameraManager: CameraManager!
 
-    /// The `locationManager` that handles location events of the map
-    public internal(set) var locationManager: LocationManager!
+    /// The `location` property handles location events of the map.
+    public internal(set) var location: LocationManager!
 
-    /// The `style` object supports run time styling
+    /// The `style` object supports run time styling.
     public internal(set) var style: Style!
 
     /// Controls the addition/removal of annotations to the map.

--- a/Tests/MapboxMapsTests/Foundation/Camera/MapboxMapsCameraTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Camera/MapboxMapsCameraTests.swift
@@ -68,7 +68,7 @@ class CameraManagerTests: XCTestCase {
                                            bearing: 8,
                                            pitch: 9)
 
-        let originalCamera = mapView.camera
+        let originalCamera = mapView.cameraOptions
 
         cameraManager.setCamera(to: expectedCamera, completion: nil)
 

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/Map/MapViewIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/Map/MapViewIntegrationTests.swift
@@ -39,7 +39,7 @@ class MapViewIntegrationTests: IntegrationTestCase {
 
             mapView.on(.mapLoaded) { [weak mapView] _ in
                 let dest = CameraOptions(center: CLLocationCoordinate2D(latitude: 10, longitude: 10), zoom: 10)
-                mapView?.cameraManager.setCamera(to: dest, animated: true, duration: 5) { _ in
+                mapView?.camera.setCamera(to: dest, animated: true, duration: 5) { _ in
                     expectation.fulfill()
                 }
             }

--- a/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
@@ -20,7 +20,7 @@ internal class OptionsIntegrationTest: MapViewIntegrationTestCase {
             options = newConfig
         }
 
-        XCTAssertEqual(mapView.gestureManager.gestureOptions, newConfig.gestures)
+        XCTAssertEqual(mapView.gestures.gestureOptions, newConfig.gestures)
         XCTAssertEqual(mapView.cameraManager.mapCameraOptions, newConfig.camera)
         XCTAssertEqual(mapView.locationManager.locationOptions, newConfig.location)
         XCTAssertTrue(

--- a/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
@@ -21,7 +21,7 @@ internal class OptionsIntegrationTest: MapViewIntegrationTestCase {
         }
 
         XCTAssertEqual(mapView.gestures.gestureOptions, newConfig.gestures)
-        XCTAssertEqual(mapView.cameraManager.mapCameraOptions, newConfig.camera)
+        XCTAssertEqual(mapView.camera.mapCameraOptions, newConfig.camera)
         XCTAssertEqual(mapView.location.locationOptions, newConfig.location)
         XCTAssertTrue(
             mapView.ornaments.ornamentConfig.ornaments.contains {

--- a/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
@@ -24,7 +24,7 @@ internal class OptionsIntegrationTest: MapViewIntegrationTestCase {
         XCTAssertEqual(mapView.cameraManager.mapCameraOptions, newConfig.camera)
         XCTAssertEqual(mapView.locationManager.locationOptions, newConfig.location)
         XCTAssertTrue(
-            mapView.ornamentsManager.ornamentConfig.ornaments.contains {
+            mapView.ornaments.ornamentConfig.ornaments.contains {
                 $0.type == .compass || $0.type == .mapboxScaleBar
             }
         )

--- a/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
@@ -22,7 +22,7 @@ internal class OptionsIntegrationTest: MapViewIntegrationTestCase {
 
         XCTAssertEqual(mapView.gestures.gestureOptions, newConfig.gestures)
         XCTAssertEqual(mapView.cameraManager.mapCameraOptions, newConfig.camera)
-        XCTAssertEqual(mapView.locationManager.locationOptions, newConfig.location)
+        XCTAssertEqual(mapView.location.locationOptions, newConfig.location)
         XCTAssertTrue(
             mapView.ornaments.ornamentConfig.ornaments.contains {
                 $0.type == .compass || $0.type == .mapboxScaleBar


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>The `Manager` suffix has been removed from `MapView.gesturesManager`, `MapView.ornamentsManager`, `MapView.cameraManager`, `MapView..locationManager`, and MapView.annotationsManager`.
 * `BaseMapView.camera` has been renamed to `BaseMapView.cameraOptions`.
 </changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR removes `manager` from the different `MapView` manager properties. It also renames `BaseMapView.camera` to `BaseMapView.cameraOptions` due to the conflict with `MapView.camera`.
### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
