### PR TITLE
Add offlineManager convenience function

### DIFF
--- a/Apps/Examples/Examples/All Examples/OfflineManagerExample.swift
+++ b/Apps/Examples/Examples/All Examples/OfflineManagerExample.swift
@@ -318,6 +318,8 @@ public class OfflineManagerExample: UIViewController, ExampleProtocol {
         button.setTitle("Show Downloads", for: .normal)
         progressContainer.isHidden = true
 
+        // It's important that the MapView use the same ResourceOptions as the
+        // OfflineManager
         let mapView = MapView(frame: mapViewContainer.bounds, mapInitOptions: mapInitOptions)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapViewContainer.addSubview(mapView)

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -17,6 +17,19 @@ open class BaseMapView: UIView {
         }
     }
 
+    /// Offline Manager initialized with the same ResourceOptions as the map view
+    ///
+    /// - Important: If you use an `OfflineManager` in conjunction with a `MapView`
+    /// they must use the same resource options. You can use this convenience
+    /// function to ensure this.
+    public func makeOfflineManager() -> OfflineManager {
+        guard let resourceOptions = resourceOptions else {
+            fatalError("resourceOptions not yet initialized")
+        }
+
+        return OfflineManager(resourceOptions: resourceOptions)
+    }
+
     private let mapClient = DelegatingMapClient()
     private let observer = DelegatingObserver()
 
@@ -24,7 +37,7 @@ open class BaseMapView: UIView {
     internal private(set) var metalView: MTKView?
 
     /// Resource options for this map view
-    internal private(set) var resourceOptions: ResourceOptions?
+    internal private(set) var resourceOptions: ResourceOptions!
 
     /// List of completion blocks that need to be completed by the displayLink
     internal var pendingAnimatorCompletionBlocks: [PendingAnimationCompletion] = []
@@ -34,6 +47,8 @@ open class BaseMapView: UIView {
 
     /// List of animators currently alive
     internal var cameraAnimators: [CameraAnimator] {
+
+        offlineManager = OfflineManager(resourceOptions: ResourceOptions())
         return cameraAnimatorsSet.allObjects
     }
 

--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -47,8 +47,6 @@ open class BaseMapView: UIView {
 
     /// List of animators currently alive
     internal var cameraAnimators: [CameraAnimator] {
-
-        offlineManager = OfflineManager(resourceOptions: ResourceOptions())
         return cameraAnimatorsSet.allObjects
     }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [ ] ~Write tests for all new functionality. If tests were not written, please explain why.~ Tests elsewhere
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [X] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Added convenience function to `BaseMapView` that returns an `OfflineManager`</changelog>`.

### Summary of changes

This PR adds a convenience `makeOfflineManager` function to `BaseMapView` that returns an `OfflineManager` that uses the same `ResourceOptions` that the map was created with.

It's important if you're using an `OfflineManager` in conjunction with a `MapView` that they use the same tile store and cache information.

cc @tobrun @pengdev 
