### PR TITLE
Make Style.uri optional and do not set a default URI if developer provides `nil`

### DIFF
--- a/Apps/Examples/Examples/All Examples/OfflineRegionManagerExample.swift
+++ b/Apps/Examples/Examples/All Examples/OfflineRegionManagerExample.swift
@@ -44,7 +44,8 @@ public class OfflineRegionManagerExample: UIViewController, ExampleProtocol {
     }
 
     internal func setupExample() {
-        let offlineRegionDef = OfflineRegionGeometryDefinition(styleURL: mapView.style.uri.rawValue,
+        let uriString = mapView.style.uri!.rawValue
+        let offlineRegionDef = OfflineRegionGeometryDefinition(styleURL: uriString,
                                                                geometry: MBXGeometry(coordinate: coord),
                                                                minZoom: zoom - 2,
                                                                maxZoom: zoom + 2,

--- a/Sources/MapboxMaps/MapView/Configuration/MapInitOptions.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/MapInitOptions.swift
@@ -37,7 +37,7 @@ public final class MapInitOptions: NSObject {
     public init(resourceOptions: ResourceOptions = ResourceOptions(accessToken: CredentialsManager.default.accessToken ?? ""),
                 mapOptions: MapOptions = MapOptions(constrainMode: .heightOnly),
                 cameraOptions: CameraOptions? = nil,
-                styleURI: StyleURI? = Style.defaultURI) {
+                styleURI: StyleURI? = .streets) {
         self.resourceOptions = resourceOptions
         self.mapOptions      = mapOptions
         self.cameraOptions   = cameraOptions

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -266,16 +266,24 @@ extension Style: StyleManagerProtocol {
         return styleManager.isStyleLoaded()
     }
 
-    public var uri: StyleURI {
+    public var uri: StyleURI? {
         get {
             let uriString = styleManager.getStyleURI()
+
+            // A "nil" style is returned as an empty string
+            if uriString.isEmpty {
+                return nil
+            }
+
             guard let styleURI = StyleURI(rawValue: uriString) else {
                 fatalError()
             }
             return styleURI
         }
         set {
-            styleManager.setStyleURIForUri(newValue.rawValue)
+            if let uriString = newValue?.rawValue {
+                styleManager.setStyleURIForUri(uriString)
+            }
         }
     }
 

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -11,9 +11,7 @@ public class Style {
     internal init(with styleManager: StyleManager) {
         self.styleManager = styleManager
 
-        let uri = StyleURI(rawValue: styleManager.getStyleURI())
-
-        if let uri = uri {
+        if let uri = StyleURI(rawValue: styleManager.getStyleURI()) {
             self.uri = uri
         }
     }

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -6,8 +6,6 @@ import MapboxMapsFoundation
 //swiftlint:disable file_length
 public class Style {
 
-    public static let defaultURI = StyleURI.streets
-
     public private(set) weak var styleManager: StyleManager!
 
     internal init(with styleManager: StyleManager) {
@@ -15,7 +13,9 @@ public class Style {
 
         let uri = StyleURI(rawValue: styleManager.getStyleURI())
 
-        self.uri = uri ?? Self.defaultURI
+        if let uri = uri {
+            self.uri = uri
+        }
     }
 
     // MARK: - Layers

--- a/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
+++ b/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
@@ -15,7 +15,7 @@ public protocol StyleManagerProtocol {
     /// - Attention:
     ///     This method should be called on the same thread where the MapboxMap
     ///     object is initialized.
-    var uri: StyleURI { get set }
+    var uri: StyleURI? { get set }
 
     /// Get or set the style via a JSON serialization string
     ///

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/Style/StyleLoadIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/Style/StyleLoadIntegrationTests.swift
@@ -5,6 +5,24 @@ import CoreLocation
 class StyleLoadIntegrationTests: MapViewIntegrationTestCase {
 
     // MARK: - Tests
+    func testNilStyleDoesNotLoad() {
+        guard let style = style else {
+            XCTFail("Should have a valid Style object")
+            return
+        }
+
+        XCTAssertNil(style.uri, "Current style should be nil.") // As set by setUp
+
+        let expectation = self.expectation(description: "Style should not load")
+        expectation.expectedFulfillmentCount = 1
+        expectation.isInverted = true
+
+        didFinishLoadingStyle = { _ in
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 10)
+    }
 
     func testLoadingDarkStyleURI() {
         loadAndIdle(for: .dark)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Write tests for all new functionality. If tests were not written, please explain why.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [X] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Made `Style.uri` an optional property.</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

Fixes a bug where a default style would be loaded even if the developer specifies `nil`. As part of this change, `Style.uri` has become optional.
