### PR TITLE
Remove unused scale param from Style.setStyleImage

### DIFF
--- a/Apps/Examples/Examples/All Examples/DataDrivenSymbolsExample.swift
+++ b/Apps/Examples/Examples/All Examples/DataDrivenSymbolsExample.swift
@@ -33,9 +33,9 @@ public class DataDrivenSymbolsExample: UIViewController, ExampleProtocol {
 
         // Add icons from the U.S. National Parks Service to the map's style.
         // Icons are located in the asset catalog
-        _ = mapView.style.setStyleImage(image: UIImage(named: "nps-restrooms")!, with: "restrooms", scale: 1.0)
-        _ = mapView.style.setStyleImage(image: UIImage(named: "nps-trailhead")!, with: "trailhead", scale: 1.0)
-        _ = mapView.style.setStyleImage(image: UIImage(named: "nps-picnic-area")!, with: "picnic-area", scale: 1.0)
+        _ = mapView.style.setStyleImage(image: UIImage(named: "nps-restrooms")!, with: "restrooms")
+        _ = mapView.style.setStyleImage(image: UIImage(named: "nps-trailhead")!, with: "trailhead")
+        _ = mapView.style.setStyleImage(image: UIImage(named: "nps-picnic-area")!, with: "picnic-area")
 
         // Access a vector tileset that contains places of interest at Yosemite National Park.
         // This tileset was created by uploading NPS shapefiles to Mapbox Studio.

--- a/Sources/MapboxMaps/Annotations/AnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationManager.swift
@@ -486,7 +486,6 @@ public class AnnotationManager {
                                                                   sdf: false,
                                                                   stretchX: [],
                                                                   stretchY: [],
-                                                                  scale: 3.0,
                                                                   imageContent: nil)
 
             if case .failure(let imageError) = expectedCustomImage {
@@ -507,7 +506,6 @@ public class AnnotationManager {
                                                                    sdf: false,
                                                                    stretchX: [],
                                                                    stretchY: [],
-                                                                   scale: 3.0,
                                                                    imageContent: nil)
 
             if case .failure(let imageError) = expectedDefaultImage {

--- a/Sources/MapboxMaps/Annotations/AnnotationStyleDelegate.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationStyleDelegate.swift
@@ -15,7 +15,6 @@ public protocol AnnotationStyleDelegate {
                        sdf: Bool,
                        stretchX: [ImageStretches],
                        stretchY: [ImageStretches],
-                       scale: CGFloat,
                        imageContent: ImageContent?) -> Result<Bool, ImageError>
 
     func getStyleImage(with identifier: String) -> Image?

--- a/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
@@ -160,15 +160,15 @@ private extension Puck2D {
         guard let topImage = configuration.resolvedTopImage, let bearingImage = configuration.resolvedBearingImage else {
             return
         }
-        if case let .failure(imageError) = style.setStyleImage(image: topImage, with: "locationIndicatorLayerTopImage", scale: 44.0) {
+        if case let .failure(imageError) = style.setStyleImage(image: topImage, with: "locationIndicatorLayerTopImage") {
             throw imageError
         }
-        if case let .failure(imageError) = style.setStyleImage(image: bearingImage, with: "locationIndicatorLayerBearingImage", scale: 44.0) {
+        if case let .failure(imageError) = style.setStyleImage(image: bearingImage, with: "locationIndicatorLayerBearingImage") {
             throw imageError
         }
 
         if let validShadowImage = configuration.shadowImage {
-            let setStyleImageResultInner = style.setStyleImage(image: validShadowImage, with: "locationIndicatorLayerShadowImage", scale: 44.0)
+            let setStyleImageResultInner = style.setStyleImage(image: validShadowImage, with: "locationIndicatorLayerShadowImage")
             if case let .failure(imageError) = setStyleImageResultInner {
                 throw imageError
             }

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -157,7 +157,6 @@ public class Style {
                            Defaults to an empty array.
      - Parameter stretchY: The array of vertical image stretch areas.
                            Defaults to an empty array.
-     - Parameter scale: The scale factor for the image.
      - Parameter imageContent: The `ImageContent` which describes where text
                                can be fit into an image. By default, this is `nil`.
      - Returns: A boolean associated with a `Result` type if the operation is successful.
@@ -169,7 +168,6 @@ public class Style {
                               sdf: Bool = false,
                               stretchX: [ImageStretches] = [],
                               stretchY: [ImageStretches] = [],
-                              scale: CGFloat,
                               imageContent: ImageContent? = nil) -> Result<Bool, ImageError> {
 
         /**

--- a/Tests/MapboxMapsTests/Annotations/MockAnnotationStyleDelegate.swift
+++ b/Tests/MapboxMapsTests/Annotations/MockAnnotationStyleDelegate.swift
@@ -9,7 +9,6 @@ final class MockAnnotationStyleDelegate: AnnotationStyleDelegate {
                        sdf: Bool,
                        stretchX: [ImageStretches],
                        stretchY: [ImageStretches],
-                       scale: CGFloat,
                        imageContent: ImageContent?) -> Result<Bool, ImageError> {
         return .success(true)
     }

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
@@ -154,13 +154,13 @@ internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase 
 
 // swiftlint:disable function_parameter_count identifier_name
 extension AnnotationManagerIntegrationTestCase: AnnotationStyleDelegate {
-    func setStyleImage(image: UIImage, with identifier: String, sdf: Bool, stretchX: [ImageStretches], stretchY: [ImageStretches], scale: CGFloat, imageContent: ImageContent?) -> Result<Bool, ImageError> {
+    func setStyleImage(image: UIImage, with identifier: String, sdf: Bool, stretchX: [ImageStretches], stretchY: [ImageStretches], imageContent: ImageContent?) -> Result<Bool, ImageError> {
         guard let style = style else {
             XCTFail("No style available")
             return .failure(.addStyleImageFailed(nil))
         }
 
-        return style.setStyleImage(image: image, with: identifier, scale: scale)
+        return style.setStyleImage(image: image, with: identifier)
     }
 
     func getStyleImage(with identifier: String) -> Image? {


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Removed unused `scale` param from `Style.setStyleImage`</changelog>`.
 - [x] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

Remove unused `scale` param from `Style.setStyleImage`