### PR TITLE
Use native scale for metalview to avoid stretching

### DIFF
--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -332,7 +332,6 @@ extension MapView: DelegatingMapClientDelegate {
 
         metalView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         metalView.autoResizeDrawable = true
-        metalView.contentScaleFactor = UIScreen.main.scale
         metalView.contentMode = .center
         metalView.isOpaque = isOpaque
         metalView.layer.isOpaque = isOpaque


### PR DESCRIPTION
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: MapView stretching on CarPlay displays

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

Removes the explicit setting of `contentScaleFactor` on metalView (MTKView) so that we use [nativeScale](https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/NativeScreenScale.html) by default. 

Verified by testing on 
- 2x handheld device (iPhone SE simulator) 
![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-05-25 at 12 19 39](https://user-images.githubusercontent.com/1863410/119548483-7d79c680-bd53-11eb-8d9a-243aef97ff9b.png)

- 3x handheld device (iPhone 11 Pro Max simulator) 
![Simulator Screen Shot - iPhone 11 Pro Max - 2021-05-25 at 12 18 46](https://user-images.githubusercontent.com/1863410/119548404-6c30ba00-bd53-11eb-9be2-17d175ba05c1.png)

- iPad simulator (various)
![Simulator Screen Shot - iPad Pro (9 7-inch) - 2021-05-25 at 12 12 15](https://user-images.githubusercontent.com/1863410/119548434-705cd780-bd53-11eb-9550-5a9f2ac2840b.png)

- CarPlay simulator with 2x scale factor
![CarPlay-2x](https://user-images.githubusercontent.com/1863410/119547342-3a6b2380-bd52-11eb-94e0-ddb1115d73e7.png)

- CarPlay simulator with 3x scale factor
![CarPlay-3x](https://user-images.githubusercontent.com/1863410/119547350-3e974100-bd52-11eb-966f-536a01519fb7.png)

Previously we implemented a contentScaleFactor to match NativeScale. However, Metal implements this by default so explicit setting is not necessary.  (Reference: https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/NativeScreenScale.html)