### PR TITLE
Add missing style parameter to Puck2D initializer in tests

### DIFF
--- a/Tests/MapboxMapsTests/Location/Pucks/Puck2DIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Location/Pucks/Puck2DIntegrationTests.swift
@@ -17,7 +17,7 @@ class Puck2DIntegrationTests: MapViewIntegrationTestCase {
         let styleContainsPuckExpectation = XCTestExpectation(description: "Style contains puck layer.")
 
         didFinishLoadingStyle = { _ in
-            let puck = Puck2D(puckStyle: .precise, locationSupportableMapView: self.mapView!, configuration: Puck2DConfiguration())
+            let puck = Puck2D(puckStyle: .precise, locationSupportableMapView: self.mapView!, style: style, configuration: Puck2DConfiguration())
             do {
                 try puck.createPreciseLocationIndicatorLayer(location: Location(with: CLLocation(latitude: 1, longitude: 1)))
                 createPuckExpectation.fulfill()
@@ -41,7 +41,7 @@ class Puck2DIntegrationTests: MapViewIntegrationTestCase {
         let styleContainsPuckExpectation = XCTestExpectation(description: "style contains puck layer.")
 
         didFinishLoadingStyle = { _ in
-            let puck = Puck2D(puckStyle: .approximate, locationSupportableMapView: self.mapView!, configuration: Puck2DConfiguration())
+            let puck = Puck2D(puckStyle: .approximate, locationSupportableMapView: self.mapView!, style: style, configuration: Puck2DConfiguration())
             do {
                 try puck.createApproximateLocationIndicatorLayer(location: Location(with: CLLocation(latitude: 1, longitude: 1)))
                 createPuckExpectation.fulfill()
@@ -64,7 +64,7 @@ class Puck2DIntegrationTests: MapViewIntegrationTestCase {
         let removePuckExpectation = XCTestExpectation(description: "Remove a precise Puck2D.")
 
         didFinishLoadingStyle = { _ in
-            let puck = Puck2D(puckStyle: .precise, locationSupportableMapView: self.mapView!, configuration: Puck2DConfiguration())
+            let puck = Puck2D(puckStyle: .precise, locationSupportableMapView: self.mapView!, style: style, configuration: Puck2DConfiguration())
 
             do {
                 try puck.createPreciseLocationIndicatorLayer(location: Location(with: CLLocation(latitude: 1, longitude: 1)))
@@ -93,7 +93,7 @@ class Puck2DIntegrationTests: MapViewIntegrationTestCase {
         let addedApproximatePuckExpectation = XCTestExpectation(description: "Style contains approximate puck layer.")
 
         didFinishLoadingStyle = { _ in
-            let puck = Puck2D(puckStyle: .precise, locationSupportableMapView: self.mapView!, configuration: Puck2DConfiguration())
+            let puck = Puck2D(puckStyle: .precise, locationSupportableMapView: self.mapView!, style: style, configuration: Puck2DConfiguration())
             do {
                 try puck.createPreciseLocationIndicatorLayer(location: location)
             } catch {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR adds the missing `style` parameter to the Puck2D initializers in the `Puck2DIntegrationTests`.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
