### PR TITLE
Added missing camera methods to Snapshotter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+### Features ✨ and improvements 🏁
+
+- Added `Snapshotter.coordinateBounds(for:)` and `Snapshotter.camera(for:padding:bearing:pitch:)`. ([#386](https://github.com/mapbox/mapbox-maps-ios/pull/386))
+
 ## 10.0.0-beta.20 - May 20, 2021
 
 ### Breaking changes ⚠️

--- a/Sources/MapboxMaps/Snapshot/Snapshotter.swift
+++ b/Sources/MapboxMaps/Snapshot/Snapshotter.swift
@@ -211,8 +211,7 @@ public class Snapshotter {
     /// - Parameter camera: The camera for which the coordinate bounds will be returned.
     /// - Returns: `CoordinateBounds` for the given `CameraOptions`
     public func coordinateBounds(for camera: CameraOptions) -> CoordinateBounds {
-        return mapSnapshotter.coordinateBoundsForCamera(
-            forCamera: MapboxCoreMaps.CameraOptions(camera))
+        return mapSnapshotter.coordinateBoundsForCamera(forCamera: MapboxCoreMaps.CameraOptions(camera))
     }
 
     /// Calculates a `CameraOptions` to fit a list of coordinates.
@@ -227,12 +226,11 @@ public class Snapshotter {
                        padding: UIEdgeInsets,
                        bearing: Double?,
                        pitch: Double?) -> CameraOptions {
-        return CameraOptions(
-            mapSnapshotter.cameraForCoordinates(
-                forCoordinates: coordinates.map(\.location),
-                padding: padding.toMBXEdgeInsetsValue(),
-                bearing: bearing?.NSNumber,
-                pitch: pitch?.NSNumber))
+        return CameraOptions(mapSnapshotter.cameraForCoordinates(
+                                forCoordinates: coordinates.map(\.location),
+                                padding: padding.toMBXEdgeInsetsValue(),
+                                bearing: bearing?.NSNumber,
+                                pitch: pitch?.NSNumber))
     }
 }
 

--- a/Sources/MapboxMaps/Snapshot/Snapshotter.swift
+++ b/Sources/MapboxMaps/Snapshot/Snapshotter.swift
@@ -1,4 +1,5 @@
 import UIKit
+import CoreLocation
 
 #if canImport(MapboxMapsFoundation)
 import MapboxMapsFoundation
@@ -59,22 +60,6 @@ public class Snapshotter {
     /// - Parameter cameraOptions: The target camera options
     public func setCamera(to cameraOptions: CameraOptions) {
         mapSnapshotter.setCameraFor(MapboxCoreMaps.CameraOptions(cameraOptions))
-    }
-
-    /// Convenience function to set the URI of the current Mapbox Style to use.
-    /// This is equivalent to setting `snapshotter.style.uri`
-    ///
-    /// - Parameter styleURI: StyleURI to apply to the snapshotter
-    public func setStyleURI(_ styleURI: StyleURI) {
-        style.uri = styleURI
-    }
-
-    /// Convenience function to set the JSON of the current Mapbox Style to use.
-    /// This is equivalent to setting `snapshotter.style.JSON`
-    ///
-    /// - Parameter JSON: Style JSON string to apply to the snapshotter
-    public func setStyleJSON(_ JSON: String) {
-        mapSnapshotter.setStyleJSONForJson(JSON)
     }
 
     /// In the tile mode, the snapshotter fetches the still image of a single tile.
@@ -217,6 +202,37 @@ public class Snapshotter {
          }
 
         return compositeImage
+    }
+
+    // MARK: - Camera
+
+    /// Returns the coordinate bounds corresponding to a given `CameraOptions`
+    ///
+    /// - Parameter camera: The camera for which the coordinate bounds will be returned.
+    /// - Returns: `CoordinateBounds` for the given `CameraOptions`
+    public func coordinateBounds(for camera: CameraOptions) -> CoordinateBounds {
+        return mapSnapshotter.coordinateBoundsForCamera(
+            forCamera: MapboxCoreMaps.CameraOptions(camera))
+    }
+
+    /// Calculates a `CameraOptions` to fit a list of coordinates.
+    ///
+    /// - Parameters:
+    ///   - coordinates: Array of coordinates that should fit within the new viewport.
+    ///   - padding: The new padding to be used by the camera.
+    ///   - bearing: The new bearing to be used by the camera.
+    ///   - pitch: The new pitch to be used by the camera.
+    /// - Returns: A `CameraOptions` that fits the provided constraints
+    public func camera(for coordinates: [CLLocationCoordinate2D],
+                       padding: UIEdgeInsets,
+                       bearing: Double?,
+                       pitch: Double?) -> CameraOptions {
+        return CameraOptions(
+            mapSnapshotter.cameraForCoordinates(
+                forCoordinates: coordinates.map(\.location),
+                padding: padding.toMBXEdgeInsetsValue(),
+                bearing: bearing?.NSNumber,
+                pitch: pitch?.NSNumber))
     }
 }
 

--- a/Sources/MapboxMaps/Snapshot/Snapshotter.swift
+++ b/Sources/MapboxMaps/Snapshot/Snapshotter.swift
@@ -61,6 +61,22 @@ public class Snapshotter {
         mapSnapshotter.setCameraFor(MapboxCoreMaps.CameraOptions(cameraOptions))
     }
 
+    /// Convenience function to set the URI of the current Mapbox Style to use.
+    /// This is equivalent to setting `snapshotter.style.uri`
+    ///
+    /// - Parameter styleURI: StyleURI to apply to the snapshotter
+    public func setStyleURI(_ styleURI: StyleURI) {
+        style.uri = styleURI
+    }
+
+    /// Convenience function to set the JSON of the current Mapbox Style to use.
+    /// This is equivalent to setting `snapshotter.style.JSON`
+    ///
+    /// - Parameter JSON: Style JSON string to apply to the snapshotter
+    public func setStyleJSON(_ JSON: String) {
+        mapSnapshotter.setStyleJSONForJson(JSON)
+    }
+
     /// In the tile mode, the snapshotter fetches the still image of a single tile.
     public var tileMode: Bool {
         get {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [X] Document any changes to public APIs.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] ~Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.~
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR adds 2 camera methods to `Snapshotter` to align with Android:
```
func coordinateBounds(for camera: CameraOptions) -> CoordinateBounds

func camera(for coordinates: [CLLocationCoordinate2D],
                       padding: UIEdgeInsets,
                       bearing: Double?,
                       pitch: Double?) -> CameraOptions
```

/cc @kiryldz 