### PR TITLE
Add source and source properties to StyleManagerProtocol

### DIFF
--- a/Apps/Examples/Examples/All Examples/AnimateGeoJSONLineExample.swift
+++ b/Apps/Examples/Examples/All Examples/AnimateGeoJSONLineExample.swift
@@ -64,8 +64,7 @@ public class AnimateGeoJSONLineExample: UIViewController, ExampleProtocol {
         lineLayer.layout?.lineJoin = .constant(.round)
 
         // Add the lineLayer to the map.
-        mapView.style.addSource(source: routeLineSource,
-                                identifier: sourceIdentifier)
+        try! mapView.style.addSource(routeLineSource, id: sourceIdentifier)
         try! mapView.style.addLayer(lineLayer)
     }
 

--- a/Apps/Examples/Examples/All Examples/AnimateLayerExample.swift
+++ b/Apps/Examples/Examples/All Examples/AnimateLayerExample.swift
@@ -92,10 +92,10 @@ public class AnimateLayerExample: UIViewController, ExampleProtocol {
         })
 
         // Add the sources and layers to the map style.
-        _ = mapView.style.addSource(source: airplaneRoute.source, identifier: airplaneRoute.identifier)
-        try! mapView.style.addLayer(lineLayer, layerPosition: nil)
+        try! mapView.style.addSource(airplaneRoute.source, id: airplaneRoute.identifier)
+        try! mapView.style.addLayer(lineLayer)
 
-        _ = mapView.style.addSource(source: airplaneSymbol.source, identifier: airplaneSymbol.identifier)
+        try! mapView.style.addSource(airplaneSymbol.source, id: airplaneSymbol.identifier)
         try! mapView.style.addLayer(airplaneSymbolLayer, layerPosition: nil)
     }
 

--- a/Apps/Examples/Examples/All Examples/DataDrivenSymbolsExample.swift
+++ b/Apps/Examples/Examples/All Examples/DataDrivenSymbolsExample.swift
@@ -39,7 +39,7 @@ public class DataDrivenSymbolsExample: UIViewController, ExampleProtocol {
         // This tileset was created by uploading NPS shapefiles to Mapbox Studio.
         var source = VectorSource()
         source.url = "mapbox://examples.ciuz0vpc"
-        _ = mapView.style.addSource(source: source, identifier: sourceLayerIdentifier)
+        try! mapView.style.addSource(source, id: sourceLayerIdentifier)
 
         // Create a symbol layer and access the layer contained.
         var layer = SymbolLayer(id: sourceLayerIdentifier)

--- a/Apps/Examples/Examples/All Examples/ExternalVectorSourceExample.swift
+++ b/Apps/Examples/Examples/All Examples/ExternalVectorSourceExample.swift
@@ -44,15 +44,15 @@ public class ExternalVectorSourceExample: UIViewController, ExampleProtocol {
         lineLayer.paint?.lineWidth = .constant(2.0)
         lineLayer.layout?.lineCap = .constant(.round)
 
-        let addSourceResult = mapView.style.addSource(source: vectorSource, identifier: sourceIdentifier)
+        do {
+            try mapView.style.addSource(vectorSource, id: sourceIdentifier)
+        } catch {
+            displayAlert(message: error.localizedDescription)
+        }
 
         // Define the layer's positioning within the layer stack so
         // that it doesn't obscure other important labels.
         let layerPosition = LayerPosition(above: nil, below: "waterway-label", at: nil)
-
-        if case .failure(let sourceError) = addSourceResult {
-            displayAlert(message: sourceError.localizedDescription)
-        }
 
         do {
             try mapView.style.addLayer(lineLayer, layerPosition: layerPosition)

--- a/Apps/Examples/Examples/All Examples/FeaturesAtPointExample.swift
+++ b/Apps/Examples/Examples/All Examples/FeaturesAtPointExample.swift
@@ -49,7 +49,7 @@ public class FeaturesAtPointExample: UIViewController, ExampleProtocol {
         fillLayer.paint?.fillOutlineColor = .constant(ColorRepresentable(color: UIColor.black))
 
         // Add the data source and style layer to the map.
-        _ = mapView.style.addSource(source: geoJSONSource, identifier: sourceIdentifier)
+        try! mapView.style.addSource(geoJSONSource, id: sourceIdentifier)
         try! mapView.style.addLayer(fillLayer, layerPosition: nil)
 
         // Set up the tap gesture

--- a/Apps/Examples/Examples/All Examples/FitCameraToGeometryExample.swift
+++ b/Apps/Examples/Examples/All Examples/FitCameraToGeometryExample.swift
@@ -43,16 +43,16 @@ public class FitCameraToGeometryExample: UIViewController, ExampleProtocol {
         polygonLayer.paint?.fillColor = .constant(ColorRepresentable(color: .gray))
         polygonLayer.source = sourceIdentifier
 
-        let addSourceResult = mapView.style?.addSource(source: source, identifier: sourceIdentifier)
-
-        if case .failure(let sourceError) = addSourceResult {
-            displayAlert(message: sourceError.localizedDescription)
+        do {
+            try mapView.style?.addSource(source, id: sourceIdentifier)
+        } catch {
+            displayAlert(message: error.localizedDescription)
         }
 
         do {
             try mapView.style?.addLayer(polygonLayer, layerPosition: nil)
-        } catch let layerError {
-            displayAlert(message: layerError.localizedDescription)
+        } catch {
+            displayAlert(message: error.localizedDescription)
         }
 
         let newCamera = mapView.mapboxMap.camera(for: polygon, padding: .zero, bearing: 0, pitch: 0)

--- a/Apps/Examples/Examples/All Examples/GeoJSONSourceExample.swift
+++ b/Apps/Examples/Examples/All Examples/GeoJSONSourceExample.swift
@@ -89,10 +89,10 @@ public class GeoJSONSourceExample: UIViewController, ExampleProtocol {
         polygonLayer.paint?.fillOpacity = .constant(0.3)
         polygonLayer.paint?.fillOutlineColor = .constant(ColorRepresentable(color: UIColor.purple))
         // Add the source and style layers to the map style.
-        _ = mapView.style.addSource(source: geoJSONSource, identifier: geoJSONDataSourceIdentifier)
-        try! mapView.style.addLayer(circleLayer, layerPosition: nil)
-        try! mapView.style.addLayer(lineLayer, layerPosition: nil)
-        try! mapView.style.addLayer(polygonLayer, layerPosition: nil)
+        try! mapView.style.addSource(geoJSONSource, id: geoJSONDataSourceIdentifier)
+        try! mapView.style.addLayer(circleLayer)
+        try! mapView.style.addLayer(lineLayer)
+        try! mapView.style.addLayer(polygonLayer)
 
         // The below line is used for internal testing purposes only.
         finish()

--- a/Apps/Examples/Examples/All Examples/LayerBelowExample.swift
+++ b/Apps/Examples/Examples/All Examples/LayerBelowExample.swift
@@ -43,7 +43,7 @@ public class LayerBelowExample: UIViewController, ExampleProtocol {
         layer.paint?.fillOutlineColor = .constant(ColorRepresentable(color: #colorLiteral(red: 0.03167597491, green: 0.3966798381, blue: 0.043041647, alpha: 1)))
 
         // Add the data source to the map
-        _ = mapView.style.addSource(source: source, identifier: sourceIdentifier)
+        try! mapView.style.addSource(source, id: sourceIdentifier)
         // Add the layer to the map below the "settlement-label" layer
         try! mapView.style.addLayer(layer, layerPosition: LayerPosition(below: "settlement-label"))
 

--- a/Apps/Examples/Examples/All Examples/LayerPositionExample.swift
+++ b/Apps/Examples/Examples/All Examples/LayerPositionExample.swift
@@ -108,7 +108,8 @@ public class LayerPositionExample: UIViewController, ExampleProtocol {
             CLLocationCoordinate2DMake(32.91648534731439, -114.43359375)
         ]])))
 
-        _ = mapView.style.addSource(source: source, identifier: sourceIdentifier)
+        try! mapView.style.addSource(source, id: sourceIdentifier)
+
         // If a layer position is not supplied, the layer is added above all other layers by default.
         try! mapView.style.addLayer(layer, layerPosition: nil)
 

--- a/Apps/Examples/Examples/All Examples/LineGradientExample.swift
+++ b/Apps/Examples/Examples/All Examples/LineGradientExample.swift
@@ -104,7 +104,7 @@ public class LineGradientExample: UIViewController, ExampleProtocol {
         lineLayer.layout?.lineJoin = .constant(.round)
 
         // Add the source and style layer to the map style.
-        mapView.style.addSource(source: geoJSONSource, identifier: geoJSONDataSourceIdentifier)
+        try! mapView.style.addSource(geoJSONSource, id: geoJSONDataSourceIdentifier)
         try! mapView.style.addLayer(lineLayer, layerPosition: nil)
     }
 }

--- a/Apps/Examples/Examples/All Examples/SceneKitExample.swift
+++ b/Apps/Examples/Examples/All Examples/SceneKitExample.swift
@@ -48,7 +48,9 @@ public class SceneKitExample: UIViewController, ExampleProtocol, CustomLayerHost
         demSource.url = "mapbox://mapbox.mapbox-terrain-dem-v1"
         demSource.tileSize = 512
         demSource.maxzoom = 14.0
-        mapView.style.addSource(source: demSource, identifier: "mapbox-dem")
+
+        try! mapView.style.addSource(demSource, id: "mapbox-dem")
+
         let terrain = Terrain(sourceId: "mapbox-dem")
         _ = self.mapView.style.setTerrain(terrain)
 

--- a/Apps/Examples/Examples/All Examples/TerrainExample.swift
+++ b/Apps/Examples/Examples/All Examples/TerrainExample.swift
@@ -33,7 +33,7 @@ public class TerrainExample: UIViewController, ExampleProtocol {
         demSource.url = "mapbox://mapbox.mapbox-terrain-dem-v1"
         demSource.tileSize = 512
         demSource.maxzoom = 14.0
-        _ = mapView.style.addSource(source: demSource, identifier: "mapbox-dem")
+        try! mapView.style.addSource(demSource, id: "mapbox-dem")
 
         var terrain = Terrain(sourceId: "mapbox-dem")
         terrain.exaggeration = .constant(1.5)

--- a/Sources/MapboxMaps/Annotations/AnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationManager.swift
@@ -347,24 +347,17 @@ public class AnnotationManager {
     /**
      Adds a new source layer for all annotations.
      */
-    internal func createAnnotationSource() -> Result<Bool, AnnotationError> {
+    internal func createAnnotationSource() throws {
 
         annotationSource = GeoJSONSource()
 
-        guard var sourceLayer = annotationSource else {
-            return .failure(.addAnnotationFailed(nil))
+        guard var source = annotationSource else {
+            throw AnnotationError.addAnnotationFailed(nil)
         }
 
-        sourceLayer.data = .featureCollection(annotationFeatures)
+        source.data = .featureCollection(annotationFeatures)
 
-        let addSourceExpectation = styleDelegate.addSource(source: sourceLayer, identifier: sourceId)
-
-        switch addSourceExpectation {
-        case .success(let bool):
-            return .success(bool)
-        case .failure(let sourceError):
-            return .failure(.addAnnotationFailed(sourceError))
-        }
+        try styleDelegate.addSource(source, id: sourceId)
     }
 
     /**
@@ -447,9 +440,7 @@ public class AnnotationManager {
         }
 
         if annotationSource == nil {
-            if case .failure(let sourceError) = createAnnotationSource() {
-                throw AnnotationError.addAnnotationFailed(sourceError)
-            }
+            try createAnnotationSource()
         } else {
             let updateSourceExpectation = styleDelegate.updateSourceProperty(id: sourceId,
                                                                              property: "data",

--- a/Sources/MapboxMaps/Annotations/AnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationManager.swift
@@ -268,15 +268,11 @@ public class AnnotationManager {
             return .failure(.removeAnnotationFailed("Failed to parse data from FeatureCollection"))
         }
 
-        let updateSourceExpectation = styleDelegate.updateSourceProperty(id: sourceId,
-                                                                         property: "data",
-                                                                         value: geoJSONDictionary)
-
-        switch updateSourceExpectation {
-        case .success(let bool):
-            return .success(bool)
-        case .failure(let sourceError):
-            return .failure(.removeAnnotationFailed(sourceError.localizedDescription))
+        do {
+            try styleDelegate.setSourceProperty(for: sourceId, property: "data", value: geoJSONDictionary)
+            return .success(true)
+        } catch {
+            return .failure(.removeAnnotationFailed(error.localizedDescription))
         }
     }
 
@@ -442,12 +438,7 @@ public class AnnotationManager {
         if annotationSource == nil {
             try createAnnotationSource()
         } else {
-            let updateSourceExpectation = styleDelegate.updateSourceProperty(id: sourceId,
-                                                                             property: "data",
-                                                                             value: geoJSON)
-            if case .failure(let sourceError) = updateSourceExpectation {
-                throw AnnotationError.addAnnotationFailed(sourceError)
-            }
+            try styleDelegate.setSourceProperty(for: sourceId, property: "data", value: geoJSON)
         }
     }
 

--- a/Sources/MapboxMaps/Annotations/AnnotationStyleDelegate.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationStyleDelegate.swift
@@ -19,8 +19,7 @@ public protocol AnnotationStyleDelegate {
 
     func getStyleImage(with identifier: String) -> Image?
 
-    func addSource(source: Source,
-                   identifier: String) -> Result<Bool, SourceError>
+    func addSource(_ source: Source, id: String) throws
 
     // swiftlint:disable identifier_name
     func updateSourceProperty(id: String,

--- a/Sources/MapboxMaps/Annotations/AnnotationStyleDelegate.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationStyleDelegate.swift
@@ -21,10 +21,7 @@ public protocol AnnotationStyleDelegate {
 
     func addSource(_ source: Source, id: String) throws
 
-    // swiftlint:disable identifier_name
-    func updateSourceProperty(id: String,
-                              property: String,
-                              value: [String: Any]) -> Result<Bool, SourceError>
+    func setSourceProperty(for sourceId: String, property: String, value: Any) throws
 
     func addLayer(_ layer: Layer, layerPosition: LayerPosition?) throws
 }

--- a/Sources/MapboxMaps/Foundation/GeoJSONManager.swift
+++ b/Sources/MapboxMaps/Foundation/GeoJSONManager.swift
@@ -40,7 +40,7 @@ public struct GeoJSONManager {
     /**
      Converts a generic object confirming to the `GeoJSONObject` protocol
      to a dictionary representation of that data. Use this method when creating
-     a new GeoJSON source with `MBXStyleManager.addStyleSource(forSourceId:properties)`.
+     a new GeoJSON source with `Style.addSource(_:properties)`.
 
      - Parameter geoJSONObject: A generic object that conforms to the `GeoJSONObject` protocol.
      - Returns: A nested dictionary that represents the `data` object of a GeoJSON feature.

--- a/Sources/MapboxMaps/Location/Pucks/Puck3D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck3D.swift
@@ -110,7 +110,7 @@ internal class Puck3D: Puck {
         modelSource.models = [key: model]
         if let data = try? JSONEncoder().encode([key: model]),
            let jsonDictionary = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-            style.updateSourceProperty(id: "puck-model-source", property: "models", value: jsonDictionary)
+            try? style.setSourceProperty(for: "puck-model-source", property: "models", value: jsonDictionary)
         }
     }
 

--- a/Sources/MapboxMaps/Location/Pucks/Puck3D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck3D.swift
@@ -77,7 +77,9 @@ internal class Puck3D: Puck {
                 return
             }
             self.removePuck()
-            style.addSource(source: self.modelSource, identifier: "puck-model-source")
+
+            // TODO: On first setup "puck-model does not have a uri"
+            try? style.addSource(self.modelSource, id: "puck-model-source")
             try! style.addLayer(self.modelLayer)
         }
 
@@ -126,6 +128,6 @@ internal class Puck3D: Puck {
         }
 
         try! style.removeLayer(withId: "puck-model-layer")
-        style.styleManager.removeStyleSource(forSourceId: "puck-model-source")
+        try! style.removeSource(withId: "puck-model-source")
     }
 }

--- a/Sources/MapboxMaps/Style/Sources.swift
+++ b/Sources/MapboxMaps/Style/Sources.swift
@@ -45,3 +45,12 @@ public extension Source {
         self = try JSONDecoder().decode(Self.self, from: sourceData)
     }
 }
+
+/// Information about a Source
+public struct SourceInfo {
+    /// The identifier of the source
+    var id: String
+
+    /// The type of the source
+    var type: SourceType
+}

--- a/Sources/MapboxMaps/Style/StyleErrors.swift
+++ b/Sources/MapboxMaps/Style/StyleErrors.swift
@@ -15,16 +15,16 @@ public enum SourceError: Error {
     case sourceDecodingFailed(Error)
 
     /// The source could not be added to the map
-    case addSourceFailed(String?)
+    case addSourceFailed(String)
+
+    /// The source could not be removed from the map
+    case removeSourceFailed(String)
 
     /// The source could not be retrieved from the map
     case getSourceFailed(String?)
 
     /// The source property could not be set.
     case setSourceProperty(String?)
-
-    /// The source could not be removed from the map
-    case removeSourceFailed(String?)
 }
 
 /// Error enum for all layer-related errors

--- a/Sources/MapboxMaps/Style/StyleErrors.swift
+++ b/Sources/MapboxMaps/Style/StyleErrors.swift
@@ -21,10 +21,10 @@ public enum SourceError: Error {
     case removeSourceFailed(String)
 
     /// The source could not be retrieved from the map
-    case getSourceFailed(String?)
+    case getSourceFailed(String)
 
     /// The source property could not be set.
-    case setSourceProperty(String?)
+    case setSourceProperty(String)
 }
 
 /// Error enum for all layer-related errors

--- a/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
+++ b/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
@@ -100,7 +100,7 @@ public protocol StyleManagerProtocol {
     func layerExists(withId id: String) -> Bool
 
     /// The ordered list of the current style layers' identifiers and types
-    var layerIdentifiers: [LayerInfo] { get }
+    var allLayerIdentifiers: [LayerInfo] { get }
 
     /// :nodoc:
     ///
@@ -165,5 +165,293 @@ public protocol StyleManagerProtocol {
     ///     An error describing why the operation was unsuccessful.
     func setLayerProperties(for layerId: String, properties: [String: Any]) throws
 
-    // TODO: source, light, terrain, image
+    // MARK: Sources
+
+    /// Adds a new style source.
+    ///
+    /// - See Also: https://docs.mapbox.com/mapbox-gl-js/style-spec/#sources
+    ///
+    /// - Parameters:
+    ///   - sourceId: An identifier for the style source.
+    ///   - properties: A JSON dictionary of style source properties.
+    ///
+    /// - Throws:
+    ///     An error describing why the operation was unsuccessful.
+    func addSource(withId sourceId: String, properties: [String: Any]) throws
+
+    /// Removes an existing style source.
+    ///
+    /// - Parameter sourceId: Identifier of the style source to remove.
+    ///
+    /// - Throws:
+    ///     An error describing why the operation was unsuccessful.
+    func removeSource(withId sourceId: String) throws
+
+    /// Checks whether a given style source exists.
+    ///
+    /// - Parameter sourceId: Style source identifier.
+    ///
+    /// - Returns: `true` if the given source exists, `false` otherwise.
+    func sourceExists(withId sourceId: String) -> Bool
+
+    /// The ordered list of the current style sources' identifiers and types
+    var allSourceIdentifiers: [SourceInfo] { get }
+
+
+
+    //
+    //    /**
+    //     * @brief Gets the value of style source \p property.
+    //     *
+    //     * @param sourceId Style source identified.
+    //     * @param property Style source property name.
+    //     * @return The value of \p property in the source with \p sourceId.
+    //     */
+    //    func _sourceProperty(for sourceId: String, property: String) -> StylePropertyValue
+    //
+    //
+    //    /**
+    //     * @brief Sets a \a value to a style source \a property.
+    //     *
+    //     * @param sourceId Style source identifier.
+    //     * @param property Style source property name.
+    //     * @param value Style source property value.
+    //     *
+    //     * @return A string describing an error if the operation was not successful, empty otherwise.
+    //     */
+    //    func setSourceProperty(for sourceId: String, property: String, value: Any) throws
+    //
+    //    /**
+    //     * @brief Gets style source properties.
+    //     *        In order to convert returned value to a json string please take a look at mapbox::common::ValueConverter.
+    //     *
+    //     * @param sourceId Style source identifier.
+    //     *
+    //     * @return Style source properties or a string describing an error if the operation was not successful.
+    //     */
+    //    func sourceProperties(for sourceId: String) throws -> [String: Any]
+    //
+    //
+    //    /**
+    //     * @brief Sets style source properties.
+    //     *        This method can be used to perform batch update for a style source properties. The structure of a
+    //     *        provided `properties` value must conform to \sa https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/
+    //     *        format for a corresponding source type. Modification of a source type
+    //     *        \sa https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#type is not allowed.
+    //     *
+    //     * @param sourceId Style source identifier.
+    //     * @param properties A map of Style source properties.
+    //     *
+    //     * @return A string describing an error if the operation was not successful, empty otherwise.
+    //     */
+    //    func setSourceProperties(for sourceId: String, properties: [String: Any]) throws
+    //
+    //    /**
+    //     * @brief Gets the default value of style source \p property.
+    //     *
+    //     * @param sourceType Style source type.
+    //     * @param property Style source property name.
+    //     * @return The default value of \p property for the sources with type \p sourceType.
+    //     */
+    //    static func sourcePropertyDefaultValue(for sourceType: String, property: String) -> StylePropertyValue
+    //
+    //
+    //    /**
+    //     * @brief Returns the zoom on which the cluster expands into several children (useful for "click to zoom" feature).
+    //     * @param sourceId GeoJSON style source identifier.
+    //     * @param cluster Cluster from which to retrieve the expansion zoom from
+    //     *
+    //     * @return The zoom on which the cluster expands into several children or a string describing an error if the operation was not successful.
+    //     */
+    //    func geoJSONSourceClusterExpansionZoom(for sourceId: String, cluster: UInt32) throws -> Float
+    //
+    //    /**
+    //     * @brief Returns the children of a cluster (on the next zoom level).
+    //     * @param sourceId GeoJSON style source identifier.
+    //     * @param cluster from which to retrieve children from
+    //     *
+    //     * @return An array of features for the underlying children or a string describing an error if the operation was not successful.
+    //     */
+    //    func geoJSONSourceClusterChildren(for sourceId: String, cluster: UInt32) throws -> [Feature] // mov
+
+
+    //
+    //
+    //    /**
+    //     * @brief Returns all the leaves of a cluster (given its cluster_id), with pagination support: limit is the number of leaves to return (set to Infinity for all points), and offset is the amount of points to skip (for pagination).
+    //     * @param sourceId GeoJSON style source identifier.
+    //     * @param cluster from which to retrieve leaves from
+    //     * @param limit is the number of points to return
+    //     * @param offset is the amount of points to skip (for pagination)
+    //     *
+    //     * @return An array of features for the underlying leaves or a string describing an error if the operation was not successful.
+    //     */
+    //    func geoJSONSourceClusterLeaves(for sourceId: String, cluster: UInt32, limit: UInt32, offset: UInt32) throws -> [MBXFeature]
+    //
+    //    /**
+    //     * @brief Updates the image of an image style source.
+    //     *
+    //     * \sa https://docs.mapbox.com/mapbox-gl-js/style-spec/#sources-image
+    //     *
+    //     * @param sourceId Style source identifier.
+    //     * @param image Pixel data of the image.
+    //     *
+    //     * @return A string describing an error if the operation was not successful, empty otherwise.
+    //     */
+    //    func updateImageSource(withId sourceId: String, image: UIImage) throws
+    //
+    //
+    //    /**
+    //     * @brief Returns the existing style sources.
+    //     *
+    //     * @return The list containing the information about existing style source objects.
+    //     */
+    //    var sources: [StyleObjectInfo] { get }
+    //
+    //    /**
+    //     * @brief Sets the style global light source properties.
+    //     *
+    //     * \sa https://docs.mapbox.com/mapbox-gl-js/style-spec/#light
+    //     *
+    //     * @param properties A map of style light properties values, with their names as key.
+    //     *
+    //     * @return A string describing an error if the operation was not successful, empty otherwise.
+    //     */
+    //    func setLight(properties: [String: Any]) throws
+    //
+    //    /**
+    //     * @brief Gets the value of a style light \a property.
+    //     *
+    //     * @param property Style light property name.
+    //     * @return Style light property value.
+    //     */
+    //    func lightPropertyValue(for property: String) -> StylePropertyValue
+    //
+    //    /**
+    //     * @brief Sets a \a value to the the style light \a property.
+    //     *
+    //     * @param property Style light property name.
+    //     * @param value Style light property value.
+    //     *
+    //     * @return A string describing an error if the operation was not successful, empty otherwise.
+    //     */
+    //    func setLightProperty(for property: String, value: Any) throws
+    //
+    //    /**
+    //     * @brief Sets the style global terrain source properties.
+    //     *
+    //     * \sa https://docs.mapbox.com/mapbox-gl-js/style-spec/#terrain
+    //     *
+    //     * @param properties A map of style terrain properties values, with their names as key.
+    //     *
+    //     * @return A string describing an error if the operation was not successful, empty otherwise.
+    //     */
+    ////    open func setStyleTerrainForProperties(_ properties: Any) -> MBXExpected
+    //    func setTerrain(for properties: [String: Any]) throws
+    //
+    //    /**
+    //     * @brief Gets the value of a style terrain \a property.
+    //     *
+    //     * @param property Style terrain property name.
+    //     * @return Style terrain property value.
+    //     */
+    //    func terrainPropertyValue(for property: String) -> StylePropertyValue
+    //
+    //    /**
+    //     * @brief Sets a \a value to the the style terrain \a property.
+    //     *
+    //     * @param property Style terrain property name.
+    //     * @param value Style terrain property value.
+    //     *
+    //     * @return A string describing an error if the operation was not successful, empty otherwise.
+    //     */
+    //    func setTerrainProperty(_ property: String, value: Any) throws
+    //
+    //
+    //    /**
+    //     * @brief Get an image from the style.
+    //     *
+    //     * @param imageId ID of the image.
+    //     *
+    //     * @return Image data associated with the given ID, or empty if no image is
+    //     * associated with that ID.
+    //     */
+    ////    open func getStyleImage(forImageId imageId: String) -> MBMImage?
+    //    func image(for imageId: String) -> UIImage?
+    //
+    //    /**
+    //     * @brief Adds an image to be used in the style. This API can also be used for updating
+    //     * an image. If the image \a id was already added, it gets replaced by the new image.
+    //     *
+    //     * The image can be used in `icon-image`, `fill-pattern`, and `line-pattern`.
+    //     *
+    //     * \sa https://www.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-image
+    //     * \sa https://www.mapbox.com/mapbox-gl-js/style-spec/#paint-line-line-pattern
+    //     * \sa https://www.mapbox.com/mapbox-gl-js/style-spec/#paint-fill-fill-pattern
+    //     *
+    //     * @param imageId ID of the image.
+    //     * @param scale Scale factor for the image.
+    //     * @param image Pixel data of the image.
+    //     * @param sdf Option to treat whether image is SDF(signed distance field) or not.
+    //     * @param stretchX An array of two-element arrays, consisting of two numbers that represent
+    //     * the from position and the to position of areas that can be stretched horizontally.
+    //     * @param stretchY An array of two-element arrays, consisting of two numbers that represent
+    //     * the from position and the to position of areas that can be stretched vertically.
+    //     * @param content An array of four numbers, with the first two specifying the left, top
+    //     * corner, and the last two specifying the right, bottom corner. If present, and if the
+    //     * icon uses icon-text-fit, the symbol's text will be fit inside the content box.
+    //     *
+    //     * @return A string describing an error if the operation was not successful, empty otherwise.
+    //     */
+    //    func addImage(_ image: UIImage, imageId: String, sdf: Bool, stretchX: [ImageStretches], stretchY: [ImageStretches], content: ImageContent?) throws
+    //
+    //    /**
+    //     * @brief Removes an image from the style.
+    //     *
+    //     * @param imageId ID of the image to remove.
+    //     *
+    //     * @return A string describing an error if the operation was not successful, empty otherwise.
+    //     */
+    //    func removeImage(forImageId imageId: String) throws
+    //
+    //    /**
+    //     * @brief Adds a custom geometry to be used in the style. To add the data, implement the fetchTileFunction callback in the options and call setStyleCustomGeometrySourceTileData()
+    //     *
+    //     * @param sourceId Style source identifier
+    //     * @param options Settings for the custom geometry
+    //     */
+    ////    open func addStyleCustomGeometrySource(forSourceId sourceId: String, options: MBMCustomGeometrySourceOptions) -> MBXExpected
+    //    func addCustomGeometrySource(for sourceId: String, options: CustomGeometrySourceOptions) throws
+    //
+    //    /**
+    //     * @brief Set tile data of a custom geometry.
+    //     *
+    //     * @param sourceId Style source identifier
+    //     * @param tileId Identifier of the tile
+    //     * @param featureCollection An array with the features to add
+    //     */
+    //    func setCustomGeometrySourceTileData(for sourceId: String, tileId: CanonicalTileID, featureCollection: [MBXFeature]) throws
+    //
+    //    /**
+    //     * @brief Invalidate tile for provided custom geometry source.
+    //     *
+    //     * @param sourceId Style source identifier
+    //     * @param tileId Identifier of the tile
+    //     *
+    //     * @return A string describing an error if the operation was not successful, empty otherwise.
+    //     */
+    //    func invalidateCustomGeometrySourceTile(for sourceId: String, tileId: CanonicalTileID) throws
+    //
+    //    /**
+    //     * @brief Invalidate region for provided custom geometry source.
+    //     *
+    //     * @param sourceId Style source identifier
+    //     * @param bounds Coordinate bounds.
+    //     *
+    //     * @return A string describing an error if the operation was not successful, empty otherwise.
+    //     */
+    ////    open func invalidateStyleCustomGeometrySourceRegion(forSourceId sourceId: String, bounds: MBMCoordinateBounds) -> MBXExpected
+    //    func invalidateCustomGeometrySourceRegion(for sourceId: String, bounds: CoordinateBounds) throws
+
+
 }

--- a/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
+++ b/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+// swiftlint:disable file_length
 public protocol StyleManagerProtocol {
     /// `true` if and only if the style JSON contents, the style specified sprite
     /// and sources are all loaded, otherwise returns `false`.
@@ -261,7 +262,6 @@ public protocol StyleManagerProtocol {
     ///     The default value for the named property for the sources with type sourceType.
     static func _sourcePropertyDefaultValue(for sourceType: String, property: String) -> StylePropertyValue
 
-
     //
     //
     //    /**
@@ -281,7 +281,6 @@ public protocol StyleManagerProtocol {
     //     * @return An array of features for the underlying children or a string describing an error if the operation was not successful.
     //     */
     //    func geoJSONSourceClusterChildren(for sourceId: String, cluster: UInt32) throws -> [Feature] // mov
-
 
     //
     //
@@ -461,3 +460,4 @@ public protocol StyleManagerProtocol {
     ////    open func invalidateStyleCustomGeometrySourceRegion(forSourceId sourceId: String, bounds: MBMCoordinateBounds) -> MBXExpected
     //    func invalidateCustomGeometrySourceRegion(for sourceId: String, bounds: CoordinateBounds) throws
 }
+// swiftlint:enable file_length

--- a/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
+++ b/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
@@ -140,6 +140,7 @@ public protocol StyleManagerProtocol {
     /// Gets the properties for a style layer.
     ///
     /// - Parameter layerId: layer id.
+    ///
     /// - Returns:
     ///     JSON dictionary representing the layer properties
     ///
@@ -197,63 +198,70 @@ public protocol StyleManagerProtocol {
     /// The ordered list of the current style sources' identifiers and types
     var allSourceIdentifiers: [SourceInfo] { get }
 
+    // MARK: Source properties
+
+    /// :nodoc:
+    ///
+    /// Gets the value of style source property.
+    ///
+    /// - Parameters:
+    ///   - sourceId: Style source identifier.
+    ///   - property: Style source property name.
+    ///
+    /// - Returns: The value of the property in the source with sourceId.
+    func _sourceProperty(for sourceId: String, property: String) -> StylePropertyValue
+
+    /// Sets a value to a style source property.
+    ///
+    /// - Parameters:
+    ///   - sourceId: Style source identifier.
+    ///   - property: Style source property name.
+    ///   - value: Style source property value (JSON value)
+    ///
+    /// - Throws:
+    ///     An error describing why the operation was unsuccessful.
+    func setSourceProperty(for sourceId: String, property: String, value: Any) throws
+
+    /// Gets style source properties.
+    ///
+    /// - Parameter sourceId: Style source identifier
+    ///
+    /// - Returns:
+    ///     JSON dictionary representing the layer properties
+    ///
+    /// - Throws:
+    ///     An error describing why the operation was unsuccessful.
+    func sourceProperties(for sourceId: String) throws -> [String: Any]
+
+    /// Sets style source properties.
+    ///
+    /// This method can be used to perform batch update for a style source properties.
+    /// The structure of a provided `properties` value must conform to the
+    /// [format](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/) for a
+    /// corresponding source type. Modification of a [source type](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#type)
+    /// is not allowed.
+    ///
+    /// - Parameters:
+    ///   - sourceId: Style source identifier
+    ///   - properties: A JSON dictionary of Style source properties
+    ///
+    /// - Throws:
+    ///     An error describing why the operation was unsuccessful.
+    func setSourceProperties(for sourceId: String, properties: [String: Any]) throws
+
+    /// :nodoc:
+    ///
+    /// Gets the default value of style source property.
+    ///
+    /// - Parameters:
+    ///   - sourceType: Style source type.
+    ///   - property: Style source property name.
+    ///
+    /// - Returns:
+    ///     The default value for the named property for the sources with type sourceType.
+    static func _sourcePropertyDefaultValue(for sourceType: String, property: String) -> StylePropertyValue
 
 
-    //
-    //    /**
-    //     * @brief Gets the value of style source \p property.
-    //     *
-    //     * @param sourceId Style source identified.
-    //     * @param property Style source property name.
-    //     * @return The value of \p property in the source with \p sourceId.
-    //     */
-    //    func _sourceProperty(for sourceId: String, property: String) -> StylePropertyValue
-    //
-    //
-    //    /**
-    //     * @brief Sets a \a value to a style source \a property.
-    //     *
-    //     * @param sourceId Style source identifier.
-    //     * @param property Style source property name.
-    //     * @param value Style source property value.
-    //     *
-    //     * @return A string describing an error if the operation was not successful, empty otherwise.
-    //     */
-    //    func setSourceProperty(for sourceId: String, property: String, value: Any) throws
-    //
-    //    /**
-    //     * @brief Gets style source properties.
-    //     *        In order to convert returned value to a json string please take a look at mapbox::common::ValueConverter.
-    //     *
-    //     * @param sourceId Style source identifier.
-    //     *
-    //     * @return Style source properties or a string describing an error if the operation was not successful.
-    //     */
-    //    func sourceProperties(for sourceId: String) throws -> [String: Any]
-    //
-    //
-    //    /**
-    //     * @brief Sets style source properties.
-    //     *        This method can be used to perform batch update for a style source properties. The structure of a
-    //     *        provided `properties` value must conform to \sa https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/
-    //     *        format for a corresponding source type. Modification of a source type
-    //     *        \sa https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#type is not allowed.
-    //     *
-    //     * @param sourceId Style source identifier.
-    //     * @param properties A map of Style source properties.
-    //     *
-    //     * @return A string describing an error if the operation was not successful, empty otherwise.
-    //     */
-    //    func setSourceProperties(for sourceId: String, properties: [String: Any]) throws
-    //
-    //    /**
-    //     * @brief Gets the default value of style source \p property.
-    //     *
-    //     * @param sourceType Style source type.
-    //     * @param property Style source property name.
-    //     * @return The default value of \p property for the sources with type \p sourceType.
-    //     */
-    //    static func sourcePropertyDefaultValue(for sourceType: String, property: String) -> StylePropertyValue
     //
     //
     //    /**
@@ -452,6 +460,4 @@ public protocol StyleManagerProtocol {
     //     */
     ////    open func invalidateStyleCustomGeometrySourceRegion(forSourceId sourceId: String, bounds: MBMCoordinateBounds) -> MBXExpected
     //    func invalidateCustomGeometrySourceRegion(for sourceId: String, bounds: CoordinateBounds) throws
-
-
 }

--- a/Tests/MapboxMapsTests/Annotations/MockAnnotationStyleDelegate.swift
+++ b/Tests/MapboxMapsTests/Annotations/MockAnnotationStyleDelegate.swift
@@ -17,15 +17,12 @@ final class MockAnnotationStyleDelegate: AnnotationStyleDelegate {
         return Image(uiImage: UIImage())
     }
 
-    func addSource(source: Source, identifier: String) -> Result<Bool, SourceError> {
-        return .success(true)
-    }
+    func addSource(_ source: Source, id: String) throws {}
 
     //swiftlint:disable identifier_name
     func updateSourceProperty(id: String, property: String, value: [String: Any]) -> Result<Bool, SourceError> {
         return .success(true)
     }
 
-    func addLayer(_ layer: Layer, layerPosition: LayerPosition?) throws {
-    }
+    func addLayer(_ layer: Layer, layerPosition: LayerPosition?) throws {}
 }

--- a/Tests/MapboxMapsTests/Annotations/MockAnnotationStyleDelegate.swift
+++ b/Tests/MapboxMapsTests/Annotations/MockAnnotationStyleDelegate.swift
@@ -17,12 +17,7 @@ final class MockAnnotationStyleDelegate: AnnotationStyleDelegate {
         return Image(uiImage: UIImage())
     }
 
-    func addSource(_ source: Source, id: String) throws {}
-
-    //swiftlint:disable identifier_name
-    func updateSourceProperty(id: String, property: String, value: [String: Any]) -> Result<Bool, SourceError> {
-        return .success(true)
-    }
-
     func addLayer(_ layer: Layer, layerPosition: LayerPosition?) throws {}
+    func addSource(_ source: Source, id: String) throws {}
+    func setSourceProperty(for sourceId: String, property: String, value: Any) throws {}
 }

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
@@ -173,21 +173,13 @@ extension AnnotationManagerIntegrationTestCase: AnnotationStyleDelegate {
     }
 
     func addSource(_ source: Source, id: String) throws {
-        guard let style = style else {
-            XCTFail("No style available")
-            throw SourceError.addSourceFailed("No style available")
-        }
-
+        let style = try XCTUnwrap(self.style)
         try style.addSource(source, id: id)
     }
 
-    func updateSourceProperty(id: String, property: String, value: [String: Any]) -> Result<Bool, SourceError> {
-        guard let style = style else {
-            XCTFail("No style available")
-            return .failure(.addSourceFailed("No style available"))
-        }
-
-        return style.updateSourceProperty(id: id, property: property, value: value)
+    func setSourceProperty(for sourceId: String, property: String, value: Any) throws {
+        let style = try XCTUnwrap(self.style)
+        try style.setSourceProperty(for: sourceId, property: property, value: value)
     }
 
     func addLayer(_ layer: Layer, layerPosition: LayerPosition?) throws {

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
@@ -28,7 +28,7 @@ internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase 
             annotationManager.addAnnotation(annotation)
 
             // When
-            let sourceResult = self.style?.getSource(identifier: annotationManager.defaultSourceId, type: GeoJSONSource.self)
+            let sourceResult = self.style?.getSource(id: annotationManager.defaultSourceId, type: GeoJSONSource.self)
             let styleLayer = self.mapView?.mapboxMap.__map.getStyleLayerProperties(forLayerId: annotationManager.defaultSymbolLayerId)
             // ❓ Core SDK call to get style layer works, but not Style API line below
             // let styleLayer = self.style?.getLayer(with: annotationManager.defaultSymbolLayerId, type: SymbolLayer.self)
@@ -112,7 +112,7 @@ internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase 
             annotationManager.addAnnotation(annotation)
 
             // When
-            let sourceResult = self.style?.getSource(identifier: annotationManager.defaultSourceId, type: GeoJSONSource.self)
+            let sourceResult = self.style?.getSource(id: annotationManager.defaultSourceId, type: GeoJSONSource.self)
             let styleLayer = self.mapView?.mapboxMap.__map.getStyleLayerProperties(forLayerId: annotationManager.defaultSymbolLayerId)
             // ❓ Core SDK call to get style layer works, but not Style API line below
             // let styleLayer = self.style?.getLayer(with: annotationManager.defaultSymbolLayerId, type: SymbolLayer.self)
@@ -172,19 +172,19 @@ extension AnnotationManagerIntegrationTestCase: AnnotationStyleDelegate {
         return style.getStyleImage(with: identifier)
     }
 
-    func addSource(source: Source, identifier: String) -> Result<Bool, SourceError> {
+    func addSource(_ source: Source, id: String) throws {
         guard let style = style else {
             XCTFail("No style available")
-            return .failure(.addSourceFailed(nil))
+            throw SourceError.addSourceFailed("No style available")
         }
 
-        return style.addSource(source: source, identifier: identifier)
+        try style.addSource(source, id: id)
     }
 
     func updateSourceProperty(id: String, property: String, value: [String: Any]) -> Result<Bool, SourceError> {
         guard let style = style else {
             XCTFail("No style available")
-            return .failure(.addSourceFailed(nil))
+            return .failure(.addSourceFailed("No style available"))
         }
 
         return style.updateSourceProperty(id: id, property: property, value: value)

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/ExampleIntegrationTest.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/ExampleIntegrationTest.swift
@@ -9,10 +9,7 @@ internal class ExampleIntegrationTest: MapViewIntegrationTestCase {
     }
 
     internal func testWaitForIdle() throws {
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let expectation = XCTestExpectation(description: "Wait for map to idle")
         expectation.expectedFulfillmentCount = 2

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/HTTP/HTTPIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/HTTP/HTTPIntegrationTests.swift
@@ -95,8 +95,6 @@ class CustomHttpService: HttpServiceInterface {
         print("TODO: download(for:callback:) conformance")
         return 0
     }
-
-    var peer: MBXPeerWrapper?
 }
 
 class HTTPIntegrationTests: MapViewIntegrationTestCase {
@@ -106,14 +104,11 @@ class HTTPIntegrationTests: MapViewIntegrationTestCase {
     override class func setUp() {
         super.setUp()
 
-        try! HttpServiceFactory.setUserDefinedForCustom(customHTTPService)
+        HttpServiceFactory.setUserDefinedForCustom(customHTTPService)
     }
 
     func testReplacingHTTPService() throws {
-        guard let style = style else {
-            XCTFail("Style should be valid")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let serviceExpectation = XCTestExpectation(description: "Requests should be made by custom HTTP stack")
         serviceExpectation.assertForOverFulfill = false
@@ -129,10 +124,7 @@ class HTTPIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testReplacingHTTPServiceAndForcedError() throws {
-        guard let style = style else {
-            XCTFail("Style should be valid")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let serviceExpectation = XCTestExpectation(description: "Mock service request should be called")
         let errorExpectation = XCTestExpectation(description: "Map should fail to load, with our custom error")
@@ -148,7 +140,7 @@ class HTTPIntegrationTests: MapViewIntegrationTestCase {
 
         didFailLoadingMap = { (_, error2) in
             XCTAssertNotNil(error2)
-            let description = error2.userInfo["description"] as? String
+            let description = error2.userInfo["message"] as? String
             XCTAssertNotNil(description)
             XCTAssert(description!.contains(errorMessage))
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/BackgroundLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/BackgroundLayerIntegrationTests.swift
@@ -14,10 +14,7 @@ class BackgroundLayerIntegrationTests: MapViewIntegrationTestCase {
     }
 
     internal func testWaitForIdle() throws {
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedLayerExpectation = XCTestExpectation(description: "Successfully added BackgroundLayer to Map")
         successfullyAddedLayerExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/CircleLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/CircleLayerIntegrationTests.swift
@@ -14,10 +14,7 @@ class CircleLayerIntegrationTests: MapViewIntegrationTestCase {
     }
 
     internal func testWaitForIdle() throws {
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedLayerExpectation = XCTestExpectation(description: "Successfully added CircleLayer to Map")
         successfullyAddedLayerExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/FillExtrusionLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/FillExtrusionLayerIntegrationTests.swift
@@ -14,10 +14,7 @@ class FillExtrusionLayerIntegrationTests: MapViewIntegrationTestCase {
     }
 
     internal func testWaitForIdle() throws {
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedLayerExpectation = XCTestExpectation(description: "Successfully added FillExtrusionLayer to Map")
         successfullyAddedLayerExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/FillLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/FillLayerIntegrationTests.swift
@@ -14,10 +14,7 @@ class FillLayerIntegrationTests: MapViewIntegrationTestCase {
     }
 
     internal func testWaitForIdle() throws {
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedLayerExpectation = XCTestExpectation(description: "Successfully added FillLayer to Map")
         successfullyAddedLayerExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/HeatmapLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/HeatmapLayerIntegrationTests.swift
@@ -14,10 +14,7 @@ class HeatmapLayerIntegrationTests: MapViewIntegrationTestCase {
     }
 
     internal func testWaitForIdle() throws {
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedLayerExpectation = XCTestExpectation(description: "Successfully added HeatmapLayer to Map")
         successfullyAddedLayerExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/HillshadeLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/HillshadeLayerIntegrationTests.swift
@@ -14,10 +14,7 @@ class HillshadeLayerIntegrationTests: MapViewIntegrationTestCase {
     }
 
     internal func testWaitForIdle() throws {
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedLayerExpectation = XCTestExpectation(description: "Successfully added HillshadeLayer to Map")
         successfullyAddedLayerExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LineLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LineLayerIntegrationTests.swift
@@ -14,10 +14,7 @@ class LineLayerIntegrationTests: MapViewIntegrationTestCase {
     }
 
     internal func testWaitForIdle() throws {
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedLayerExpectation = XCTestExpectation(description: "Successfully added LineLayer to Map")
         successfullyAddedLayerExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LocationIndicatorLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LocationIndicatorLayerIntegrationTests.swift
@@ -14,10 +14,7 @@ class LocationIndicatorLayerIntegrationTests: MapViewIntegrationTestCase {
     }
 
     internal func testWaitForIdle() throws {
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedLayerExpectation = XCTestExpectation(description: "Successfully added LocationIndicatorLayer to Map")
         successfullyAddedLayerExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/ModelLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/ModelLayerIntegrationTests.swift
@@ -1,4 +1,4 @@
-// This file is generated
+// This file is NOT CURRENTLY generated
 import XCTest
 
 #if canImport(MapboxMaps)
@@ -14,10 +14,7 @@ class ModelLayerIntegrationTests: MapViewIntegrationTestCase {
     }
 
     internal func testWaitForIdle() throws {
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedLayerExpectation = XCTestExpectation(description: "Successfully added ModelLayer to Map")
         successfullyAddedLayerExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/RasterLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/RasterLayerIntegrationTests.swift
@@ -14,10 +14,7 @@ class RasterLayerIntegrationTests: MapViewIntegrationTestCase {
     }
 
     internal func testWaitForIdle() throws {
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedLayerExpectation = XCTestExpectation(description: "Successfully added RasterLayer to Map")
         successfullyAddedLayerExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/SkyLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/SkyLayerIntegrationTests.swift
@@ -14,10 +14,7 @@ class SkyLayerIntegrationTests: MapViewIntegrationTestCase {
     }
 
     internal func testWaitForIdle() throws {
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedLayerExpectation = XCTestExpectation(description: "Successfully added SkyLayer to Map")
         successfullyAddedLayerExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/SymbolLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/SymbolLayerIntegrationTests.swift
@@ -14,10 +14,7 @@ class SymbolLayerIntegrationTests: MapViewIntegrationTestCase {
     }
 
     internal func testWaitForIdle() throws {
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedLayerExpectation = XCTestExpectation(description: "Successfully added SymbolLayer to Map")
         successfullyAddedLayerExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/GeoJsonSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/GeoJsonSourceIntegrationTests.swift
@@ -10,12 +10,8 @@ import Turf
 
 class GeoJSONSourceIntegrationTests: MapViewIntegrationTestCase {
     
-    func testAdditionAndRemovalOfSource() {
-
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+    func testAdditionAndRemovalOfSource() throws {
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedSourceExpectation = XCTestExpectation(description: "Successfully added GeoJSONSource to Map")
         successfullyAddedSourceExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/GeoJsonSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/GeoJsonSourceIntegrationTests.swift
@@ -39,17 +39,15 @@ class GeoJSONSourceIntegrationTests: MapViewIntegrationTestCase {
             source.prefetchZoomDelta = Double.testSourceValue()
             
             // Add the source
-            let addResult = style.addSource(source: source, identifier: "test-source")
-
-            switch (addResult) {
-                case .success(_):
+            do {
+                try style.addSource(source, id: "test-source")
                 successfullyAddedSourceExpectation.fulfill()
-                case .failure(let error):
-                    XCTFail("Failed to add GeoJSONSource because of error: \(error)")
+            } catch {
+                XCTFail("Failed to add GeoJSONSource because of error: \(error)")
             }
 
             // Retrieve the source
-            let retrieveResult = style.getSource(identifier: "test-source", type: GeoJSONSource.self)
+            let retrieveResult = style.getSource(id: "test-source", type: GeoJSONSource.self)
 
             switch (retrieveResult) {
                 case .success(_):

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/ImageSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/ImageSourceIntegrationTests.swift
@@ -10,12 +10,8 @@ import Turf
 
 class ImageSourceIntegrationTests: MapViewIntegrationTestCase {
     
-    func testAdditionAndRemovalOfSource() {
-
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+    func testAdditionAndRemovalOfSource() throws {
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedSourceExpectation = XCTestExpectation(description: "Successfully added ImageSource to Map")
         successfullyAddedSourceExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/ImageSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/ImageSourceIntegrationTests.swift
@@ -32,17 +32,15 @@ class ImageSourceIntegrationTests: MapViewIntegrationTestCase {
             source.prefetchZoomDelta = Double.testSourceValue()
             
             // Add the source
-            let addResult = style.addSource(source: source, identifier: "test-source")
-
-            switch (addResult) {
-                case .success(_):
+            do {
+                try style.addSource(source, id: "test-source")
                 successfullyAddedSourceExpectation.fulfill()
-                case .failure(let error):
-                    XCTFail("Failed to add ImageSource because of error: \(error)")
+            } catch {
+                XCTFail("Failed to add ImageSource because of error: \(error)")
             }
 
             // Retrieve the source
-            let retrieveResult = style.getSource(identifier: "test-source", type: ImageSource.self)
+            let retrieveResult = style.getSource(id: "test-source", type: ImageSource.self)
 
             switch (retrieveResult) {
                 case .success(_):

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterDemSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterDemSourceIntegrationTests.swift
@@ -41,17 +41,15 @@ class RasterDemSourceIntegrationTests: MapViewIntegrationTestCase {
             source.maxOverscaleFactorForParentTiles = Double.testSourceValue()
             
             // Add the source
-            let addResult = style.addSource(source: source, identifier: "test-source")
-
-            switch (addResult) {
-                case .success(_):
+            do {
+                try style.addSource(source, id: "test-source")
                 successfullyAddedSourceExpectation.fulfill()
-                case .failure(let error):
-                    XCTFail("Failed to add RasterDemSource because of error: \(error)")
+            } catch {
+                XCTFail("Failed to add RasterDemSource because of error: \(error)")
             }
 
             // Retrieve the source
-            let retrieveResult = style.getSource(identifier: "test-source", type: RasterDemSource.self)
+            let retrieveResult = style.getSource(id: "test-source", type: RasterDemSource.self)
 
             switch (retrieveResult) {
                 case .success(_):

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterDemSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterDemSourceIntegrationTests.swift
@@ -10,12 +10,8 @@ import Turf
 
 class RasterDemSourceIntegrationTests: MapViewIntegrationTestCase {
     
-    func testAdditionAndRemovalOfSource() {
-
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+    func testAdditionAndRemovalOfSource() throws {
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedSourceExpectation = XCTestExpectation(description: "Successfully added RasterDemSource to Map")
         successfullyAddedSourceExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterSourceIntegrationTests.swift
@@ -41,17 +41,15 @@ class RasterSourceIntegrationTests: MapViewIntegrationTestCase {
             source.maxOverscaleFactorForParentTiles = Double.testSourceValue()
             
             // Add the source
-            let addResult = style.addSource(source: source, identifier: "test-source")
-
-            switch (addResult) {
-                case .success(_):
+            do {
+                try style.addSource(source, id: "test-source")
                 successfullyAddedSourceExpectation.fulfill()
-                case .failure(let error):
-                    XCTFail("Failed to add RasterSource because of error: \(error)")
+            } catch {
+                XCTFail("Failed to add RasterSource because of error: \(error)")
             }
 
             // Retrieve the source
-            let retrieveResult = style.getSource(identifier: "test-source", type: RasterSource.self)
+            let retrieveResult = style.getSource(id: "test-source", type: RasterSource.self)
 
             switch (retrieveResult) {
                 case .success(_):

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterSourceIntegrationTests.swift
@@ -10,12 +10,8 @@ import Turf
 
 class RasterSourceIntegrationTests: MapViewIntegrationTestCase {
     
-    func testAdditionAndRemovalOfSource() {
-
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+    func testAdditionAndRemovalOfSource() throws {
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedSourceExpectation = XCTestExpectation(description: "Successfully added RasterSource to Map")
         successfullyAddedSourceExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/VectorSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/VectorSourceIntegrationTests.swift
@@ -40,17 +40,15 @@ class VectorSourceIntegrationTests: MapViewIntegrationTestCase {
             source.maxOverscaleFactorForParentTiles = Double.testSourceValue()
             
             // Add the source
-            let addResult = style.addSource(source: source, identifier: "test-source")
-
-            switch (addResult) {
-                case .success(_):
+            do {
+                try style.addSource(source, id: "test-source")
                 successfullyAddedSourceExpectation.fulfill()
-                case .failure(let error):
-                    XCTFail("Failed to add VectorSource because of error: \(error)")
+            } catch {
+                XCTFail("Failed to add VectorSource because of error: \(error)")
             }
 
             // Retrieve the source
-            let retrieveResult = style.getSource(identifier: "test-source", type: VectorSource.self)
+            let retrieveResult = style.getSource(id: "test-source", type: VectorSource.self)
 
             switch (retrieveResult) {
                 case .success(_):

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/VectorSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/VectorSourceIntegrationTests.swift
@@ -10,12 +10,8 @@ import Turf
 
 class VectorSourceIntegrationTests: MapViewIntegrationTestCase {
     
-    func testAdditionAndRemovalOfSource() {
-
-        guard let style = style else {
-            XCTFail("There should be valid MapView and Style objects created by setUp.")
-            return
-        }
+    func testAdditionAndRemovalOfSource() throws {
+        let style = try XCTUnwrap(self.style)
 
         let successfullyAddedSourceExpectation = XCTestExpectation(description: "Successfully added VectorSource to Map")
         successfullyAddedSourceExpectation.expectedFulfillmentCount = 1


### PR DESCRIPTION
Continuation of #317 

<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [X] Document any changes to public APIs.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [X] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Refactored Style source and source property management.</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This is PR 2 of N (see #317):

- Adds source and source property functions that throw rather than returning a `Result` type.
- Removes `updateSourceProperty(...)`, replacing it with `setSourceProperty(...)`
- Updates tests and examples accordingly.