### PR TITLE
[MapView][Part 5] Make AnnotationManager own annotation-related options

### DIFF
--- a/Sources/MapboxMaps/Annotations/AnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationManager.swift
@@ -93,7 +93,11 @@ public class AnnotationManager {
     /**
      Options used by the annotation manager.
      */
-    internal var annotationOptions: AnnotationOptions
+    public var options = AnnotationOptions() {
+        didSet {
+            Log.warning(forMessage: "Updating annotation manager options is not supported at this time.", category: "Annotations")
+        }
+    }
 
     /**
      The default source identifier, which will be used by the `AnnotationManager` by default.
@@ -104,7 +108,7 @@ public class AnnotationManager {
      The source identifier used by the `AnnotationManager`.
      */
     internal var sourceId: String {
-        return annotationOptions.sourceId ?? defaultSourceId
+        return options.sourceId ?? defaultSourceId
     }
 
     /**
@@ -146,14 +150,12 @@ public class AnnotationManager {
     internal init(for mapView: AnnotationSupportableMap,
                   mapEventsObservable: MapEventsObservable,
                   with styleDelegate: AnnotationStyleDelegate,
-                  options: AnnotationOptions,
                   interactionDelegate: AnnotationInteractionDelegate? = nil) {
 
         self.mapView = mapView
         self.mapEventsObservable = mapEventsObservable
         self.styleDelegate = styleDelegate
         self.interactionDelegate = interactionDelegate
-        self.annotationOptions = options
         annotations = [:]
         annotationFeatures = FeatureCollection(features: [])
         userInteractionEnabled = true
@@ -169,11 +171,6 @@ public class AnnotationManager {
             self.lineLayer = nil
             self.fillLayer = nil
         }
-    }
-
-    internal func updateAnnotationOptions(with newOptions: AnnotationOptions) {
-        self.annotationOptions = newOptions
-        Log.warning(forMessage: "Updating annotation manager is not supported at this time.", category: "Annotations")
     }
 
     // MARK: - Public functions
@@ -517,7 +514,7 @@ public class AnnotationManager {
             "Point"
         }
 
-        try styleDelegate.addLayer(symbolLayer, layerPosition: annotationOptions.layerPosition)
+        try styleDelegate.addLayer(symbolLayer, layerPosition: options.layerPosition)
 
         self.symbolLayer = symbolLayer
     }
@@ -539,7 +536,7 @@ public class AnnotationManager {
             "LineString"
         }
 
-        try styleDelegate.addLayer(lineLayer, layerPosition: annotationOptions.layerPosition)
+        try styleDelegate.addLayer(lineLayer, layerPosition: options.layerPosition)
         self.lineLayer = lineLayer
     }
 
@@ -559,7 +556,7 @@ public class AnnotationManager {
             "Polygon"
         }
 
-        try styleDelegate.addLayer(fillLayer, layerPosition: annotationOptions.layerPosition)
+        try styleDelegate.addLayer(fillLayer, layerPosition: options.layerPosition)
         self.fillLayer = fillLayer
     }
 

--- a/Sources/MapboxMaps/MapView/Configuration/MapConfig.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/MapConfig.swift
@@ -3,7 +3,5 @@ import Foundation
 /// `MapConfig` is the structure used to configure the map with a set of capabilities
 public struct MapConfig: Equatable {
 
-    public var annotations: AnnotationOptions = AnnotationOptions()
-
     public init() {}
 }

--- a/Sources/MapboxMaps/MapView/MapView+Managers.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Managers.swift
@@ -23,16 +23,13 @@ extension MapView {
         setupUserLocationManager(with: self)
 
         // Initialize/Configure annotations manager
-        setupAnnotationManager(with: self, mapEventsObservable: mapboxMap, style: style, options: mapConfig.annotations)
+        setupAnnotationManager(with: self, mapEventsObservable: mapboxMap, style: style)
     }
 
     /// Updates the map with new configuration options. Causes underlying structures to reload configuration synchronously.
     /// - Parameter update: A closure that is fed the current map options and manipulates it in some way.
     public func update(with updateMapConfig: (inout MapConfig) -> Void) {
         updateMapConfig(&mapConfig) // This mutates the map options
-
-        // Update the managers in order
-        updateAnnotationManager(with: mapConfig.annotations)
     }
 
     internal func setupGestures(with view: UIView, cameraManager: CameraAnimationsManager) {
@@ -52,12 +49,8 @@ extension MapView {
         location = LocationManager(locationSupportableMapView: locationSupportableMapView)
     }
 
-    internal func setupAnnotationManager(with annotationSupportableMap: AnnotationSupportableMap, mapEventsObservable: MapEventsObservable, style: Style, options: AnnotationOptions) {
-        annotations = AnnotationManager(for: annotationSupportableMap, mapEventsObservable: mapEventsObservable, with: style, options: options)
-    }
-
-    internal func updateAnnotationManager(with newOptions: AnnotationOptions) {
-        annotations.updateAnnotationOptions(with: newOptions)
+    internal func setupAnnotationManager(with annotationSupportableMap: AnnotationSupportableMap, mapEventsObservable: MapEventsObservable, style: Style) {
+        annotations = AnnotationManager(for: annotationSupportableMap, mapEventsObservable: mapEventsObservable, with: style)
     }
 
     internal func setupStyle(with map: Map) {

--- a/Tests/MapboxMapsTests/Annotations/AnnotationInteractionDelegateTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/AnnotationInteractionDelegateTests.swift
@@ -41,8 +41,7 @@ class AnnotationInteractionDelegateTests: XCTestCase {
         // Given
         let annotationManager = AnnotationManager(for: annotationSupportableMapMock,
                                                   mapEventsObservable: annotationMapEventsObservableMock,
-                                                  with: annotationSupportableStyleMock,
-                                                  options: AnnotationOptions())
+                                                  with: annotationSupportableStyleMock)
         annotationManager.interactionDelegate = self
         let annotation = PointAnnotation(coordinate: defaultCoordinate)
         _ = annotationManager.addAnnotation(annotation)

--- a/Tests/MapboxMapsTests/Annotations/AnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/AnnotationManagerTests.swift
@@ -21,8 +21,7 @@ final class AnnotationManagerTests: XCTestCase {
         annotationMapEventsObservable = MockMapEventsObservable()
         annotationManager = AnnotationManager(for: annotationSupportableMap,
                                               mapEventsObservable: annotationMapEventsObservable,
-                                              with: annotationSupportableStyle,
-                                              options: AnnotationOptions())
+                                              with: annotationSupportableStyle)
     }
 
     override func tearDown() {

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/AnnotationManagerIntegrationTests.swift
@@ -32,8 +32,7 @@ internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase 
             let annotation = PointAnnotation(coordinate: mapView.cameraState.center)
             let annotationManager = AnnotationManager(for: mapView,
                                                       mapEventsObservable: mapView.mapboxMap,
-                                                      with: self,
-                                                      options: AnnotationOptions())
+                                                      with: self)
             annotationManager.addAnnotation(annotation)
 
             _ = try! style.sourceProperties(for: annotationManager.defaultSourceId)
@@ -65,8 +64,7 @@ internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase 
             let position = LayerPosition(above: nil, below: nil, at: requiredIndex)
             let annotationManager = AnnotationManager(for: mapView,
                                                       mapEventsObservable: mapView.mapboxMap,
-                                                      with: self,
-                                                      options: AnnotationOptions(layerPosition: position))
+                                                      with: self)
             annotationManager.addAnnotation(annotation)
 
             guard let layerId = annotationManager.layerId(for: PointAnnotation.self) else {
@@ -113,8 +111,7 @@ internal class AnnotationManagerIntegrationTestCase: MapViewIntegrationTestCase 
             var annotation = PointAnnotation(coordinate: mapView.cameraState.center)
             let annotationManager = AnnotationManager(for: mapView,
                                                       mapEventsObservable: mapView.mapboxMap,
-                                                      with: self,
-                                                      options: AnnotationOptions())
+                                                      with: self)
             annotation.userInfo = ["TestKey": true]
             annotationManager.addAnnotation(annotation)
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR makes the `AnnotationManager` own any annotation-related options, i.e., the `AnnotationOptions`.