### PR TITLE
support CLLocationDirection/course for bearing

### DIFF
--- a/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
@@ -13,26 +13,15 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         view.addSubview(mapView)
 
-        mapView.mapboxMap.onNext(.styleLoaded) { _ in
-            self.setupExample()
-        }
+        // Granularly configure the location puck with a `Puck2DConfiguration`
+        let configuration = Puck2DConfiguration(topImage: UIImage(named: "star"))
+        mapView.location.options.puckType = .puck2D(configuration)
+        mapView.location.options.puckBearingSource = .course
     }
 
     override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         // The below line is used for internal testing purposes only.
         finish()
-    }
-
-    internal func setupExample() {
-
-        // Granularly configure the location puck with a `Puck2DConfiguration`
-        let configuration = Puck2DConfiguration(topImage: UIImage(named: "star"))
-        mapView.location.options.puckType = .puck2D(configuration)
-
-        let coordinate = CLLocationCoordinate2D(latitude: 39.085006, longitude: -77.150925)
-        mapView.mapboxMap.setCamera(to: CameraOptions(center: coordinate,
-                                                          zoom: 14,
-                                                          pitch: 0))
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+## main
+
+### Features ✨ and improvements 🏁
+- Fixed an issue where location updates were only happening via `heading: CLHeading`. You may now specify `mapView.location.options.puckBearingSource = .course` so that location puck will update based on `course: CLDirection`. Note that this value will use `heading: CLHeading` by default. ([#428](https://github.com/mapbox/mapbox-maps-ios/pull/428))
+
 ## 10.0.0-beta.21 - June 3, 2021
 
 ### Breaking changes ⚠️

--- a/Sources/MapboxMaps/Location/LocationConsumer.swift
+++ b/Sources/MapboxMaps/Location/LocationConsumer.swift
@@ -3,7 +3,7 @@ import CoreLocation
 
 @objc public class Location: NSObject {
     public let heading: CLHeading?
-    public let internalLocation: CLLocation
+    internal let internalLocation: CLLocation
 
     public var coordinate: CLLocationCoordinate2D {
         return internalLocation.coordinate

--- a/Sources/MapboxMaps/Location/LocationManager.swift
+++ b/Sources/MapboxMaps/Location/LocationManager.swift
@@ -56,7 +56,7 @@ public class LocationManager: NSObject {
             }
 
             if options.puckBearingSource != oldValue.puckBearingSource {
-                locationPuckManager?.changePuckBearingSource(to: options.puckBearingSource)
+                locationPuckManager?.puckBearingSource = options.puckBearingSource
             }
         }
     }

--- a/Sources/MapboxMaps/Location/LocationManager.swift
+++ b/Sources/MapboxMaps/Location/LocationManager.swift
@@ -54,6 +54,10 @@ public class LocationManager: NSObject {
             if let puckType = options.puckType, puckType != oldValue.puckType {
                 locationPuckManager?.changePuckType(to: puckType)
             }
+
+            if options.puckBearingSource != oldValue.puckBearingSource {
+                locationPuckManager?.changePuckBearingSource(to: options.puckBearingSource)
+            }
         }
     }
 
@@ -196,13 +200,13 @@ private extension LocationManager {
             locationProvider.startUpdatingHeading()
 
             if let locationPuckManager = locationPuckManager {
-                // This serves as a reset and handles the case if permissions were changed for accuracy
+                // This serves as a reset and handles the case if permissions were changed for accuracy 
                 locationPuckManager.changePuckStyle(to: currentPuckStyle)
             } else {
-                let locationPuckManager = LocationPuckManager(
-                    locationSupportableMapView: locationSupportableMapView,
-                    style: style,
-                    puckType: puckType)
+                let locationPuckManager = LocationPuckManager(locationSupportableMapView: locationSupportableMapView,
+                                                              style: style,
+                                                              puckType: puckType,
+                                                              puckBearingSource: options.puckBearingSource)
                 consumers.add(locationPuckManager)
                 self.locationPuckManager = locationPuckManager
             }

--- a/Sources/MapboxMaps/Location/LocationManager.swift
+++ b/Sources/MapboxMaps/Location/LocationManager.swift
@@ -1,10 +1,6 @@
 import CoreLocation
 import UIKit
 
-#if canImport(MapboxMapsFoundation)
-import MapboxMapsFoundation
-#endif
-
 /// An object responsible for notifying the map view about location-related events,
 /// such as a change in the device’s location.
 public class LocationManager: NSObject {

--- a/Sources/MapboxMaps/Location/LocationOptions.swift
+++ b/Sources/MapboxMaps/Location/LocationOptions.swift
@@ -24,6 +24,10 @@ public struct LocationOptions: Equatable {
     /// Sets the type of puck that should be used
     public var puckType: PuckType?
 
+    /// Specifies if a `Puck` should use `Heading` or `Course` for the bearing
+    /// This is an experimental option
+    public var puckBearingSource: PuckBearingSource = .heading
+
     public init() {}
 
 }

--- a/Sources/MapboxMaps/Location/LocationOptions.swift
+++ b/Sources/MapboxMaps/Location/LocationOptions.swift
@@ -1,7 +1,4 @@
 import Foundation
-#if canImport(MapboxMapsFoundation)
-import MapboxMapsFoundation
-#endif
 import CoreLocation
 
 /// A struct to configure a `LocationManager`

--- a/Sources/MapboxMaps/Location/LocationSupportableMapView.swift
+++ b/Sources/MapboxMaps/Location/LocationSupportableMapView.swift
@@ -1,21 +1,10 @@
 import Foundation
 import CoreLocation
 
-#if canImport(MapboxMapsFoundation)
-import MapboxMapsFoundation
-#endif
-
-#if canImport(MapboxMapsStyle)
-import MapboxMapsStyle
-#endif
-
-public protocol LocationSupportableMapView: UIView {
+internal protocol LocationSupportableMapView: UIView {
 
     /// Returns the screen coordinate for a given location coordinate (lat-long)
     func point(for coordinate: CLLocationCoordinate2D) -> CGPoint
-
-    /// Allows the `LocationSupportableMapView` to subscribe to a delegate
-    func subscribeRenderFrameHandler(_ handler: @escaping (MapboxCoreMaps.Event) -> Void)
 
     /// Allows the `LocationSupportableMapView` to subscrive to a delegate function and handle style change events
     func subscribeStyleChangeHandler(_ handler: @escaping (MapboxCoreMaps.Event) -> Void)

--- a/Sources/MapboxMaps/Location/Pucks/LocationPuckManager.swift
+++ b/Sources/MapboxMaps/Location/Pucks/LocationPuckManager.swift
@@ -2,16 +2,6 @@ import CoreLocation
 import MapboxCoreMaps
 import UIKit
 
-@_implementationOnly import MapboxCommon_Private
-
-#if canImport(MapboxMapsFoundation)
-import MapboxMapsFoundation
-#endif
-
-#if canImport(MapboxMapsStyle)
-import MapboxMapsStyle
-#endif
-
 // MARK: PuckStyle Enum
 /// This enum represents the different styles of pucks that can be generated
 internal enum PuckStyle {
@@ -98,7 +88,7 @@ internal class LocationPuckManager: LocationConsumer {
 
         var puck: Puck
 
-        
+
         switch puckType {
         case let .puck2D(configuration):
             puck = Puck2D(puckStyle: puckStyle,

--- a/Sources/MapboxMaps/Location/Pucks/LocationPuckManager.swift
+++ b/Sources/MapboxMaps/Location/Pucks/LocationPuckManager.swift
@@ -59,7 +59,13 @@ internal class LocationPuckManager: LocationConsumer {
     internal private(set) var puckType: PuckType
 
     /// The type of value that should be passed for bearing
-    internal var puckBearingSource: PuckBearingSource
+    internal var puckBearingSource: PuckBearingSource = .heading {
+        didSet{
+            if puck != nil {
+                puck?.puckBearingSource = puckBearingSource
+            }
+        }
+    }
 
     internal init(locationSupportableMapView: LocationSupportableMapView,
                   style: LocationStyleDelegate?,
@@ -92,6 +98,7 @@ internal class LocationPuckManager: LocationConsumer {
 
         var puck: Puck
 
+        
         switch puckType {
         case let .puck2D(configuration):
             puck = Puck2D(puckStyle: puckStyle,
@@ -129,15 +136,5 @@ internal class LocationPuckManager: LocationConsumer {
         } else {
             createPuck()
         }
-    }
-
-    internal func changePuckBearingSource(to newPuckBearingSource: PuckBearingSource) {
-        guard var puck = self.puck else {
-            Log.warning(forMessage: "Puck must exist to change a PuckBearingSource", category: "Location")
-            return
-        }
-
-        puckBearingSource = newPuckBearingSource
-        puck.puckBearingSource = newPuckBearingSource
     }
 }

--- a/Sources/MapboxMaps/Location/Pucks/LocationPuckManager.swift
+++ b/Sources/MapboxMaps/Location/Pucks/LocationPuckManager.swift
@@ -22,7 +22,10 @@ public enum PuckType: Equatable {
 // MARK: PuckBearingSource
 /// This enum controls how the puck is oriented
 public enum PuckBearingSource: Equatable {
+    /// A setting that tells the puck to orient the bearing using `heading: CLHeading`
     case heading
+
+    /// A setting that tells the puck to orient the bearing using `course: CLLocationDirection`
     case course
 }
 
@@ -51,9 +54,7 @@ internal class LocationPuckManager: LocationConsumer {
     /// The type of value that should be passed for bearing
     internal var puckBearingSource: PuckBearingSource = .heading {
         didSet{
-            if puck != nil {
-                puck?.puckBearingSource = puckBearingSource
-            }
+            puck?.puckBearingSource = puckBearingSource
         }
     }
 
@@ -87,7 +88,6 @@ internal class LocationPuckManager: LocationConsumer {
         }
 
         var puck: Puck
-
 
         switch puckType {
         case let .puck2D(configuration):

--- a/Sources/MapboxMaps/Location/Pucks/LocationPuckManager.swift
+++ b/Sources/MapboxMaps/Location/Pucks/LocationPuckManager.swift
@@ -53,7 +53,7 @@ internal class LocationPuckManager: LocationConsumer {
 
     /// The type of value that should be passed for bearing
     internal var puckBearingSource: PuckBearingSource = .heading {
-        didSet{
+        didSet {
             puck?.puckBearingSource = puckBearingSource
         }
     }

--- a/Sources/MapboxMaps/Location/Pucks/Puck.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck.swift
@@ -1,7 +1,3 @@
-#if canImport(MapboxMapsFoundation)
-import MapboxMapsFoundation
-#endif
-
 /// This protocol is used to help manipulate the different type of puck views we have
 internal protocol Puck {
 

--- a/Sources/MapboxMaps/Location/Pucks/Puck.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck.swift
@@ -8,6 +8,9 @@ internal protocol Puck {
     /// Property that stores the current `PuckStyle` of the puck
     var puckStyle: PuckStyle { get set }
 
+    /// Property that stores the current `PuckBearingSource` of the puck
+    var puckBearingSource: PuckBearingSource { get set }
+
     /// Property that references the mapView that the puck should be draw
     var locationSupportableMapView: LocationSupportableMapView? { get }
 

--- a/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
@@ -3,14 +3,6 @@ import MapboxCoreMaps
 @_implementationOnly import MapboxCoreMaps_Private
 @_implementationOnly import MapboxCommon_Private
 
-#if canImport(MapboxMapsFoundation)
-import MapboxMapsFoundation
-#endif
-
-#if canImport(MapboxMapsStyle)
-import MapboxMapsStyle
-#endif
-
 public struct Puck2DConfiguration: Equatable {
 
     /// Image to use as the top of the location indicator.

--- a/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
@@ -56,16 +56,19 @@ internal class Puck2D: Puck {
 
     // MARK: Protocol Properties
     internal var puckStyle: PuckStyle
+    internal var puckBearingSource: PuckBearingSource
 
     internal weak var locationSupportableMapView: LocationSupportableMapView?
     internal weak var style: LocationStyleDelegate?
 
     // MARK: Initializers
     internal init(puckStyle: PuckStyle,
+                  puckBearingSource: PuckBearingSource,
                   locationSupportableMapView: LocationSupportableMapView,
                   style: LocationStyleDelegate,
                   configuration: Puck2DConfiguration) {
         self.puckStyle = puckStyle
+        self.puckBearingSource = puckBearingSource
         self.locationSupportableMapView = locationSupportableMapView
         self.style = style
         self.configuration = configuration
@@ -87,8 +90,13 @@ internal class Puck2D: Puck {
             ]
 
             var bearing: Double = 0.0
-            if let latestBearing = location.heading {
-                bearing = latestBearing.trueHeading
+            switch puckBearingSource {
+            case .heading:
+                if let latestBearing = location.heading {
+                    bearing = latestBearing.trueHeading
+                }
+            case .course:
+                bearing = location.course
             }
 
             do {

--- a/Sources/MapboxMaps/Location/Pucks/Puck3D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck3D.swift
@@ -39,12 +39,18 @@ internal class Puck3D: Puck {
 
     // MARK: Protocol Properties
     internal var puckStyle: PuckStyle
+    internal var puckBearingSource: PuckBearingSource
     internal weak var locationSupportableMapView: LocationSupportableMapView?
     internal weak var style: LocationStyleDelegate?
 
     // MARK: Initializers
-    internal init(puckStyle: PuckStyle, locationSupportableMapView: LocationSupportableMapView, style: LocationStyleDelegate, configuration: Puck3DConfiguration) {
+    internal init(puckStyle: PuckStyle,
+                  puckBearingSource: PuckBearingSource,
+                  locationSupportableMapView: LocationSupportableMapView,
+                  style: LocationStyleDelegate,
+                  configuration: Puck3DConfiguration) {
         self.puckStyle = puckStyle
+        self.puckBearingSource = puckBearingSource
         self.locationSupportableMapView = locationSupportableMapView
         self.style = style
         self.configuration = configuration
@@ -101,11 +107,20 @@ internal class Puck3D: Puck {
               var model = modelSource.models?.values.first else { return }
 
         model.position = [location.coordinate.longitude, location.coordinate.latitude]
-        if var orientation = model.orientation,
-           let validDirection = location.headingDirection {
 
-            let initialOrientation = initialPuckOrientation != nil ? initialPuckOrientation![2] : 0
-            orientation[2] = initialOrientation + validDirection
+        var validDirection: Double = 0.0
+        switch puckBearingSource {
+        case .heading:
+            if let validHeadingDirection = location.headingDirection {
+                validDirection = validHeadingDirection
+            }
+        case .course:
+            validDirection = location.course
+        }
+
+        if var orientation = model.orientation {
+            let initalOrientation = initialPuckOrientation != nil ? initialPuckOrientation![2] : 0
+            orientation[2] = initalOrientation + validDirection
             model.orientation = orientation
         }
 

--- a/Sources/MapboxMaps/Location/Pucks/Puck3D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck3D.swift
@@ -2,14 +2,6 @@ import UIKit
 import MapboxCoreMaps
 import MapboxCommon
 
-#if canImport(MapboxMapsFoundation)
-import MapboxMapsFoundation
-#endif
-
-#if canImport(MapboxMapsStyle)
-import MapboxMapsStyle
-#endif
-
 public struct Puck3DConfiguration: Equatable {
 
     /// The model to use as the locaiton puck

--- a/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
@@ -86,4 +86,20 @@ internal class LocationManagerTests: XCTestCase {
         XCTAssertEqual(locationManager.options, locationOptions2)
         XCTAssertEqual(locationManager.locationPuckManager?.puckType, locationOptions2.puckType)
     }
+
+    func testUpdateLocationOptionsWithCoursePuckBearingSource() {
+        var locationOptions = LocationOptions()
+        locationOptions.puckType = .puck2D()
+        let locationManager = LocationManager(locationSupportableMapView: locationSupportableMapView,
+                                              style: locationSupportableStyle)
+
+        locationManager.options = locationOptions
+        XCTAssertEqual(locationManager.locationPuckManager?.puckBearingSource, .heading)
+
+        locationOptions.puckBearingSource = .course
+        locationManager.options = locationOptions
+
+        XCTAssertEqual(locationManager.options, locationOptions)
+        XCTAssertEqual(locationManager.locationPuckManager?.puckBearingSource, .course)
+    }
 }

--- a/Tests/MapboxMapsTests/Location/LocationSupportableMapViewMock.swift
+++ b/Tests/MapboxMapsTests/Location/LocationSupportableMapViewMock.swift
@@ -18,10 +18,6 @@ class LocationSupportableMapViewMock: UIView, LocationSupportableMapView {
         return .zero
     }
 
-    func subscribeRenderFrameHandler(_ handler: @escaping (MapboxCoreMaps.Event) -> Void) {
-        print("Pass through implementation")
-    }
-
     func subscribeStyleChangeHandler(_ handler: @escaping (MapboxCoreMaps.Event) -> Void) {
         print("Pass through implementation")
     }

--- a/Tests/MapboxMapsTests/Location/Pucks/Puck2DIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Location/Pucks/Puck2DIntegrationTests.swift
@@ -18,6 +18,7 @@ class Puck2DIntegrationTests: MapViewIntegrationTestCase {
 
         didFinishLoadingStyle = { _ in
             let puck = Puck2D(puckStyle: .precise,
+                              puckBearingSource: .heading,
                               locationSupportableMapView: self.mapView!,
                               style: style,
                               configuration: Puck2DConfiguration())
@@ -45,6 +46,7 @@ class Puck2DIntegrationTests: MapViewIntegrationTestCase {
 
         didFinishLoadingStyle = { _ in
             let puck = Puck2D(puckStyle: .approximate,
+                              puckBearingSource: .heading,
                               locationSupportableMapView: self.mapView!,
                               style: style,
                               configuration: Puck2DConfiguration())
@@ -71,6 +73,7 @@ class Puck2DIntegrationTests: MapViewIntegrationTestCase {
 
         didFinishLoadingStyle = { _ in
             let puck = Puck2D(puckStyle: .precise,
+                              puckBearingSource: .heading,
                               locationSupportableMapView: self.mapView!,
                               style: style,
                               configuration: Puck2DConfiguration())
@@ -103,6 +106,7 @@ class Puck2DIntegrationTests: MapViewIntegrationTestCase {
 
         didFinishLoadingStyle = { _ in
             let puck = Puck2D(puckStyle: .precise,
+                              puckBearingSource: .heading,
                               locationSupportableMapView: self.mapView!,
                               style: style,
                               configuration: Puck2DConfiguration())

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/LocationManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/LocationManagerIntegrationTests.swift
@@ -45,6 +45,33 @@ internal class LocationManagerIntegrationTestCase: MapViewIntegrationTestCase {
         wait(for: expectations, timeout: 5.0)
     }
 
+    internal func testChangePuckBearingSourceTakesEffect() {
+        style?.uri = .outdoors
+
+        let puckBearingSourceUsesHeading = XCTestExpectation(description: "Checks bearing updates are via heading")
+        let puckBearingSourceUsesCourse = XCTestExpectation(description: "Checks bearing updates are via course")
+
+        didBecomeIdle = { mapView in
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+
+                // Create a location manager
+                let locationManager = self.setupLocationManager(with: mapView)
+
+                // Sanity check for the default case
+                XCTAssertEqual(locationManager.options.puckBearingSource, .heading)
+                puckBearingSourceUsesHeading.fulfill()
+
+                locationManager.options.puckBearingSource = .course
+                XCTAssertEqual(locationManager.options.puckBearingSource, .course)
+                puckBearingSourceUsesCourse.fulfill()
+            }
+        }
+
+        let expectations = [puckBearingSourceUsesHeading, puckBearingSourceUsesCourse]
+        wait(for: expectations, timeout: 5.0)
+    }
+
     private func setupLocationManager(with mapView: MapView) -> LocationManager {
         let locationManager = LocationManager(locationSupportableMapView: mapView, style: mapView.mapboxMap.style)
         return locationManager


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: An issue where location puck was not tracking course

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes
This change brings the support for `course` when updating the `locationPuck`. There is a new option that the developer can specify whether the bearing should be updated via `heading: CLHeading` or via `course: CLLocationDirection`