### PR TITLE
Remove setAccessToken / workaround in ResourceOptionsManager

### DIFF
--- a/Sources/MapboxMaps/Foundation/Extensions/Core/ResourceOptions.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/ResourceOptions.swift
@@ -33,11 +33,13 @@ public struct ResourceOptions {
     ///
     /// - Attention:
     ///     If you create a `ResourceOptions` (rather than using `ResourceOptionsManager`
-    ///     to manage one), you will need to ensure that you set the `TileStore`'s
-    ///     access token at the same time. For example:
+    ///     to manage one) that uses a custom TileStore, you will need to ensure
+    ///     that you set the `TileStore`'s access token at the same time.
+    ///
+    ///     For example:
     ///
     ///     ```
-    ///     tileStore.setAccessToken(resourceOptions.accessToken)
+    ///     tileStore.setOptionForKey(TileStoreOptions.mapboxAccessToken, value: accessToken)
     ///     ```
     public var tileStore: TileStore?
 

--- a/Sources/MapboxMaps/Foundation/ResourceOptionsManager.swift
+++ b/Sources/MapboxMaps/Foundation/ResourceOptionsManager.swift
@@ -54,7 +54,7 @@ public class ResourceOptionsManager {
     }
 
     private var _resourceOptions: ResourceOptions!
-    private var tileStore: TileStore!
+    private var tileStore: TileStore?
     private var bundle: Bundle
 
     /// Initializes a `ResourceOptionsManager` with an optional access token.
@@ -100,12 +100,7 @@ public class ResourceOptionsManager {
         _resourceOptions = resourceOptions
         _resourceOptions.accessToken = token
 
-        let resolvedTileStore = resourceOptions.tileStore ?? TileStore.default
-        if resourceOptions.tileStoreUsageMode != .disabled {
-            resolvedTileStore.setAccessToken(token)
-        }
-
-        tileStore = resolvedTileStore
+        tileStore = resourceOptions.tileStore
     }
 
     internal func defaultAccessToken() -> String {

--- a/Sources/MapboxMaps/Offline/TileStore+MapboxMaps.swift
+++ b/Sources/MapboxMaps/Offline/TileStore+MapboxMaps.swift
@@ -26,11 +26,6 @@ extension TileStore {
         return TileStore.__getInstanceForPath(path)
     }
 
-    /// Convenience to set the access token for a TileStore
-    public func setAccessToken(_ accessToken: String) {
-        setOptionForKey(TileStoreOptions.mapboxAccessToken, value: accessToken)
-    }
-
     /// Loads a new tile region or updates the existing one.
     ///
     /// - Parameters:

--- a/Tests/MapboxMapsTests/MapView/Integration Tests/OfflineManagerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MapView/Integration Tests/OfflineManagerIntegrationTests.swift
@@ -34,7 +34,7 @@ internal class OfflineManagerIntegrationTestCase: IntegrationTestCase {
         try TileStore.removeDirectory(at: tileStorePathURL!)
 
         tileStore = TileStore.shared(for: tileStorePathURL.path)
-        tileStore.setAccessToken(accessToken)
+        tileStore.setOptionForKey(TileStoreOptions.mapboxAccessToken, value: accessToken)
         weakTileStore = tileStore
 
         resourceOptions = ResourceOptions(accessToken: accessToken,

--- a/Tests/MapboxMapsTests/MigrationGuide/MigrationGuideIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MigrationGuide/MigrationGuideIntegrationTests.swift
@@ -179,13 +179,14 @@ class MigrationGuideIntegrationTests: IntegrationTestCase {
     func testMapViewConfiguration() throws {
 
         let mapView = MapView(frame: .zero)
-        let someBounds = CoordinateBounds(southwest: CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                                          northeast: CLLocationCoordinate2D(latitude: 1, longitude: 1))
 
         //-->
+        let restrictedBounds = CoordinateBounds(southwest: CLLocationCoordinate2D(latitude: 10, longitude: 10),
+                                                northeast: CLLocationCoordinate2D(latitude: 11, longitude: 11))
+
         // Configure map to show a scale bar
         mapView.ornaments.options.scaleBar.visibility = .visible
-        mapView.camera.options = CameraBoundsOptions(bounds: someBounds)
+        mapView.camera.options = CameraBoundsOptions(bounds: restrictedBounds)
         //<--
     }
 
@@ -359,6 +360,11 @@ class MigrationGuideIntegrationTests: IntegrationTestCase {
                                                      maxZoom: 15.0,
                                                      minZoom: 8.0)
         //<--
+
+        // Can also set directly, though this will trigger 3 didSets
+        mapView.camera.options.bounds = restrictedBounds
+        mapView.camera.options.minZoom = 8.0
+        mapView.camera.options.maxZoom = 15.0
     }
 
     func testGeoJSONSource() {

--- a/Tests/MapboxMapsTests/MigrationGuide/OfflineGuideIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MigrationGuide/OfflineGuideIntegrationTests.swift
@@ -57,6 +57,12 @@ class OfflineGuideIntegrationTests: XCTestCase {
     // Test TileRegionLoadOptions
     func testDefineATileRegion() throws {
         //-->
+        // When providing a `TileStore` to `ResourceOptions`, you must ensure that
+        // the `TileStore` is correctly initialized using `setOptionForKey(_:value:)`.
+        // This includes providing an access token, if you are not using a default
+        // from the application's Info.plist
+        tileStore.setOptionForKey(TileStoreOptions.mapboxAccessToken, value: accessToken)
+        
         let offlineManager = OfflineManager(resourceOptions: ResourceOptions(accessToken: accessToken,
                                                                              tileStore: tileStore))
 

--- a/Tests/MapboxMapsTests/MigrationGuide/OfflineGuideIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MigrationGuide/OfflineGuideIntegrationTests.swift
@@ -26,7 +26,7 @@ class OfflineGuideIntegrationTests: XCTestCase {
         tileStorePathURL = try TileStore.fileURLForDirectory(for: name.fileSystemSafeString())
         tileStore = TileStore.shared(for: tileStorePathURL.path)
 
-        tileStore.setAccessToken(accessToken)
+        tileStore.setOptionForKey(TileStoreOptions.mapboxAccessToken, value: accessToken)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/MapboxMapsTests/MigrationGuide/OfflineGuideIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MigrationGuide/OfflineGuideIntegrationTests.swift
@@ -62,7 +62,7 @@ class OfflineGuideIntegrationTests: XCTestCase {
         // This includes providing an access token, if you are not using a default
         // from the application's Info.plist
         tileStore.setOptionForKey(TileStoreOptions.mapboxAccessToken, value: accessToken)
-        
+
         let offlineManager = OfflineManager(resourceOptions: ResourceOptions(accessToken: accessToken,
                                                                              tileStore: tileStore))
 


### PR DESCRIPTION
Removes `TileStore.setAccessToken` convenience as we review APIs. Removes setting of access token by `ResourceOptionsManager`. It's the developer's responsibility to ensure the customized `TileStore` is initialized with a valid access token (and any other options).