### PR TITLE
Make testMapCanBeLoadedWithoutNetworkConnectivity concurrent

### DIFF
--- a/Tests/MapboxMapsTests/MapView/Integration Tests/OfflineManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/OfflineManagerIntegrationTests.swift
@@ -191,7 +191,28 @@ internal class OfflineManagerIntegrationTestCase: IntegrationTestCase {
         }
 
         // 1. Load TileRegion from network
-        try testProgressAndCompletionBlocksBaseCase()
+        let tileRegionLoaded = XCTestExpectation(description: "Tile region has loaded")
+
+        /// Perform the download
+        tileStore.loadTileRegion(forId: tileRegionId,
+                                 loadOptions: tileRegionLoadOptions!) { _ in }
+            completion: { result in
+            DispatchQueue.main.async {
+                switch result {
+                case let .success(region):
+                    if region.requiredResourceCount == region.completedResourceCount {
+                        print("✔︎")
+                        tileRegionLoaded.fulfill()
+                    } else {
+                        print("𐄂")
+                        XCTFail("Not all items were loaded")
+                    }
+                case let .failure(error):
+                    print("𐄂")
+                    XCTFail("Download failed with error: \(error)")
+                }
+            }
+        }
 
         // - - - - - - - -
         // 2. stylepack
@@ -213,7 +234,7 @@ internal class OfflineManagerIntegrationTestCase: IntegrationTestCase {
             }
         }
 
-        wait(for: [stylePackLoaded], timeout: 30.0)
+        wait(for: [stylePackLoaded, tileRegionLoaded], timeout: 30.0)
 
         // - - - - - - - -
         // 3. Disable load-from-network, and try launch map at this location


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Write tests for all new functionality. If tests were not written, please explain why.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

This PR changes the above test so that downloading style pack and tile region are concurrent operations.

FYI @pengdev 