### PR TITLE
Fix NSNumber conversion.

### DIFF
--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -238,6 +238,9 @@
 		CA0C426926028ED30054D9D0 /* AnnotationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C426826028ED30054D9D0 /* AnnotationOptions.swift */; };
 		CA0C427E2602BECE0054D9D0 /* LayerPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C427D2602BECE0054D9D0 /* LayerPosition.swift */; };
 		CA0C43052602BF2D0054D9D0 /* LayerPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C42942602BF000054D9D0 /* LayerPositionTests.swift */; };
+		CA19C342263B411C00748F1A /* MapInitOptionsTests.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5A6922A2627566A00A03412 /* MapInitOptionsTests.xib */; };
+		CA19C344263B412700748F1A /* empty-style-chicago.json in Resources */ = {isa = PBXBuildFile; fileRef = CA19C343263B412700748F1A /* empty-style-chicago.json */; };
+		CA19C345263B412700748F1A /* empty-style-chicago.json in Resources */ = {isa = PBXBuildFile; fileRef = CA19C343263B412700748F1A /* empty-style-chicago.json */; };
 		CA2E4A1B2538D3530096DEDE /* MapViewIntegrationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA53616D2537ECA600A8AE38 /* MapViewIntegrationTestCase.swift */; };
 		CA2E4A1C2538D3530096DEDE /* IntegrationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5361862537EE0600A8AE38 /* IntegrationTestCase.swift */; };
 		CA2E4A1D2538D3530096DEDE /* DidIdleFailureIntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2E498825380B300096DEDE /* DidIdleFailureIntegrationTest.swift */; };
@@ -659,6 +662,7 @@
 		CA0C426826028ED30054D9D0 /* AnnotationOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnnotationOptions.swift; sourceTree = "<group>"; };
 		CA0C427D2602BECE0054D9D0 /* LayerPosition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayerPosition.swift; sourceTree = "<group>"; };
 		CA0C42942602BF000054D9D0 /* LayerPositionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayerPositionTests.swift; sourceTree = "<group>"; };
+		CA19C343263B412700748F1A /* empty-style-chicago.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "empty-style-chicago.json"; sourceTree = "<group>"; };
 		CA2E498825380B300096DEDE /* DidIdleFailureIntegrationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DidIdleFailureIntegrationTest.swift; sourceTree = "<group>"; };
 		CA355C06256EEA7C00FD1DB7 /* FlyToInterpolator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlyToInterpolator.swift; sourceTree = "<group>"; };
 		CA4453C52436E71500477B4F /* MapboxTestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MapboxTestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1445,6 +1449,7 @@
 		B5A692292627566A00A03412 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				CA19C343263B412700748F1A /* empty-style-chicago.json */,
 				B5A6922A2627566A00A03412 /* MapInitOptionsTests.xib */,
 			);
 			name = Resources;
@@ -1764,6 +1769,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				CA0B373925C4BEAE00B3396E /* Assets.xcassets in Resources */,
+				CA19C345263B412700748F1A /* empty-style-chicago.json in Resources */,
+				CA19C342263B411C00748F1A /* MapInitOptionsTests.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1784,6 +1791,7 @@
 				CA549002251C404B00F829A3 /* geometry-collection.geojson in Resources */,
 				CA549003251C404B00F829A3 /* simple-line.geojson in Resources */,
 				CA549004251C404B00F829A3 /* multipolygon.geojson in Resources */,
+				CA19C344263B412700748F1A /* empty-style-chicago.json in Resources */,
 				07E816DA256D72E500ACFA73 /* Assets.xcassets in Resources */,
 				CA549005251C404B00F829A3 /* featurecollection.geojson in Resources */,
 				CA549006251C404B00F829A3 /* polygon.geojson in Resources */,

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -49,8 +49,8 @@ public final class MapboxMap {
             __map.cameraForCoordinateBounds(
                 for: coordinateBounds,
                 padding: padding.toMBXEdgeInsetsValue(),
-                bearing: bearing.map(NSNumber.init),
-                pitch: pitch.map(NSNumber.init)))
+                bearing: bearing?.NSNumber,
+                pitch: pitch?.NSNumber))
     }
 
     /// Calculates a `CameraOptions` to fit a list of coordinates.
@@ -69,8 +69,8 @@ public final class MapboxMap {
             __map.cameraForCoordinates(
                 forCoordinates: coordinates.map(\.location),
                 padding: padding.toMBXEdgeInsetsValue(),
-                bearing: bearing.map(NSNumber.init),
-                pitch: pitch.map(NSNumber.init)))
+                bearing: bearing?.NSNumber,
+                pitch: pitch?.NSNumber))
     }
 
     /// Calculates a `CameraOptions` to fit a list of coordinates into a sub-rect of the map.
@@ -108,8 +108,8 @@ public final class MapboxMap {
             __map.cameraForGeometry(
                 for: MBXGeometry(geometry: geometry),
                 padding: padding.toMBXEdgeInsetsValue(),
-                bearing: bearing.map(NSNumber.init),
-                pitch: pitch.map(NSNumber.init)))
+                bearing: bearing?.NSNumber,
+                pitch: pitch?.NSNumber))
     }
 
     // MARK: - CameraOptions to CoordinateBounds

--- a/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import MapboxMaps
+import Turf
 
 final class MapboxMapTests: XCTestCase {
 
@@ -94,6 +95,41 @@ final class MapboxMapTests: XCTestCase {
                 northeast,
                 southeast
             ],
+            padding: .zero,
+            bearing: 0,
+            pitch: 0)
+
+        XCTAssertEqual(expectedCenter.latitude, camera.center!.latitude, accuracy: 0.25)
+        XCTAssertEqual(expectedCenter.longitude, camera.center!.longitude, accuracy: 0.25)
+        XCTAssertEqual(camera.bearing, 0)
+        XCTAssertEqual(camera.padding, .zero)
+        XCTAssertEqual(camera.pitch, 0)
+    }
+
+    func testCameraForGeometry() {
+        // A 1:1 square
+        let southwest = CLLocationCoordinate2DMake(0, 0)
+        let northwest = CLLocationCoordinate2DMake(4, 0)
+        let northeast = CLLocationCoordinate2DMake(4, 4)
+        let southeast = CLLocationCoordinate2DMake(0, 4)
+
+        let coordinates = [
+            southwest,
+            northwest,
+            northeast,
+            southeast,
+        ]
+
+        let latitudeDelta =  northeast.latitude - southeast.latitude
+        let longitudeDelta = southeast.longitude - southwest.longitude
+
+        let expectedCenter = CLLocationCoordinate2DMake(northeast.latitude - (latitudeDelta / 2),
+                                                        southeast.longitude - (longitudeDelta / 2))
+
+        let geometry = Geometry.polygon(Polygon([coordinates]))
+
+        let camera = mapboxMap.camera(
+            for: geometry,
             padding: .zero,
             bearing: 0,
             pitch: 0)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Write tests for all new functionality. If tests were not written, please explain why.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

This PR fixes an "invalid selector" crash. This was likely due to the fact that NSNumber is a class cluster, and the abstract base type was being initialized.

Also adds a missing resource file to the MapboxMaps Xcode project