### PR TITLE
Style: refactor getX and generic functions

### DIFF
--- a/Apps/Examples/Examples/All Examples/AnimateGeoJSONLineExample.swift
+++ b/Apps/Examples/Examples/All Examples/AnimateGeoJSONLineExample.swift
@@ -86,8 +86,8 @@ public class AnimateGeoJSONLineExample: UIViewController, ExampleProtocol {
 
             let updatedLine = Feature(LineString(currentCoordinates))
             self.routeLineSource.data = .feature(updatedLine)
-            _ = self.mapView.style.updateGeoJSON(for: self.sourceIdentifier,
-                                                 with: updatedLine)
+            try! self.mapView.style.updateGeoJSONSource(withId: self.sourceIdentifier,
+                                                        geoJSON: updatedLine)
         }
     }
 

--- a/Apps/Examples/Examples/All Examples/AnimateLayerExample.swift
+++ b/Apps/Examples/Examples/All Examples/AnimateLayerExample.swift
@@ -115,8 +115,8 @@ public class AnimateLayerExample: UIViewController, ExampleProtocol {
             geoJSON.properties = ["bearing": coordinate.direction(to: nextCoordinate)]
 
             // Update the airplane source layer with the new coordinate and bearing.
-            _ = self.mapView.style.updateGeoJSON(for: self.airplaneSymbol.identifier,
-                                                 with: geoJSON)
+            try! self.mapView.style.updateGeoJSONSource(withId: self.airplaneSymbol.identifier,
+                                                        geoJSON: geoJSON)
 
             runCount += 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ Mapbox welcomes participation and contributions from everyone.
       * Removing default values for parameters
       * Making `bearing` and `pitch` parameters optional
       * Adding the `camera(for:camera:rect:)` variant
-  - `OrnamentOptions` should now be accessed via `MapView.ornaments.options`. `MapConfig.ornaments` has been removed. Updates can be applied directly to `OrnamentsManager.options`. Previously the map's ornament options were updated on `MapConfig.ornaments` with `MapView.update`. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310)) 
-  - `OrnamentOptions` now uses structs to manage options for individual ornaments. For example, `OrnamentOptions.scaleBarPosition` is now `OrnamentOptions.scaleBar.position`. ([#318](https://github.com/mapbox/mapbox-maps-ios/pull/318))
-  - The `LogoView` class is now private. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310))
+- `OrnamentOptions` should now be accessed via `MapView.ornaments.options`. `MapConfig.ornaments` has been removed. Updates can be applied directly to `OrnamentsManager.options`. Previously the map's ornament options were updated on `MapConfig.ornaments` with `MapView.update`. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310)) 
+- `OrnamentOptions` now uses structs to manage options for individual ornaments. For example, `OrnamentOptions.scaleBarPosition` is now `OrnamentOptions.scaleBar.position`. ([#318](https://github.com/mapbox/mapbox-maps-ios/pull/318))
+- The `LogoView` class is now private. ([#310](https://github.com/mapbox/mapbox-maps-ios/pull/310))
+- `Style` has been significantly refactored, for example:
+  - Synchronous APIs returning `Result` types now throw.
+  - A number of APIs previously accessed via `__map` are now available via the `Style` object.
+  - APIs with a `get` prefix have been renamed; for example `getLayer<T>(with:type:)` to `layer<T>(withId:type:) throws` and `getSource<T>(id:type:)` to `source<T>(withId:type:) throws`
 
 ### Features ✨ and improvements 🏁
 

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -424,30 +424,6 @@ extension Style: StyleManagerProtocol {
         return StyleManager.getStyleSourcePropertyDefaultValue(forSourceType: sourceType, property: property)
     }
 
-    // MARK: - Clustering
-
-    public func geoJSONSourceClusterExpansionZoom(for sourceId: String, cluster: UInt32) throws -> Float {
-        return try handleExpected {
-            return styleManager.getStyleGeoJSONSourceClusterExpansionZoom(forSourceId: sourceId, cluster: cluster)
-        }
-    }
-
-    public func geoJSONSourceClusterChildren(for sourceId: String, cluster: UInt32) throws -> [Feature] {
-        let features: [MBXFeature] = try handleExpected {
-            return styleManager.getStyleGeoJSONSourceClusterChildren(forSourceId: sourceId, cluster: cluster)
-        }
-
-        return features.compactMap { Feature($0) }
-    }
-
-    public func geoJSONSourceClusterLeaves(for sourceId: String, cluster: UInt32, limit: UInt32, offset: UInt32) throws -> [Feature] {
-        let features: [MBXFeature] = try handleExpected {
-            return styleManager.getStyleGeoJSONSourceClusterLeaves(forSourceId: sourceId, cluster: cluster, limit: limit, offset: offset)
-        }
-
-        return features.compactMap { Feature($0) }
-    }
-
     // MARK: - Image source
 
     public func updateImageSource(withId id: String, image: UIImage) throws {

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -173,18 +173,18 @@ public class Style {
         return _sourceProperty(for: sourceId, property: property).value
     }
 
-    /**
-     Updates the `data` property of a given `GeoJSONSource` with a new value
-     conforming to the `GeoJSONObject` protocol.
-
-     - Parameter id: The identifier representing the GeoJSON source.
-     - Parameter geoJSON: The new GeoJSON to be associated with the source data.
-
-     - Throws: StyleError or type conversion errors
-
-     - Attention: This method is only effective with sources of `GeoJSONSource` type,
-             and should not be used to update other source types.
-     */
+    /// Updates the `data` property of a given `GeoJSONSource` with a new value
+    /// conforming to the `GeoJSONObject` protocol.
+    ///
+    /// - Parameters:
+    ///   - id: The identifier representing the GeoJSON source.
+    ///   - geoJSON: The new GeoJSON to be associated with the source data. i.e.
+    ///   a feature or feature collection.
+    ///
+    /// - Throws: StyleError or type conversion errors
+    ///
+    /// - Attention: This method is only effective with sources of `GeoJSONSource`
+    /// type, and cannot be used to update other source types.
     public func updateGeoJSONSource<T: GeoJSONObject>(withId id: String, geoJSON: T) throws {
         guard let sourceInfo = allSourceIdentifiers.first(where: { $0.id == id }),
               sourceInfo.type == .geoJson else {

--- a/Sources/MapboxMaps/Style/StyleEncodable.swift
+++ b/Sources/MapboxMaps/Style/StyleEncodable.swift
@@ -8,12 +8,12 @@ public protocol StyleDecodable {
 
 public extension StyleEncodable where Self: Encodable {
     /// Given an Encodable object return the JSON dictionary representation
-    /// - Throws: Errors occurring during encoding, or `StyleEncodingError.invalidJSONObject`
+    /// - Throws: Errors occurring during encoding, or `TypeConversionError.invalidJSONObject`
     /// - Returns: A JSON dictionary representing the object.
     func jsonObject() throws -> [String: Any] {
         let data = try JSONEncoder().encode(self)
         guard let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            throw StyleEncodingError.invalidJSONObject
+            throw TypeConversionError.invalidJSONObject
         }
         return jsonObject
     }

--- a/Sources/MapboxMaps/Style/StyleErrors.swift
+++ b/Sources/MapboxMaps/Style/StyleErrors.swift
@@ -2,95 +2,30 @@ import Foundation
 
 // MARK: - Style error types
 
-public enum StyleEncodingError: Error {
+/// Type of errors thrown by the `Style` APIs.
+public struct StyleError: RawRepresentable, LocalizedError {
+    /// :nodoc:
+    public typealias RawValue = String
+
+    /// :nodoc:
+    public var rawValue: String
+
+    /// :nodoc:
+    public init?(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    internal init(message: String) {
+        self.rawValue = message
+    }
+
+    /// Error message
+    public var errorDescription: String? {
+        return rawValue
+    }
+}
+
+public enum TypeConversionError: Error {
     case invalidJSONObject
-}
-
-/// All source related errors
-public enum SourceError: Error {
-    /// The source could not be encoded to JSON
-    case sourceEncodingFailed(Error)
-
-    /// The source could not be decoded from JSON
-    case sourceDecodingFailed(Error)
-
-    /// The source could not be added to the map
-    case addSourceFailed(String)
-
-    /// The source could not be removed from the map
-    case removeSourceFailed(String)
-
-    /// The source could not be retrieved from the map
-    case getSourceFailed(String)
-
-    /// The source property could not be set.
-    case setSourceProperty(String)
-
-    /// Temporary error for clustering.
-    case getSourceClusterDetailsFailed(String)
-}
-
-/// Error enum for all layer-related errors
-public enum LayerError: Error {
-    /// The layer provided to the map in `addLayer()` could not be encoded
-    case layerEncodingFailed(Error?)
-
-    /// The layer retrieved from the map could not be decoded.
-    case layerDecodingFailed(Error)
-
-    /// Adding the style layer to the map failed
-    case addLayerFailed(String)
-
-    /// Remove the style layer from the map failed
-    case removeLayerFailed(String)
-
-    /// Setting layer property(s) failed
-    case setLayerPropertyFailed(String)
-
-    /// The layer properties for a layer are nil
-    case getStyleLayerFailed(String)
-
-    /// The retrieved layer is nil
-    case retrievedLayerIsNil
-
-    /// Updating the layer failed with error
-    case updateStyleLayerFailed(Error)
-}
-
-/// Error enum for all image-related errors
-public enum ImageError: Error {
-    /// Converting the input image to internal `Image` format failed.
-    case convertingImageFailed(String?)
-
-    /// Adding the image to the style's sprite failed.
-    case addStyleImageFailed(String)
-
-    /// The style image does not exist in the sprite
-    case getStyleImageFailed(String)
-
-    /// Temporary
-    case imageSourceImageUpdateFailed(String)
-    case removeImageFailed(String)
-}
-
-/// Error enum for all terrain-related errors
-public enum TerrainError: Error {
-    /// Decoding terrain failed
-    case setTerrainProperty(String)
-
-    /// Adding terrain failed
-    case addTerrainFailed(String)
-}
-
-/// Enum for all light-related errors
-public enum LightError: Error {
-    /// Adding a new light object to style failed
-    case addLightFailed(String)
-
-    /// Retrieving a light object from style failed
-    case getLightFailed(Error)
-}
-
-public enum TemporaryError: Error {
-    case failure(String)
+    case unexpectedType
 }

--- a/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
+++ b/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
@@ -263,53 +263,6 @@ public protocol StyleManagerProtocol {
     ///     The default value for the named property for the sources with type sourceType.
     static func _sourcePropertyDefaultValue(for sourceType: String, property: String) -> StylePropertyValue
 
-    // MARK: Clustering
-
-    /// Returns the zoom on which the cluster expands into several children
-    /// (useful for "click to zoom" feature).
-    ///
-    /// - Parameters:
-    ///   - sourceId: GeoJSON style source identifier.
-    ///   - cluster: Cluster from which to retrieve the expansion zoom.
-    ///
-    /// - Returns:
-    ///     The zoom on which the cluster expands into several children
-    ///
-    /// - Throws:
-    ///     An error describing why the operation was unsuccessful.
-    func geoJSONSourceClusterExpansionZoom(for sourceId: String, cluster: UInt32) throws -> Float
-
-    /// Returns the children of a cluster (on the next zoom level).
-    ///
-    /// - Parameters:
-    ///   - sourceId: GeoJSON style source identifier.
-    ///   - cluster: Cluster from which to retrieve children.
-    ///
-    /// - Returns:
-    ///     An array of features for the underlying children
-    ///
-    /// - Throws:
-    ///     An error describing why the operation was unsuccessful.
-    func geoJSONSourceClusterChildren(for sourceId: String, cluster: UInt32) throws -> [Feature]
-
-    /// Returns all the leaves of a cluster (given its cluster_id), with
-    /// pagination support: limit is the number of leaves to return (set
-    /// to `UInt32.max` for all points), and offset is the amount of points to skip
-    /// (for pagination).
-    ///
-    /// - Parameters:
-    ///   - sourceId: GeoJSON style source identifier.
-    ///   - cluster: Cluster from which to retrieve leaves.
-    ///   - limit: The number of points to return.
-    ///   - offset: The number of points to skip (for pagination).
-    ///   
-    /// - Returns:
-    ///     An array of features for the underlying children
-    ///
-    /// - Throws:
-    ///     An error describing why the operation was unsuccessful.
-    func geoJSONSourceClusterLeaves(for sourceId: String, cluster: UInt32, limit: UInt32, offset: UInt32) throws -> [Feature]
-
     // MARK: Image source
 
     /// Updates the image of an image style source.

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
@@ -24,7 +24,7 @@ internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase 
 
             guard let self = self,
                   let style = self.style else {
-                XCTFail()
+                XCTFail("nil test or style")
                 return
             }
 
@@ -103,7 +103,7 @@ internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase 
 
             guard let self = self,
                   let style = self.style else {
-                XCTFail()
+                XCTFail("nil test or style")
                 return
             }
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/BackgroundLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/BackgroundLayerIntegrationTests.swift
@@ -49,13 +49,11 @@ class BackgroundLayerIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the layer
-            let retrieveResult = style.getLayer(with: "test-id", type: BackgroundLayer.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                    successfullyRetrievedLayerExpectation.fulfill()    
-                case .failure(let error):
-                    XCTFail("Failed to retreive BackgroundLayer because of error: \(error)")   
+            do {
+                _ = try style.layer(withId: "test-id", type: BackgroundLayer.self)
+                successfullyRetrievedLayerExpectation.fulfill()
+            } catch {
+                XCTFail("Failed to retrieve BackgroundLayer because of error: \(error)")   
             }
         }
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/CircleLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/CircleLayerIntegrationTests.swift
@@ -62,13 +62,11 @@ class CircleLayerIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the layer
-            let retrieveResult = style.getLayer(with: "test-id", type: CircleLayer.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                    successfullyRetrievedLayerExpectation.fulfill()    
-                case .failure(let error):
-                    XCTFail("Failed to retreive CircleLayer because of error: \(error)")   
+            do {
+                _ = try style.layer(withId: "test-id", type: CircleLayer.self)
+                successfullyRetrievedLayerExpectation.fulfill()
+            } catch {
+                XCTFail("Failed to retrieve CircleLayer because of error: \(error)")   
             }
         }
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/FillExtrusionLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/FillExtrusionLayerIntegrationTests.swift
@@ -56,13 +56,11 @@ class FillExtrusionLayerIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the layer
-            let retrieveResult = style.getLayer(with: "test-id", type: FillExtrusionLayer.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                    successfullyRetrievedLayerExpectation.fulfill()    
-                case .failure(let error):
-                    XCTFail("Failed to retreive FillExtrusionLayer because of error: \(error)")   
+            do {
+                _ = try style.layer(withId: "test-id", type: FillExtrusionLayer.self)
+                successfullyRetrievedLayerExpectation.fulfill()
+            } catch {
+                XCTFail("Failed to retrieve FillExtrusionLayer because of error: \(error)")   
             }
         }
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/FillLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/FillLayerIntegrationTests.swift
@@ -55,13 +55,11 @@ class FillLayerIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the layer
-            let retrieveResult = style.getLayer(with: "test-id", type: FillLayer.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                    successfullyRetrievedLayerExpectation.fulfill()    
-                case .failure(let error):
-                    XCTFail("Failed to retreive FillLayer because of error: \(error)")   
+            do {
+                _ = try style.layer(withId: "test-id", type: FillLayer.self)
+                successfullyRetrievedLayerExpectation.fulfill()
+            } catch {
+                XCTFail("Failed to retrieve FillLayer because of error: \(error)")   
             }
         }
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/HeatmapLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/HeatmapLayerIntegrationTests.swift
@@ -51,13 +51,11 @@ class HeatmapLayerIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the layer
-            let retrieveResult = style.getLayer(with: "test-id", type: HeatmapLayer.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                    successfullyRetrievedLayerExpectation.fulfill()    
-                case .failure(let error):
-                    XCTFail("Failed to retreive HeatmapLayer because of error: \(error)")   
+            do {
+                _ = try style.layer(withId: "test-id", type: HeatmapLayer.self)
+                successfullyRetrievedLayerExpectation.fulfill()
+            } catch {
+                XCTFail("Failed to retrieve HeatmapLayer because of error: \(error)")   
             }
         }
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/HillshadeLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/HillshadeLayerIntegrationTests.swift
@@ -53,13 +53,11 @@ class HillshadeLayerIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the layer
-            let retrieveResult = style.getLayer(with: "test-id", type: HillshadeLayer.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                    successfullyRetrievedLayerExpectation.fulfill()    
-                case .failure(let error):
-                    XCTFail("Failed to retreive HillshadeLayer because of error: \(error)")   
+            do {
+                _ = try style.layer(withId: "test-id", type: HillshadeLayer.self)
+                successfullyRetrievedLayerExpectation.fulfill()
+            } catch {
+                XCTFail("Failed to retrieve HillshadeLayer because of error: \(error)")   
             }
         }
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LineLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LineLayerIntegrationTests.swift
@@ -66,13 +66,11 @@ class LineLayerIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the layer
-            let retrieveResult = style.getLayer(with: "test-id", type: LineLayer.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                    successfullyRetrievedLayerExpectation.fulfill()    
-                case .failure(let error):
-                    XCTFail("Failed to retreive LineLayer because of error: \(error)")   
+            do {
+                _ = try style.layer(withId: "test-id", type: LineLayer.self)
+                successfullyRetrievedLayerExpectation.fulfill()
+            } catch {
+                XCTFail("Failed to retrieve LineLayer because of error: \(error)")   
             }
         }
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LocationIndicatorLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LocationIndicatorLayerIntegrationTests.swift
@@ -66,13 +66,11 @@ class LocationIndicatorLayerIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the layer
-            let retrieveResult = style.getLayer(with: "test-id", type: LocationIndicatorLayer.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                    successfullyRetrievedLayerExpectation.fulfill()    
-                case .failure(let error):
-                    XCTFail("Failed to retreive LocationIndicatorLayer because of error: \(error)")   
+            do {
+                _ = try style.layer(withId: "test-id", type: LocationIndicatorLayer.self)
+                successfullyRetrievedLayerExpectation.fulfill()
+            } catch {
+                XCTFail("Failed to retrieve LocationIndicatorLayer because of error: \(error)")   
             }
         }
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/ModelLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/ModelLayerIntegrationTests.swift
@@ -46,13 +46,11 @@ class ModelLayerIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the layer
-            let retrieveResult = style.getLayer(with: "test-id", type: ModelLayer.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                    successfullyRetrievedLayerExpectation.fulfill()    
-                case .failure(let error):
-                    XCTFail("Failed to retrieve ModelLayer because of error: \(error)")
+            do {
+                _ = try style.layer(withId: "test-id", type: ModelLayer.self)
+                successfullyRetrievedLayerExpectation.fulfill()
+            } catch {
+                XCTFail("Failed to retrieve ModelLayer because of error: \(error)")
             }
         }
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/RasterLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/RasterLayerIntegrationTests.swift
@@ -57,13 +57,11 @@ class RasterLayerIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the layer
-            let retrieveResult = style.getLayer(with: "test-id", type: RasterLayer.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                    successfullyRetrievedLayerExpectation.fulfill()    
-                case .failure(let error):
-                    XCTFail("Failed to retreive RasterLayer because of error: \(error)")   
+            do {
+                _ = try style.layer(withId: "test-id", type: RasterLayer.self)
+                successfullyRetrievedLayerExpectation.fulfill()
+            } catch {
+                XCTFail("Failed to retrieve RasterLayer because of error: \(error)")   
             }
         }
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/SkyLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/SkyLayerIntegrationTests.swift
@@ -51,13 +51,11 @@ class SkyLayerIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the layer
-            let retrieveResult = style.getLayer(with: "test-id", type: SkyLayer.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                    successfullyRetrievedLayerExpectation.fulfill()    
-                case .failure(let error):
-                    XCTFail("Failed to retreive SkyLayer because of error: \(error)")   
+            do {
+                _ = try style.layer(withId: "test-id", type: SkyLayer.self)
+                successfullyRetrievedLayerExpectation.fulfill()
+            } catch {
+                XCTFail("Failed to retrieve SkyLayer because of error: \(error)")   
             }
         }
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/SymbolLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/SymbolLayerIntegrationTests.swift
@@ -105,13 +105,11 @@ class SymbolLayerIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the layer
-            let retrieveResult = style.getLayer(with: "test-id", type: SymbolLayer.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                    successfullyRetrievedLayerExpectation.fulfill()    
-                case .failure(let error):
-                    XCTFail("Failed to retreive SymbolLayer because of error: \(error)")   
+            do {
+                _ = try style.layer(withId: "test-id", type: SymbolLayer.self)
+                successfullyRetrievedLayerExpectation.fulfill()
+            } catch {
+                XCTFail("Failed to retrieve SymbolLayer because of error: \(error)")   
             }
         }
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/GeoJsonSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/GeoJsonSourceIntegrationTests.swift
@@ -43,12 +43,10 @@ class GeoJSONSourceIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the source
-            let retrieveResult = style.getSource(id: "test-source", type: GeoJSONSource.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                successfullyRetrievedSourceExpectation.fulfill()    
-                case .failure(let error):
+            do {
+                _ = try style.source(withId: "test-source", type: GeoJSONSource.self)
+                successfullyRetrievedSourceExpectation.fulfill()
+            } catch {
                 XCTFail("Failed to retrieve GeoJSONSource because of error: \(error)")
             }
         }

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/ImageSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/ImageSourceIntegrationTests.swift
@@ -36,12 +36,10 @@ class ImageSourceIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the source
-            let retrieveResult = style.getSource(id: "test-source", type: ImageSource.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                successfullyRetrievedSourceExpectation.fulfill()    
-                case .failure(let error):
+            do {
+                _ = try style.source(withId: "test-source", type: ImageSource.self)
+                successfullyRetrievedSourceExpectation.fulfill()
+            } catch {
                 XCTFail("Failed to retrieve ImageSource because of error: \(error)")
             }
         }

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterDemSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterDemSourceIntegrationTests.swift
@@ -45,12 +45,10 @@ class RasterDemSourceIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the source
-            let retrieveResult = style.getSource(id: "test-source", type: RasterDemSource.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                successfullyRetrievedSourceExpectation.fulfill()    
-                case .failure(let error):
+            do {
+                _ = try style.source(withId: "test-source", type: RasterDemSource.self)
+                successfullyRetrievedSourceExpectation.fulfill()
+            } catch {
                 XCTFail("Failed to retrieve RasterDemSource because of error: \(error)")
             }
         }

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterSourceIntegrationTests.swift
@@ -45,12 +45,10 @@ class RasterSourceIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the source
-            let retrieveResult = style.getSource(id: "test-source", type: RasterSource.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                successfullyRetrievedSourceExpectation.fulfill()    
-                case .failure(let error):
+            do {
+                _ = try style.source(withId: "test-source", type: RasterSource.self)
+                successfullyRetrievedSourceExpectation.fulfill()
+            } catch {
                 XCTFail("Failed to retrieve RasterSource because of error: \(error)")
             }
         }

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/VectorSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/VectorSourceIntegrationTests.swift
@@ -44,12 +44,10 @@ class VectorSourceIntegrationTests: MapViewIntegrationTestCase {
             }
 
             // Retrieve the source
-            let retrieveResult = style.getSource(id: "test-source", type: VectorSource.self)
-
-            switch (retrieveResult) {
-                case .success(_):
-                successfullyRetrievedSourceExpectation.fulfill()    
-                case .failure(let error):
+            do {
+                _ = try style.source(withId: "test-source", type: VectorSource.self)
+                successfullyRetrievedSourceExpectation.fulfill()
+            } catch {
                 XCTFail("Failed to retrieve VectorSource because of error: \(error)")
             }
         }

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -37,6 +37,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                     XCTAssert(layer.paint?.backgroundColor == newBackgroundLayer.paint?.backgroundColor)
                     layer.paint?.backgroundColor = .constant(.init(color: .blue))
                 }
+                expectation.fulfill()
             } catch {
                 XCTFail("Could not update background layer due to error: \(error)")
             }

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -33,7 +33,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             }
 
             do {
-                try style.updateLayer(id: newBackgroundLayer.id, type: BackgroundLayer.self) { (layer) throws in
+                try style.updateLayer(withId: newBackgroundLayer.id, type: BackgroundLayer.self) { (layer) throws in
                     XCTAssert(layer.paint?.backgroundColor == newBackgroundLayer.paint?.backgroundColor)
                     layer.paint?.backgroundColor = .constant(.init(color: .blue))
                 }

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -32,28 +32,22 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                 XCTFail("Could not add background layer due to error: \(error)")
             }
 
-            let result2 = style.updateLayer(id: newBackgroundLayer.id, type: BackgroundLayer.self) { (layer) in
-                XCTAssert(layer.paint?.backgroundColor == newBackgroundLayer.paint?.backgroundColor)
-                layer.paint?.backgroundColor = .constant(.init(color: .blue))
-            }
-
-            switch result2 {
-            case .success:
-                expectation.fulfill()
-            case .failure(let error):
+            do {
+                try style.updateLayer(id: newBackgroundLayer.id, type: BackgroundLayer.self) { (layer) throws in
+                    XCTAssert(layer.paint?.backgroundColor == newBackgroundLayer.paint?.backgroundColor)
+                    layer.paint?.backgroundColor = .constant(.init(color: .blue))
+                }
+            } catch {
                 XCTFail("Could not update background layer due to error: \(error)")
             }
 
-            let result3 = style.getLayer(with: newBackgroundLayer.id, type: BackgroundLayer.self)
-
-            switch result3 {
-            case .success(let retrievedLayer):
+            do {
+                let retrievedLayer = try style.layer(withId: newBackgroundLayer.id, type: BackgroundLayer.self)
                 XCTAssert(retrievedLayer.paint?.backgroundColor == .constant(.init(color: .blue)))
                 expectation.fulfill()
-            case .failure(let error):
+            } catch {
                 XCTFail("Could not retrieve background layer due to error: \(error)")
             }
-
         }
 
         wait(for: [expectation], timeout: 5.0)
@@ -88,7 +82,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                 for step in stride(from: 0, to: layers.count, by: 3) {
 
                     let newLayerPosition = LayerPosition(above: nil, below: nil, at: step)
-                    try style._moveLayer(with: "test-id", to: newLayerPosition)
+                    try style._moveLayer(withId: "test-id", to: newLayerPosition)
 
                     // Get layer position
                     let layers = style.styleManager.getStyleLayers()
@@ -118,22 +112,15 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
         expectation.expectedFulfillmentCount = expectedLayerCount
 
         didFinishLoadingStyle = { _ in
-            let layers = mapView.mapboxMap.__map.getStyleLayers()
+            let layers = style.allLayerIdentifiers
             XCTAssertEqual(layers.count, expectedLayerCount)
 
             for layer in layers {
-                guard let type = LayerType(rawValue: layer.type) else {
-                    XCTFail("Failed to create LayerType from \(layer.type)")
-                    continue
-                }
-
-                let result = style._layer(with: layer.id, type: type.layerType)
-
-                switch result {
-                case .success:
+                do {
+                    _ = try style._layer(withId: layer.id, type: layer.type.layerType)
                     expectation.fulfill()
-                default:
-                    XCTFail("Failed to get line layer with id \(layer.id), error \(result)")
+                } catch {
+                    XCTFail("Failed to get line layer with id \(layer.id), error \(error)")
                 }
             }
         }

--- a/scripts/device-farm/testspec.yml
+++ b/scripts/device-farm/testspec.yml
@@ -41,13 +41,18 @@ phases:
 
       - cp -R /tmp/unzipped-ipa/Payload/$APP_NAME.app /tmp/test-root/$CONFIG-iphoneos
 
-
   # The test phase includes commands that run your test suite execution.
   test:
     commands:
       - xcodebuild -version
       - ls -ladF /Applications/Xcode*.*
       - cd /tmp/test-root && xcodebuild test-without-building -destination id=$DEVICEFARM_DEVICE_UDID -xctestrun device.xctestrun -derivedDataPath $DEVICEFARM_LOG_DIR -resultBundlePath $DEVICEFARM_LOG_DIR/$SCHEME.$CONFIG.$DATE.xcresult -enableCodeCoverage YES
+
+
+  # The post test phase includes are commands that are run after your tests are executed.
+  post_test:
+    commands:
+      - chmod -R 777 $DEVICEFARM_LOG_DIR
 
 # The artifacts phase lets you specify the location where your tests logs,
 # device logs will be stored. And also let you specify the location of your test


### PR DESCRIPTION
Continuation of #321, #320, #317

<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [X] Document any changes to public APIs.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] ~Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.~ Manual edit.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

- Renamed the following APIs:
    - `getLayer<T>(with:type:)` to `layer<T>(withId:type:) throws`
    - `updateLayer<T>(id:type:update:)` to `updateLayer<T>(withId:type:update:) throws`
    - `getSource<T>(id:type:)` to `source<T>(withId:type:) throws`
    - `updateGeoJSON<T>(for:with:)` to `updateGeoJSONSource<T>(withId:geoJSON:) throws`
