### PR TITLE
Expose prefetchZoomDelta directly as part of RenderOptions

### DIFF
--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -54,8 +54,7 @@ open class MapView: UIView {
 
     public var options = RenderOptions() {
         didSet {
-            let defaultPrefetchZoomDelta: UInt8 = 4
-            mapboxMap.__map.setPrefetchZoomDeltaForDelta(options.prefetchesTiles ? defaultPrefetchZoomDelta : 0)
+            mapboxMap.__map.setPrefetchZoomDeltaForDelta(options.prefetchZoomDelta)
             preferredFPS = options.preferredFramesPerSecond
             metalView?.presentsWithTransaction = options.presentsWithTransaction
         }
@@ -166,9 +165,7 @@ open class MapView: UIView {
         }
 
         // Set prefetchZoomDelta
-        let defaultPrefetchZoomDelta: UInt8 = 4
-        mapboxMap.__map.setPrefetchZoomDeltaForDelta(
-            options.prefetchesTiles ? defaultPrefetchZoomDelta : 0)
+        mapboxMap.__map.setPrefetchZoomDeltaForDelta(options.prefetchZoomDelta)
 
         // Set preferrredFPS
         preferredFPS = options.preferredFramesPerSecond

--- a/Sources/MapboxMaps/MapView/Configuration/RenderOptions.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/RenderOptions.swift
@@ -13,15 +13,10 @@ public struct RenderOptions: Equatable {
     ///  See Also `CADisplayLink.preferredFramesPerSecond`
     public var preferredFramesPerSecond: PreferredFPS = .normal
 
-    ///  A Boolean value indicating whether the map should prefetch tiles.
-    ///
-    ///  When this property is set to `true`, the map view prefetches tiles designed for
-    ///  a low zoom level and displays them until receiving more detailed tiles for the
-    ///  current zoom level. The prefetched tiles typically contain simplified versions
-    ///  of each shape, improving the map view’s perceived performance.
-    ///
-    ///  The default value of this property is `true`.
-    public var prefetchesTiles: Bool = true
+    /// When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
+    /// map at lower resolution as quick as possible. It will get clamped at the tile source
+    /// minimum zoom. The default `PrefetchZoomDelta` is 4.
+    public var prefetchZoomDelta: UInt8 = 4
 
     /// A Boolean value that indicates whether the underlying `CAMetalLayer` of the `MapView`
     /// presents its content using a CoreAnimation transaction


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR exposes `prefetchesZoomDelta` as part of `RenderOptions` so that a developer can set it as they see fit instead of pre-empting it with a default value
