### PR TITLE
Re-enable offline tests

### DIFF
--- a/Sources/MapboxMaps/Foundation/Extensions/Core/ResourceOptions.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/ResourceOptions.swift
@@ -51,7 +51,7 @@ extension ResourceOptions {
         // Update the TileStore with the access token from the ResourceOptions
         if tileStoreUsageMode != .disabled {
             let tileStore = tileStore ?? TileStore.getInstance()
-            tileStore.setOptionForKey(TileStoreOptions.mapboxAccessToken, value: accessToken)
+            tileStore.setAccessToken(accessToken)
         }
 
         let cacheURL = try? ResourceOptions.cacheURLIncludingSubdirectory()

--- a/Sources/MapboxMaps/Offline/TileStore+MapboxMaps.swift
+++ b/Sources/MapboxMaps/Offline/TileStore+MapboxMaps.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 extension TileStore {
+    /// Convenience to set the access token for a TileStore
+    public func setAccessToken(_ accessToken: String) {
+        setOptionForKey(TileStoreOptions.mapboxAccessToken, value: accessToken)
+    }
+
     /// Loads a new tile region or updates the existing one.
     ///
     /// - Parameters:

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/OfflineManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/OfflineManagerIntegrationTests.swift
@@ -78,7 +78,7 @@ internal class OfflineManagerIntegrationTestCase: IntegrationTestCase {
         tileStore.loadTileRegion(forId: tileRegionId,
                                  loadOptions: tileRegionLoadOptions!) { _ in
             DispatchQueue.main.async {
-                print(".", terminator:"")
+                print(".", terminator: "")
                 downloadInProgress.fulfill()
             }
         } completion: { result in

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/OfflineManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/OfflineManagerIntegrationTests.swift
@@ -2,31 +2,38 @@ import XCTest
 @testable import MapboxMaps
 
 // swiftlint:disable force_cast
-internal class OfflineManagerIntegrationTestCase: MapViewIntegrationTestCase {
+internal class OfflineManagerIntegrationTestCase: IntegrationTestCase {
 
-    // MARK: Reusable test properties
+    var tileStorePathURL: URL!
+    var tileStore: TileStore!
+    var resourceOptions: ResourceOptions!
+    var offlineManager: OfflineManager!
+    var tileRegionId = ""
 
-    /// Offline manager properties
-    private lazy var resourceOptions = ResourceOptions(accessToken: accessToken)
-    private lazy var offlineManager = OfflineManager(resourceOptions: resourceOptions)
-    private let tileRegionId = "myTileRegion"
-
-    /// Tokyo coordinates
-    private let tokyoCoord = CLLocationCoordinate2D(latitude: 35.682027, longitude: 139.769305)
-
-    /// Tile Region Options
-    internal var tileRegionLoadOptions: TileRegionLoadOptions?
+    let tokyoCoord = CLLocationCoordinate2D(latitude: 35.682027, longitude: 139.769305)
+    var tileRegionLoadOptions: TileRegionLoadOptions!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
+        accessToken = try mapboxAccessToken()
 
-        /// Create an offline region with tiles using the "outdoors" style
-        let stylePackOptions = StylePackLoadOptions(glyphsRasterizationMode: .ideographsRasterizedLocally,
-                                                    metadata: ["tag": "my-outdoors-style-pack"])!
+        tileRegionId = "tile-region-\(name)"
 
+        // TileStore
+        tileStorePathURL = try TileStore.fileURLForDirectory(for: name.fileSystemSafeString())
+        tileStore = TileStore.getInstanceForPath(tileStorePathURL.path)
+
+        // OfflineManager
+        // Setting the TileStore here has the side effect of setting its access
+        // token
+        resourceOptions = ResourceOptions(accessToken: accessToken,
+                                          tileStore: tileStore)
+
+        offlineManager = OfflineManager(resourceOptions: resourceOptions)
+
+        // Setup TileRegionLoadOptions
         let outdoorsOptions = TilesetDescriptorOptions(styleURI: .outdoors,
-                                                       zoomRange: 0...16,
-                                                       stylePackOptions: stylePackOptions)
+                                                       zoomRange: 0...16)
 
         let outdoorsDescriptor = offlineManager.createTilesetDescriptor(for: outdoorsOptions)
 
@@ -40,18 +47,27 @@ internal class OfflineManagerIntegrationTestCase: MapViewIntegrationTestCase {
                                                       metadata: ["tag": "my-outdoors-tile-region"],
                                                       tileLoadOptions: tileLoadOptions,
                                                       averageBytesPerSecond: nil)!
+
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+
+        tileStore = nil
         tileRegionLoadOptions = nil
+        resourceOptions = nil
+        offlineManager = nil
+
+        // Wait before removing directory
+        let expectation = self.expectation(description: "Wait...")
+        _ = XCTWaiter.wait(for: [expectation], timeout: 1.0)
+
+        try TileStore.removeDirectory(at: tileStorePathURL)
     }
 
     // MARK: Test Cases
 
     internal func testProgressAndCompletionBlocksBaseCase() throws {
-
-        throw XCTSkip("Test is failing - disabled temporarily")
 
         /// Expectations to be fulfilled
         let downloadInProgress = XCTestExpectation(description: "Downloading offline tiles in progress")
@@ -59,128 +75,181 @@ internal class OfflineManagerIntegrationTestCase: MapViewIntegrationTestCase {
         let completionBlockReached = XCTestExpectation(description: "Checks that completion block closure has been reached")
 
         /// Perform the download
-        TileStore.getInstance().loadTileRegion(forId: tileRegionId,
-                                               loadOptions: tileRegionLoadOptions!) { _ in
+        tileStore.loadTileRegion(forId: tileRegionId,
+                                 loadOptions: tileRegionLoadOptions!) { _ in
             DispatchQueue.main.async {
+                print(".", terminator:"")
                 downloadInProgress.fulfill()
             }
         } completion: { result in
-            switch result {
-            case .success(let region):
-                if region.requiredResourceCount == region.completedResourceCount {
-                    completionBlockReached.fulfill()
-                } else {
-                    XCTFail("Not all items were loaded")
+            DispatchQueue.main.async {
+                switch result {
+                case let .success(region):
+                    if region.requiredResourceCount == region.completedResourceCount {
+                        print("✔︎")
+                        completionBlockReached.fulfill()
+                    } else {
+                        print("𐄂")
+                        XCTFail("Not all items were loaded")
+                    }
+                case let .failure(error):
+                    print("𐄂")
+                    XCTFail("Download failed with error: \(error)")
                 }
-            case .failure(let error):
-                XCTFail("Download failed with error: \(error)")
             }
         }
 
         let expectations = [downloadInProgress, completionBlockReached]
-        wait(for: expectations, timeout: 5.0)
+        wait(for: expectations, timeout: 30.0)
     }
 
     internal func testProgressCanBeCancelled() throws {
-        throw XCTSkip("Test is failing - disabled temporarily")
-
         /// Expectations to be fulfilled
         let downloadWasCancelled = XCTestExpectation(description: "Checks a cancel function was reached and that the download was canceled")
 
         /// Perform the download
-        let download = TileStore.getInstance().loadTileRegion(forId: tileRegionId,
-                                                              loadOptions: tileRegionLoadOptions!) { _ in }
-        completion: { result in
-            switch result {
-            case .success:
-                XCTFail("Result reached success block, therefore download was not canceled")
-            case .failure(let error):
-                let tileError = error as! TileRegionError
-                if tileError == .canceled("Load was canceled") {
-                    downloadWasCancelled.fulfill()
-                } else {
-                    XCTFail("Download was not canceled")
+        let download = tileStore.loadTileRegion(forId: tileRegionId,
+                                                loadOptions: tileRegionLoadOptions!) { _ in }
+            completion: { result in
+                DispatchQueue.main.async {
+                    switch result {
+                    case .success:
+                        XCTFail("Result reached success block, therefore download was not canceled")
+                    case let .failure(error):
+                        if case TileRegionError.canceled = error {
+                            downloadWasCancelled.fulfill()
+                        } else {
+                            XCTFail("Download was not canceled")
+                        }
+                    }
+                }
+            }
+
+        DispatchQueue.main.async {
+            download.cancel()
+        }
+
+        let expectations = [downloadWasCancelled]
+        wait(for: expectations, timeout: 10.0)
+    }
+
+    internal func testOfflineRegionCanBeDeleted() throws {
+        /// Expectations to be fulfilled
+        let tileRegionDownloaded = XCTestExpectation(description: "Downloaded offline tiles")
+
+        /// Perform the download
+        tileStore.loadTileRegion(forId: tileRegionId,
+                                 loadOptions: tileRegionLoadOptions!) { _ in }
+            completion: { result in
+                DispatchQueue.main.async {
+                    switch result {
+                    case .success(let region):
+                        if region.requiredResourceCount == region.completedResourceCount {
+                            tileRegionDownloaded.fulfill()
+                        } else {
+                            XCTFail("Not all items were loaded")
+                        }
+
+                    case .failure(let error):
+                        print("𐄂")
+                        XCTFail("Download failed with error: \(error)")
+                    }
+                }
+            }
+
+        wait(for: [tileRegionDownloaded], timeout: 30.0)
+
+        // Now delete
+        let downloadWasDeleted = XCTestExpectation(description: "Downloaded offline tiles were deleted")
+
+        tileStore.removeTileRegion(forId: self.tileRegionId)
+
+        tileStore.allTileRegions { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let tileRegions):
+                    if tileRegions.count == 0 {
+                        downloadWasDeleted.fulfill()
+                    } else {
+                        XCTFail("Tile regions still remain.")
+                    }
+                case .failure(let error):
+                    XCTFail("Error getting tile regions with error: \(error)")
                 }
             }
         }
 
-        download.cancel()
-
-        let expectations = [downloadWasCancelled]
-        wait(for: expectations, timeout: 5.0)
-    }
-
-    internal func testOfflineRegionCanBeDeleted() throws {
-        throw XCTSkip("Test is failing - disabled temporarily")
-
-        /// Expectations to be fulfilled
-        let downloadWasDeleted = XCTestExpectation(description: "Downloaded offline tiles were deleted")
-
-        /// Perform the download
-        TileStore.getInstance().loadTileRegion(forId: tileRegionId,
-                                               loadOptions: tileRegionLoadOptions!) { _ in }
-            completion: { result in
-                switch result {
-                case .success(let region):
-                    if region.requiredResourceCount == region.completedResourceCount {
-                        /// Waiting for the load tile to complete
-                        TileStore.getInstance().removeTileRegion(forId: self.tileRegionId)
-
-                        TileStore.getInstance().allTileRegions(completion: { result in
-                            switch result {
-                            case .success(let tileRegions):
-                                if tileRegions.count == 0 {
-                                    downloadWasDeleted.fulfill()
-                                }
-                            case .failure(let error):
-                                XCTFail("Error getting tile regions with error: \(error)")
-                            }
-                        })
-                    }
-                case .failure(let error):
-                    XCTFail("Test failed with error: \(error)")
-                }
-            }
-
-        let expectations = [downloadWasDeleted]
-        wait(for: expectations, timeout: 5.0)
+        wait(for: [downloadWasDeleted], timeout: 5.0)
     }
 
     internal func testMapCanBeLoadedWithoutNetworkConnectivity() throws {
-        throw XCTSkip("Test is failing - disabled temporarily")
+
+        guard let rootView = rootViewController?.view else {
+            throw XCTSkip("No valid UIWindow or root view controller")
+        }
+
+        guard MTLCreateSystemDefaultDevice() != nil else {
+            throw XCTSkip("No valid Metal device (OS version or VM?)")
+        }
+
+        // 1. Load TileRegion from network
+        try testProgressAndCompletionBlocksBaseCase()
+
+        // - - - - - - - -
+        // 2. stylepack
+
+        let stylePackLoaded = expectation(description: "StylePack was loaded")
+        let stylePackOptions = StylePackLoadOptions(glyphsRasterizationMode: .ideographsRasterizedLocally,
+                                                    metadata: ["tag": "my-outdoors-style-pack"])!
+
+        offlineManager.loadStylePack(for: .outdoors,
+                                     loadOptions: stylePackOptions) { result in
+            DispatchQueue.main.async {
+                print("StylePack completed: \(result)")
+                switch result {
+                case let .failure(error):
+                    XCTFail("stylePackLoaded error: \(error)")
+                case .success:
+                    stylePackLoaded.fulfill()
+                }
+            }
+        }
+
+        wait(for: [stylePackLoaded], timeout: 30.0)
+
+        // - - - - - - - -
+        // 3. Disable load-from-network, and try launch map at this location
+        NetworkConnectivity.getInstance().setMapboxStackConnectedForConnected(false)
+
+        let cameraOptions = CameraOptions(center: tokyoCoord, zoom: 16)
+        let mapInitOptions = MapInitOptions(resourceOptions: resourceOptions,
+                                            cameraOptions: cameraOptions,
+                                            styleURI: .outdoors)
+        let mapView = MapView(frame: rootView.bounds, mapInitOptions: mapInitOptions)
+        rootView.addSubview(mapView)
 
         /// Expectations to be fulfilled
         let mapIsUsingDatabase = XCTestExpectation(description: "Map is using database for resources")
         mapIsUsingDatabase.assertForOverFulfill = false
+
         let mapWasLoaded = XCTestExpectation(description: "Map was loaded")
 
-        /// Perform the download
-        TileStore.getInstance().loadTileRegion(forId: tileRegionId,
-                                               loadOptions: tileRegionLoadOptions!) { _ in } completion: { _ in }
-
-        NetworkConnectivity.getInstance().setMapboxStackConnectedForConnected(false)
-
-        let mapboxMap = try XCTUnwrap(mapView?.mapboxMap)
-
-        mapboxMap.onEvery(.resourceRequest) { event in
+        mapView.mapboxMap.onEvery(.resourceRequest) { event in
             let eventElements = event.data as! [String: Any]
-
             let source = eventElements["data-source"] as! String
-
-            switch source {
-            case "network":
+            if source == "network" {
                 XCTFail("Loading is occurring from the network")
-            default:
+            } else {
                 mapIsUsingDatabase.fulfill()
             }
         }
 
-        mapboxMap.onNext(.mapLoaded) { _ in
+        mapView.mapboxMap.onNext(.mapLoaded) { _ in
             mapWasLoaded.fulfill()
         }
 
         let expectations = [mapIsUsingDatabase, mapWasLoaded]
-        wait(for: expectations, timeout: 5.0)
+        wait(for: expectations, timeout: 5.0, enforceOrder: true)
 
         NetworkConnectivity.getInstance().setMapboxStackConnectedForConnected(true)
     }

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/OfflineManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/OfflineManagerIntegrationTests.swift
@@ -62,7 +62,9 @@ internal class OfflineManagerIntegrationTestCase: IntegrationTestCase {
         let expectation = self.expectation(description: "Wait...")
         _ = XCTWaiter.wait(for: [expectation], timeout: 1.0)
 
-        try TileStore.removeDirectory(at: tileStorePathURL)
+        if let tileStorePathURL = tileStorePathURL {
+            try TileStore.removeDirectory(at: tileStorePathURL)
+        }
     }
 
     // MARK: Test Cases

--- a/Tests/MapboxMapsTests/MigrationGuide/OfflineGuideIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MigrationGuide/OfflineGuideIntegrationTests.swift
@@ -38,7 +38,9 @@ class OfflineGuideIntegrationTests: XCTestCase {
         let expectation = self.expectation(description: "Wait...")
         _ = XCTWaiter.wait(for: [expectation], timeout: 1.0)
 
-        try TileStore.removeDirectory(at: tileStorePathURL)
+        if let tileStorePathURL = tileStorePathURL {
+            try TileStore.removeDirectory(at: tileStorePathURL)
+        }
     }
 
     // Test StylePackLoadOptions

--- a/Tests/MapboxMapsTests/MigrationGuide/OfflineGuideIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MigrationGuide/OfflineGuideIntegrationTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MapboxMaps
+@testable import MapboxMaps
 import XCTest
 
 // These tests are used for documentation purposes
@@ -9,6 +9,37 @@ import XCTest
 //swiftlint:disable empty_enum_arguments
 class OfflineGuideIntegrationTests: XCTestCase {
     let tokyoCoord = CLLocationCoordinate2D(latitude: 35.682027, longitude: 139.769305)
+
+    var tileStorePathURL: URL!
+    var tileStore: TileStore!
+    var accessToken: String!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        do {
+            accessToken = try mapboxAccessToken()
+        } catch {
+            throw XCTSkip("Mapbox access token not found")
+        }
+
+        tileStorePathURL = try TileStore.fileURLForDirectory(for: name.fileSystemSafeString())
+        tileStore = TileStore.getInstanceForPath(tileStorePathURL.path)
+
+        tileStore.setAccessToken(accessToken)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+
+        tileStore = nil
+
+        // Wait before removing directory
+        let expectation = self.expectation(description: "Wait...")
+        _ = XCTWaiter.wait(for: [expectation], timeout: 1.0)
+
+        try TileStore.removeDirectory(at: tileStorePathURL)
+    }
 
     // Test StylePackLoadOptions
     func testDefineAStylePackage() throws {
@@ -22,10 +53,9 @@ class OfflineGuideIntegrationTests: XCTestCase {
 
     // Test TileRegionLoadOptions
     func testDefineATileRegion() throws {
-        let accessToken = try mapboxAccessToken()
-
         //-->
-        let offlineManager = OfflineManager(resourceOptions: ResourceOptions(accessToken: accessToken))
+        let offlineManager = OfflineManager(resourceOptions: ResourceOptions(accessToken: accessToken,
+                                                                             tileStore: tileStore))
 
         // 1. Create the tile set descriptor
         let options = TilesetDescriptorOptions(styleURI: .outdoors, zoomRange: 0...16)
@@ -83,14 +113,9 @@ class OfflineGuideIntegrationTests: XCTestCase {
     func testLoadAndCancelStylePack() throws {
 
         let expectation = self.expectation(description: "style pack should be canceled")
-        var accessToken: String = ""
-        do {
-            accessToken = try mapboxAccessToken()
-        } catch {
-            _ = XCTSkip("Mapbox access token not found")
-        }
 
-        let offlineManager = OfflineManager(resourceOptions: ResourceOptions(accessToken: accessToken))
+        let offlineManager = OfflineManager(resourceOptions: ResourceOptions(accessToken: accessToken,
+                                                                             tileStore: tileStore))
         let stylePackLoadOptions = StylePackLoadOptions(glyphsRasterizationMode: .ideographsRasterizedLocally)!
 
         let handleCancelation = {
@@ -138,14 +163,8 @@ class OfflineGuideIntegrationTests: XCTestCase {
 
     func testLoadAndCancelTileRegion() throws {
         let expectation = self.expectation(description: "Tile region download should be canceled")
-        var accessToken: String = ""
-        do {
-            accessToken = try mapboxAccessToken()
-        } catch {
-            _ = XCTSkip("Mapbox access token not found")
-        }
-
-        let offlineManager = OfflineManager(resourceOptions: ResourceOptions(accessToken: accessToken))
+        let offlineManager = OfflineManager(resourceOptions: ResourceOptions(accessToken: accessToken,
+                                                                             tileStore: tileStore))
 
         // Create the tile set descriptor
         let options = TilesetDescriptorOptions(styleURI: .outdoors, zoomRange: 0...16)
@@ -172,7 +191,7 @@ class OfflineGuideIntegrationTests: XCTestCase {
             descriptors: [tilesetDescriptor],
             tileLoadOptions: tileLoadOptions)!
 
-        let tileRegionCancelable = TileStore.getInstance().loadTileRegion(
+        let tileRegionCancelable = tileStore.loadTileRegion(
             forId: tileRegionId,
             loadOptions: tileRegionLoadOptions) { _ in
             //
@@ -205,14 +224,9 @@ class OfflineGuideIntegrationTests: XCTestCase {
 
     func testFetchingAllStylePacks() throws {
         let expectation = self.expectation(description: "Style packs should be fetched without error")
-        var accessToken: String = ""
-        do {
-            accessToken = try mapboxAccessToken()
-        } catch {
-            _ = XCTSkip("Mapbox access token not found")
-        }
 
-        let offlineManager = OfflineManager(resourceOptions: ResourceOptions(accessToken: accessToken))
+        let offlineManager = OfflineManager(resourceOptions: ResourceOptions(accessToken: accessToken,
+                                                                             tileStore: tileStore))
 
         let handleStylePacks = { (stylePacks: [StylePack]) in
             // During testing there should be no style packs
@@ -248,8 +262,6 @@ class OfflineGuideIntegrationTests: XCTestCase {
     }
 
     func testFetchingAllTileRegions() throws {
-        throw XCTSkip("Test occasionally fails since tileRegions can be non-empty")
-
         let expectation = self.expectation(description: "Style packs should be fetched without error")
 
         let handleTileRegions = { (tileRegions: [TileRegion]) in
@@ -271,7 +283,8 @@ class OfflineGuideIntegrationTests: XCTestCase {
 
         //-->
         // Get a list of tile regions that are currently available.
-        TileStore.getInstance().allTileRegions { result in
+        // TileStore.getInstance()
+        tileStore.allTileRegions { result in
             switch result {
             case let .success(tileRegions):
                 handleTileRegions(tileRegions)
@@ -289,8 +302,8 @@ class OfflineGuideIntegrationTests: XCTestCase {
     }
 
     func testDeleteStylePack() throws {
-        let accessToken = try mapboxAccessToken()
-        let resourceOptions = ResourceOptions(accessToken: accessToken)
+        let resourceOptions = ResourceOptions(accessToken: accessToken,
+                                              tileStore: tileStore)
         let offlineManager = OfflineManager(resourceOptions: resourceOptions)
 
         //-->
@@ -324,7 +337,8 @@ class OfflineGuideIntegrationTests: XCTestCase {
 
     func testDeleteTileRegions() throws {
         //-->
-        TileStore.getInstance().removeTileRegion(forId: "my-tile-region-id")
+        //TileStore.getInstance().removeTileRegion(forId: "my-tile-region-id")
+        tileStore.removeTileRegion(forId: "my-tile-region-id")
         //<--
 
         // Note this will not remove the downloaded tile packs, instead, it will
@@ -335,7 +349,7 @@ class OfflineGuideIntegrationTests: XCTestCase {
         // disk quota to zero. This will ensure tile regions are fully evicted.
 
         //-->
-        TileStore.getInstance().setOptionForKey(TileStoreOptions.diskQuota, value: 0)
+        tileStore.setOptionForKey(TileStoreOptions.diskQuota, value: 0)
         //<--
 
         // Wait *some time* before the test calls exit()

--- a/Tests/MapboxMapsTests/Offline/TileStore+Tests.swift
+++ b/Tests/MapboxMapsTests/Offline/TileStore+Tests.swift
@@ -1,0 +1,46 @@
+import MapboxMaps
+
+extension TileStore {
+    internal static func fileURLForDirectory(for relativePath: String) throws -> URL {
+        var cacheDirectoryURL = try FileManager.default.url(for: .applicationSupportDirectory,
+                                                            in: .userDomainMask,
+                                                            appropriateFor: nil,
+                                                            create: true)
+
+        cacheDirectoryURL = cacheDirectoryURL.appendingPathComponent("com.mapbox.maps")
+        cacheDirectoryURL = cacheDirectoryURL.appendingPathComponent("tile-store")
+        cacheDirectoryURL = cacheDirectoryURL.appendingPathComponent(relativePath)
+
+        try FileManager.default.createDirectory(at: cacheDirectoryURL,
+                                                withIntermediateDirectories: true,
+                                                attributes: nil)
+        cacheDirectoryURL.setTemporaryResourceValue(true, forKey: .isExcludedFromBackupKey)
+        return cacheDirectoryURL
+    }
+
+    internal static func removeDirectory(at fileURL: URL) throws {
+        let fileManager = FileManager.default
+        let resourceKeys = Set<URLResourceKey>([.isDirectoryKey])
+        var fileURLs: [URL] = []
+
+        guard let enumerator = fileManager.enumerator(at: fileURL, includingPropertiesForKeys: Array(resourceKeys)) else {
+            return
+        }
+
+        for case let pathURL as URL in enumerator {
+            let resourceValues = try? pathURL.resourceValues(forKeys: resourceKeys)
+
+            if let isDirectory = resourceValues?.isDirectory, isDirectory {
+                continue
+            }
+
+            fileURLs.append(pathURL)
+        }
+
+        // Remove files
+        try fileURLs.forEach {
+            try fileManager.removeItem(at: $0)
+        }
+        try fileManager.removeItem(at: fileURL)
+    }
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Write tests for all new functionality. If tests were not written, please explain why.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

This PR re-enables offline tests. For these tests a new TileStore is created at a custom path, so that the tests do not interfere with each other. We still need to do the same for CacheManager.

There is a known issue that style packs and tile regions cannot be downloaded at the same time, so in `testMapCanBeLoadedWithoutNetworkConnectivity` these operations are handled serially.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
