### PR TITLE
Adding public access to the SourceInfo Id and SourceType properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Mapbox welcomes participation and contributions from everyone.
 
  - `StyleURI`, `PreferredFPS`, and `AnimationOwner` are now structs. ([#285](https://github.com/mapbox/mapbox-maps-ios/pull/285))
  
+### Features ✨ and improvements 🏁
+
+- `SourceInfo` properties have been updated to be public ([#349](https://github.com/mapbox/mapbox-maps-ios/pull/349))
+
 ## 10.0.0-beta.19.1 - May 7, 2021
 
 ### Breaking changes ⚠️

--- a/Sources/MapboxMaps/Style/Sources.swift
+++ b/Sources/MapboxMaps/Style/Sources.swift
@@ -49,8 +49,8 @@ public extension Source {
 /// Information about a Source
 public struct SourceInfo {
     /// The identifier of the source
-    var id: String
+    public var id: String
 
     /// The type of the source
-    var type: SourceType
+    public var type: SourceType
 }


### PR DESCRIPTION

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes
`Style` has a public computed variable that returns all the Source Identifiers currently added to the StyleManager, `allSourceIdentifiers` which is helpful to validate what has already been added, however the properties of the `SourceInfo` that it returns are not public so you can't validate it against local models.

This PR makes the `id` and `type` on `SourceInfo` public so consuming applications can use `allSourceIdentifiers`.  

Example usage would be:
```
var existingSourceIds = map.style.allSourceIdentifiers.map { $0.id }
```
