### PR TITLE
Re-enable snapshot tests

### DIFF
--- a/Tests/MapboxMapsTests/Snapshot/MapboxMapsSnapshotTests.swift
+++ b/Tests/MapboxMapsTests/Snapshot/MapboxMapsSnapshotTests.swift
@@ -129,9 +129,6 @@ class MapboxMapsSnapshotTests: XCTestCase {
         snapshotterNew.start(overlayHandler: nil) { (result) in
             switch result {
             case let .success(image) :
-                let newAttachment = XCTAttachment(image: image)
-                newAttachment.lifetime = .keepAlways
-                self.add(newAttachment)
                 // Compare snapshot asset data vs snapshot image data
                 let path = Bundle.mapboxMapsTests.path(forResource: "Snapshot-Asset", ofType: "png")!
                 let url = URL(fileURLWithPath: path)
@@ -140,6 +137,9 @@ class MapboxMapsSnapshotTests: XCTestCase {
                 if expectedImageData != image.pngData() {
                     // TODO: Image comparison
                     print("warning: Image data does not match.")
+                    let newAttachment = XCTAttachment(image: image)
+                    newAttachment.lifetime = .keepAlways
+                    self.add(newAttachment)
                 }
                 XCTAssertEqual(expectedImageData.count, image.pngData()!.count, accuracy: 5000)
 

--- a/Tests/MapboxMapsTests/Snapshot/MapboxMapsSnapshotTests.swift
+++ b/Tests/MapboxMapsTests/Snapshot/MapboxMapsSnapshotTests.swift
@@ -11,6 +11,11 @@ class MapboxMapsSnapshotTests: XCTestCase {
     var newAttachment: XCTAttachment!
     var resourceOptions: ResourceOptions!
 
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try guardForMetalDevice()
+    }
+
     // Create snapshot options
     private func snapshotterOptions() throws -> MapSnapshotOptions {
         let accessToken = try mapboxAccessToken()
@@ -131,8 +136,11 @@ class MapboxMapsSnapshotTests: XCTestCase {
                 let path = Bundle.mapboxMapsTests.path(forResource: "Snapshot-Asset", ofType: "png")!
                 let url = URL(fileURLWithPath: path)
                 let expectedImageData = try! Data(contentsOf: url)
-                // TO DO Image comparison
-//                XCTAssertEqual(expectedImageData, image.pngData(), "has the camera changed?")
+
+                if expectedImageData != image.pngData() {
+                    // TODO: Image comparison
+                    print("warning: Image data does not match.")
+                }
                 XCTAssertEqual(expectedImageData.count, image.pngData()!.count, accuracy: 5000)
 
             case.failure :

--- a/Tests/MapboxMapsTests/Snapshot/MapboxMapsSnapshotTests.swift
+++ b/Tests/MapboxMapsTests/Snapshot/MapboxMapsSnapshotTests.swift
@@ -38,7 +38,7 @@ class MapboxMapsSnapshotTests: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
-    func TODO_testCapturingSnapshotterInSnapshotCompletion() throws {
+    func testCapturingSnapshotterInSnapshotCompletion() throws {
         weak var weakSnapshotter: Snapshotter?
         try autoreleasepool {
             let expectation = self.expectation(description: "snapshot")
@@ -58,7 +58,7 @@ class MapboxMapsSnapshotTests: XCTestCase {
     }
 
     // Testing snapshot overlay
-    func TODO_testSnapshotOverlay() throws {
+    func testSnapshotOverlay() throws {
         let options = try snapshotterOptions()
         let snapshotter = Snapshotter(options: options)
         let cameraOptions = CameraOptions(center: CLLocationCoordinate2D(latitude: 38.9180379, longitude: -77.0600235), zoom: 5)
@@ -86,7 +86,7 @@ class MapboxMapsSnapshotTests: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
-    func TODO_testSnapshotSizeAndScaleAccuracy() {
+    func testSnapshotSizeAndScaleAccuracy() {
         let imageRect = CGRect(x: 0, y: 0, width: 300, height: 300)
         let options = try! snapshotterOptions()
         let snapshotter = Snapshotter(options: options) //should have protocol for GLnative (may have been ticketed)
@@ -114,7 +114,7 @@ class MapboxMapsSnapshotTests: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
-    func TODO_testSnapshotLogoVisibility() throws {
+    func testSnapshotLogoVisibility() throws {
         let options = try snapshotterOptions()
         let snapshotterNew = Snapshotter(options: options)
         let cameraOptions = CameraOptions(center: CLLocationCoordinate2D(latitude: 38.9180379, longitude: -77.0600235), zoom: 5)


### PR DESCRIPTION
This PR re-enables snapshot tests that were disabled due to crashes.