### PR TITLE
Remove ResourceOptionsManager.reset

### DIFF
--- a/Sources/MapboxMaps/Foundation/ResourceOptionsManager.swift
+++ b/Sources/MapboxMaps/Foundation/ResourceOptionsManager.swift
@@ -35,10 +35,9 @@ public class ResourceOptionsManager {
         return defaultInstance!
     }
 
-    /// :nodoc:
     /// Convenience function to remove the default instance. Calling `default`
     /// again will re-create the default instance.
-    internal static func destroyDefault() {
+    public static func destroyDefault() {
         defaultInstance = nil
     }
 
@@ -91,14 +90,6 @@ public class ResourceOptionsManager {
     internal init(resourceOptions: ResourceOptions, for bundle: Bundle) {
         self.bundle = bundle
         update(resourceOptions)
-    }
-
-    /// Reset the manager to a default `ResourceOptions` using the specified
-    /// access token.
-    ///
-    /// - Parameter accessToken: Valid access token or `nil`
-    internal func reset(resourceOptions: ResourceOptions? = nil) {
-        self.resourceOptions = resourceOptions ?? ResourceOptions(accessToken: defaultAccessToken())
     }
 
     private func update(_ resourceOptions: ResourceOptions) {

--- a/Tests/MapboxMapsTests/Foundation/ResourceOptionsManagerTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/ResourceOptionsManagerTests.swift
@@ -5,7 +5,7 @@ class ResourceOptionsManagerTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        ResourceOptionsManager.default.reset()
+        ResourceOptionsManager.destroyDefault()
     }
 
     override func tearDownWithError() throws {
@@ -45,16 +45,14 @@ class ResourceOptionsManagerTests: XCTestCase {
     }
 
     func testResettingResourceOptionsManager() throws {
-        let resourceOptions = ResourceOptions(accessToken: "")
-        let rom = ResourceOptionsManager(resourceOptions: resourceOptions, for: .mapboxMapsTests)
-        let token = rom.resourceOptions.accessToken
+        let token = ResourceOptionsManager.default.resourceOptions.accessToken
 
-        rom.resourceOptions.accessToken = "custom-token"
+        ResourceOptionsManager.default.resourceOptions.accessToken = "custom-token"
 
-        XCTAssertEqual("custom-token", rom.resourceOptions.accessToken, "Resource options is a value type")
+        XCTAssertEqual("custom-token", ResourceOptionsManager.default.resourceOptions.accessToken, "Resource options is a value type")
 
-        rom.reset()
+        ResourceOptionsManager.destroyDefault()
 
-        XCTAssertEqual(token, rom.resourceOptions.accessToken, "Token should have been reset")
+        XCTAssertEqual(token, ResourceOptionsManager.default.resourceOptions.accessToken, "Token should have been reset")
     }
 }


### PR DESCRIPTION
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Updated ~Write tests for all new functionality. If tests were not written, please explain why.~
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

This PR removes `ResourceOptionsManager.reset` which had limited functionality, and makes `destroyDefault` public.