### PR TITLE
Move options for ornaments into individual structs

### DIFF
--- a/Apps/Examples/Examples/All Examples/BasicMapExample.swift
+++ b/Apps/Examples/Examples/All Examples/BasicMapExample.swift
@@ -12,7 +12,7 @@ public class BasicMapExample: UIViewController, ExampleProtocol {
 
         mapView = MapView(frame: view.bounds)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        mapView.ornaments.options.scaleBarVisibility = .visible
+        mapView.ornaments.options.scaleBarOptions.visibility = .visible
 
         view.addSubview(mapView)
     }

--- a/Apps/Examples/Examples/All Examples/BasicMapExample.swift
+++ b/Apps/Examples/Examples/All Examples/BasicMapExample.swift
@@ -12,7 +12,7 @@ public class BasicMapExample: UIViewController, ExampleProtocol {
 
         mapView = MapView(frame: view.bounds)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        mapView.ornaments.options.scaleBarOptions.visibility = .visible
+        mapView.ornaments.options.scaleBar.visibility = .visible
 
         view.addSubview(mapView)
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Mapbox welcomes participation and contributions from everyone.
       * Making `bearing` and `pitch` parameters optional
       * Adding the `camera(for:camera:rect:)` variant
   - `OrnamentOptions` should now be accessed via `MapView.ornaments.options`. `MapConfig.ornaments` has been removed. Updates can be applied directly to `OrnamentsManager.options`. Previously the map's ornament options were updated on `MapConfig.ornaments` with `MapView.update`. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310)) 
+  - `OrnamentOptions` now uses structs to manage options for individual ornaments. For example, `OrnamentOptions.scaleBarPosition` is now `OrnamentOptions.scaleBar.position`. ([#318](https://github.com/mapbox/mapbox-maps-ios/pull/318))
   - The `LogoView` class is now private. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310))
 
 ### Features ✨ and improvements 🏁

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Mapbox welcomes participation and contributions from everyone.
 ### Features ✨ and improvements 🏁
 
 - `OrnamentsManager` is now a public class and can be accessed via the `MapView`'s `ornaments` property.
-- `CompassDirectionFormatter` is now public. It provides a string representation of a `CLLocationDirection` and supports the same languages as in pre-v10 versions of the Maps SDK. ([#300](https://github.com/mapbox/mapbox-maps-ios/pull/300))
+- `CompassDirectionFormatter` is now public. It provides a string representation of a `CLLocationDirection` and supports the same languages as in pre-v10 versions of the Maps SDK. ([#300](https://github.com/mapbox/mapbox-maps-ios/pull/300))- `OrnamentOptions` should now be accessed via `MapView.ornaments.options`. Updates can be applied directly to the `options` property. Previously the map's ornament options were updated via `MapConfig.ornaments`. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310)) 
+- The `LogoView` class is now private. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310))
 
 ## 10.0.0-beta.18.1 - April 28, 2021  
 

--- a/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
@@ -10,9 +10,12 @@ private let defaultOrnamentsMargin = CGPoint(x: 8.0, y: 8.0)
 public struct OrnamentOptions: Equatable {
 
     // MARK: - Scale Bar
+    /// The ornament options for the scale bar. The scale bar has a default position of `.topLeft`.
     public var scaleBarOptions: CompassScaleBarOptions = CompassScaleBarOptions(position: .topLeft)
 
     // MARK: - Compass
+
+    /// The ornament options for the compass view. The compass view has a default position of `.topRight`.
     public var compassViewOptions: CompassScaleBarOptions = CompassScaleBarOptions(position: .topRight)
     // MARK: - Logo View
 
@@ -22,20 +25,30 @@ public struct OrnamentOptions: Equatable {
      information. See https://docs.mapbox.com/help/how-mapbox-works/attribution/
      for details.
      */
+    /// The ornament options for the logo view. The logo view has a default position of `.bottomLeft`.
     public var logoViewOptions: AttributionLogoViewOptions = AttributionLogoViewOptions(position: .bottomLeft)
 
     // MARK: - Attribution Button
-    public var attributionButtonOptions: AttributionLogoViewOptions = AttributionLogoViewOptions(position: .bottomLeft)
+    /// The orname options for the attribution button. The attribution button has a default position of `.bottomRight`.
+    public var attributionButtonOptions: AttributionLogoViewOptions = AttributionLogoViewOptions(position: .bottomRight)
 }
 
+/// Used to configure position, margin, and visibility for the map's scale bar and compass view.
 public struct CompassScaleBarOptions: Equatable {
     public var position: OrnamentPosition
+    /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
     public var margins: CGPoint = defaultOrnamentsMargin
+    /// The default value for this property is `.adaptive`.
     public var visibility: OrnamentVisibility = .adaptive
 }
 
+/// Used to configure the map's logo view and attribution button.
 public struct AttributionLogoViewOptions: Equatable {
     public var position: OrnamentPosition
+
+    /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
     public var margins: CGPoint = defaultOrnamentsMargin
+
+    /// The default value for this property is `true`.
     public var _isVisible: Bool = true
 }

--- a/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
@@ -10,11 +10,10 @@ private let defaultOrnamentsMargin = CGPoint(x: 8.0, y: 8.0)
 public struct OrnamentOptions: Equatable {
 
     // MARK: - Scale Bar
-    public var scaleBarOptions: ScaleBarOptions = ScaleBarOptions()
+    public var scaleBarOptions: CompassScaleBarOptions = CompassScaleBarOptions(position: .topLeft)
 
     // MARK: - Compass
-    public var compassViewOptions: CompassViewOptions = CompassViewOptions()
-
+    public var compassViewOptions: CompassScaleBarOptions = CompassScaleBarOptions(position: .topRight)
     // MARK: - Logo View
 
     /**
@@ -23,32 +22,20 @@ public struct OrnamentOptions: Equatable {
      information. See https://docs.mapbox.com/help/how-mapbox-works/attribution/
      for details.
      */
-    public var logoViewOptions: LogoViewOptions = LogoViewOptions()
+    public var logoViewOptions: AttributionLogoViewOptions = AttributionLogoViewOptions(position: .bottomLeft)
 
     // MARK: - Attribution Button
-    public var attributionButtonOptions: AttributionViewOptions = AttributionViewOptions()
+    public var attributionButtonOptions: AttributionLogoViewOptions = AttributionLogoViewOptions(position: .bottomLeft)
 }
 
-public struct ScaleBarOptions: Equatable {
-    public var scaleBarPosition: OrnamentPosition = .topLeft
-    public var scaleBarMargins: CGPoint = defaultOrnamentsMargin
-    public var scaleBarVisibility: OrnamentVisibility = .adaptive
+public struct CompassScaleBarOptions: Equatable {
+    public var position: OrnamentPosition
+    public var margins: CGPoint = defaultOrnamentsMargin
+    public var visibility: OrnamentVisibility = .adaptive
 }
 
-public struct CompassViewOptions: Equatable {
-    public var compassViewPosition: OrnamentPosition = .topRight
-    public var compassViewMargins: CGPoint = defaultOrnamentsMargin
-    public var compassVisibility: OrnamentVisibility = .adaptive
-}
-
-public struct LogoViewOptions: Equatable {
-    public var _logoViewIsVisible: Bool = true
-    public var logoViewPosition: OrnamentPosition = .bottomLeft
-    public var logoViewMargins: CGPoint = defaultOrnamentsMargin
-}
-
-public struct AttributionViewOptions: Equatable {
-    public var _attributionButtonIsVisible: Bool = true
-    public var attributionButtonPosition: OrnamentPosition = .bottomRight
-    public var attributionButtonMargins: CGPoint = defaultOrnamentsMargin
+public struct AttributionLogoViewOptions: Equatable {
+    public var position: OrnamentPosition
+    public var margins: CGPoint = defaultOrnamentsMargin
+    public var _isVisible: Bool = true
 }

--- a/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
@@ -29,7 +29,7 @@ public struct OrnamentOptions: Equatable {
     public var logoViewOptions: AttributionLogoViewOptions = AttributionLogoViewOptions(position: .bottomLeft)
 
     // MARK: - Attribution Button
-    /// The orname options for the attribution button. The attribution button has a default position of `.bottomRight`.
+    /// The ornament options for the attribution button. The attribution button has a default position of `.bottomRight`.
     public var attributionButtonOptions: AttributionLogoViewOptions = AttributionLogoViewOptions(position: .bottomRight)
 }
 

--- a/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
@@ -10,16 +10,10 @@ private let defaultOrnamentsMargin = CGPoint(x: 8.0, y: 8.0)
 public struct OrnamentOptions: Equatable {
 
     // MARK: - Scale Bar
-
-    public var scaleBarPosition: OrnamentPosition = .topLeft
-    public var scaleBarMargins: CGPoint = defaultOrnamentsMargin
-    public var scaleBarVisibility: OrnamentVisibility = .adaptive
+    public var scaleBarOptions: ScaleBarOptions = ScaleBarOptions()
 
     // MARK: - Compass
-
-    public var compassViewPosition: OrnamentPosition = .topRight
-    public var compassViewMargins: CGPoint = defaultOrnamentsMargin
-    public var compassVisibility: OrnamentVisibility = .adaptive
+    public var compassViewOptions: CompassViewOptions = CompassViewOptions()
 
     // MARK: - Logo View
 
@@ -29,13 +23,31 @@ public struct OrnamentOptions: Equatable {
      information. See https://docs.mapbox.com/help/how-mapbox-works/attribution/
      for details.
      */
+    public var logoViewOptions: LogoViewOptions = LogoViewOptions()
 
+    // MARK: - Attribution Button
+    public var attributionButtonOptions: AttributionViewOptions = AttributionViewOptions()
+}
+
+public struct ScaleBarOptions: Equatable {
+    public var scaleBarPosition: OrnamentPosition = .topLeft
+    public var scaleBarMargins: CGPoint = defaultOrnamentsMargin
+    public var scaleBarVisibility: OrnamentVisibility = .adaptive
+}
+
+public struct CompassViewOptions: Equatable {
+    public var compassViewPosition: OrnamentPosition = .topRight
+    public var compassViewMargins: CGPoint = defaultOrnamentsMargin
+    public var compassVisibility: OrnamentVisibility = .adaptive
+}
+
+public struct LogoViewOptions: Equatable {
     public var _logoViewIsVisible: Bool = true
     public var logoViewPosition: OrnamentPosition = .bottomLeft
     public var logoViewMargins: CGPoint = defaultOrnamentsMargin
+}
 
-    // MARK: - Attribution Button
-
+public struct AttributionViewOptions: Equatable {
     public var _attributionButtonIsVisible: Bool = true
     public var attributionButtonPosition: OrnamentPosition = .bottomRight
     public var attributionButtonMargins: CGPoint = defaultOrnamentsMargin

--- a/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
@@ -17,8 +17,8 @@ public struct OrnamentOptions: Equatable {
 
     /// The ornament options for the compass view. The compass view has a default position of `.topRight`.
     public var compassViewOptions: CompassScaleBarOptions = CompassScaleBarOptions(position: .topRight)
-    // MARK: - Logo View
 
+    // MARK: - Logo View
     /**
      Per our terms of service, a Mapbox map is required to display both
      a Mapbox logo as well as an information icon that contains attribution
@@ -45,10 +45,8 @@ public struct CompassScaleBarOptions: Equatable {
 /// Used to configure the map's logo view and attribution button.
 public struct AttributionLogoViewOptions: Equatable {
     public var position: OrnamentPosition
-
     /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
     public var margins: CGPoint = defaultOrnamentsMargin
-
     /// The default value for this property is `true`.
     public var _isVisible: Bool = true
 }

--- a/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
@@ -11,12 +11,12 @@ public struct OrnamentOptions: Equatable {
 
     // MARK: - Scale Bar
     /// The ornament options for the scale bar.
-    public var scaleBarOptions = ScaleBarViewOptions()
+    public var scaleBar = ScaleBarViewOptions()
 
     // MARK: - Compass
 
     /// The ornament options for the compass view.
-    public var compassViewOptions = CompassViewOptions()
+    public var compass = CompassViewOptions()
 
     // MARK: - Logo View
     /**
@@ -26,11 +26,11 @@ public struct OrnamentOptions: Equatable {
      for details.
      */
     /// The ornament options for the logo view.
-    public var logoViewOptions = LogoViewOptions()
+    public var logo = LogoViewOptions()
 
     // MARK: - Attribution Button
     /// The ornament options for the attribution button.
-    public var attributionButtonOptions = AttributionButtonOptions()
+    public var attributionButton = AttributionButtonOptions()
 }
 
 public protocol BaseOrnamentOptions: Equatable {

--- a/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
@@ -10,13 +10,13 @@ private let defaultOrnamentsMargin = CGPoint(x: 8.0, y: 8.0)
 public struct OrnamentOptions: Equatable {
 
     // MARK: - Scale Bar
-    /// The ornament options for the scale bar. The scale bar has a default position of `.topLeft`.
-    public var scaleBarOptions: CompassScaleBarOptions = CompassScaleBarOptions(position: .topLeft)
+    /// The ornament options for the scale bar.
+    public var scaleBarOptions = ScaleBarViewOptions()
 
     // MARK: - Compass
 
-    /// The ornament options for the compass view. The compass view has a default position of `.topRight`.
-    public var compassViewOptions: CompassScaleBarOptions = CompassScaleBarOptions(position: .topRight)
+    /// The ornament options for the compass view.
+    public var compassViewOptions = CompassViewOptions()
 
     // MARK: - Logo View
     /**
@@ -25,26 +25,53 @@ public struct OrnamentOptions: Equatable {
      information. See https://docs.mapbox.com/help/how-mapbox-works/attribution/
      for details.
      */
-    /// The ornament options for the logo view. The logo view has a default position of `.bottomLeft`.
-    public var logoViewOptions: AttributionLogoViewOptions = AttributionLogoViewOptions(position: .bottomLeft)
+    /// The ornament options for the logo view.
+    public var logoViewOptions = LogoViewOptions()
 
     // MARK: - Attribution Button
-    /// The ornament options for the attribution button. The attribution button has a default position of `.bottomRight`.
-    public var attributionButtonOptions: AttributionLogoViewOptions = AttributionLogoViewOptions(position: .bottomRight)
+    /// The ornament options for the attribution button.
+    public var attributionButtonOptions = AttributionButtonOptions()
 }
 
-/// Used to configure position, margin, and visibility for the map's scale bar and compass view.
-public struct CompassScaleBarOptions: Equatable {
-    public var position: OrnamentPosition
+public protocol BaseOrnamentOptions: Equatable {
+    var position: OrnamentPosition { get set }
+    var margins: CGPoint { get set }
+}
+
+/// Used to configure position, margin, and visibility for the map's scale bar.
+public struct ScaleBarViewOptions: BaseOrnamentOptions {
+    /// The default value for this property is `.topLeft`.
+    public var position: OrnamentPosition = .topLeft
     /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
     public var margins: CGPoint = defaultOrnamentsMargin
     /// The default value for this property is `.adaptive`.
     public var visibility: OrnamentVisibility = .adaptive
 }
 
-/// Used to configure the map's logo view and attribution button.
-public struct AttributionLogoViewOptions: Equatable {
-    public var position: OrnamentPosition
+/// Used to configure position, margin, and visibility for the map's compass view.
+public struct CompassViewOptions: BaseOrnamentOptions {
+    /// The default value for this property is `.topRight`.
+    public var position: OrnamentPosition = .topRight
+    /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
+    public var margins: CGPoint = defaultOrnamentsMargin
+    /// The default value for this property is `.adaptive`.
+    public var visibility: OrnamentVisibility = .adaptive
+}
+
+/// Used to configure position, margin, and visibility for the map's attribution button.
+public struct AttributionButtonOptions: Equatable {
+    /// The default value for this property is `.bottomRight`.
+    public var position: OrnamentPosition = .bottomRight
+    /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
+    public var margins: CGPoint = defaultOrnamentsMargin
+    /// The default value for this property is `true`.
+    public var _isVisible: Bool = true
+}
+
+/// Used to configure position, margin, and visibility for the map's logo view.
+public struct LogoViewOptions: Equatable {
+    /// The default value for this property is `.bottomLeft`.
+    public var position: OrnamentPosition = .bottomLeft
     /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
     public var margins: CGPoint = defaultOrnamentsMargin
     /// The default value for this property is `true`.

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -44,7 +44,7 @@ public class OrnamentsManager: NSObject {
         view.addSubview(scalebarView)
 
         // Compass View
-        compassView = MapboxCompassOrnamentView(visibility: options.compassViewOptions.compassVisibility)
+        compassView = MapboxCompassOrnamentView(visibility: options.compassViewOptions.visibility)
         compassView.translatesAutoresizingMaskIntoConstraints = false
         compassView.tapAction = { [weak view] in
             view?.compassTapped()
@@ -80,25 +80,33 @@ public class OrnamentsManager: NSObject {
         constraints.removeAll()
 
         // Update the position for the ornaments
-        let logoViewConstraints = constraints(with: logoView, position: options.logoViewPosition, margins: options.logoViewMargins)
+        let logoViewConstraints = constraints(with: logoView,
+                                              position: options.logoViewOptions.position,
+                                              margins: options.logoViewOptions.margins)
         constraints.append(contentsOf: logoViewConstraints)
 
-        let compassViewConstraints = constraints(with: compassView, position: options.compassViewPosition, margins: options.compassViewMargins)
+        let compassViewConstraints = constraints(with: compassView,
+                                                 position: options.compassViewOptions.position,
+                                                 margins: options.compassViewOptions.margins)
         constraints.append(contentsOf: compassViewConstraints)
 
-        let scaleBarViewConstraints = constraints(with: scalebarView, position: options.scaleBarPosition, margins: options.scaleBarMargins)
+        let scaleBarViewConstraints = constraints(with: scalebarView,
+                                                  position: options.scaleBarOptions.position,
+                                                  margins: options.scaleBarOptions.margins)
         constraints.append(contentsOf: scaleBarViewConstraints)
 
-        let attributionButtonConstraints = constraints(with: attributionButton, position: options.attributionButtonPosition, margins: options.attributionButtonMargins)
+        let attributionButtonConstraints = constraints(with: attributionButton,
+                                                       position: options.attributionButtonOptions.position,
+                                                       margins: options.attributionButtonOptions.margins)
         constraints.append(contentsOf: attributionButtonConstraints)
 
         // Activate new constraints
         NSLayoutConstraint.activate(constraints)
 
-        logoView.isHidden = !options._logoViewIsVisible
-        scalebarView.isHidden = options.scaleBarVisibility == .hidden
-        compassView.isHidden = options.compassVisibility == .hidden
-        attributionButton.isHidden = !options._attributionButtonIsVisible
+        logoView.isHidden = !options.logoViewOptions._isVisible
+        scalebarView.isHidden = options.scaleBarOptions.visibility == .hidden
+        compassView.isHidden = options.compassViewOptions.visibility == .hidden
+        attributionButton.isHidden = !options.attributionButtonOptions._isVisible
     }
 
     private func constraints(with view: UIView, position: OrnamentPosition, margins: CGPoint) -> [NSLayoutConstraint] {

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -44,7 +44,7 @@ public class OrnamentsManager: NSObject {
         view.addSubview(scalebarView)
 
         // Compass View
-        compassView = MapboxCompassOrnamentView(visibility: options.compassViewOptions.visibility)
+        compassView = MapboxCompassOrnamentView(visibility: options.compass.visibility)
         compassView.translatesAutoresizingMaskIntoConstraints = false
         compassView.tapAction = { [weak view] in
             view?.compassTapped()
@@ -81,32 +81,32 @@ public class OrnamentsManager: NSObject {
 
         // Update the position for the ornaments
         let logoViewConstraints = constraints(with: logoView,
-                                              position: options.logoViewOptions.position,
-                                              margins: options.logoViewOptions.margins)
+                                              position: options.logo.position,
+                                              margins: options.logo.margins)
         constraints.append(contentsOf: logoViewConstraints)
 
         let compassViewConstraints = constraints(with: compassView,
-                                                 position: options.compassViewOptions.position,
-                                                 margins: options.compassViewOptions.margins)
+                                                 position: options.compass.position,
+                                                 margins: options.compass.margins)
         constraints.append(contentsOf: compassViewConstraints)
 
         let scaleBarViewConstraints = constraints(with: scalebarView,
-                                                  position: options.scaleBarOptions.position,
-                                                  margins: options.scaleBarOptions.margins)
+                                                  position: options.scaleBar.position,
+                                                  margins: options.scaleBar.margins)
         constraints.append(contentsOf: scaleBarViewConstraints)
 
         let attributionButtonConstraints = constraints(with: attributionButton,
-                                                       position: options.attributionButtonOptions.position,
-                                                       margins: options.attributionButtonOptions.margins)
+                                                       position: options.attributionButton.position,
+                                                       margins: options.attributionButton.margins)
         constraints.append(contentsOf: attributionButtonConstraints)
 
         // Activate new constraints
         NSLayoutConstraint.activate(constraints)
 
-        logoView.isHidden = !options.logoViewOptions._isVisible
-        scalebarView.isHidden = options.scaleBarOptions.visibility == .hidden
-        compassView.isHidden = options.compassViewOptions.visibility == .hidden
-        attributionButton.isHidden = !options.attributionButtonOptions._isVisible
+        logoView.isHidden = !options.logo._isVisible
+        scalebarView.isHidden = options.scaleBar.visibility == .hidden
+        compassView.isHidden = options.compass.visibility == .hidden
+        attributionButton.isHidden = !options.attributionButton._isVisible
     }
 
     private func constraints(with view: UIView, position: OrnamentPosition, margins: CGPoint) -> [NSLayoutConstraint] {

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -44,7 +44,7 @@ public class OrnamentsManager: NSObject {
         view.addSubview(scalebarView)
 
         // Compass View
-        compassView = MapboxCompassOrnamentView(visibility: options.compassVisibility)
+        compassView = MapboxCompassOrnamentView(visibility: options.compassViewOptions.compassVisibility)
         compassView.translatesAutoresizingMaskIntoConstraints = false
         compassView.tapAction = { [weak view] in
             view?.compassTapped()

--- a/Tests/MapboxMapsTests/Ornaments/OrnamentManagerTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/OrnamentManagerTests.swift
@@ -27,7 +27,7 @@ class OrnamentManagerTests: XCTestCase {
 
     func testInitializer() {
         XCTAssertEqual(ornamentSupportableView.subviews.count, 4)
-        XCTAssertEqual(ornamentsManager.options.attributionButtonMargins, options.attributionButtonMargins)
+        XCTAssertEqual(ornamentsManager.options.attributionButtonOptions.margins, options.attributionButtonOptions.margins)
 
     }
 
@@ -38,12 +38,12 @@ class OrnamentManagerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(options.compassVisibility, .adaptive)
-        options.compassVisibility = .hidden
+        XCTAssertEqual(options.compassViewOptions.visibility, .adaptive)
+        options.compassViewOptions.visibility = .hidden
 
         ornamentsManager.options = options
 
-        XCTAssertEqual(options.compassVisibility, .hidden)
+        XCTAssertEqual(options.compassViewOptions.visibility, .hidden)
 
         let updatedSubviews = ornamentSupportableView.subviews.filter { $0.isKind(of: MapboxCompassOrnamentView.self) }
         guard let isUpdatedCompassHidden = updatedSubviews.first?.isHidden else {

--- a/Tests/MapboxMapsTests/Ornaments/OrnamentManagerTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/OrnamentManagerTests.swift
@@ -27,7 +27,7 @@ class OrnamentManagerTests: XCTestCase {
 
     func testInitializer() {
         XCTAssertEqual(ornamentSupportableView.subviews.count, 4)
-        XCTAssertEqual(ornamentsManager.options.attributionButtonOptions.margins, options.attributionButtonOptions.margins)
+        XCTAssertEqual(ornamentsManager.options.attributionButton.margins, options.attributionButton.margins)
 
     }
 
@@ -38,12 +38,12 @@ class OrnamentManagerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(options.compassViewOptions.visibility, .adaptive)
-        options.compassViewOptions.visibility = .hidden
+        XCTAssertEqual(options.compass.visibility, .adaptive)
+        options.compass.visibility = .hidden
 
         ornamentsManager.options = options
 
-        XCTAssertEqual(options.compassViewOptions.visibility, .hidden)
+        XCTAssertEqual(options.compass.visibility, .hidden)
 
         let updatedSubviews = ornamentSupportableView.subviews.filter { $0.isKind(of: MapboxCompassOrnamentView.self) }
         guard let isUpdatedCompassHidden = updatedSubviews.first?.isHidden else {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR breaks the different ornament options into separate structs, which are then accessed via properties on OrnamentOptions. Therefore, `OrnamentOptions.scaleBarVisibility` becomes `OrnamentOptions.scaleBar.visibility`.
### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
