### PR TITLE
handle rotation for debug app by enabling autoresizing

### DIFF
--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -18,8 +18,9 @@ public class DebugViewController: UIViewController {
 
         // Deliberately set nil style
         mapView = MapView(frame: view.bounds, mapInitOptions: MapInitOptions(styleURI: nil))
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.location.options.puckType = .puck2D()
-
+        
         view.addSubview(mapView)
 
         // Convenience that takes a closure that's called when the style

--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -20,7 +20,7 @@ public class DebugViewController: UIViewController {
         mapView = MapView(frame: view.bounds, mapInitOptions: MapInitOptions(styleURI: nil))
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.location.options.puckType = .puck2D()
-        
+
         view.addSubview(mapView)
 
         // Convenience that takes a closure that's called when the style


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Before (upon rotation from portrait to landscape):
![simulator_screenshot_0C2C2F4C-087C-409D-B3DC-4CCF88001226](https://user-images.githubusercontent.com/1863410/119539284-3d154b00-bd49-11eb-8ac1-67c5136a5776.png)

After (upon rotation from portrait to landscape): 
![simulator_screenshot_9D38ADF9-E6F4-46D5-8CD3-F891E0D4B913](https://user-images.githubusercontent.com/1863410/119539609-9b422e00-bd49-11eb-9de5-817f74e267bf.png)

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

This pull request applies a fix for device orientation handling in the debug examples by adding an autoresizing mask to the DebugViewController's view.
