### PR TITLE
[MapView][Part 2] Make LocationManager hold LocationOptions directly

### DIFF
--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -17,9 +17,7 @@ public class DebugViewController: UIViewController {
         super.viewDidLoad()
 
         mapView = MapView(frame: view.bounds)
-        mapView.update { (mapOptions) in
-            mapOptions.location.puckType = .puck2D()
-        }
+        mapView.location.options.puckType = .puck2D()
 
         view.addSubview(mapView)
 

--- a/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
@@ -26,11 +26,9 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
 
     internal func setupExample() {
 
-        mapView.update { (mapOptions) in
-            // Granularly configure the location puck with a `Puck2DConfiguration`
-            let configuration = Puck2DConfiguration(topImage: UIImage(named: "star"))
-            mapOptions.location.puckType = .puck2D(configuration)
-        }
+        // Granularly configure the location puck with a `Puck2DConfiguration`
+        let configuration = Puck2DConfiguration(topImage: UIImage(named: "star"))
+        mapView.location.options.puckType = .puck2D(configuration)
 
         let coordinate = CLLocationCoordinate2D(latitude: 39.085006, longitude: -77.150925)
         mapView.camera.setCamera(to: CameraOptions(center: coordinate,

--- a/Apps/Examples/Examples/All Examples/Custom3DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom3DPuckExample.swift
@@ -26,49 +26,47 @@ public class Custom3DPuckExample: UIViewController, ExampleProtocol {
 
     internal func setupExample() {
 
-        mapView.update { (mapOptions) in
-            // Fetch the `gltf` asset
-            let uri = Bundle.main.url(forResource: "race_car_model",
-                                      withExtension: "gltf")
+        // Fetch the `gltf` asset
+        let uri = Bundle.main.url(forResource: "race_car_model",
+                                  withExtension: "gltf")
 
-            // Instantiate the model
-            let myModel = Model(uri: uri,
-                                position: [-177.150925, 39.085006],
-                                orientation: [0, 0, 0])
+        // Instantiate the model
+        let myModel = Model(uri: uri,
+                            position: [-177.150925, 39.085006],
+                            orientation: [0, 0, 0])
 
-            // Setting an expression to  scale the model based on camera zoom
-            let scalingExpression = Exp(.interpolate) {
-                Exp(.linear)
-                Exp(.zoom)
-                0
-                Exp(.literal) {
-                    [256000.0, 256000.0, 256000.0]
-                }
-                4
-                Exp(.literal) {
-                    [40000.0, 40000.0, 40000.0]
-                }
-                8
-                Exp(.literal) {
-                    [2000.0, 2000.0, 2000.0]
-                }
-                12
-                Exp(.literal) {
-                    [100.0, 100.0, 100.0]
-                }
-                16
-                Exp(.literal) {
-                    [7.0, 7.0, 7.0]
-                }
-                20
-                Exp(.literal) {
-                    [1.0, 1.0, 1.0]
-                }
+        // Setting an expression to  scale the model based on camera zoom
+        let scalingExpression = Exp(.interpolate) {
+            Exp(.linear)
+            Exp(.zoom)
+            0
+            Exp(.literal) {
+                [256000.0, 256000.0, 256000.0]
             }
-
-            let configuration = Puck3DConfiguration(model: myModel, modelScale: .expression(scalingExpression))
-            mapOptions.location.puckType = .puck3D(configuration)
+            4
+            Exp(.literal) {
+                [40000.0, 40000.0, 40000.0]
+            }
+            8
+            Exp(.literal) {
+                [2000.0, 2000.0, 2000.0]
+            }
+            12
+            Exp(.literal) {
+                [100.0, 100.0, 100.0]
+            }
+            16
+            Exp(.literal) {
+                [7.0, 7.0, 7.0]
+            }
+            20
+            Exp(.literal) {
+                [1.0, 1.0, 1.0]
+            }
         }
+
+        let configuration = Puck3DConfiguration(model: myModel, modelScale: .expression(scalingExpression))
+        mapView.location.options.puckType = .puck3D(configuration)
 
         let coordinate = CLLocationCoordinate2D(latitude: 39.085006, longitude: -77.150925)
         mapView.camera.setCamera(to: CameraOptions(center: coordinate,

--- a/Apps/Examples/Examples/All Examples/TrackingModeExample.swift
+++ b/Apps/Examples/Examples/All Examples/TrackingModeExample.swift
@@ -21,9 +21,7 @@ public class TrackingModeExample: UIViewController, ExampleProtocol {
         cameraLocationConsumer = CameraLocationConsumer(mapView: mapView)
 
         // Add user position icon to the map with location indicator layer
-        mapView.update { (mapOptions) in
-            mapOptions.location.puckType = .puck2D()
-        }
+        mapView.location.options.puckType = .puck2D()
 
         // Allows the delegate to receive information about map events.
         mapView.mapboxMap.onNext(.mapLoaded) { _ in

--- a/Sources/MapboxMaps/MapView/Configuration/MapConfig.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/MapConfig.swift
@@ -6,9 +6,6 @@ public struct MapConfig: Equatable {
     /// Used to configure the camera of the map
     public var camera: MapCameraOptions = MapCameraOptions()
 
-    /// Used to configure the location provider
-    public var location: LocationOptions = LocationOptions()
-
     public var render: RenderOptions = RenderOptions()
 
     public var annotations: AnnotationOptions = AnnotationOptions()

--- a/Sources/MapboxMaps/MapView/MapView+Managers.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Managers.swift
@@ -23,7 +23,7 @@ extension MapView {
         setupOrnaments(with: self)
 
         // Initialize/Configure location manager
-        setupUserLocationManager(with: self, options: mapConfig.location)
+        setupUserLocationManager(with: self)
 
         // Initialize/Configure annotations manager
         setupAnnotationManager(with: self, mapEventsObservable: mapboxMap, style: style, options: mapConfig.annotations)
@@ -37,7 +37,6 @@ extension MapView {
         // Update the managers in order
         updateMapView(with: mapConfig.render)
         updateCamera(with: mapConfig.camera)
-        updateUserLocationManager(with: mapConfig.location)
         updateAnnotationManager(with: mapConfig.annotations)
     }
 
@@ -74,14 +73,9 @@ extension MapView {
         ornaments = OrnamentsManager(view: view, options: OrnamentOptions())
     }
 
-    internal func setupUserLocationManager(with locationSupportableMapView: LocationSupportableMapView, options: LocationOptions) {
+    internal func setupUserLocationManager(with locationSupportableMapView: LocationSupportableMapView) {
 
-        location = LocationManager(locationOptions: options,
-                                          locationSupportableMapView: locationSupportableMapView)
-    }
-
-    internal func updateUserLocationManager(with options: LocationOptions) {
-        location.updateLocationOptions(with: mapConfig.location)
+        location = LocationManager(locationSupportableMapView: locationSupportableMapView)
     }
 
     internal func setupAnnotationManager(with annotationSupportableMap: AnnotationSupportableMap, mapEventsObservable: MapEventsObservable, style: Style, options: AnnotationOptions) {

--- a/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
@@ -24,19 +24,15 @@ internal class LocationManagerTests: XCTestCase {
     func testLocationManagerDefaultInitialization() {
         let locationOptions = LocationOptions()
 
-        let locationManager = LocationManager(
-            locationOptions: locationOptions,
-            locationSupportableMapView: locationSupportableMapView)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView)
 
-        XCTAssertEqual(locationManager.locationOptions, locationOptions)
+        XCTAssertEqual(locationManager.options, locationOptions)
         XCTAssertTrue(locationManager.locationSupportableMapView === locationSupportableMapView)
         XCTAssertNil(locationManager.delegate)
     }
 
     func testAddLocationConsumer() {
-        let locationManager = LocationManager(
-            locationOptions: LocationOptions(),
-            locationSupportableMapView: locationSupportableMapView)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView)
         let locationConsumer = LocationConsumerMock()
 
         locationManager.addLocationConsumer(newConsumer: locationConsumer)
@@ -47,45 +43,39 @@ internal class LocationManagerTests: XCTestCase {
     func testUpdateLocationOptionsWithModifiedPuckType() {
         var locationOptions = LocationOptions()
         locationOptions.puckType = .puck2D(Puck2DConfiguration(scale: .constant(1.0)))
-        let locationManager = LocationManager(
-            locationOptions: locationOptions,
-            locationSupportableMapView: locationSupportableMapView)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView)
 
         var locationOptions2 = LocationOptions()
         locationOptions2.puckType = .puck2D(Puck2DConfiguration(scale: .constant(2.0)))
-        locationManager.updateLocationOptions(with: locationOptions2)
+        locationManager.options = locationOptions2
 
-        XCTAssertEqual(locationManager.locationOptions, locationOptions2)
+        XCTAssertEqual(locationManager.options, locationOptions2)
         XCTAssertEqual(locationManager.locationPuckManager?.puckType, locationOptions2.puckType)
     }
 
     func testUpdateLocationOptionsWithPuckTypeSetToNil() {
         var locationOptions = LocationOptions()
         locationOptions.puckType = .puck2D()
-        let locationManager = LocationManager(
-            locationOptions: locationOptions,
-            locationSupportableMapView: locationSupportableMapView)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView)
 
         var locationOptions2 = LocationOptions()
         locationOptions2.puckType = nil
-        locationManager.updateLocationOptions(with: locationOptions2)
+        locationManager.options = locationOptions2
 
-        XCTAssertEqual(locationManager.locationOptions, locationOptions2)
+        XCTAssertEqual(locationManager.options, locationOptions2)
         XCTAssertNil(locationManager.locationPuckManager)
     }
 
     func testUpdateLocationOptionsWithPuckTypeSetToNonNil() {
         var locationOptions = LocationOptions()
         locationOptions.puckType = nil
-        let locationManager = LocationManager(
-            locationOptions: locationOptions,
-            locationSupportableMapView: locationSupportableMapView)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView)
 
         var locationOptions2 = LocationOptions()
         locationOptions2.puckType = .puck2D()
-        locationManager.updateLocationOptions(with: locationOptions2)
+        locationManager.options = locationOptions2
 
-        XCTAssertEqual(locationManager.locationOptions, locationOptions2)
+        XCTAssertEqual(locationManager.options, locationOptions2)
         XCTAssertEqual(locationManager.locationPuckManager?.puckType, locationOptions2.puckType)
     }
 }

--- a/Tests/MapboxMapsTests/Location/Pucks/Puck3DIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Location/Pucks/Puck3DIntegrationTests.swift
@@ -13,11 +13,8 @@ final class Puck3DIntegrationTests: XCTestCase {
     func testPuck3DDeinitializationDoesNotCrash() {
         autoreleasepool {
             let mapView = MapView(frame: .zero)
-            mapView.update { (options) in
-                options.location.puckType = .puck3D(
-                    Puck3DConfiguration(
-                        model: Model()))
-            }
+            mapView.location.options.puckType = .puck3D(Puck3DConfiguration(
+                                                            model: Model()))
         }
         // there is no assertion here because this test is
         // merely ensuring that Puck3D does not crash when

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/LocationManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/LocationManagerIntegrationTests.swift
@@ -46,11 +46,7 @@ internal class LocationManagerIntegrationTestCase: MapViewIntegrationTestCase {
     }
 
     private func setupLocationManager(with mapView: MapView) -> LocationManager {
-        let locationProviderOptions = LocationOptions()
-
-        let locationManager = LocationManager(locationOptions: locationProviderOptions,
-                                              locationSupportableMapView: mapView)
-
+        let locationManager = LocationManager(locationSupportableMapView: mapView)
         return locationManager
     }
 

--- a/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
@@ -11,18 +11,12 @@ internal class OptionsIntegrationTest: MapViewIntegrationTestCase {
         }
 
         var newConfig = MapboxMaps.MapConfig()
-        newConfig.location.puckType = nil
-        newConfig.location.activityType = .automotiveNavigation
         newConfig.camera.animationDuration = 0.1
 
         mapView.update { (options) in
             options = newConfig
         }
         XCTAssertEqual(mapView.camera.mapCameraOptions, newConfig.camera)
-        XCTAssertEqual(mapView.location.locationOptions, newConfig.location)
-        let ornaments = mapView.subviews.filter { $0.isKind(of: MapboxCompassOrnamentView.self) || $0.isKind(of: MapboxScaleBarOrnamentView.self) }
-
-        XCTAssertEqual(ornaments.count, 2)
         XCTAssertEqual(mapView.metalView?.presentsWithTransaction, true)
     }
 }

--- a/Tests/MapboxMapsTests/MigrationGuide/MigrationGuideIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MigrationGuide/MigrationGuideIntegrationTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import MapboxMaps
 import Turf
 
-// swiftlint:disable force_cast file_length orphaned_doc_comment type_body_length
+// swiftlint:disable force_cast file_length orphaned_doc_comment
 
 class MigrationGuideIntegrationTests: IntegrationTestCase {
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

LocationManager now holds the `LocationOptions` directly similar to gestures.

The call site is now:

```swift
mapView.location.options.puckType = .puck2D()
```