### PR TITLE
Document safe area interaction with ornaments

### DIFF
--- a/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
@@ -3,6 +3,10 @@ import UIKit
 private let defaultOrnamentsMargin = CGPoint(x: 8.0, y: 8.0)
 
 /// Used to configure Ornament-specific capabilities of the map
+///
+/// All margin values are relative to the MapView's safe area. To allow the safe area
+/// (and thereby ornaments) to track the presence of navigation bars and tab bars,
+/// make MapView the root view of a view controller.
 public struct OrnamentOptions: Equatable {
 
     // MARK: - Scale Bar

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -74,7 +74,7 @@ public class OrnamentsManager: NSObject {
         }
     }
 
-    internal func updateOrnaments() {
+    private func updateOrnaments() {
         // Remove previously-added constraints
         NSLayoutConstraint.deactivate(constraints)
         constraints.removeAll()
@@ -101,43 +101,25 @@ public class OrnamentsManager: NSObject {
         attributionButton.isHidden = !options._attributionButtonIsVisible
     }
 
-    func constraints(with view: UIView, position: OrnamentPosition, margins: CGPoint) -> [NSLayoutConstraint] {
-        let universalLayoutGuide = layoutGuide(for: view)
-
+    private func constraints(with view: UIView, position: OrnamentPosition, margins: CGPoint) -> [NSLayoutConstraint] {
+        let layoutGuide = view.superview!.safeAreaLayoutGuide
         switch position {
         case .topLeft:
             return [
-                view.leftAnchor.constraint(equalTo: universalLayoutGuide.leftAnchor,
-                                           constant: margins.x),
-                view.topAnchor.constraint(equalTo: universalLayoutGuide.topAnchor,
-                                          constant: margins.y)
-            ]
+                view.leftAnchor.constraint(equalTo: layoutGuide.leftAnchor, constant: margins.x),
+                view.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: margins.y)]
         case .topRight:
             return  [
-                view.rightAnchor.constraint(equalTo: universalLayoutGuide.rightAnchor,
-                                            constant: -margins.x),
-                view.topAnchor.constraint(equalTo: universalLayoutGuide.topAnchor,
-                                          constant: margins.y)
-            ]
+                view.rightAnchor.constraint(equalTo: layoutGuide.rightAnchor, constant: -margins.x),
+                view.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: margins.y)]
         case .bottomLeft:
             return [
-                view.leftAnchor.constraint(equalTo: universalLayoutGuide.leftAnchor,
-                                           constant: margins.x),
-                view.bottomAnchor.constraint(equalTo: universalLayoutGuide.bottomAnchor,
-                                             constant: -margins.y)
-            ]
+                view.leftAnchor.constraint(equalTo: layoutGuide.leftAnchor, constant: margins.x),
+                view.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor, constant: -margins.y)]
         case .bottomRight:
             return [
-                view.rightAnchor.constraint(equalTo: universalLayoutGuide.rightAnchor,
-                                            constant: -margins.x),
-                view.bottomAnchor.constraint(equalTo: universalLayoutGuide.bottomAnchor,
-                                             constant: -margins.y)
-            ]
+                view.rightAnchor.constraint(equalTo: layoutGuide.rightAnchor, constant: -margins.x),
+                view.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor, constant: -margins.y)]
         }
-    }
-
-    func layoutGuide(for view: UIView) -> UILayoutGuide {
-        let superview = view.superview!
-        return superview.safeAreaLayoutGuide
     }
 }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

No new functionality, so no tests.

Added documentation about how to allow ornament layouts to track the appearance/disappearance of navigation/tab bars.

Did some minor cleanup in OrnamentsManager to remove dead code and make some methods private that were previously internal.