### PR TITLE
Fix Car Play Stretching

### DIFF
--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -347,7 +347,7 @@ extension MapView: DelegatingMapClientDelegate {
         metalView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         metalView.autoResizeDrawable = true
         metalView.contentScaleFactor = pixelRatio
-        metalView.contentMode = .scaleAspectFill
+        metalView.contentMode = .scaleToFill
         metalView.isOpaque = isOpaque
         metalView.layer.isOpaque = isOpaque
         metalView.isPaused = true

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -347,7 +347,7 @@ extension MapView: DelegatingMapClientDelegate {
         metalView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         metalView.autoResizeDrawable = true
         metalView.contentScaleFactor = pixelRatio
-        metalView.contentMode = .scaleToFill
+        metalView.contentMode = .scaleAspectFill
         metalView.isOpaque = isOpaque
         metalView.layer.isOpaque = isOpaque
         metalView.isPaused = true

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -69,6 +69,8 @@ open class MapView: UIView {
     private var displayCallback: (() -> Void)?
     @objc dynamic internal var displayLink: CADisplayLink?
 
+    /// Holding onto this value that comes from `MapOptions` since there is a race condition between
+    /// getting a `MetalView`, and intializing a `MapView`
     private var pixelRatio: CGFloat = 0.0
 
     @IBInspectable private var styleURI__: String = ""

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -347,7 +347,7 @@ extension MapView: DelegatingMapClientDelegate {
         metalView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         metalView.autoResizeDrawable = true
         metalView.contentScaleFactor = pixelRatio
-        metalView.contentMode = .scaleToFill
+        metalView.contentMode = .center
         metalView.isOpaque = isOpaque
         metalView.layer.isOpaque = isOpaque
         metalView.isPaused = true

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -69,6 +69,8 @@ open class MapView: UIView {
     private var displayCallback: (() -> Void)?
     @objc dynamic internal var displayLink: CADisplayLink?
 
+    private var pixelRatio: CGFloat = 3.0 /// Same default value as found in `MapInitOptions`
+
     @IBInspectable private var styleURI__: String = ""
 
     /// Outlet that can be used when initializing a MapView with a Storyboard or
@@ -135,6 +137,9 @@ open class MapView: UIView {
         } else {
             resolvedMapInitOptions = mapInitOptions
         }
+
+        self.pixelRatio = CGFloat(resolvedMapInitOptions.mapOptions.pixelRatio)
+
         mapClient.delegate = self
         mapboxMap = MapboxMap(mapClient: mapClient, mapInitOptions: resolvedMapInitOptions)
 
@@ -341,8 +346,8 @@ extension MapView: DelegatingMapClientDelegate {
 
         metalView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         metalView.autoResizeDrawable = true
-        metalView.contentScaleFactor = CGFloat(self.mapboxMap.options.pixelRatio)
-        metalView.contentMode = .center
+        metalView.contentScaleFactor = pixelRatio
+        metalView.contentMode = .scaleToFill
         metalView.isOpaque = isOpaque
         metalView.layer.isOpaque = isOpaque
         metalView.isPaused = true

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -341,7 +341,7 @@ extension MapView: DelegatingMapClientDelegate {
 
         metalView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         metalView.autoResizeDrawable = true
-        metalView.contentScaleFactor = UIScreen.main.scale
+        metalView.contentScaleFactor = CGFloat(self.mapboxMap.options.pixelRatio)
         metalView.contentMode = .center
         metalView.isOpaque = isOpaque
         metalView.layer.isOpaque = isOpaque

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -69,7 +69,7 @@ open class MapView: UIView {
     private var displayCallback: (() -> Void)?
     @objc dynamic internal var displayLink: CADisplayLink?
 
-    private var pixelRatio: CGFloat = 3.0 /// Same default value as found in `MapInitOptions`
+    private var pixelRatio: CGFloat = 0.0
 
     @IBInspectable private var styleURI__: String = ""
 


### PR DESCRIPTION
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: MapView stretching on CarPlay displays

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

Removes the explicit setting of `contentScaleFactor` on metalView (MTKView) so that we use [nativeScale](https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/NativeScreenScale.html) by default. 

Verified by testing on 
- 2x handheld device (iPhone SE simulator) 
![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-05-25 at 12 19 39](https://user-images.githubusercontent.com/1863410/119548483-7d79c680-bd53-11eb-8d9a-243aef97ff9b.png)

- 3x handheld device (iPhone 11 Pro Max simulator) 
![Simulator Screen Shot - iPhone 11 Pro Max - 2021-05-25 at 12 18 46](https://user-images.githubusercontent.com/1863410/119548404-6c30ba00-bd53-11eb-9be2-17d175ba05c1.png)

- iPad simulator (various)
![Simulator Screen Shot - iPad Pro (9 7-inch) - 2021-05-25 at 12 12 15](https://user-images.githubusercontent.com/1863410/119548434-705cd780-bd53-11eb-9550-5a9f2ac2840b.png)

- CarPlay simulator with 2x scale factor
![CarPlay-2x](https://user-images.githubusercontent.com/1863410/119547342-3a6b2380-bd52-11eb-94e0-ddb1115d73e7.png)

- CarPlay simulator with 3x scale factor
![CarPlay-3x](https://user-images.githubusercontent.com/1863410/119547350-3e974100-bd52-11eb-966f-536a01519fb7.png)

Previously we implemented a default contentScaleFactor, however, Metal implements this by default.  (Reference: https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/NativeScreenScale.html)

This change means that when setting up a `MapView`, you should provide a pixelRatio for effective scaling. Consider using the active screen scaleFactor to find the most appropriate value. For example, if you are using `CarPlay`, you should initialize your `MapView` with `MapOptions` that contains a `pixelRatio: CPWindow.screen.scale`