### PR TITLE
Refactor cache path

### DIFF
--- a/Sources/MapboxMaps/Foundation/Extensions/Core/ResourceOptions.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/ResourceOptions.swift
@@ -54,7 +54,7 @@ extension ResourceOptions {
             tileStore.setOptionForKey(TileStoreOptions.mapboxAccessToken, value: accessToken)
         }
 
-        let cacheURL = ResourceOptions.cacheURLIncludingSubdirectory()
+        let cacheURL = try? ResourceOptions.cacheURLIncludingSubdirectory()
         let resolvedCachePath = cachePath == nil ? cacheURL?.path : cachePath
         self.init(
             __accessToken: accessToken,
@@ -72,33 +72,21 @@ extension ResourceOptions {
         __cacheSize?.uint64Value
     }
 
-    private static func cacheURLIncludingSubdirectory() -> URL? {
-        guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return nil }
-
-        var cacheDirectoryURL: URL
-        do {
-            cacheDirectoryURL = try FileManager.default.url(for: .applicationSupportDirectory,
+    private static func cacheURLIncludingSubdirectory() throws -> URL? {
+        var cacheDirectoryURL = try FileManager.default.url(for: .applicationSupportDirectory,
                                                             in: .userDomainMask,
                                                             appropriateFor: nil,
                                                             create: true)
-        } catch {
-            return nil
-        }
 
-        cacheDirectoryURL = cacheDirectoryURL.appendingPathComponent(bundleIdentifier)
-        cacheDirectoryURL.appendPathComponent(".mapbox")
+        cacheDirectoryURL = cacheDirectoryURL.appendingPathComponent("com.mapbox.maps")
 
-        do {
-            try FileManager.default.createDirectory(at: cacheDirectoryURL,
-                                                    withIntermediateDirectories: true,
-                                                    attributes: nil)
-        } catch {
-            return nil
-        }
+        try FileManager.default.createDirectory(at: cacheDirectoryURL,
+                                                withIntermediateDirectories: true,
+                                                attributes: nil)
 
         cacheDirectoryURL.setTemporaryResourceValue(true, forKey: .isExcludedFromBackupKey)
 
-        return cacheDirectoryURL.appendingPathComponent("cache.db")
+        return cacheDirectoryURL.appendingPathComponent("ambient_cache.db")
     }
 
     /// :nodoc:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [X] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Changed cache path location.</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR changes the cache path to `<app-support-dir>/com.mapbox.maps/ambient_cache.db`
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

Developers should delete previous versions of apps from device/simulators.