### PR TITLE
Add internal map delegates, create platform Projection class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Mapbox welcomes participation and contributions from everyone.
 - `MapboxMap.__map` is now private. ([#374](https://github.com/mapbox/mapbox-maps-ios/pull/374))
 - Added `CameraManagerProtocol.setCameraBounds`, `MapboxMap.prefetchZoomDelta`, `MapboxMap.options`, `MapboxMap.reduceMemoryUse()`, `MapboxMap.resourceOptions` and `MapboxMap.elevation(at:)`. ([#374](https://github.com/mapbox/mapbox-maps-ios/pull/374))
 - Removed `OfflineError.invalidResult` and `OfflineError.typeMismatch`. ([#374](https://github.com/mapbox/mapbox-maps-ios/pull/374))
+- Updated `Projection` APIs to be more Swift-like. ([#390](https://github.com/mapbox/mapbox-maps-ios/pull/390))
+
+### Bug fixes 🐞
+
+- Fixed bug with `TileStore.tileRegionGeometry` returning invalid value. ([#390](https://github.com/mapbox/mapbox-maps-ios/pull/390))
 
 ### Features ✨ and improvements 🏁
 
@@ -49,7 +54,6 @@ Mapbox welcomes participation and contributions from everyone.
      - `OfflineSwitch` (which replaces NetworkConnectivity)
      - `OfflineRegionManager` (though this API is deprecated)
  - Adds `loadStyleURI` and `loadStyleJSON` to `MapboxMap`. ([#354](https://github.com/mapbox/mapbox-maps-ios/pull/354))
-
 
 ### Bug fixes 🐞
 

--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 		CAE43EE7265462B7006F43E9 /* MockMapFeatureQueryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE43EE4265462B7006F43E9 /* MockMapFeatureQueryable.swift */; };
 		CAE43EE8265462B7006F43E9 /* MapboxMapsAnnotationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE43EE5265462B7006F43E9 /* MapboxMapsAnnotationsTests.swift */; };
 		CAE43EEA26546426006F43E9 /* MapViewIntegrationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA53616D2537ECA600A8AE38 /* MapViewIntegrationTestCase.swift */; };
+		CAE643E2265C831E00C9E223 /* MapTransformable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE643E1265C831E00C9E223 /* MapTransformable.swift */; };
 		CAED9FB1258C69DB003CCEFE /* MapViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAED9FAF258C69DB003CCEFE /* MapViewTests.swift */; };
 		CAEDA0B0258E8188003CCEFE /* MapViewIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAEDA0AE258E8188003CCEFE /* MapViewIntegrationTests.swift */; };
 /* End PBXBuildFile section */
@@ -760,6 +761,7 @@
 		CAE43EE12654627E006F43E9 /* TileStore+Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "TileStore+Tests.swift"; path = "../../Offline/TileStore+Tests.swift"; sourceTree = "<group>"; };
 		CAE43EE4265462B7006F43E9 /* MockMapFeatureQueryable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockMapFeatureQueryable.swift; sourceTree = "<group>"; };
 		CAE43EE5265462B7006F43E9 /* MapboxMapsAnnotationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapboxMapsAnnotationsTests.swift; sourceTree = "<group>"; };
+		CAE643E1265C831E00C9E223 /* MapTransformable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapTransformable.swift; sourceTree = "<group>"; };
 		CAED9FAF258C69DB003CCEFE /* MapViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewTests.swift; sourceTree = "<group>"; };
 		CAEDA0AE258E8188003CCEFE /* MapViewIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewIntegrationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1222,6 +1224,7 @@
 		1F11C1102421B05600F8397B /* MapboxMapsFoundation */ = {
 			isa = PBXGroup;
 			children = (
+				CAE643E1265C831E00C9E223 /* MapTransformable.swift */,
 				CAB77E462654ACE90071D74C /* CameraManagerProtocol.swift */,
 				CA6245FF26289D6400C79547 /* Cancelable.swift */,
 				CABCDF362620E03A00D61635 /* CredentialsManager.swift */,
@@ -2065,6 +2068,7 @@
 				0CD62F0F2458852D006421D1 /* PitchGestureHandler.swift in Sources */,
 				0C8D815524F6B4A800717E88 /* Value.swift in Sources */,
 				0CD62F0E2458852A006421D1 /* RotateGestureHandler.swift in Sources */,
+				CAE643E2265C831E00C9E223 /* MapTransformable.swift in Sources */,
 				0C1AF560244E47C1008D2A10 /* GestureOptions.swift in Sources */,
 				07729A592462461800440187 /* CameraOptions.swift in Sources */,
 				0CD62F1F24588734006421D1 /* LocationProviderDelegate.swift in Sources */,

--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -340,7 +340,10 @@
 		CAE43EE7265462B7006F43E9 /* MockMapFeatureQueryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE43EE4265462B7006F43E9 /* MockMapFeatureQueryable.swift */; };
 		CAE43EE8265462B7006F43E9 /* MapboxMapsAnnotationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE43EE5265462B7006F43E9 /* MapboxMapsAnnotationsTests.swift */; };
 		CAE43EEA26546426006F43E9 /* MapViewIntegrationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA53616D2537ECA600A8AE38 /* MapViewIntegrationTestCase.swift */; };
-		CAE643E2265C831E00C9E223 /* MapTransformable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE643E1265C831E00C9E223 /* MapTransformable.swift */; };
+		CAE643E5265D7D4000C9E223 /* MapTransformDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE643E3265D7D4000C9E223 /* MapTransformDelegate.swift */; };
+		CAE643E6265D7D4000C9E223 /* MapProjectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE643E4265D7D4000C9E223 /* MapProjectionDelegate.swift */; };
+		CAE643E9265D7D6400C9E223 /* ProjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE643E8265D7D6400C9E223 /* ProjectionTests.swift */; };
+		CAE643EA265D7D6400C9E223 /* ProjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE643E8265D7D6400C9E223 /* ProjectionTests.swift */; };
 		CAED9FB1258C69DB003CCEFE /* MapViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAED9FAF258C69DB003CCEFE /* MapViewTests.swift */; };
 		CAEDA0B0258E8188003CCEFE /* MapViewIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAEDA0AE258E8188003CCEFE /* MapViewIntegrationTests.swift */; };
 /* End PBXBuildFile section */
@@ -761,7 +764,9 @@
 		CAE43EE12654627E006F43E9 /* TileStore+Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "TileStore+Tests.swift"; path = "../../Offline/TileStore+Tests.swift"; sourceTree = "<group>"; };
 		CAE43EE4265462B7006F43E9 /* MockMapFeatureQueryable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockMapFeatureQueryable.swift; sourceTree = "<group>"; };
 		CAE43EE5265462B7006F43E9 /* MapboxMapsAnnotationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapboxMapsAnnotationsTests.swift; sourceTree = "<group>"; };
-		CAE643E1265C831E00C9E223 /* MapTransformable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapTransformable.swift; sourceTree = "<group>"; };
+		CAE643E3265D7D4000C9E223 /* MapTransformDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapTransformDelegate.swift; sourceTree = "<group>"; };
+		CAE643E4265D7D4000C9E223 /* MapProjectionDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapProjectionDelegate.swift; sourceTree = "<group>"; };
+		CAE643E8265D7D6400C9E223 /* ProjectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectionTests.swift; sourceTree = "<group>"; };
 		CAED9FAF258C69DB003CCEFE /* MapViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewTests.swift; sourceTree = "<group>"; };
 		CAEDA0AE258E8188003CCEFE /* MapViewIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewIntegrationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1224,7 +1229,8 @@
 		1F11C1102421B05600F8397B /* MapboxMapsFoundation */ = {
 			isa = PBXGroup;
 			children = (
-				CAE643E1265C831E00C9E223 /* MapTransformable.swift */,
+				CAE643E4265D7D4000C9E223 /* MapProjectionDelegate.swift */,
+				CAE643E3265D7D4000C9E223 /* MapTransformDelegate.swift */,
 				CAB77E462654ACE90071D74C /* CameraManagerProtocol.swift */,
 				CA6245FF26289D6400C79547 /* Cancelable.swift */,
 				CABCDF362620E03A00D61635 /* CredentialsManager.swift */,
@@ -1251,6 +1257,7 @@
 		1F11C11B2421B05600F8397B /* MapboxMapsFoundationTests */ = {
 			isa = PBXGroup;
 			children = (
+				CAE643E7265D7D6400C9E223 /* Projection */,
 				B5A6921A262754DF00A03412 /* CredentialsManagerTests.swift */,
 				B5A69219262754DF00A03412 /* DelegatingMapClientTests.swift */,
 				B5A69216262754DF00A03412 /* DelegatingObserverTests.swift */,
@@ -1669,6 +1676,14 @@
 			path = Glyphs;
 			sourceTree = "<group>";
 		};
+		CAE643E7265D7D6400C9E223 /* Projection */ = {
+			isa = PBXGroup;
+			children = (
+				CAE643E8265D7D6400C9E223 /* ProjectionTests.swift */,
+			);
+			path = Projection;
+			sourceTree = "<group>";
+		};
 		CAED9FAE258C69A7003CCEFE /* Unit Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -2041,6 +2056,7 @@
 				0CD62F1024588530006421D1 /* GestureManager.swift in Sources */,
 				CAE43ED5265460FE006F43E9 /* MapFeatureQueryable.swift in Sources */,
 				0C708F3124EB1EE2003CE791 /* CircleLayer.swift in Sources */,
+				CAE643E6265D7D4000C9E223 /* MapProjectionDelegate.swift in Sources */,
 				0CD62F0724588501006421D1 /* PinchGestureHandler.swift in Sources */,
 				0782B17B258C236B00D5FCE5 /* MBXGeometry.swift in Sources */,
 				B529341D2624E9D6003B181C /* DelegatingMapClient.swift in Sources */,
@@ -2068,7 +2084,6 @@
 				0CD62F0F2458852D006421D1 /* PitchGestureHandler.swift in Sources */,
 				0C8D815524F6B4A800717E88 /* Value.swift in Sources */,
 				0CD62F0E2458852A006421D1 /* RotateGestureHandler.swift in Sources */,
-				CAE643E2265C831E00C9E223 /* MapTransformable.swift in Sources */,
 				0C1AF560244E47C1008D2A10 /* GestureOptions.swift in Sources */,
 				07729A592462461800440187 /* CameraOptions.swift in Sources */,
 				0CD62F1F24588734006421D1 /* LocationProviderDelegate.swift in Sources */,
@@ -2096,6 +2111,7 @@
 				0CD62F182458865A006421D1 /* CameraView.swift in Sources */,
 				0C088AC526387EA400107B5E /* DateProvider.swift in Sources */,
 				CAE43EDA26546192006F43E9 /* OfflineSwitch.swift in Sources */,
+				CAE643E5265D7D4000C9E223 /* MapTransformDelegate.swift in Sources */,
 				CA5890DB264B00CE0060987A /* WeakSet.swift in Sources */,
 				2B8637E62463F36400698135 /* DistanceFormatter.swift in Sources */,
 				CA9F8CE32641F95C00A8BCB6 /* StyleManagerProtocol.swift in Sources */,
@@ -2165,6 +2181,7 @@
 				CA4E2DD8264DC66F0039D80E /* MockLocationStyleDelegate.swift in Sources */,
 				CAE43EE7265462B7006F43E9 /* MockMapFeatureQueryable.swift in Sources */,
 				CAE43EE32654627E006F43E9 /* TileStore+Tests.swift in Sources */,
+				CAE643EA265D7D6400C9E223 /* ProjectionTests.swift in Sources */,
 				B53B8663260D719100C86BAA /* TestConveniences.swift in Sources */,
 				B53B8650260D718B00C86BAA /* Stub.swift in Sources */,
 				CA0B380D25C4C01400B3396E /* IntegrationTestCase.swift in Sources */,
@@ -2225,6 +2242,7 @@
 				CA0C43052602BF2D0054D9D0 /* LayerPositionTests.swift in Sources */,
 				0C32CA2425F982300057ED31 /* GeoJsonSourceTests.swift in Sources */,
 				0C5CFCF125BB951B0001E753 /* SkyLayerTests.swift in Sources */,
+				CAE643E9265D7D6400C9E223 /* ProjectionTests.swift in Sources */,
 				0C32CA2725F982300057ED31 /* VectorSourceTests.swift in Sources */,
 				CA548FDF251C404B00F829A3 /* MapboxMapsSnapshotTests.swift in Sources */,
 				CAE43EE22654627E006F43E9 /* TileStore+Tests.swift in Sources */,

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "a94ee53a29e4fa36d41f9156a9ece6501a6022b6",
+          "revision": "b293ea5976b2b91d8aceff8096e24107de94afad",
           "version": "10.0.0-beta.23"
         }
       },

--- a/Sources/MapboxMaps/Foundation/Camera/FlyToInterpolator.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/FlyToInterpolator.swift
@@ -78,8 +78,8 @@ internal struct FlyToInterpolator {
         // Unwrap
         let sourceCoordUnwrapped = sourceCoord.unwrapForShortestPath(destCoord)
 
-        let sourcePointTemp = Projection.project(for: sourceCoordUnwrapped, zoomScale: Double(sourceScale))
-        let destPointTemp   = Projection.project(for: destCoord, zoomScale: Double(sourceScale))
+        let sourcePointTemp = Projection.project(sourceCoordUnwrapped, zoomScale: Double(sourceScale))
+        let destPointTemp   = Projection.project(destCoord, zoomScale: Double(sourceScale))
         sourcePoint         = CGPoint(x: sourcePointTemp.x, y: sourcePointTemp.y)
         destPoint           = CGPoint(x: destPointTemp.x, y: destPointTemp.y)
 
@@ -215,7 +215,7 @@ internal struct FlyToInterpolator {
 
         let position = MercatorCoordinate(x: Double(interpolated.x), y: Double(interpolated.y))
 
-        return Projection.unproject(for: position, zoomScale: Double(sourceScale))
+        return Projection.unproject(position, zoomScale: Double(sourceScale))
     }
 
     /// Calculates the zoom level given a fraction in [0,1].

--- a/Sources/MapboxMaps/Foundation/Camera/FlyToInterpolator.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/FlyToInterpolator.swift
@@ -78,8 +78,8 @@ internal struct FlyToInterpolator {
         // Unwrap
         let sourceCoordUnwrapped = sourceCoord.unwrapForShortestPath(destCoord)
 
-        let sourcePointTemp = Projection.project(sourceCoordUnwrapped, zoomScale: Double(sourceScale))
-        let destPointTemp   = Projection.project(destCoord, zoomScale: Double(sourceScale))
+        let sourcePointTemp = Projection.project(sourceCoordUnwrapped, zoomScale: sourceScale)
+        let destPointTemp   = Projection.project(destCoord, zoomScale: sourceScale)
         sourcePoint         = CGPoint(x: sourcePointTemp.x, y: sourcePointTemp.y)
         destPoint           = CGPoint(x: destPointTemp.x, y: destPointTemp.y)
 
@@ -215,7 +215,7 @@ internal struct FlyToInterpolator {
 
         let position = MercatorCoordinate(x: Double(interpolated.x), y: Double(interpolated.y))
 
-        return Projection.unproject(position, zoomScale: Double(sourceScale))
+        return Projection.unproject(position, zoomScale: sourceScale)
     }
 
     /// Calculates the zoom level given a fraction in [0,1].

--- a/Sources/MapboxMaps/Foundation/MapProjectionDelegate.swift
+++ b/Sources/MapboxMaps/Foundation/MapProjectionDelegate.swift
@@ -51,7 +51,7 @@ internal protocol MapProjectionDelegate: AnyObject {
 }
 
 public class Projection: MapProjectionDelegate {
-    private init() {}
+    internal init() {}
 
     public static func metersPerPoint(for latitude: CLLocationDegrees, zoom: CGFloat) -> Double {
         return MapboxCoreMaps.Projection.getMetersPerPixelAtLatitude(forLatitude: latitude, zoom: Double(zoom))

--- a/Sources/MapboxMaps/Foundation/MapProjectionDelegate.swift
+++ b/Sources/MapboxMaps/Foundation/MapProjectionDelegate.swift
@@ -1,0 +1,73 @@
+import CoreLocation
+
+public protocol MapProjectionDelegate {
+    /// Calculate distance spanned by one pixel at the specified latitude and
+    /// zoom level.
+    ///
+    /// - Parameters:
+    ///   - latitude: The latitude for which to return the value
+    ///   - zoom: The zoom level
+    ///
+    /// - Returns: Meters
+    static func metersPerPoint(for latitude: CLLocationDegrees, zoom: CGFloat) -> Double
+
+    /// Calculate Spherical Mercator ProjectedMeters coordinates.
+    /// - Parameter coordinate: Coordinate at which to calculate the projected
+    ///     meters
+    ///
+    /// - Returns: Spherical Mercator ProjectedMeters coordinates
+    static func projectedMeters(for coordinate: CLLocationCoordinate2D) -> ProjectedMeters
+
+    /// Calculate a coordinate for a Spherical Mercator projected
+    /// meters.
+    ///
+    /// - Parameter projectedMeters: Spherical Mercator ProjectedMeters coordinates
+    ///
+    /// - Returns: A coordinate
+    static func coordinate(for projectedMeters: ProjectedMeters) -> CLLocationCoordinate2D
+
+    /// Calculate a point on the map in Mercator Projection for a given
+    /// coordinate at the specified zoom scale.
+    ///
+    /// - Parameters:
+    ///   - coordinate: The coordinate for which to return the value.
+    ///   - zoomScale: The current zoom factor applied on the map, is used to
+    ///         calculate the world size as tileSize * zoomScale (i.e.
+    ///         512 * 2 ^ Zoom level) where tileSize is the width of a tile
+    ///         in points.
+    /// - Returns: Mercator coordinate
+    static func project(_ coordinate: CLLocationCoordinate2D, zoomScale: CGFloat) -> MercatorCoordinate
+
+    /// Calculate a coordinate for a given point on the map in Mercator Projection.
+    ///
+    /// - Parameters:
+    ///   - mercatorCoordinate: Point on the map in Mercator projection.
+    ///   - zoomScale: The current zoom factor applied on the map, is used to
+    ///         calculate the world size as tileSize * zoomScale (i.e.
+    ///         512 * 2 ^ Zoom level) where tileSize is the width of a tile in
+    ///         points.
+    /// - Returns: Unprojected coordinate
+    static func unproject(_ mercatorCoordinate: MercatorCoordinate, zoomScale: CGFloat) -> CLLocationCoordinate2D
+}
+
+struct Projection: MapProjectionDelegate {
+    public static func metersPerPoint(for latitude: CLLocationDegrees, zoom: CGFloat) -> Double {
+        return MapboxCoreMaps.Projection.getMetersPerPixelAtLatitude(forLatitude: latitude, zoom: Double(zoom))
+    }
+
+    public static func projectedMeters(for coordinate: CLLocationCoordinate2D) -> ProjectedMeters {
+        return MapboxCoreMaps.Projection.projectedMetersForCoordinate(for: coordinate)
+    }
+
+    public static func coordinate(for projectedMeters: ProjectedMeters) -> CLLocationCoordinate2D {
+        return MapboxCoreMaps.Projection.coordinateForProjectedMeters(for: projectedMeters)
+    }
+
+    public static func project(_ coordinate: CLLocationCoordinate2D, zoomScale: CGFloat) -> MercatorCoordinate {
+        return MapboxCoreMaps.Projection.project(for: coordinate, zoomScale: Double(zoomScale))
+    }
+
+    public static func unproject(_ mercatorCoordinate: MercatorCoordinate, zoomScale: CGFloat) -> CLLocationCoordinate2D {
+        return MapboxCoreMaps.Projection.unproject(for: mercatorCoordinate, zoomScale: Double(zoomScale))
+    }
+}

--- a/Sources/MapboxMaps/Foundation/MapProjectionDelegate.swift
+++ b/Sources/MapboxMaps/Foundation/MapProjectionDelegate.swift
@@ -1,6 +1,6 @@
 import CoreLocation
 
-public protocol MapProjectionDelegate {
+internal protocol MapProjectionDelegate: AnyObject {
     /// Calculate distance spanned by one pixel at the specified latitude and
     /// zoom level.
     ///
@@ -50,7 +50,9 @@ public protocol MapProjectionDelegate {
     static func unproject(_ mercatorCoordinate: MercatorCoordinate, zoomScale: CGFloat) -> CLLocationCoordinate2D
 }
 
-struct Projection: MapProjectionDelegate {
+public class Projection: MapProjectionDelegate {
+    private init() {}
+
     public static func metersPerPoint(for latitude: CLLocationDegrees, zoom: CGFloat) -> Double {
         return MapboxCoreMaps.Projection.getMetersPerPixelAtLatitude(forLatitude: latitude, zoom: Double(zoom))
     }

--- a/Sources/MapboxMaps/Foundation/MapTransformDelegate.swift
+++ b/Sources/MapboxMaps/Foundation/MapTransformDelegate.swift
@@ -1,4 +1,4 @@
-internal protocol MapTransformable {
+internal protocol MapTransformDelegate: AnyObject {
     /// Gets the size of the map in points
     var size: CGSize { get set }
 

--- a/Sources/MapboxMaps/Foundation/MapTransformable.swift
+++ b/Sources/MapboxMaps/Foundation/MapTransformable.swift
@@ -1,0 +1,31 @@
+internal protocol MapTransformable {
+    /// Gets the size of the map in points
+    var size: CGSize { get set }
+
+    /// Notify map about gesture being in progress.
+    var isGestureInProgress: Bool { get set }
+
+    /// Tells the map rendering engine that the animation is currently performed
+    /// by the user (e.g. with a `setCamera()` calls series). It adjusts the
+    /// engine for the animation use case.
+    /// In particular, it brings more stability to symbol placement and rendering.
+    var isUserAnimationInProgress: Bool { get set }
+
+    /// Returns the map's options
+    var options: MapOptions { get }
+
+    /// Set the map north orientation
+    ///
+    /// - Parameter northOrientation: The map north orientation to set
+    func setNorthOrientation(northOrientation: NorthOrientation)
+
+    /// Set the map constrain mode
+    ///
+    /// - Parameter constrainMode: The map constraint mode to set
+    func setConstrainMode(_ constrainMode: ConstrainMode)
+
+    /// Set the map viewport mode
+    ///
+    /// - Parameter viewportMode: The map viewport mode to set
+    func setViewportMode(_ viewportMode: ViewportMode)
+}

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -160,7 +160,7 @@ public final class MapboxMap {
     }
 }
 
-extension MapboxMap: MapTransformable {
+extension MapboxMap: MapTransformDelegate {
     internal var size: CGSize {
         get {
             CGSize(__map.getSize())

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -8,15 +8,6 @@ public final class MapboxMap {
     /// The underlying renderer object responsible for rendering the map
     private let __map: Map
 
-    internal var size: CGSize {
-        get {
-            CGSize(__map.getSize())
-        }
-        set {
-            __map.setSizeFor(Size(newValue))
-        }
-    }
-
     /// The `style` object supports run time styling.
     public internal(set) var style: Style
 
@@ -106,11 +97,6 @@ public final class MapboxMap {
         }
     }
 
-    /// Returns the map's options
-    public var options: MapOptions {
-        return __map.getOptions()
-    }
-
     /// Reduces memory use. Useful to call when the application gets paused or
     /// sent to background.
     internal func reduceMemoryUse() {
@@ -171,6 +157,51 @@ public final class MapboxMap {
         rect = rect.extend(from: nePoint)
 
         return rect
+    }
+}
+
+extension MapboxMap: MapTransformable {
+    internal var size: CGSize {
+        get {
+            CGSize(__map.getSize())
+        }
+        set {
+            __map.setSizeFor(Size(newValue))
+        }
+    }
+
+    internal var isGestureInProgress: Bool {
+        get {
+            return __map.isGestureInProgress()
+        }
+        set {
+            __map.setGestureInProgressForInProgress(newValue)
+        }
+    }
+
+    internal var isUserAnimationInProgress: Bool {
+        get {
+            return __map.isUserAnimationInProgress()
+        }
+        set {
+            __map.setUserAnimationInProgressForInProgress(newValue)
+        }
+    }
+
+    public var options: MapOptions {
+        return __map.getOptions()
+    }
+
+    internal func setNorthOrientation(northOrientation: NorthOrientation) {
+        __map.setNorthOrientationFor(northOrientation)
+    }
+
+    internal func setConstrainMode(_ constrainMode: ConstrainMode) {
+        __map.setConstrainModeFor(constrainMode)
+    }
+
+    internal func setViewportMode(_ viewportMode: ViewportMode) {
+        __map.setViewportModeFor(viewportMode)
     }
 }
 

--- a/Sources/MapboxMaps/MapView/MapView+Supportable.swift
+++ b/Sources/MapboxMaps/MapView/MapView+Supportable.swift
@@ -37,7 +37,7 @@ extension MapView: LocationSupportableMapView {
     }
 
     public func metersPerPointAtLatitude(latitude: CLLocationDegrees) -> CLLocationDistance {
-        return Projection.getMetersPerPixelAtLatitude(forLatitude: latitude, zoom: Double(cameraState.zoom))
+        return Projection.metersPerPoint(for: latitude, zoom: cameraState.zoom)
     }
 
     public func subscribeRenderFrameHandler(_ handler: @escaping (MapboxCoreMaps.Event) -> Void) {

--- a/Sources/MapboxMaps/Offline/TileStore+MapboxMaps.swift
+++ b/Sources/MapboxMaps/Offline/TileStore+MapboxMaps.swift
@@ -158,8 +158,8 @@ extension TileStore {
     ///     user-controlled thread.
     public func tileRegionGeometry(forId id: String,
                                    completion: @escaping (Result<Geometry, Error>) -> Void) {
-        __getTileRegion(forId: id,
-                        callback: tileStoreClosureAdapter(for: completion, type: Geometry.self))
+        __getTileRegionGeometry(forId: id,
+                                callback: tileStoreClosureAdapter(for: completion, type: Geometry.self))
     }
 
     /// Fetch a tile region's associated metadata

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -67,9 +67,9 @@ public class OrnamentsManager: NSObject {
         view.subscribeCameraChangeHandler { [scalebarView, compassView] (cameraState) in
 
             // Update the scale bar
-            scalebarView.metersPerPoint = Projection.getMetersPerPixelAtLatitude(
-                forLatitude: cameraState.center.latitude,
-                zoom: Double(cameraState.zoom))
+            scalebarView.metersPerPoint = Projection.metersPerPoint(
+                for: cameraState.center.latitude,
+                zoom: cameraState.zoom)
 
             // Update the compass
             compassView.currentBearing = Double(cameraState.bearing)

--- a/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
@@ -140,4 +140,15 @@ final class MapboxMapTests: XCTestCase {
         XCTAssertEqual(camera.padding, .zero)
         XCTAssertEqual(camera.pitch, 0)
     }
+
+    func testProtocolConformance() {
+        let map = MapboxMap(mapClient: MockMapClient(), mapInitOptions: MapInitOptions())
+
+        // Compilation check only
+        _ = map as MapTransformDelegate
+        _ = map as CameraManagerProtocol
+        _ = map as MapFeatureQueryable
+        _ = map as ObservableProtocol
+        _ = map as MapEventsObservable
+    }
 }

--- a/Tests/MapboxMapsTests/Foundation/Projection/ProjectionTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Projection/ProjectionTests.swift
@@ -47,11 +47,13 @@ class ProjectionTests: XCTestCase {
         let lat45 = 2946.8675024093595
         let minusLat45 = 5245.132497590641
         let coords = [
-            (CLLocationCoordinate2D(latitude: 45, longitude: -180), MercatorCoordinate(x: 0,    y: lat45)),     // top left
-            (CLLocationCoordinate2D(latitude: 45, longitude: 180),  MercatorCoordinate(x: 8192, y: lat45)),     // top right
-            (CLLocationCoordinate2D(latitude: -45, longitude: -180),MercatorCoordinate(x: 0,    y: minusLat45)),  // bot left
-            (CLLocationCoordinate2D(latitude: -45, longitude: 180), MercatorCoordinate(x: 8192, y: minusLat45)),  // bot right
-            (CLLocationCoordinate2D(latitude: 0, longitude: 0),     MercatorCoordinate(x: 4096, y: 4096)),  // middle
+            // swiftlint:disable comma
+            (CLLocationCoordinate2D(latitude: 45, longitude: -180),  MercatorCoordinate(x: 0,    y: lat45)),        // top left
+            (CLLocationCoordinate2D(latitude: 45, longitude: 180),   MercatorCoordinate(x: 8192, y: lat45)),        // top right
+            (CLLocationCoordinate2D(latitude: -45, longitude: -180), MercatorCoordinate(x: 0,    y: minusLat45)),   // bot left
+            (CLLocationCoordinate2D(latitude: -45, longitude: 180),  MercatorCoordinate(x: 8192, y: minusLat45)),   // bot right
+            (CLLocationCoordinate2D(latitude: 0, longitude: 0),      MercatorCoordinate(x: 4096, y: 4096)),         // middle
+            // swiftlint:enable comma
         ]
 
         let zoom: CGFloat = 4

--- a/Tests/MapboxMapsTests/Foundation/Projection/ProjectionTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Projection/ProjectionTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import MapboxMaps
+
+class ProjectionTests: XCTestCase {
+
+    var projectorType: MapProjectionDelegate.Type!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        projectorType = Projection.self
+    }
+
+    func testMetersPerPoint() {
+        let metersPerPointN = projectorType.metersPerPoint(for: 40.0, zoom: 16)
+        let metersPerPointS = projectorType.metersPerPoint(for: -40.0, zoom: 16)
+
+        XCTAssertEqual(metersPerPointN, metersPerPointS)
+        XCTAssertEqual(metersPerPointN, 0.91388626079034951, accuracy: 0.000001)
+    }
+
+    func testProjectedMeters() {
+        let coords = [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            CLLocationCoordinate2D(latitude: 0, longitude: 180),
+            CLLocationCoordinate2D(latitude: 0, longitude: -180),
+            CLLocationCoordinate2D(latitude: 45, longitude: 90),
+            CLLocationCoordinate2D(latitude: -45, longitude: -90),
+        ]
+
+        let projectedMeters: [ProjectedMeters] = coords.map {
+            let meters = projectorType.projectedMeters(for: $0)
+
+            // Test round trip
+            let coordinate = projectorType.coordinate(for: meters)
+            XCTAssertEqual(coordinate.latitude, $0.latitude, accuracy: 0.000001)
+            XCTAssertEqual(coordinate.longitude, $0.longitude, accuracy: 0.000001)
+            return meters
+        }
+
+        XCTAssertEqual(projectedMeters[1].easting, -projectedMeters[2].easting, accuracy: 0.000001)
+        XCTAssertEqual(projectedMeters[3].easting, -projectedMeters[4].easting, accuracy: 0.000001)
+        XCTAssertEqual(projectedMeters[3].northing, -projectedMeters[4].northing, accuracy: 0.000001)
+    }
+
+    func testProject() {
+
+        let lat45 = 2946.8675024093595
+        let minusLat45 = 5245.132497590641
+        let coords = [
+            (CLLocationCoordinate2D(latitude: 45, longitude: -180), MercatorCoordinate(x: 0,    y: lat45)),     // top left
+            (CLLocationCoordinate2D(latitude: 45, longitude: 180),  MercatorCoordinate(x: 8192, y: lat45)),     // top right
+            (CLLocationCoordinate2D(latitude: -45, longitude: -180),MercatorCoordinate(x: 0,    y: minusLat45)),  // bot left
+            (CLLocationCoordinate2D(latitude: -45, longitude: 180), MercatorCoordinate(x: 8192, y: minusLat45)),  // bot right
+            (CLLocationCoordinate2D(latitude: 0, longitude: 0),     MercatorCoordinate(x: 4096, y: 4096)),  // middle
+        ]
+
+        let zoom: CGFloat = 4
+        let zoomScale = pow(2, zoom)
+
+        for coord in coords {
+            let mercator = projectorType.project(coord.0, zoomScale: zoomScale)
+            XCTAssertEqual(mercator.x, coord.1.x, accuracy: 0.0000001)
+            XCTAssertEqual(mercator.y, coord.1.y, accuracy: 0.0000001)
+
+            // Test round trip
+            let coordinate = projectorType.unproject(mercator, zoomScale: zoomScale)
+            XCTAssertEqual(coordinate.latitude, coord.0.latitude, accuracy: 0.0000001)
+            XCTAssertEqual(coordinate.longitude, coord.0.longitude, accuracy: 0.0000001)
+        }
+    }
+
+    func testMercatorMinMaxProject() {
+        let northPole = CLLocationCoordinate2D(latitude: 90, longitude: 0)
+        let southPole = CLLocationCoordinate2D(latitude: -90, longitude: 0)
+
+        let zoom: CGFloat = 0
+        let zoomScale = pow(2, zoom)
+
+        let northMercator = projectorType.project(northPole, zoomScale: zoomScale)
+        let northPole2 = projectorType.unproject(northMercator, zoomScale: zoomScale)
+        XCTAssertNotEqual(northPole2.latitude, northPole.latitude)
+        XCTAssertEqual(northPole2.latitude, 85.051, accuracy: 0.001)
+
+        let southMercator = projectorType.project(southPole, zoomScale: zoomScale)
+        let southPole2 = projectorType.unproject(southMercator, zoomScale: zoomScale)
+        XCTAssertNotEqual(southPole2.latitude, southPole.latitude)
+        XCTAssertEqual(southPole2.latitude, -85.051, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [X] Document any changes to public APIs.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR:
- Introduces `MapTransformDelegate` and `MapProjectionDelegate` protocols, both currently `internal`
- Creates a platform specific `Projection` class that implements `MapProjectionDelegate`, shadowing the one from MapboxCoreMaps.
- Fixes a minor TileStore bug with `tileRegionGeometry`

The two protocols match Android, except for [`getMetersPerPixelAtLatitude(latitude: Double)`](https://github.com/mapbox/mapbox-maps-android/blob/52cb487484d3b0c5db48fcd5b7df9e0ebbcffcbc/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/MapProjectionDelegate.kt#L22-L30). Also on Android `MapboxMap` conforms to `MapProjectionDelegate`, for iOS it's a new platform `Projection`

### Developer impact

Developers will need to update any existing use of `Projection` in their code.