### PR TITLE
[MapView][Part 1] Move GestureOptions into GestureManager

### DIFF
--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -121,6 +121,9 @@
 		0C9DE3B3252C2A1F00880CC8 /* GeoJSONSourceDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9DE382252C299800880CC8 /* GeoJSONSourceDataTests.swift */; };
 		0CA3DD61257AAE3B00B12C8F /* SkyLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA3DD5E257AAE3B00B12C8F /* SkyLayer.swift */; };
 		0CAC3CAA2534E8CC00D031E7 /* ResourceOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAC3CA92534E8CC00D031E7 /* ResourceOptions.swift */; };
+		0CB90C6D264CC292003008A5 /* GestureType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB90C6B264CC292003008A5 /* GestureType.swift */; };
+		0CB90C6E264CC292003008A5 /* CameraManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB90C6C264CC292003008A5 /* CameraManagerProtocol.swift */; };
+		0CB90C73264CC2A5003008A5 /* GestureHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB90C72264CC2A5003008A5 /* GestureHandler.swift */; };
 		0CBCF28E25409F030025F7B3 /* ResolvedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CBCF28D25409F030025F7B3 /* ResolvedImage.swift */; };
 		0CC6EF0B25C3263400BFB153 /* ModelLayerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC6EEFC25C3263400BFB153 /* ModelLayerIntegrationTests.swift */; };
 		0CC6EF0E25C3263400BFB153 /* BackgroundLayerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC6EEFD25C3263400BFB153 /* BackgroundLayerIntegrationTests.swift */; };
@@ -538,6 +541,9 @@
 		0C9DE382252C299800880CC8 /* GeoJSONSourceDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoJSONSourceDataTests.swift; sourceTree = "<group>"; };
 		0CA3DD5E257AAE3B00B12C8F /* SkyLayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkyLayer.swift; sourceTree = "<group>"; };
 		0CAC3CA92534E8CC00D031E7 /* ResourceOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceOptions.swift; sourceTree = "<group>"; };
+		0CB90C6B264CC292003008A5 /* GestureType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GestureType.swift; sourceTree = "<group>"; };
+		0CB90C6C264CC292003008A5 /* CameraManagerProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraManagerProtocol.swift; sourceTree = "<group>"; };
+		0CB90C72264CC2A5003008A5 /* GestureHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GestureHandler.swift; sourceTree = "<group>"; };
 		0CBCF28D25409F030025F7B3 /* ResolvedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolvedImage.swift; sourceTree = "<group>"; };
 		0CBCF2D7254229630025F7B3 /* STYLE_README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = STYLE_README.md; path = ../../../Mapbox/STYLE_README.md; sourceTree = "<group>"; };
 		0CC6EEFC25C3263400BFB153 /* ModelLayerIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelLayerIntegrationTests.swift; sourceTree = "<group>"; };
@@ -1177,6 +1183,7 @@
 		0CC8BD29242405AA00288A9B /* GestureHandlers */ = {
 			isa = PBXGroup;
 			children = (
+				0CB90C72264CC2A5003008A5 /* GestureHandler.swift */,
 				0CC8BD2A242405AA00288A9B /* PanGestureHandler.swift */,
 				0CC8BD2B242405AA00288A9B /* TapGestureHandler.swift */,
 				0CF118A2243D1C630097779A /* PinchGestureHandler.swift */,
@@ -1272,6 +1279,8 @@
 		1F2AD7302421C462006592F4 /* MapboxMapsGestures */ = {
 			isa = PBXGroup;
 			children = (
+				0CB90C6C264CC292003008A5 /* CameraManagerProtocol.swift */,
+				0CB90C6B264CC292003008A5 /* GestureType.swift */,
 				B5B55D50260E4D4500EBB589 /* GestureManager+GestureHandlerDelegate.swift */,
 				0CC8BD29242405AA00288A9B /* GestureHandlers */,
 				0CC8BD2C242405AA00288A9B /* GestureManager.swift */,
@@ -2047,6 +2056,7 @@
 				CA6245E92627F37B00C79547 /* OfflineManager+MapboxMaps.swift in Sources */,
 				B575018F26334BB800937A9E /* OrnamentOptions.swift in Sources */,
 				0CD62F23245887C8006421D1 /* OrnamentsManager.swift in Sources */,
+				0CB90C6D264CC292003008A5 /* GestureType.swift in Sources */,
 				CA0C427E2602BECE0054D9D0 /* LayerPosition.swift in Sources */,
 				07A0BCCB2582F16300B8E109 /* GeoJSONManager.swift in Sources */,
 				0C708F2724EB1EE2003CE791 /* LineLayer.swift in Sources */,
@@ -2116,6 +2126,8 @@
 				0782AFE6258BFD2300D5FCE5 /* CoreLocation.swift in Sources */,
 				2B8637D52461601100698135 /* MapboxScaleBarOrnamentView.swift in Sources */,
 				0CD62F0824588505006421D1 /* QuickZoomGestureHandler.swift in Sources */,
+				0CB90C6E264CC292003008A5 /* CameraManagerProtocol.swift in Sources */,
+				0CB90C73264CC2A5003008A5 /* GestureHandler.swift in Sources */,
 				0CBCF28E25409F030025F7B3 /* ResolvedImage.swift in Sources */,
 				CAC1960B25AE98F400F69FEA /* GlyphsRasterizationOptions.swift in Sources */,
 				0706C49225B1128A008733C0 /* Terrain.swift in Sources */,

--- a/Sources/MapboxMaps/Gestures/CameraManagerProtocol.swift
+++ b/Sources/MapboxMaps/Gestures/CameraManagerProtocol.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+internal protocol CameraManagerProtocol: AnyObject {
+
+    var mapView: BaseMapView? { get }
+
+    var mapCameraOptions: MapCameraOptions { get }
+
+    func setCamera(to camera: CameraOptions)
+
+    func ease(to camera: CameraOptions,
+              duration: TimeInterval,
+              curve: UIView.AnimationCurve,
+              completion: AnimationCompletion?) -> CameraAnimator?
+
+    func cancelAnimations()
+}
+
+extension CameraAnimationsManager: CameraManagerProtocol { }

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/GestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/GestureHandler.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+internal class GestureHandler {
+
+    /// The view that the gesture handler is operating on
+    weak var view: UIView?
+
+    /// The underlying gestureRecognizer that this handler is managing
+    var gestureRecognizer: UIGestureRecognizer?
+
+    /// The delegate that the gesture handler calls to manipulate the view
+    weak var delegate: GestureHandlerDelegate!
+
+    init(for view: UIView, withDelegate delegate: GestureHandlerDelegate) {
+        self.view = view
+        self.delegate = delegate
+    }
+
+    deinit {
+        if let validGestureRecognizer = self.gestureRecognizer {
+            self.view?.removeGestureRecognizer(validGestureRecognizer)
+        }
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureType.swift
+++ b/Sources/MapboxMaps/Gestures/GestureType.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+public enum GestureType: Hashable {
+    /// The pan gesture type
+    case pan
+
+    /// The tap gesture type
+    case tap(numberOfTaps: Int, numberOfTouches: Int)
+
+    /// The zoom gesture type
+    case pinch
+
+    /// The rotate gesture type
+    case rotate
+
+    /// The quick zoom gesture type
+    case quickZoom
+
+    /// The pitch gesture type
+    case pitch
+
+    // Generates a handler for every gesture type
+    // swiftlint:disable explicit_acl
+    func makeHandler(for view: UIView,
+                     delegate: GestureHandlerDelegate,
+                     contextProvider: GestureContextProvider,
+                     gestureOptions: GestureOptions) -> GestureHandler {
+        switch self {
+        case .pan:
+            return PanGestureHandler(for: view, withDelegate: delegate, panScrollMode: gestureOptions.scrollingMode)
+        case .tap(let numberOfTaps, let numberOfTouches):
+            return TapGestureHandler(for: view,
+                                     numberOfTapsRequired: numberOfTaps,
+                                     numberOfTouchesRequired: numberOfTouches,
+                                     withDelegate: delegate)
+        case .pinch:
+            return PinchGestureHandler(for: view, withDelegate: delegate)
+        case .rotate:
+            return RotateGestureHandler(for: view, withDelegate: delegate, andContextProvider: contextProvider)
+        case .quickZoom:
+            return QuickZoomGestureHandler(for: view, withDelegate: delegate)
+        case .pitch:
+            return PitchGestureHandler(for: view, withDelegate: delegate)
+        }
+    }
+
+    // Provides understanding of equality between gesture types
+    public static func == (lhs: GestureType, rhs: GestureType) -> Bool {
+        switch (lhs, rhs) {
+        // Compares two pan gesture types (always true)
+        case (.pan, .pan):
+            return true
+        // Compares two tap gesture types with potentially different parameterized values
+        case (let .tap(lhsNumberOfTaps, lhsNumberOfTouches), let .tap(rhsNumberOfTaps, rhsNumberOfTouches)):
+            return lhsNumberOfTaps == rhsNumberOfTaps &&
+                   lhsNumberOfTouches == rhsNumberOfTouches
+        // Compares two pinch gesture types (always true)
+        case (.pinch, .pinch):
+            return true
+        // Compares two rotate gesture types (always true)
+        case (.rotate, .rotate):
+            return true
+        // Compares two long press gesture types (always true)
+        case (.quickZoom, .quickZoom):
+            return true
+        case (.pitch, .pitch):
+            return true
+        default:
+            return false
+        }
+    }
+
+}

--- a/Sources/MapboxMaps/MapView/Configuration/MapConfig.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/MapConfig.swift
@@ -2,8 +2,6 @@ import Foundation
 
 /// `MapConfig` is the structure used to configure the map with a set of capabilities
 public struct MapConfig: Equatable {
-    /// Used to configure the gestures on the map
-    public var gestures: GestureOptions = GestureOptions()
 
     /// Used to configure the camera of the map
     public var camera: MapCameraOptions = MapCameraOptions()

--- a/Sources/MapboxMaps/MapView/MapView+Managers.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Managers.swift
@@ -17,7 +17,7 @@ extension MapView {
         setupStyle(with: mapboxMap.__map)
 
         // Initialize/Configure gesture manager
-        setupGestures(with: self, options: mapConfig.gestures, cameraManager: camera)
+        setupGestures(with: self, cameraManager: camera)
 
         // Initialize/Configure ornaments manager
         setupOrnaments(with: self)
@@ -37,7 +37,6 @@ extension MapView {
         // Update the managers in order
         updateMapView(with: mapConfig.render)
         updateCamera(with: mapConfig.camera)
-        updateGestures(with: mapConfig.gestures)
         updateUserLocationManager(with: mapConfig.location)
         updateAnnotationManager(with: mapConfig.annotations)
     }
@@ -59,12 +58,8 @@ extension MapView {
         metalView?.presentsWithTransaction = newOptions.presentsWithTransaction
     }
 
-    internal func setupGestures(with view: UIView, options: GestureOptions, cameraManager: CameraAnimationsManager) {
-        gestures = GestureManager(for: view, options: options, cameraManager: cameraManager)
-    }
-
-    internal func updateGestures(with newOptions: GestureOptions) {
-        gestures.updateGestureOptions(with: newOptions)
+    internal func setupGestures(with view: UIView, cameraManager: CameraAnimationsManager) {
+        gestures = GestureManager(for: view, cameraManager: cameraManager)
     }
 
     internal func setupCamera(for view: MapView, options: MapCameraOptions) {

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -26,7 +26,6 @@ final class GestureManagerTests: XCTestCase {
         cameraManager.mapView = mapView
         initialGestureOptions = GestureOptions()
         gestureManager = GestureManager(for: mapView,
-                                        options: initialGestureOptions,
                                         cameraManager: cameraManager)
     }
 
@@ -55,10 +54,12 @@ final class GestureManagerTests: XCTestCase {
 
         var options = GestureOptions()
         options.pitchEnabled = false
-        let gestureManager = GestureManager(for: mapView, options: options, cameraManager: cameraManager)
+        let gestureManager = GestureManager(
+            for: mapView,
+            cameraManager: cameraManager)
 
         options.pitchEnabled = true
-        gestureManager.updateGestureOptions(with: options)
+        gestureManager.options = options
 
         XCTAssert(gestureManager.gestureHandlers.count == 7)
     }
@@ -70,7 +71,7 @@ final class GestureManagerTests: XCTestCase {
         options.zoomEnabled = false
         options.rotateEnabled = false
 
-        gestureManager.updateGestureOptions(with: options)
+        gestureManager.options = options
 
         XCTAssert(gestureManager.gestureHandlers.count == 0)
     }

--- a/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
@@ -14,13 +14,10 @@ internal class OptionsIntegrationTest: MapViewIntegrationTestCase {
         newConfig.location.puckType = nil
         newConfig.location.activityType = .automotiveNavigation
         newConfig.camera.animationDuration = 0.1
-        newConfig.gestures.scrollEnabled = false
 
         mapView.update { (options) in
             options = newConfig
         }
-
-        XCTAssertEqual(mapView.gestures.gestureOptions, newConfig.gestures)
         XCTAssertEqual(mapView.camera.mapCameraOptions, newConfig.camera)
         XCTAssertEqual(mapView.location.locationOptions, newConfig.location)
         let ornaments = mapView.subviews.filter { $0.isKind(of: MapboxCompassOrnamentView.self) || $0.isKind(of: MapboxScaleBarOrnamentView.self) }

--- a/Tests/MapboxMapsTests/MigrationGuide/MigrationGuideIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MigrationGuide/MigrationGuideIntegrationTests.swift
@@ -168,8 +168,6 @@ class MigrationGuideIntegrationTests: IntegrationTestCase {
         mapView.ornaments.options.scaleBar.visibility = .visible
 
         mapView.update { (mapOptions) in
-            // Configure map to disable pitch gestures
-            mapOptions.gestures.pitchEnabled = false
 
             // Configure map to restrict panning to a set of coordinate bounds
             mapOptions.camera.restrictedCoordinateBounds = someBounds


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>GestureOptions are owned by GestureManager directly</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR makes the `GestureManager` directly hold and expose the `GestureOptions`. It allows a developer to directly manipulate the options instead of going via `update`. 
