### PR TITLE
[MapView][Part 4] Make BaseMapView own rendering-related configuration options.

### DIFF
--- a/Sources/MapboxMaps/Foundation/BaseMapView.swift
+++ b/Sources/MapboxMaps/Foundation/BaseMapView.swift
@@ -32,6 +32,15 @@ open class BaseMapView: UIView {
 
     private let mapClient = DelegatingMapClient()
 
+    public var options = RenderOptions() {
+        didSet {
+            let defaultPrefetchZoomDelta: UInt8 = 4
+            mapboxMap.__map.setPrefetchZoomDeltaForDelta(options.prefetchesTiles ? defaultPrefetchZoomDelta : 0)
+            preferredFPS = options.preferredFramesPerSecond
+            metalView?.presentsWithTransaction = options.presentsWithTransaction
+        }
+    }
+
     /// The underlying metal view that is used to render the map
     internal private(set) var metalView: MTKView?
 
@@ -60,7 +69,7 @@ open class BaseMapView: UIView {
     /// a nib.
     @IBOutlet internal private(set) weak var mapInitOptionsProvider: MapInitOptionsProvider?
 
-    internal var preferredFPS: PreferredFPS = .normal {
+    internal var preferredFPS: PreferredFPS = .maximum {
         didSet {
             updateDisplayLinkPreferredFramesPerSecond()
         }
@@ -129,6 +138,14 @@ open class BaseMapView: UIView {
         if let cameraOptions = resolvedMapInitOptions.cameraOptions {
             mapboxMap.__map.setCameraFor(MapboxCoreMaps.CameraOptions(cameraOptions))
         }
+
+        // Set prefetchZoomDelta
+        let defaultPrefetchZoomDelta: UInt8 = 4
+        mapboxMap.__map.setPrefetchZoomDeltaForDelta(
+            options.prefetchesTiles ? defaultPrefetchZoomDelta : 0)
+
+        // Set preferrredFPS
+        preferredFPS = options.preferredFramesPerSecond
     }
 
     private func checkForMetalSupport() {
@@ -181,6 +198,7 @@ open class BaseMapView: UIView {
             let target = BaseMapViewProxy(mapView: self)
             displayLink = window?.screen.displayLink(withTarget: target, selector: #selector(target.updateFromDisplayLink))
 
+            preferredFPS = options.preferredFramesPerSecond
             updateDisplayLinkPreferredFramesPerSecond()
             displayLink?.add(to: .current, forMode: .common)
 
@@ -219,18 +237,8 @@ open class BaseMapView: UIView {
     }
 
     func updateDisplayLinkPreferredFramesPerSecond() {
-
         if let displayLink = displayLink {
-
-            var newFrameRate: PreferredFPS = .maximum
-
-            if preferredFPS == .normal {
-                // TODO: Check for legacy device
-            } else {
-                newFrameRate = preferredFPS
-            }
-
-            displayLink.preferredFramesPerSecond = newFrameRate.rawValue
+            displayLink.preferredFramesPerSecond = preferredFPS.rawValue
         }
     }
 
@@ -293,7 +301,7 @@ extension BaseMapView: DelegatingMapClientDelegate {
         metalView.layer.isOpaque = isOpaque
         metalView.isPaused = true
         metalView.enableSetNeedsDisplay = true
-        metalView.presentsWithTransaction = true
+        metalView.presentsWithTransaction = options.presentsWithTransaction
 
         insertSubview(metalView, at: 0)
         self.metalView = metalView

--- a/Sources/MapboxMaps/MapView/Configuration/MapConfig.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/MapConfig.swift
@@ -3,8 +3,6 @@ import Foundation
 /// `MapConfig` is the structure used to configure the map with a set of capabilities
 public struct MapConfig: Equatable {
 
-    public var render: RenderOptions = RenderOptions()
-
     public var annotations: AnnotationOptions = AnnotationOptions()
 
     public init() {}

--- a/Sources/MapboxMaps/MapView/MapView+Managers.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Managers.swift
@@ -7,9 +7,6 @@ extension MapView {
     /// Configures/Initializes the map with `mapConfig`
     internal func setupManagers() {
 
-        // Initialize/configure the map if needed
-        setupMapView(with: mapConfig.render)
-
         // Initialize/Configure camera manager first since Gestures needs it as dependency
         setupCamera(view: self)
 
@@ -35,25 +32,7 @@ extension MapView {
         updateMapConfig(&mapConfig) // This mutates the map options
 
         // Update the managers in order
-        updateMapView(with: mapConfig.render)
         updateAnnotationManager(with: mapConfig.annotations)
-    }
-
-    internal func setupMapView(with renderOptions: RenderOptions) {
-
-        // Set prefetch zoom delta
-        let defaultPrefetchZoomDelta: UInt8 = 4
-        self.mapboxMap.__map.setPrefetchZoomDeltaForDelta(renderOptions.prefetchesTiles ? defaultPrefetchZoomDelta : 0)
-        self.preferredFPS = renderOptions.preferredFramesPerSecond
-        metalView?.presentsWithTransaction = renderOptions.presentsWithTransaction
-    }
-
-    internal func updateMapView(with newOptions: RenderOptions) {
-        // Set prefetch zoom delta
-        let defaultPrefetchZoomDelta: UInt8 = 4
-        self.mapboxMap.__map.setPrefetchZoomDeltaForDelta(newOptions.prefetchesTiles ? defaultPrefetchZoomDelta : 0)
-        self.preferredFPS = newOptions.preferredFramesPerSecond
-        metalView?.presentsWithTransaction = newOptions.presentsWithTransaction
     }
 
     internal func setupGestures(with view: UIView, cameraManager: CameraAnimationsManager) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR makes the `BaseMapView` own the rendering-related options that used to be present in `MapConfig`, i.e., the `RenderOptions`.