### PR TITLE
Fix logic in initial compass visibility check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Mapbox welcomes participation and contributions from everyone.
  - `StyleURI`, `PreferredFPS`, and `AnimationOwner` are now structs. ([#285](https://github.com/mapbox/mapbox-maps-ios/pull/285))
  - The `layout` and `paint` substructs for each layer are now merged into the root layer struct. ([#362](https://github.com/mapbox/mapbox-maps-ios/pull/362))
  
+### Bug fixes 🐞
+
+- Fixed an issue where the map's scale bar and compass view could trigger `layoutSubviews()` for the map view. ([#338](https://github.com/mapbox/mapbox-maps-ios/pull/338)) 
+
 ## 10.0.0-beta.19.1 - May 7, 2021
 
 ### Breaking changes ⚠️

--- a/Sources/MapboxMaps/Ornaments/Compass/MapboxCompassOrnamentView.swift
+++ b/Sources/MapboxMaps/Ornaments/Compass/MapboxCompassOrnamentView.swift
@@ -42,7 +42,7 @@ internal class MapboxCompassOrnamentView: UIButton {
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
         self.visibility = visibility
-        containerView.isHidden = visibility == .visible
+        containerView.isHidden = visibility != .visible
         let bundle = Bundle.mapboxMaps
         accessibilityLabel = NSLocalizedString("COMPASS_A11Y_LABEL",
                                                tableName: Constants.localizableTableName,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR fixes a logic issue in the visibility check when initializing the compass view.

It also adds a changelog entry for https://github.com/mapbox/mapbox-maps-ios/pull/338

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
