### PR TITLE
Check whether puck layer exists before trying to remove

### DIFF
--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -90,4 +90,18 @@ public class DebugViewController: UIViewController {
             print("The map failed to load.. \(type) = \(message)")
         }
     }
+
+    var willCount = 0
+
+    public override func viewWillLayoutSubviews() {
+        willCount += 1
+        print("viewWillLayoutSubviews \(willCount)")
+    }
+
+    var didCount = 0
+
+    public override func viewDidLayoutSubviews() {
+        didCount += 1
+        print("viewDidLayoutSubviews \(didCount)")
+    }
 }

--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -90,18 +90,4 @@ public class DebugViewController: UIViewController {
             print("The map failed to load.. \(type) = \(message)")
         }
     }
-
-    var willCount = 0
-
-    public override func viewWillLayoutSubviews() {
-        willCount += 1
-        print("viewWillLayoutSubviews \(willCount)")
-    }
-
-    var didCount = 0
-
-    public override func viewDidLayoutSubviews() {
-        didCount += 1
-        print("viewDidLayoutSubviews \(didCount)")
-    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ Mapbox welcomes participation and contributions from everyone.
 ### Breaking changes ⚠️
 
   - `OrnamentOptions.logo._isVisible` and `OrnamentOptions.attributionButton._isVisible` have been replaced with `OrnamentOptions.logo.visibility` and `OrnamentOptions.attributionButton.visibility`. ([#326](https://github.com/mapbox/mapbox-maps-ios/pull/326))
-  
+
+### Bug fixes 🐞
+
   - Fixed an issue where location pucks would not be rendered. ([#331](https://github.com/mapbox/mapbox-maps-ios/pull/331))
 
 ## 10.0.0-beta.19 - May 6, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+### Breaking changes ⚠️
+
+  - `OrnamentOptions.logo._isVisible` and `OrnamentOptions.attributionButton._isVisible` have been replaced with `OrnamentOptions.logo.visibility` and `OrnamentOptions.attributionButton.visibility`. ([#326](https://github.com/mapbox/mapbox-maps-ios/pull/326))
+  
+  - Fixed an issue where location pucks would not be rendered. ([#331](https://github.com/mapbox/mapbox-maps-ios/pull/331))
+
 ## 10.0.0-beta.19 - May 6, 2021
 
 ### Breaking changes ⚠️

--- a/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
@@ -153,7 +153,9 @@ private extension Puck2D {
     func createPreciseLocationIndicatorLayer(location: Location) throws {
         guard let style = locationSupportableMapView?.style else { return }
 
-        try style.removeLayer(withId: "approximate-puck")
+        if style.layerExists(withId: "approximate-puck") {
+            try style.removeLayer(withId: "approximate-puck")
+        }
         // Call customizationHandler to allow developers to granularly modify the layer
 
         // Add images to sprite sheet
@@ -207,7 +209,9 @@ private extension Puck2D {
     func createApproximateLocationIndicatorLayer(location: Location) throws {
         guard let style = locationSupportableMapView?.style else { return }
         // TODO: Handle removal of precise indicator properly.
-        try style.removeLayer(withId: "puck")
+        if style.layerExists(withId: "puck") {
+            try style.removeLayer(withId: "puck")
+        }
 
         // Create Layer
         var layer = LocationIndicatorLayer(id: "approximate-puck")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes
This PR fixes an issue where location pucks weren't rendered. If another puck layer didn't already exist, the method to create a puck would throw an error.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
