### PR TITLE
Add destroyRenderer to MapboxMap deinit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### Bug fixes 🐞
 
-- Fixed bug with `TileStore.tileRegionGeometry` returning invalid value. ([#390](https://github.com/mapbox/mapbox-maps-ios/pull/390))
+- Fixed a bug with `TileStore.tileRegionGeometry` returning invalid value. ([#390](https://github.com/mapbox/mapbox-maps-ios/pull/390))
+- Fixed a bug where the underlying renderer was not being destroyed. ([#395](https://github.com/mapbox/mapbox-maps-ios/pull/395))
 
 ### Features ✨ and improvements 🏁
 

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -94,6 +94,10 @@ open class MapView: UIView {
         return CGPoint(x: xAfterPadding, y: yAfterPadding)
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     /// Initialize a MapView
     /// - Parameters:
     ///   - frame: frame for the MapView.
@@ -137,6 +141,10 @@ open class MapView: UIView {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(willTerminate),
                                                name: UIApplication.willTerminateNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(didReceiveMemoryWarning),
+                                               name: UIApplication.didReceiveMemoryWarningNotification,
                                                object: nil)
 
         // Use the overriding style URI if provided (currently from IB)
@@ -308,6 +316,10 @@ open class MapView: UIView {
             validateDisplayLink()
             dormant = true
         }
+    }
+
+    @objc func didReceiveMemoryWarning() {
+        mapboxMap.reduceMemoryUse()
     }
 
     required public init?(coder: NSCoder) {

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -17,6 +17,7 @@ public final class MapboxMap {
         eventHandlers.allObjects.forEach {
             $0.cancel()
         }
+        __map.destroyRenderer()
     }
 
     internal init(mapClient: MapClient, mapInitOptions: MapInitOptions) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

This PR:
- adds a call to `destroyRenderer()` in `MapboxMap.deinit`.
- adds a call to `reduceMemoryUse()` when a low memory warning is received
- Removes MapView as a notification observer.