### PR TITLE
Remove animation capabilities from CameraAnimationsManager.setCamera()

### DIFF
--- a/Apps/Examples/Examples/All Examples/CameraAnimationExample.swift
+++ b/Apps/Examples/Examples/All Examples/CameraAnimationExample.swift
@@ -20,7 +20,8 @@ public class CameraAnimationExample: UIViewController, ExampleProtocol {
             guard let self = self else { return }
 
             // Center the map camera over New York City.
-            let centerCoordinate = CLLocationCoordinate2D(latitude: 40.7128, longitude: -74.0060)
+            let centerCoordinate = CLLocationCoordinate2D(
+                latitude: 40.7128, longitude: -74.0060)
 
             let newCamera = CameraOptions(center: centerCoordinate,
                                           padding: .zero,
@@ -29,9 +30,7 @@ public class CameraAnimationExample: UIViewController, ExampleProtocol {
                                           bearing: 180.0,
                                           pitch: 15.0)
 
-            self.mapView.camera.setCamera(to: newCamera,
-                                                 animated: true,
-                                                 duration: 5.0) { _ in
+            self.mapView.camera.ease(to: newCamera, duration: 5.0) { (_) in
                 // The below line is used for internal testing purposes only.
                 self.finish()
             }

--- a/Apps/Examples/Examples/All Examples/FitCameraToGeometryExample.swift
+++ b/Apps/Examples/Examples/All Examples/FitCameraToGeometryExample.swift
@@ -56,10 +56,9 @@ public class FitCameraToGeometryExample: UIViewController, ExampleProtocol {
         }
 
         let newCamera = mapView.mapboxMap.camera(for: polygon, padding: .zero, bearing: 0, pitch: 0)
-        mapView.camera.setCamera(to: newCamera) { _ in
-            // The below line is used for internal testing purposes only.
-            self.finish()
-        }
+        mapView.camera.setCamera(to: newCamera)
+        // The below line is used for internal testing purposes only.
+        self.finish()
     }
 
     fileprivate func displayAlert(message: String) {

--- a/Apps/Examples/Examples/All Examples/LineGradientExample.swift
+++ b/Apps/Examples/Examples/All Examples/LineGradientExample.swift
@@ -22,7 +22,7 @@ public class LineGradientExample: UIViewController, ExampleProtocol {
             // Set the center coordinate and zoom level.
             let centerCoordinate = CLLocationCoordinate2D(latitude: 38.875, longitude: -77.035)
             let camera = CameraOptions(center: centerCoordinate, zoom: 12.0)
-            self?.mapView.camera.setCamera(to: camera, animated: true, duration: 0, completion: nil)
+            self?.mapView.camera.setCamera(to: camera)
         }
     }
 

--- a/Apps/Examples/Examples/All Examples/RestrictCoordinateBoundsExample.swift
+++ b/Apps/Examples/Examples/All Examples/RestrictCoordinateBoundsExample.swift
@@ -17,7 +17,7 @@ public class RestrictCoordinateBoundsExample: UIViewController, ExampleProtocol 
                                       northeast: CLLocationCoordinate2D(latitude: 66.61, longitude: -13.47))
         let camera = mapView.mapboxMap.camera(for: bounds, padding: .zero, bearing: 0, pitch: 0)
         // Set the camera's center coordinate.
-        mapView.camera.setCamera(to: camera, completion: nil)
+        mapView.camera.setCamera(to: camera)
 
         mapView.update { (mapOptions) in
             mapOptions.camera.restrictedCoordinateBounds = bounds

--- a/Apps/Examples/Examples/All Examples/SwiftUIExample.swift
+++ b/Apps/Examples/Examples/All Examples/SwiftUIExample.swift
@@ -89,8 +89,7 @@ internal struct SwiftUIMapView: UIViewRepresentable {
     /// If your `SwiftUIMapView` is reconfigured externally, SwiftUI will invoke `updateUIView(_:context:)`
     /// to give you an opportunity to re-sync the state of the underlying map view.
     func updateUIView(_ mapView: MapView, context: Context) {
-        mapView.camera.setCamera(to: CameraOptions(center: camera.center, zoom: camera.zoom),
-                                        animated: false)
+        mapView.camera.setCamera(to: CameraOptions(center: camera.center, zoom: camera.zoom))
         /// Since changing the style causes annotations to be removed from the map
         /// we only call the setter if the value has changed.
         if mapView.style.uri != styleURI {

--- a/Apps/Examples/Examples/All Examples/TrackingModeExample.swift
+++ b/Apps/Examples/Examples/All Examples/TrackingModeExample.swift
@@ -47,8 +47,8 @@ public class CameraLocationConsumer: LocationConsumer {
     }
 
     public func locationUpdate(newLocation: Location) {
-        mapView?.camera.setCamera(to: CameraOptions(center: newLocation.coordinate, zoom: 15),
-                                         animated: true,
-                                         duration: 1.3)
+        mapView?.camera.ease(
+            to: CameraOptions(center: newLocation.coordinate, zoom: 15),
+            duration: 1.3)
     }
 }

--- a/Sources/MapboxMaps/Gestures/GestureManager+GestureHandlerDelegate.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager+GestureHandlerDelegate.swift
@@ -12,18 +12,18 @@ extension GestureManager: GestureHandlerDelegate {
 
         // Single tapping twice with one finger will cause the map to zoom in
         if numberOfTaps == 2 && numberOfTouches == 1 {
-            cameraManager.setCamera(to: CameraOptions(zoom: mapView.cameraState.zoom + 1.0),
-                                    animated: true,
-                                    duration: 0.3,
-                                    completion: nil)
+            _ = cameraManager.ease(to: CameraOptions(zoom: mapView.cameraState.zoom + 1.0),
+                                   duration: 0.3,
+                                   curve: .easeOut,
+                                   completion: nil)
         }
 
         // Double tapping twice with two fingers will cause the map to zoom out
         if numberOfTaps == 2 && numberOfTouches == 2 {
-            cameraManager.setCamera(to: CameraOptions(zoom: mapView.cameraState.zoom - 1.0),
-                                    animated: true,
-                                    duration: 0.3,
-                                    completion: nil)
+            _ = cameraManager.ease(to: CameraOptions(zoom: mapView.cameraState.zoom - 1.0),
+                                   duration: 0.3,
+                                   curve: .easeOut,
+                                   completion: nil)
         }
     }
 
@@ -34,13 +34,10 @@ extension GestureManager: GestureHandlerDelegate {
     // MapView has been panned
     internal func panned(from startPoint: CGPoint, to endPoint: CGPoint) {
 
-        if let cameraOptions = cameraManager.mapView?.mapboxMap.__map.getDragCameraOptionsFor(fromPoint: startPoint.screenCoordinate, toPoint: endPoint.screenCoordinate) {
-
-            cameraManager.setCamera(to: CameraOptions(cameraOptions),
-                                    animated: false,
-                                    duration: 0,
-                                    completion: nil)
-
+        if let cameraOptions = cameraManager.mapView?.mapboxMap.__map.getDragCameraOptionsFor(
+            fromPoint: startPoint.screenCoordinate,
+            toPoint: endPoint.screenCoordinate) {
+            cameraManager.setCamera(to: CameraOptions(cameraOptions))
         }
     }
 
@@ -50,10 +47,11 @@ extension GestureManager: GestureHandlerDelegate {
         if endPoint != driftEndPoint,
            let driftCameraOptions = cameraManager.mapView?.mapboxMap.__map.getDragCameraOptionsFor(fromPoint: endPoint.screenCoordinate, toPoint: driftEndPoint.screenCoordinate) {
 
-            cameraManager.setCamera(to: CameraOptions(driftCameraOptions),
-                                    animated: true,
-                                    duration: Double(cameraManager.mapCameraOptions.decelerationRate),
-                                    completion: nil)
+            _ = cameraManager.ease(
+                    to: CameraOptions(driftCameraOptions),
+                    duration: Double(cameraManager.mapCameraOptions.decelerationRate),
+                    curve: .easeOut,
+                    completion: nil)
         }
         cameraManager.mapView?.mapboxMap.__map.dragEnd()
     }
@@ -76,26 +74,17 @@ extension GestureManager: GestureHandlerDelegate {
     }
 
     internal func pinchScaleChanged(with newScale: CGFloat, andAnchor anchor: CGPoint) {
-        cameraManager.setCamera(to: CameraOptions(anchor: anchor, zoom: newScale),
-                                animated: false,
-                                duration: 0,
-                                completion: nil)
+        cameraManager.setCamera(to: CameraOptions(anchor: anchor, zoom: newScale))
     }
 
     internal func pinchEnded(with finalScale: CGFloat, andDrift possibleDrift: Bool, andAnchor anchor: CGPoint) {
-        cameraManager.setCamera(to: CameraOptions(anchor: anchor, zoom: finalScale),
-                                animated: false,
-                                duration: 0,
-                                completion: nil)
+        cameraManager.setCamera(to: CameraOptions(anchor: anchor, zoom: finalScale))
         unrotateIfNeededForGesture(with: .ended)
     }
 
     internal func quickZoomChanged(with newScale: CGFloat, and anchor: CGPoint) {
         let zoom = max(newScale, cameraManager.mapCameraOptions.minimumZoomLevel)
-        cameraManager.setCamera(to: CameraOptions(anchor: anchor, zoom: zoom),
-                                animated: false,
-                                duration: 0,
-                                completion: nil)
+        cameraManager.setCamera(to: CameraOptions(anchor: anchor, zoom: zoom))
     }
 
     internal func quickZoomEnded() {
@@ -127,19 +116,14 @@ extension GestureManager: GestureHandlerDelegate {
             changedAngleInDegrees = changedAngleInDegrees > 30.0 ? 30.0 : changedAngleInDegrees
         }
 
-        cameraManager.setCamera(to: CameraOptions(bearing: CLLocationDirection(changedAngleInDegrees)),
-                                animated: false,
-                                duration: 0,
-                                completion: nil)
+        cameraManager.setCamera(
+            to: CameraOptions(bearing: CLLocationDirection(changedAngleInDegrees)))
     }
 
     internal func rotationEnded(with finalAngle: CGFloat, and anchor: CGPoint, with pinchState: UIGestureRecognizer.State) {
         var finalAngleInDegrees = finalAngle * 180.0 / .pi * -1
         finalAngleInDegrees = finalAngleInDegrees.truncatingRemainder(dividingBy: 360.0)
-        cameraManager.setCamera(to: CameraOptions(bearing: CLLocationDirection(finalAngleInDegrees)),
-                                animated: false,
-                                duration: 0,
-                                completion: nil)
+        cameraManager.setCamera(to: CameraOptions(bearing: CLLocationDirection(finalAngleInDegrees)))
     }
 
     internal func unrotateIfNeededForGesture(with pinchState: UIGestureRecognizer.State) {
@@ -155,10 +139,7 @@ extension GestureManager: GestureHandlerDelegate {
             && pinchState != .began
             && pinchState != .changed {
             if currentBearing != 0.0 && isRotationAllowed() == false {
-                cameraManager.setCamera(to: CameraOptions(bearing: 0),
-                                        animated: false,
-                                        duration: 0,
-                                        completion: nil)
+                cameraManager.setCamera(to: CameraOptions(bearing: 0))
             }
 
             // TODO: Add snapping behavior to "north" if bearing is less than some tolerance
@@ -182,10 +163,7 @@ extension GestureManager: GestureHandlerDelegate {
     }
 
     internal func pitchChanged(newPitch: CGFloat) {
-        cameraManager.setCamera(to: CameraOptions(pitch: newPitch),
-                                animated: false,
-                                duration: 0,
-                                completion: nil)
+        cameraManager.setCamera(to: CameraOptions(pitch: newPitch))
     }
 
     internal func pitchEnded() {

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -112,10 +112,12 @@ internal protocol CameraManagerProtocol: AnyObject {
 
     var mapCameraOptions: MapCameraOptions { get }
 
-    func setCamera(to camera: CameraOptions,
-                   animated: Bool,
-                   duration: TimeInterval,
-                   completion: ((UIViewAnimatingPosition) -> Void)?)
+    func setCamera(to camera: CameraOptions)
+
+    func ease(to camera: CameraOptions,
+              duration: TimeInterval,
+              curve: UIView.AnimationCurve,
+              completion: AnimationCompletion?) -> CameraAnimator?
 
     func cancelAnimations()
 }

--- a/Tests/MapboxMapsTests/Foundation/MapboxMapsFoundationTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapboxMapsFoundationTests.swift
@@ -79,46 +79,6 @@ class MapboxMapsFoundationTests: XCTestCase {
         XCTAssertEqual(coordinate.longitude, CLLocationDegrees(0), accuracy: accuracy)
     }
 
-    func testPointToCoordinateInSubViewEqualOrigins() {
-//        let subViewRect = CGRect(x: 0,
-//                                 y: 0,
-//                                 width: mapView.bounds.size.width / 2,
-//                                 height: mapView.bounds.size.height / 2)
-//        let subview = UIView(frame: subViewRect)
-//
-//        mapView.addSubview(subview)
-//
-//        /**
-//         We shouldn't expect the centers to be the same, since now that the
-//         mapView is offset. The "center" is in the space of the parent view.
-//         */
-//        subview.center = CGPoint(x: mapView.bounds.midX, y: mapView.bounds.midY)
-//        XCTAssertNotEqual(subview.center, mapView.center, "Center of both views are not equal")
-//        XCTAssertEqual(subview.frame.origin.x, 25.0)
-//        XCTAssertEqual(subview.frame.origin.y, 25.0)
-//
-//        let updatedSubViewOrigin = subview.frame.origin
-//        let originCoordinateA = mapView.mapboxMap.coordinate(for: updatedSubViewOrigin)
-//        let originCoordinateB = mapView.mapboxMap.coordinate(for: CGPoint.zero)
-//
-//        XCTAssertEqual(originCoordinateA.latitude, originCoordinateB.latitude, accuracy: accuracy)
-//        XCTAssertEqual(originCoordinateA.longitude, originCoordinateB.longitude, accuracy: accuracy)
-
-        // The subview's origin is expected to be 1/4 of the map view's height and width
-//        let expectedSubViewOrigin = CGPoint(x: mapView.bounds.width * 0.25, y: mapView.bounds.height * 0.25)
-//        let convertedSubViewOrigin = mapView.convert(expectedSubViewOrigin, to: subview)
-//        // So this should be zero
-//        XCTAssertEqual(convertedSubViewOrigin, .zero)
-//
-//        let originCoordinateC = mapView.convert(convertedSubViewOrigin, toCoordinateFrom: subview)
-//
-//        XCTAssertEqual(originCoordinateB.latitude, originCoordinateC.latitude, accuracy: accuracy)
-//        XCTAssertEqual(originCoordinateB.longitude, originCoordinateC.longitude, accuracy: accuracy)
-//
-//        XCTAssertEqual(originCoordinateA.latitude, originCoordinateC.latitude, accuracy: accuracy)
-//        XCTAssertEqual(originCoordinateA.longitude, originCoordinateC.longitude, accuracy: accuracy)
-    }
-
     func testPointToCoordinateWithBoundsShifted() {
         // Shift bounds down and right 1/2 of the map's size
         mapView.bounds = CGRect(x: mapView.frame.midX,

--- a/Tests/MapboxMapsTests/Gestures/MockCameraManager.swift
+++ b/Tests/MapboxMapsTests/Gestures/MockCameraManager.swift
@@ -14,24 +14,38 @@ final class MockCameraManager: CameraManagerProtocol {
 
     struct SetCameraParameters {
         var camera: CameraOptions
-        var animated: Bool
-        var duration: TimeInterval
-        var completion: ((UIViewAnimatingPosition) -> Void)?
     }
 
     let setCameraStub = Stub<SetCameraParameters, Void>()
 
-    func setCamera(to camera: CameraOptions,
-                   animated: Bool,
-                   duration: TimeInterval,
-                   completion: ((UIViewAnimatingPosition) -> Void)?) {
+    func setCamera(to camera: CameraOptions) {
         setCameraStub.call(
-            with: SetCameraParameters(camera: camera,
-                                      animated: animated,
-                                      duration: duration,
-                                      completion: completion))
+            with: SetCameraParameters(camera: camera))
     }
 
+    struct EaseToCameraParameters {
+        var camera: CameraOptions
+        var duration: TimeInterval
+        var curve: UIView.AnimationCurve
+        var completion: AnimationCompletion?
+    }
+
+    let easeToStub = Stub<EaseToCameraParameters, CameraAnimator?>(defaultReturnValue: nil)
+    func ease(to camera: CameraOptions,
+              duration: TimeInterval,
+              curve: UIView.AnimationCurve,
+              completion: AnimationCompletion?) -> CameraAnimator? {
+
+        return easeToStub.call(
+            with: EaseToCameraParameters(
+                camera: camera,
+                duration: duration,
+                curve: curve,
+                completion: completion))
+    }
+
+    let cancelAnimationsStub = Stub<Void, Void>()
     func cancelAnimations() {
+        cancelAnimationsStub.call()
     }
 }

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/Map/MapViewIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/Map/MapViewIntegrationTests.swift
@@ -39,7 +39,7 @@ class MapViewIntegrationTests: IntegrationTestCase {
 
             mapView.on(.mapLoaded) { [weak mapView] _ in
                 let dest = CameraOptions(center: CLLocationCoordinate2D(latitude: 10, longitude: 10), zoom: 10)
-                mapView?.camera.setCamera(to: dest, animated: true, duration: 5) { _ in
+                mapView?.camera.ease(to: dest, duration: 5) { (_) in
                     expectation.fulfill()
                 }
             }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Animation capabilities of `mapView.camera.setCamera()` have been removed</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR removes the animation capabilities of `setCamera()` on `CameraAnimationsManager`, which is the first step to removing this entirely from the scope of `CameraAnimationsManager`.

The animation capabilities of `setCamera` are now provided via the `ease(to:)` method on `CameraAnimationsManager`.
