### PR TITLE
[Ornaments] Remove ornament options from MapConfig

### DIFF
--- a/Apps/Examples/Examples/All Examples/BasicMapExample.swift
+++ b/Apps/Examples/Examples/All Examples/BasicMapExample.swift
@@ -12,9 +12,7 @@ public class BasicMapExample: UIViewController, ExampleProtocol {
 
         mapView = MapView(frame: view.bounds)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        mapView.update { (mapOptions) in
-            mapOptions.ornaments.scaleBarVisibility = .visible
-        }
+        mapView.ornaments.options.scaleBarVisibility = .visible
 
         view.addSubview(mapView)
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Mapbox welcomes participation and contributions from everyone.
       * Removing default values for parameters
       * Making `bearing` and `pitch` parameters optional
       * Adding the `camera(for:camera:rect:)` variant
-  - `OrnamentOptions` should now be accessed via `MapView.ornaments.options`. Updates can be applied directly to the `options` property. Previously the map's ornament options were updated via `MapConfig.ornaments`. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310)) 
+  - `OrnamentOptions` should now be accessed via `MapView.ornaments.options`. `MapConfig.ornaments` has been removed. Updates can be applied directly to `OrnamentsManager.options`. Previously the map's ornament options were updated on `MapConfig.ornaments` with `MapView.update`. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310)) 
   - The `LogoView` class is now private. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310))
 
 ### Features ✨ and improvements 🏁

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Mapbox welcomes participation and contributions from everyone.
   - `OrnamentOptions` should now be accessed via `MapView.ornaments.options`. Updates can be applied directly to the `options` property. Previously the map's ornament options were updated via `MapConfig.ornaments`. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310)) 
   - The `LogoView` class is now private. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310))
 
+### Features ✨ and improvements 🏁
+
+- `OrnamentsManager` is now a public class and can be accessed via the `MapView`'s `ornaments` property.
+
 ## 10.0.0-beta.18.1 - April 28, 2021  
 
 ### Breaking changes ⚠️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Mapbox welcomes participation and contributions from everyone.
       * Removing default values for parameters
       * Making `bearing` and `pitch` parameters optional
       * Adding the `camera(for:camera:rect:)` variant
+  - `OrnamentOptions` should now be accessed via `MapView.ornaments.options`. Updates can be applied directly to the `options` property. Previously the map's ornament options were updated via `MapConfig.ornaments`. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310)) 
+  - The `LogoView` class is now private. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310))
 
 ## 10.0.0-beta.18.1 - April 28, 2021  
 

--- a/Sources/MapboxMaps/Foundation/LogoView.swift
+++ b/Sources/MapboxMaps/Foundation/LogoView.swift
@@ -1,13 +1,13 @@
 import UIKit
 
 // swiftlint:disable function_body_length file_length type_body_length
-public class LogoView: UIView {
+internal class LogoView: UIView {
 
-    public enum LogoSize: RawRepresentable {
+    internal enum LogoSize: RawRepresentable {
         case regular
         case compact
 
-        public init?(rawValue: CGSize) {
+        internal init?(rawValue: CGSize) {
             if rawValue == CGSize(width: 85, height: 21) {
                 self = .regular
             } else if rawValue == CGSize(width: 16, height: 16) {
@@ -17,7 +17,7 @@ public class LogoView: UIView {
             }
         }
 
-        public var rawValue: CGSize {
+        internal var rawValue: CGSize {
             switch self {
             case .regular:
                 return CGSize(width: 85, height: 21)
@@ -33,22 +33,22 @@ public class LogoView: UIView {
         }
     }
 
-    public override var intrinsicContentSize: CGSize {
+    internal override var intrinsicContentSize: CGSize {
         return logoSize.rawValue
     }
 
-    public init(logoSize: LogoSize) {
+    internal init(logoSize: LogoSize) {
         let frame = CGRect(origin: .zero, size: logoSize.rawValue)
         self.logoSize = logoSize
         super.init(frame: frame)
         backgroundColor = UIColor.clear
     }
 
-    public override func draw(_ rect: CGRect) {
+    internal override func draw(_ rect: CGRect) {
         drawMapboxLogoOrnamentViewFullCanvas(frame: rect, resizing: .aspectFit)
     }
 
-    public required init?(coder: NSCoder) {
+    internal required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/Sources/MapboxMaps/MapView/Configuration/MapConfig.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/MapConfig.swift
@@ -5,9 +5,6 @@ public struct MapConfig: Equatable {
     /// Used to configure the gestures on the map
     public var gestures: GestureOptions = GestureOptions()
 
-    /// Used to configure the ornaments on the map
-    internal var ornaments: OrnamentOptions = OrnamentOptions()
-
     /// Used to configure the camera of the map
     public var camera: MapCameraOptions = MapCameraOptions()
 

--- a/Sources/MapboxMaps/MapView/Configuration/MapConfig.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/MapConfig.swift
@@ -6,7 +6,7 @@ public struct MapConfig: Equatable {
     public var gestures: GestureOptions = GestureOptions()
 
     /// Used to configure the ornaments on the map
-    public var ornaments: OrnamentOptions = OrnamentOptions()
+    internal var ornaments: OrnamentOptions = OrnamentOptions()
 
     /// Used to configure the camera of the map
     public var camera: MapCameraOptions = MapCameraOptions()

--- a/Sources/MapboxMaps/MapView/MapView+Managers.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Managers.swift
@@ -20,7 +20,7 @@ extension MapView {
         setupGestures(with: self, options: mapConfig.gestures, cameraManager: camera)
 
         // Initialize/Configure ornaments manager
-        setupOrnaments(with: self, options: OrnamentOptions())
+        setupOrnaments(with: self)
 
         // Initialize/Configure location manager
         setupUserLocationManager(with: self, options: mapConfig.location)
@@ -75,7 +75,7 @@ extension MapView {
         camera.updateMapCameraOptions(newOptions: newOptions)
     }
 
-    internal func setupOrnaments(with view: OrnamentSupportableView, options: OrnamentOptions) {
+    internal func setupOrnaments(with view: OrnamentSupportableView) {
         ornaments = OrnamentsManager(view: view, options: OrnamentOptions())
     }
 

--- a/Sources/MapboxMaps/MapView/MapView+Managers.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Managers.swift
@@ -20,7 +20,7 @@ extension MapView {
         setupGestures(with: self, options: mapConfig.gestures, cameraManager: camera)
 
         // Initialize/Configure ornaments manager
-        setupOrnaments(with: self, options: mapConfig.ornaments)
+        setupOrnaments(with: self, options: OrnamentOptions())
 
         // Initialize/Configure location manager
         setupUserLocationManager(with: self, options: mapConfig.location)
@@ -38,7 +38,6 @@ extension MapView {
         updateMapView(with: mapConfig.render)
         updateCamera(with: mapConfig.camera)
         updateGestures(with: mapConfig.gestures)
-        updateOrnaments(with: mapConfig.ornaments)
         updateUserLocationManager(with: mapConfig.location)
         updateAnnotationManager(with: mapConfig.annotations)
     }
@@ -77,11 +76,7 @@ extension MapView {
     }
 
     internal func setupOrnaments(with view: OrnamentSupportableView, options: OrnamentOptions) {
-        ornaments = OrnamentsManager(view: view, options: options)
-    }
-
-    internal func updateOrnaments(with newOptions: OrnamentOptions) {
-        ornaments.options = newOptions
+        ornaments = OrnamentsManager(view: view, options: OrnamentOptions())
     }
 
     internal func setupUserLocationManager(with locationSupportableMapView: LocationSupportableMapView, options: LocationOptions) {

--- a/Sources/MapboxMaps/MapView/MapView.swift
+++ b/Sources/MapboxMaps/MapView/MapView.swift
@@ -12,7 +12,7 @@ open class MapView: BaseMapView {
     public internal(set) var gestures: GestureManager!
 
     /// The `ornaments`object will be responsible for all ornaments on the map.
-    internal var ornaments: OrnamentsManager!
+    public var ornaments: OrnamentsManager!
 
     /// The `camera` object manages a camera's view lifecycle..
     public internal(set) var camera: CameraAnimationsManager!

--- a/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
@@ -35,16 +35,4 @@ public struct OrnamentOptions: Equatable {
     public var _attributionButtonIsVisible: Bool = true
     public var attributionButtonPosition: OrnamentPosition = .bottomRight
     public var attributionButtonMargins: CGPoint = defaultOrnamentsMargin
-
-    // MARK: - Validation
-
-    /// `true` if there is at most one non-hidden ornament in each position; `false` otherwise.
-    internal var isValid: Bool {
-        let positions = [
-            scaleBarVisibility != .hidden ? scaleBarPosition : nil,
-            compassVisibility != .hidden ? compassViewPosition : nil,
-            _logoViewIsVisible ? logoViewPosition : nil,
-            _attributionButtonIsVisible ? attributionButtonPosition : nil].compactMap { $0 }
-        return Set(positions).count == positions.count
-    }
 }

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -139,28 +139,6 @@ public class OrnamentsManager: NSObject {
 
     func layoutGuide(for view: UIView) -> UILayoutGuide {
         let superview = view.superview!
-        if #available(iOS 11.0, *) {
-            return superview.safeAreaLayoutGuide
-        } else {
-            let layoutGuideIdentifier = "mapboxSafeAreaLayoutGuide"
-            // If there's already a generated layout guide, return it
-            if let layoutGuide = superview.layoutGuides.filter({ $0.identifier == layoutGuideIdentifier }).first {
-                return layoutGuide
-            } else {
-                // If not, then make a new one based off the view's edges.
-                let layoutGuide = UILayoutGuide()
-                layoutGuide.identifier = layoutGuideIdentifier
-                superview.addLayoutGuide(layoutGuide)
-
-                NSLayoutConstraint.activate([
-                    layoutGuide.leftAnchor.constraint(equalTo: superview.leftAnchor),
-                    layoutGuide.rightAnchor.constraint(equalTo: superview.rightAnchor),
-                    layoutGuide.topAnchor.constraint(equalTo: superview.topAnchor),
-                    layoutGuide.bottomAnchor.constraint(equalTo: superview.bottomAnchor)
-                ])
-
-                return layoutGuide
-            }
-        }
+        return superview.safeAreaLayoutGuide
     }
 }

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -14,12 +14,11 @@ public enum OrnamentVisibility: String, Equatable {
     case visible
 }
 
-internal class OrnamentsManager: NSObject {
+public class OrnamentsManager: NSObject {
 
-    /// The `OrnamentOptions` that is used to set up the required ornaments on the map
-    internal var options: OrnamentOptions {
+    /// The `OrnamentOptions` object that is used to set up the required ornaments on the map
+    public var options: OrnamentOptions {
         didSet {
-            assert(options.isValid, "More than one ornament in a single position.")
             updateOrnaments()
         }
     }

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -16,7 +16,7 @@ public enum OrnamentVisibility: String, Equatable {
 
 public class OrnamentsManager: NSObject {
 
-    /// The `OrnamentOptions` object that is used to set up the required ornaments on the map
+    /// The `OrnamentOptions` object that is used to set up and update the required ornaments on the map.
     public var options: OrnamentOptions {
         didSet {
             updateOrnaments()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog> </changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR:
- Makes the `OrnamentsManager` class public, enabling `MapView.ornaments` to be public. This allows `OrnamentsManager` to act as an access point for ornaments options. 
- Removes the `ornaments` property from the `MapConfig`.
- Makes `OrnamentsManager.options` public. This allows the options to be updated via `MapView.ornaments.options`.
- Removes a check for if the iOS version is greater than iOS 11.
- Updates `BasicMapViewExample` to reflect these changes.

Tailwork:
- Update migration guide
### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
