### PR TITLE
Make GestureManager.delegate public

### DIFF
--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -25,7 +25,8 @@ public final class GestureManager: NSObject {
     /// The camera manager that responds to gestures.
     internal let cameraManager: CameraAnimationsManagerProtocol
 
-    internal weak var delegate: GestureManagerDelegate?
+    /// Set this delegate to be called back if a gesture begins
+    public weak var delegate: GestureManagerDelegate?
 
     internal init(for view: UIView, cameraManager: CameraAnimationsManagerProtocol) {
         self.cameraManager = cameraManager


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes https://github.com/mapbox/mapbox-maps-ios/issues/389

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>GestureManager.delegate is now public again.</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes
This PR makes `GestureManager.delegate` public. This was mistakenly made internal in an earlier PR.