### PR TITLE
Split out style from LocationSupportableMapView

### DIFF
--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -258,6 +258,9 @@
 		CA4AE07B252D655000183075 /* PolygonAnnotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07D2C80B2523ECC40025C2BA /* PolygonAnnotationTests.swift */; };
 		CA4AE0DB252D655A00183075 /* AnnotationInteractionDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07163339252546C80014A772 /* AnnotationInteractionDelegateTests.swift */; };
 		CA4AE123252D656600183075 /* MockAnnotationStyleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A5DEB625155B9500A27F8B /* MockAnnotationStyleDelegate.swift */; };
+		CA4E2DBE264DC5FD0039D80E /* MockLocationStyleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4E2DBD264DC5FD0039D80E /* MockLocationStyleDelegate.swift */; };
+		CA4E2DCE264DC6680039D80E /* LocationStyleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4E2DC2264DC6300039D80E /* LocationStyleDelegate.swift */; };
+		CA4E2DD8264DC66F0039D80E /* MockLocationStyleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4E2DBD264DC5FD0039D80E /* MockLocationStyleDelegate.swift */; };
 		CA548FD3251C404B00F829A3 /* PolygonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B863836246D300500698135 /* PolygonTests.swift */; };
 		CA548FD4251C404B00F829A3 /* MapboxMapsCameraTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC8DA47243BE4A400A19318 /* MapboxMapsCameraTests.swift */; };
 		CA548FD5251C404B00F829A3 /* MapboxCompassOrnamentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3593792476DEB800E67344 /* MapboxCompassOrnamentViewTests.swift */; };
@@ -723,6 +726,8 @@
 		CA4453C72436E71500477B4F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CA4453D52436E71900477B4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CA4453D92436ED2A00477B4F /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		CA4E2DBD264DC5FD0039D80E /* MockLocationStyleDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockLocationStyleDelegate.swift; sourceTree = "<group>"; };
+		CA4E2DC2264DC6300039D80E /* LocationStyleDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationStyleDelegate.swift; sourceTree = "<group>"; };
 		CA53616D2537ECA600A8AE38 /* MapViewIntegrationTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewIntegrationTestCase.swift; sourceTree = "<group>"; };
 		CA5361862537EE0600A8AE38 /* IntegrationTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTestCase.swift; sourceTree = "<group>"; };
 		CA54900D251C404B00F829A3 /* MapboxMapsTestsWithHost.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxMapsTestsWithHost.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1373,15 +1378,16 @@
 		1FF65A51244E33E10069B561 /* MapboxMapsLocation */ = {
 			isa = PBXGroup;
 			children = (
-				C6B58BC7252E53AD0063AC3E /* Pucks */,
-				1FF65A67244E34000069B561 /* LocationManager.swift */,
+				1FF65A78244F78540069B561 /* AppleLocationProvider.swift */,
 				0C9640E02531056700CABD3E /* LocationConsumer.swift */,
+				1FF65A67244E34000069B561 /* LocationManager.swift */,
+				1FF65A86245354E30069B561 /* LocationOptions.swift */,
 				1FF65A6D244E53F50069B561 /* LocationPermissionsDelegate.swift */,
 				1FF65A74244F6E320069B561 /* LocationProvider.swift */,
 				1FF65A76244F77070069B561 /* LocationProviderDelegate.swift */,
-				1FF65A78244F78540069B561 /* AppleLocationProvider.swift */,
-				1FF65A86245354E30069B561 /* LocationOptions.swift */,
+				CA4E2DC2264DC6300039D80E /* LocationStyleDelegate.swift */,
 				0CECCCCC253491A80000FC64 /* LocationSupportableMapView.swift */,
+				C6B58BC7252E53AD0063AC3E /* Pucks */,
 			);
 			name = MapboxMapsLocation;
 			path = ../Sources/MapboxMaps/Location;
@@ -1390,12 +1396,13 @@
 		1FF65A5C244E33E10069B561 /* MapboxMapsLocationTests */ = {
 			isa = PBXGroup;
 			children = (
-				B53B8760260D73D600C86BAA /* Pucks */,
+				C64ED33B253F819B00ADADFB /* LocationConsumerMock.swift */,
+				C64ED320253F7E9100ADADFB /* LocationManagerTests.swift */,
 				B53B86D8260D735B00C86BAA /* LocationOptionsTests.swift */,
 				C64ED305253F7CF500ADADFB /* LocationSupportableMapViewMock.swift */,
-				C64ED320253F7E9100ADADFB /* LocationManagerTests.swift */,
-				C64ED33B253F819B00ADADFB /* LocationConsumerMock.swift */,
+				CA4E2DBD264DC5FD0039D80E /* MockLocationStyleDelegate.swift */,
 				0C2CDA2D25D1A51C006D068F /* PuckTypeTests.swift */,
+				B53B8760260D73D600C86BAA /* Pucks */,
 			);
 			name = MapboxMapsLocationTests;
 			path = ../Tests/MapboxMapsTests/Location;
@@ -2079,6 +2086,7 @@
 				0C088ACC26388E3400107B5E /* CameraAnimationsManager.swift in Sources */,
 				CA6245D52627E72A00C79547 /* TileRegionLoadOptions+MapboxMaps.swift in Sources */,
 				5A9648FE246429C3001FF05D /* MapboxCompassOrnamentView.swift in Sources */,
+				CA4E2DCE264DC6680039D80E /* LocationStyleDelegate.swift in Sources */,
 				0C8AA1F3257FE1830037FD6B /* MapEvents.swift in Sources */,
 				B5B55D4C260E4D2900EBB589 /* MBXEdgeInsets.swift in Sources */,
 				0C479F90251CEC340025EC4F /* Snapshotter.swift in Sources */,
@@ -2148,6 +2156,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B53B8623260D717700C86BAA /* XCTestCase+MapboxAccessToken.swift in Sources */,
+				CA4E2DD8264DC66F0039D80E /* MockLocationStyleDelegate.swift in Sources */,
 				B53B8663260D719100C86BAA /* TestConveniences.swift in Sources */,
 				B53B8650260D718B00C86BAA /* Stub.swift in Sources */,
 				CA0B380D25C4C01400B3396E /* IntegrationTestCase.swift in Sources */,
@@ -2201,6 +2210,7 @@
 				0CC6EF1125C3263400BFB153 /* CircleLayerIntegrationTests.swift in Sources */,
 				C6C5CDC9264C12D00097FCD1 /* MigrationGuideIntegrationTests.swift in Sources */,
 				0C5CFCF425BB951B0001E753 /* FillLayerTests.swift in Sources */,
+				CA4E2DBE264DC5FD0039D80E /* MockLocationStyleDelegate.swift in Sources */,
 				B54B7F0B25DB192C003FD6CA /* MockCameraManager.swift in Sources */,
 				0C5CFCEB25BB951B0001E753 /* HillshadeLayerTests.swift in Sources */,
 				CA0C43052602BF2D0054D9D0 /* LayerPositionTests.swift in Sources */,

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -194,7 +194,7 @@ open class MapView: UIView {
         ornaments = OrnamentsManager(view: self, options: OrnamentOptions())
 
         // Initialize/Configure location manager
-        location = LocationManager(locationSupportableMapView: self)
+        location = LocationManager(locationSupportableMapView: self, style: style)
 
         // Initialize/Configure annotations manager
         annotations = AnnotationManager(for: self, mapEventsObservable: mapboxMap, with: style)

--- a/Sources/MapboxMaps/Location/LocationManager.swift
+++ b/Sources/MapboxMaps/Location/LocationManager.swift
@@ -35,6 +35,9 @@ public class LocationManager: NSObject {
     /// `MapView` that has specific functionality to support location
     internal weak var locationSupportableMapView: LocationSupportableMapView!
 
+    /// Style that has limited functionality to support location
+    internal weak var style: LocationStyleDelegate?
+
     /// Manager that handles the visual puck element.
     /// Only created if `showsUserLocation` is `true`
     internal var locationPuckManager: LocationPuckManager?
@@ -54,10 +57,12 @@ public class LocationManager: NSObject {
         }
     }
 
-    internal init(locationSupportableMapView: LocationSupportableMapView) {
+    internal init(locationSupportableMapView: LocationSupportableMapView, style: LocationStyleDelegate) {
 
         /// Allows location updates to be reflected on screen using delegate method
         self.locationSupportableMapView = locationSupportableMapView
+
+        self.style = style
 
         super.init()
 
@@ -196,6 +201,7 @@ private extension LocationManager {
             } else {
                 let locationPuckManager = LocationPuckManager(
                     locationSupportableMapView: locationSupportableMapView,
+                    style: style,
                     puckType: puckType)
                 consumers.add(locationPuckManager)
                 self.locationPuckManager = locationPuckManager

--- a/Sources/MapboxMaps/Location/LocationStyleDelegate.swift
+++ b/Sources/MapboxMaps/Location/LocationStyleDelegate.swift
@@ -1,0 +1,20 @@
+internal protocol LocationStyleDelegate: AnyObject {
+    func addLayer(_ layer: Layer, layerPosition: LayerPosition?) throws
+    func removeLayer(withId id: String) throws
+    func layerExists(withId id: String) -> Bool
+    func setLayerProperties(for layerId: String, properties: [String: Any]) throws
+    func addSource(_ source: Source, id: String) throws
+    func removeSource(withId id: String) throws
+    func setSourceProperty(for sourceId: String, property: String, value: Any) throws
+    func addImage(_ image: UIImage, id: String, sdf: Bool, stretchX: [ImageStretches], stretchY: [ImageStretches], content: ImageContent?) throws
+}
+
+extension LocationStyleDelegate {
+    internal func addLayer(_ layer: Layer, layerPosition: LayerPosition? = nil) throws {
+        try addLayer(layer, layerPosition: layerPosition)
+    }
+
+    internal func addImage(_ image: UIImage, id: String, sdf: Bool = false, stretchX: [ImageStretches] = [], stretchY: [ImageStretches] = [], content: ImageContent? = nil) throws {
+        try addImage(image, id: id, sdf: sdf, stretchX: stretchX, stretchY: stretchY, content: content)
+    }
+}

--- a/Sources/MapboxMaps/Location/LocationStyleDelegate.swift
+++ b/Sources/MapboxMaps/Location/LocationStyleDelegate.swift
@@ -6,6 +6,8 @@ internal protocol LocationStyleDelegate: AnyObject {
     func addSource(_ source: Source, id: String) throws
     func removeSource(withId id: String) throws
     func setSourceProperty(for sourceId: String, property: String, value: Any) throws
+
+    //swiftlint:disable function_parameter_count
     func addImage(_ image: UIImage, id: String, sdf: Bool, stretchX: [ImageStretches], stretchY: [ImageStretches], content: ImageContent?) throws
 }
 

--- a/Sources/MapboxMaps/Location/LocationSupportableMapView.swift
+++ b/Sources/MapboxMaps/Location/LocationSupportableMapView.swift
@@ -23,25 +23,3 @@ public protocol LocationSupportableMapView: UIView {
     /// Gets meters per point at latitude for calculating accuracy ring
     func metersPerPointAtLatitude(latitude: CLLocationDegrees) -> CLLocationDistance
 }
-
-internal protocol LocationStyleDelegate: AnyObject {
-    func addLayer(_ layer: Layer, layerPosition: LayerPosition?) throws
-    func removeLayer(withId id: String) throws
-    func layerExists(withId id: String) -> Bool
-    func setLayerProperties(for layerId: String, properties: [String: Any]) throws
-    func addSource(_ source: Source, id: String) throws
-    func removeSource(withId id: String) throws 
-    func setSourceProperty(for sourceId: String, property: String, value: Any) throws
-    func addImage(_ image: UIImage, id: String, sdf: Bool, stretchX: [ImageStretches], stretchY: [ImageStretches], content: ImageContent?) throws
-}
-
-extension LocationStyleDelegate {
-    internal func addLayer(_ layer: Layer, layerPosition: LayerPosition? = nil) throws {
-        try addLayer(layer, layerPosition: layerPosition)
-    }
-
-    internal func addImage(_ image: UIImage, id: String, sdf: Bool = false, stretchX: [ImageStretches] = [], stretchY: [ImageStretches] = [], content: ImageContent? = nil) throws {
-        try addImage(image, id: id, sdf: sdf, stretchX: stretchX, stretchY: stretchY, content: content)
-    }
-}
-

--- a/Sources/MapboxMaps/Location/LocationSupportableMapView.swift
+++ b/Sources/MapboxMaps/Location/LocationSupportableMapView.swift
@@ -11,9 +11,6 @@ import MapboxMapsStyle
 
 public protocol LocationSupportableMapView: UIView {
 
-    /// Matching the style property in `MapView`
-    var style: Style! { get }
-
     /// Returns the screen coordinate for a given location coordinate (lat-long)
     func screenCoordinate(for locationCoordinate: CLLocationCoordinate2D) -> ScreenCoordinate
 
@@ -25,5 +22,26 @@ public protocol LocationSupportableMapView: UIView {
 
     /// Gets meters per point at latitude for calculating accuracy ring
     func metersPerPointAtLatitude(latitude: CLLocationDegrees) -> CLLocationDistance
-
 }
+
+internal protocol LocationStyleDelegate: AnyObject {
+    func addLayer(_ layer: Layer, layerPosition: LayerPosition?) throws
+    func removeLayer(withId id: String) throws
+    func layerExists(withId id: String) -> Bool
+    func setLayerProperties(for layerId: String, properties: [String: Any]) throws
+    func addSource(_ source: Source, id: String) throws
+    func removeSource(withId id: String) throws 
+    func setSourceProperty(for sourceId: String, property: String, value: Any) throws
+    func addImage(_ image: UIImage, id: String, sdf: Bool, stretchX: [ImageStretches], stretchY: [ImageStretches], content: ImageContent?) throws
+}
+
+extension LocationStyleDelegate {
+    internal func addLayer(_ layer: Layer, layerPosition: LayerPosition? = nil) throws {
+        try addLayer(layer, layerPosition: layerPosition)
+    }
+
+    internal func addImage(_ image: UIImage, id: String, sdf: Bool = false, stretchX: [ImageStretches] = [], stretchY: [ImageStretches] = [], content: ImageContent? = nil) throws {
+        try addImage(image, id: id, sdf: sdf, stretchX: stretchX, stretchY: stretchY, content: content)
+    }
+}
+

--- a/Sources/MapboxMaps/Location/Pucks/LocationPuckManager.swift
+++ b/Sources/MapboxMaps/Location/Pucks/LocationPuckManager.swift
@@ -40,6 +40,9 @@ internal class LocationPuckManager: LocationConsumer {
     /// MapView that supports location events
     internal private(set) weak var locationSupportableMapView: LocationSupportableMapView?
 
+    /// Style protocol that supports limited style APIs
+    internal private(set) weak var style: LocationStyleDelegate?
+
     /// The current  puck style
     internal private(set) var puckStyle: PuckStyle
 
@@ -47,10 +50,12 @@ internal class LocationPuckManager: LocationConsumer {
     internal private(set) var puckType: PuckType
 
     internal init(locationSupportableMapView: LocationSupportableMapView,
+                  style: LocationStyleDelegate?,
                   puckType: PuckType) {
         puckStyle = .precise
         self.puckType = puckType
         self.locationSupportableMapView = locationSupportableMapView
+        self.style = style
     }
 
     /// LocationConsumer protocol method that will handle location updates
@@ -66,14 +71,24 @@ internal class LocationPuckManager: LocationConsumer {
     }
 
     internal func createPuck() {
-        guard let locationSupportableMapView = self.locationSupportableMapView else { return }
+        guard let locationSupportableMapView = locationSupportableMapView,
+              let style = style else {
+            return
+        }
+
         var puck: Puck
 
         switch puckType {
         case let .puck2D(configuration):
-            puck = Puck2D(puckStyle: puckStyle, locationSupportableMapView: locationSupportableMapView, configuration: configuration)
+            puck = Puck2D(puckStyle: puckStyle,
+                          locationSupportableMapView: locationSupportableMapView,
+                          style: style,
+                          configuration: configuration)
         case let .puck3D(configuration):
-            puck = Puck3D(puckStyle: puckStyle, locationSupportableMapView: locationSupportableMapView, configuration: configuration)
+            puck = Puck3D(puckStyle: puckStyle,
+                          locationSupportableMapView: locationSupportableMapView,
+                          style: style,
+                          configuration: configuration)
         }
 
         if let location = latestLocation {

--- a/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
@@ -152,6 +152,7 @@ internal class Puck2D: Puck {
 private extension Puck2D {
     func createPreciseLocationIndicatorLayer(location: Location) throws {
         guard let style = style else {
+            Log.warning(forMessage: "Puck2D.createPreciseLocationIndicatorLayer - Style does not exit.", category: "Location")
             return
         }
 
@@ -210,6 +211,7 @@ private extension Puck2D {
 
     func createApproximateLocationIndicatorLayer(location: Location) throws {
         guard let style = style else {
+            Log.warning(forMessage: "Puck2D.createApproximateLocationIndicatorLayer - Style does not exit.", category: "Location")
             return
         }
 

--- a/Sources/MapboxMaps/Location/Pucks/Puck3D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck3D.swift
@@ -40,11 +40,13 @@ internal class Puck3D: Puck {
     // MARK: Protocol Properties
     internal var puckStyle: PuckStyle
     internal weak var locationSupportableMapView: LocationSupportableMapView?
+    internal weak var style: LocationStyleDelegate?
 
     // MARK: Initializers
-    internal init(puckStyle: PuckStyle, locationSupportableMapView: LocationSupportableMapView, configuration: Puck3DConfiguration) {
+    internal init(puckStyle: PuckStyle, locationSupportableMapView: LocationSupportableMapView, style: LocationStyleDelegate, configuration: Puck3DConfiguration) {
         self.puckStyle = puckStyle
         self.locationSupportableMapView = locationSupportableMapView
+        self.style = style
         self.configuration = configuration
         modelLayer = ModelLayer(id: "puck-model-layer")
         modelSource = ModelSource()
@@ -73,7 +75,7 @@ internal class Puck3D: Puck {
 
         let addStyle = { [weak self] in
             guard let self = self,
-                  let style = self.locationSupportableMapView?.style else {
+                  let style = self.style else {
                 return
             }
             self.removePuck()
@@ -94,7 +96,7 @@ internal class Puck3D: Puck {
 
     // MARK: Protocol Implementation
     internal func updateLocation(location: Location) {
-        guard let style = locationSupportableMapView?.style,
+        guard let style = style,
               let key = modelSource.models?.keys.first,
               var model = modelSource.models?.values.first else { return }
 
@@ -121,9 +123,8 @@ internal class Puck3D: Puck {
 
     /// This function will remove the puck from `mapView`
     private func removePuck() {
-        guard
-            let style = locationSupportableMapView?.style,
-            style.layerExists(withId: "puck-model-layer") else {
+        guard let style = style,
+              style.layerExists(withId: "puck-model-layer") else {
             return
         }
 

--- a/Sources/MapboxMaps/MapView/MapView+Supportable.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Supportable.swift
@@ -53,4 +53,6 @@ extension MapView: LocationSupportableMapView {
     }
 }
 
+extension Style: LocationStyleDelegate { }
+
 extension Style: AnnotationStyleDelegate { }

--- a/Sources/MapboxMaps/Style/Sources.swift
+++ b/Sources/MapboxMaps/Style/Sources.swift
@@ -49,8 +49,8 @@ public extension Source {
 /// Information about a Source
 public struct SourceInfo {
     /// The identifier of the source
-    var id: String
+    public var id: String
 
     /// The type of the source
-    var type: SourceType
+    public var type: SourceType
 }

--- a/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
@@ -27,7 +27,8 @@ internal class LocationManagerTests: XCTestCase {
     func testLocationManagerDefaultInitialization() {
         let locationOptions = LocationOptions()
 
-        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView, style: locationSupportableStyle)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView,
+                                              style: locationSupportableStyle)
 
         XCTAssertEqual(locationManager.options, locationOptions)
         XCTAssertTrue(locationManager.locationSupportableMapView === locationSupportableMapView)
@@ -35,7 +36,8 @@ internal class LocationManagerTests: XCTestCase {
     }
 
     func testAddLocationConsumer() {
-        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView, style: locationSupportableStyle)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView,
+                                              style: locationSupportableStyle)
         let locationConsumer = LocationConsumerMock()
 
         locationManager.addLocationConsumer(newConsumer: locationConsumer)
@@ -46,11 +48,8 @@ internal class LocationManagerTests: XCTestCase {
     func testUpdateLocationOptionsWithModifiedPuckType() {
         var locationOptions = LocationOptions()
         locationOptions.puckType = .puck2D(Puck2DConfiguration(scale: .constant(1.0)))
-        let locationManager = LocationManager(
-            locationOptions: locationOptions,
-            locationSupportableMapView: locationSupportableMapView,
-            style: locationSupportableStyle)
-        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView, style: locationSupportableStyle)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView,
+                                              style: locationSupportableStyle)
 
         var locationOptions2 = LocationOptions()
         locationOptions2.puckType = .puck2D(Puck2DConfiguration(scale: .constant(2.0)))
@@ -63,7 +62,8 @@ internal class LocationManagerTests: XCTestCase {
     func testUpdateLocationOptionsWithPuckTypeSetToNil() {
         var locationOptions = LocationOptions()
         locationOptions.puckType = .puck2D()
-        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView, style: locationSupportableStyle)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView,
+                                              style: locationSupportableStyle)
 
         var locationOptions2 = LocationOptions()
         locationOptions2.puckType = nil
@@ -76,7 +76,8 @@ internal class LocationManagerTests: XCTestCase {
     func testUpdateLocationOptionsWithPuckTypeSetToNonNil() {
         var locationOptions = LocationOptions()
         locationOptions.puckType = nil
-        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView, style: locationSupportableStyle)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView,
+                                              style: locationSupportableStyle)
 
         var locationOptions2 = LocationOptions()
         locationOptions2.puckType = .puck2D()

--- a/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
@@ -10,21 +10,24 @@ import MapboxMapsFoundation
 internal class LocationManagerTests: XCTestCase {
 
     var locationSupportableMapView: LocationSupportableMapViewMock!
+    var locationSupportableStyle: MockLocationStyleDelegate!
 
     override func setUp() {
         locationSupportableMapView = LocationSupportableMapViewMock()
+        locationSupportableStyle = MockLocationStyleDelegate()
         super.setUp()
     }
 
     override func tearDown() {
         locationSupportableMapView = nil
+        locationSupportableStyle = nil
         super.tearDown()
     }
 
     func testLocationManagerDefaultInitialization() {
         let locationOptions = LocationOptions()
 
-        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView, style: locationSupportableStyle)
 
         XCTAssertEqual(locationManager.options, locationOptions)
         XCTAssertTrue(locationManager.locationSupportableMapView === locationSupportableMapView)
@@ -32,7 +35,7 @@ internal class LocationManagerTests: XCTestCase {
     }
 
     func testAddLocationConsumer() {
-        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView, style: locationSupportableStyle)
         let locationConsumer = LocationConsumerMock()
 
         locationManager.addLocationConsumer(newConsumer: locationConsumer)
@@ -43,7 +46,11 @@ internal class LocationManagerTests: XCTestCase {
     func testUpdateLocationOptionsWithModifiedPuckType() {
         var locationOptions = LocationOptions()
         locationOptions.puckType = .puck2D(Puck2DConfiguration(scale: .constant(1.0)))
-        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView)
+        let locationManager = LocationManager(
+            locationOptions: locationOptions,
+            locationSupportableMapView: locationSupportableMapView,
+            style: locationSupportableStyle)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView, style: locationSupportableStyle)
 
         var locationOptions2 = LocationOptions()
         locationOptions2.puckType = .puck2D(Puck2DConfiguration(scale: .constant(2.0)))
@@ -56,7 +63,7 @@ internal class LocationManagerTests: XCTestCase {
     func testUpdateLocationOptionsWithPuckTypeSetToNil() {
         var locationOptions = LocationOptions()
         locationOptions.puckType = .puck2D()
-        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView, style: locationSupportableStyle)
 
         var locationOptions2 = LocationOptions()
         locationOptions2.puckType = nil
@@ -69,7 +76,7 @@ internal class LocationManagerTests: XCTestCase {
     func testUpdateLocationOptionsWithPuckTypeSetToNonNil() {
         var locationOptions = LocationOptions()
         locationOptions.puckType = nil
-        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView)
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView, style: locationSupportableStyle)
 
         var locationOptions2 = LocationOptions()
         locationOptions2.puckType = .puck2D()

--- a/Tests/MapboxMapsTests/Location/LocationSupportableMapViewMock.swift
+++ b/Tests/MapboxMapsTests/Location/LocationSupportableMapViewMock.swift
@@ -13,7 +13,6 @@ import UIKit
 #endif
 
 class LocationSupportableMapViewMock: UIView, LocationSupportableMapView {
-    var style: Style!
 
     func subscribeRenderFrameHandler(_ handler: @escaping (MapboxCoreMaps.Event) -> Void) {
         print("Pass through implementation")

--- a/Tests/MapboxMapsTests/Location/MockLocationStyleDelegate.swift
+++ b/Tests/MapboxMapsTests/Location/MockLocationStyleDelegate.swift
@@ -1,0 +1,13 @@
+import Foundation
+@testable import MapboxMaps
+
+class MockLocationStyleDelegate: LocationStyleDelegate {
+    func addLayer(_ layer: Layer, layerPosition: LayerPosition?) throws {}
+    func removeLayer(withId id: String) throws {}
+    func layerExists(withId id: String) -> Bool { return false }
+    func setLayerProperties(for layerId: String, properties: [String: Any]) throws {}
+    func addSource(_ source: Source, id: String) throws {}
+    func removeSource(withId id: String) throws {}
+    func setSourceProperty(for sourceId: String, property: String, value: Any) throws {}
+    func addImage(_ image: UIImage, id: String, sdf: Bool, stretchX: [ImageStretches], stretchY: [ImageStretches], content: ImageContent?) throws {}
+}

--- a/Tests/MapboxMapsTests/Location/MockLocationStyleDelegate.swift
+++ b/Tests/MapboxMapsTests/Location/MockLocationStyleDelegate.swift
@@ -9,5 +9,7 @@ class MockLocationStyleDelegate: LocationStyleDelegate {
     func addSource(_ source: Source, id: String) throws {}
     func removeSource(withId id: String) throws {}
     func setSourceProperty(for sourceId: String, property: String, value: Any) throws {}
+
+    //swiftlint:disable function_parameter_count
     func addImage(_ image: UIImage, id: String, sdf: Bool, stretchX: [ImageStretches], stretchY: [ImageStretches], content: ImageContent?) throws {}
 }

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/LocationManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/LocationManagerIntegrationTests.swift
@@ -46,7 +46,7 @@ internal class LocationManagerIntegrationTestCase: MapViewIntegrationTestCase {
     }
 
     private func setupLocationManager(with mapView: MapView) -> LocationManager {
-        let locationManager = LocationManager(locationSupportableMapView: mapView)
+        let locationManager = LocationManager(locationSupportableMapView: mapView, style: mapView.style)
         return locationManager
     }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [X] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Removed style from LocationSupportableMapView</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This removes `LocationSupportableMapView.style`, moving it to a new `LocationStyleDelegate` (naming mirroring `AnnotationStyleDelegate`.

This is a prelude to being able to move `Style` from `MapView` to `MapboxMap`.