### PR TITLE
[MapView][Part 3]Move mapCameraOptions to CameraAnimationsManager

### DIFF
--- a/Apps/Examples/Examples/All Examples/RestrictCoordinateBoundsExample.swift
+++ b/Apps/Examples/Examples/All Examples/RestrictCoordinateBoundsExample.swift
@@ -15,13 +15,15 @@ public class RestrictCoordinateBoundsExample: UIViewController, ExampleProtocol 
 
         let bounds = CoordinateBounds(southwest: CLLocationCoordinate2D(latitude: 63.33, longitude: -25.52),
                                       northeast: CLLocationCoordinate2D(latitude: 66.61, longitude: -13.47))
+
+        // Restrict the camera to `bounds`.
+        mapView.camera.options.restrictedCoordinateBounds = bounds
+
+        // Center the camera on the bounds
         let camera = mapView.mapboxMap.camera(for: bounds, padding: .zero, bearing: 0, pitch: 0)
+
         // Set the camera's center coordinate.
         mapView.camera.setCamera(to: camera)
-
-        mapView.update { (mapOptions) in
-            mapOptions.camera.restrictedCoordinateBounds = bounds
-        }
     }
 
     override public func viewDidAppear(_ animated: Bool) {

--- a/Sources/MapboxMaps/Foundation/Camera/CameraAnimationsManager.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraAnimationsManager.swift
@@ -19,7 +19,17 @@ internal protocol CameraAnimatorInterface: CameraAnimator {
 public class CameraAnimationsManager {
 
     /// Used to set up camera specific configuration
-    public internal(set) var mapCameraOptions: MapCameraOptions
+    public var options = MapCameraOptions() {
+        didSet {
+            let boundOptions = CameraBoundsOptions(
+                __bounds: options.restrictedCoordinateBounds ?? nil,
+                maxZoom: options.maximumZoomLevel as NSNumber,
+                minZoom: options.minimumZoomLevel as NSNumber,
+                maxPitch: options.maximumPitch as NSNumber,
+                minPitch: options.minimumPitch as NSNumber)
+            mapView?.mapboxMap.__map.setBoundsFor(boundOptions)
+        }
+    }
 
     /// List of animators currently alive
     public var cameraAnimators: [CameraAnimator] {
@@ -30,18 +40,6 @@ public class CameraAnimationsManager {
         return mapView.cameraAnimators
     }
 
-    /// Used to update the map's camera options and pass them to the core Map.
-    internal func updateMapCameraOptions(newOptions: MapCameraOptions) {
-        let boundOptions = CameraBoundsOptions(
-            __bounds: newOptions.restrictedCoordinateBounds ?? nil,
-            maxZoom: newOptions.maximumZoomLevel as NSNumber,
-            minZoom: newOptions.minimumZoomLevel as NSNumber,
-            maxPitch: newOptions.maximumPitch as NSNumber,
-            minPitch: newOptions.minimumPitch as NSNumber)
-        mapView?.mapboxMap.__map.setBoundsFor(boundOptions)
-        mapCameraOptions = newOptions
-    }
-
     /// Internal camera animator used for animated transition
     internal var internalAnimator: CameraAnimator?
 
@@ -50,9 +48,8 @@ public class CameraAnimationsManager {
 
     internal weak var mapView: BaseMapView?
 
-    public init(for mapView: BaseMapView, with mapCameraOptions: MapCameraOptions) {
+    internal init(mapView: BaseMapView) {
         self.mapView = mapView
-        self.mapCameraOptions = mapCameraOptions
     }
 
     // MARK: Setting a new camera

--- a/Sources/MapboxMaps/Gestures/CameraManagerProtocol.swift
+++ b/Sources/MapboxMaps/Gestures/CameraManagerProtocol.swift
@@ -4,7 +4,7 @@ internal protocol CameraManagerProtocol: AnyObject {
 
     var mapView: BaseMapView? { get }
 
-    var mapCameraOptions: MapCameraOptions { get }
+    var options: MapCameraOptions { get }
 
     func setCamera(to camera: CameraOptions)
 

--- a/Sources/MapboxMaps/Gestures/GestureManager+GestureHandlerDelegate.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager+GestureHandlerDelegate.swift
@@ -49,7 +49,7 @@ extension GestureManager: GestureHandlerDelegate {
 
             _ = cameraManager.ease(
                     to: CameraOptions(driftCameraOptions),
-                    duration: Double(cameraManager.mapCameraOptions.decelerationRate),
+                    duration: Double(cameraManager.options.decelerationRate),
                     curve: .easeOut,
                     completion: nil)
         }
@@ -83,7 +83,7 @@ extension GestureManager: GestureHandlerDelegate {
     }
 
     internal func quickZoomChanged(with newScale: CGFloat, and anchor: CGPoint) {
-        let zoom = max(newScale, cameraManager.mapCameraOptions.minimumZoomLevel)
+        let zoom = max(newScale, cameraManager.options.minimumZoomLevel)
         cameraManager.setCamera(to: CameraOptions(anchor: anchor, zoom: zoom))
     }
 
@@ -95,7 +95,7 @@ extension GestureManager: GestureHandlerDelegate {
             return false
         }
 
-        return mapView.cameraState.zoom >= cameraManager.mapCameraOptions.minimumZoomLevel
+        return mapView.cameraState.zoom >= cameraManager.options.minimumZoomLevel
     }
 
     internal func rotationStartAngle() -> CGFloat {

--- a/Sources/MapboxMaps/MapView/Configuration/MapConfig.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/MapConfig.swift
@@ -3,9 +3,6 @@ import Foundation
 /// `MapConfig` is the structure used to configure the map with a set of capabilities
 public struct MapConfig: Equatable {
 
-    /// Used to configure the camera of the map
-    public var camera: MapCameraOptions = MapCameraOptions()
-
     public var render: RenderOptions = RenderOptions()
 
     public var annotations: AnnotationOptions = AnnotationOptions()

--- a/Sources/MapboxMaps/MapView/MapView+Managers.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Managers.swift
@@ -11,7 +11,7 @@ extension MapView {
         setupMapView(with: mapConfig.render)
 
         // Initialize/Configure camera manager first since Gestures needs it as dependency
-        setupCamera(for: self, options: mapConfig.camera)
+        setupCamera(view: self)
 
         // Initialize/Configure style manager
         setupStyle(with: mapboxMap.__map)
@@ -36,7 +36,6 @@ extension MapView {
 
         // Update the managers in order
         updateMapView(with: mapConfig.render)
-        updateCamera(with: mapConfig.camera)
         updateAnnotationManager(with: mapConfig.annotations)
     }
 
@@ -61,12 +60,8 @@ extension MapView {
         gestures = GestureManager(for: view, cameraManager: cameraManager)
     }
 
-    internal func setupCamera(for view: MapView, options: MapCameraOptions) {
-        camera = CameraAnimationsManager(for: view, with: mapConfig.camera)
-    }
-
-    internal func updateCamera(with newOptions: MapCameraOptions) {
-        camera.updateMapCameraOptions(newOptions: newOptions)
+    internal func setupCamera(view: MapView) {
+        camera = CameraAnimationsManager(mapView: view)
     }
 
     internal func setupOrnaments(with view: OrnamentSupportableView) {

--- a/Tests/MapboxMapsTests/Gestures/MockCameraManager.swift
+++ b/Tests/MapboxMapsTests/Gestures/MockCameraManager.swift
@@ -10,7 +10,7 @@ final class MockCameraManager: CameraManagerProtocol {
 
     var mapView: BaseMapView?
 
-    var mapCameraOptions = MapCameraOptions()
+    var options = MapCameraOptions()
 
     struct SetCameraParameters {
         var camera: CameraOptions

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/FeatureQueryingTest.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/FeatureQueryingTest.swift
@@ -22,7 +22,7 @@ internal class FeatureQueryingTest: MapViewIntegrationTestCase {
         let featureQueryExpectation = XCTestExpectation(description: "Wait for features to be queried.")
 
         didFinishLoadingStyle = { mapView in
-            let cameraManager = CameraAnimationsManager(for: mapView, with: MapCameraOptions())
+            let cameraManager = CameraAnimationsManager(mapView: mapView)
             cameraManager.setCamera(to: CameraOptions(center: self.centerCoordinate,
                                     zoom: 15.0))
         }
@@ -56,7 +56,7 @@ internal class FeatureQueryingTest: MapViewIntegrationTestCase {
         let featureQueryExpectation = XCTestExpectation(description: "Wait for features to be queried.")
 
         didFinishLoadingStyle = { mapView in
-            let cameraManager = CameraAnimationsManager(for: mapView, with: MapCameraOptions())
+            let cameraManager = CameraAnimationsManager(mapView: mapView)
             cameraManager.setCamera(to: CameraOptions(center: self.centerCoordinate,
                                     zoom: 15.0))
         }

--- a/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/OptionsIntegrationTests.swift
@@ -11,12 +11,11 @@ internal class OptionsIntegrationTest: MapViewIntegrationTestCase {
         }
 
         var newConfig = MapboxMaps.MapConfig()
-        newConfig.camera.animationDuration = 0.1
 
         mapView.update { (options) in
             options = newConfig
         }
-        XCTAssertEqual(mapView.camera.mapCameraOptions, newConfig.camera)
+
         XCTAssertEqual(mapView.metalView?.presentsWithTransaction, true)
     }
 }

--- a/Tests/MapboxMapsTests/MigrationGuide/MigrationGuideIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MigrationGuide/MigrationGuideIntegrationTests.swift
@@ -178,12 +178,7 @@ class MigrationGuideIntegrationTests: IntegrationTestCase {
         //-->
         // Configure map to show a scale bar
         mapView.ornaments.options.scaleBar.visibility = .visible
-
-        mapView.update { (mapOptions) in
-
-            // Configure map to restrict panning to a set of coordinate bounds
-            mapOptions.camera.restrictedCoordinateBounds = someBounds
-        }
+        mapView.camera.options.restrictedCoordinateBounds = someBounds
         //<--
     }
 
@@ -353,12 +348,9 @@ class MigrationGuideIntegrationTests: IntegrationTestCase {
         let sw = CLLocationCoordinate2DMake(-12, -46)
         let ne = CLLocationCoordinate2DMake(2, 43)
         let restrictedBounds = CoordinateBounds(southwest: sw, northeast: ne)
-
-        mapView.update { ( mapOptions ) in
-            mapOptions.camera.minimumZoomLevel = 8.0
-            mapOptions.camera.maximumZoomLevel = 15.0
-            mapOptions.camera.restrictedCoordinateBounds = restrictedBounds
-        }
+        mapView.camera.options.minimumZoomLevel = 8.0
+        mapView.camera.options.maximumZoomLevel = 15.0
+        mapView.camera.options.restrictedCoordinateBounds = restrictedBounds
         //<--
     }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>MapCameraOptions is now owned directly by `mapView.camera` </changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR moves the handling of the camera options to the `CameraAnimationsManager`. Setting the `options` property will directly call into the renderer to update bound options.

