### PR TITLE
[Ornaments, testing] Update `isOnRight` when scale bar's position is updated

### DIFF
--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -96,6 +96,8 @@ public class OrnamentsManager: NSObject {
         let scaleBarViewConstraints = constraints(with: scalebarView,
                                                   position: options.scaleBar.position,
                                                   margins: options.scaleBar.margins)
+        let scaleBarPosition = options.scaleBar.position
+        scalebarView.isOnRight = scaleBarPosition == .bottomRight || scaleBarPosition == .topRight
         constraints.append(contentsOf: scaleBarViewConstraints)
 
         let attributionButtonConstraints = constraints(with: attributionButton,

--- a/Tests/MapboxMapsTests/Ornaments/OrnamentManagerTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/OrnamentManagerTests.swift
@@ -53,4 +53,20 @@ class OrnamentManagerTests: XCTestCase {
 
         XCTAssertNotEqual(isInitialCompassHidden, isUpdatedCompassHidden)
     }
+
+    func testScaleBarOnRight() throws {
+        let initialSubviews = ornamentSupportableView.subviews.filter { $0 is MapboxScaleBarOrnamentView }
+
+        let scaleBar = try XCTUnwrap(initialSubviews.first as? MapboxScaleBarOrnamentView, "The ornament supportable map view should include a scale bar")
+        XCTAssertFalse(scaleBar.isOnRight, "The default scale bar should be on the left initially.")
+
+        ornamentsManager.options.scaleBar.position = .topRight
+        XCTAssertTrue(scaleBar.isOnRight, "The scale bar should be on the right after the position has been updated to topRight.")
+
+        ornamentsManager.options.scaleBar.position = .bottomLeft
+        XCTAssertFalse(scaleBar.isOnRight, "The default scale bar should be on the left after updating position to bottomLeft.")
+
+        ornamentsManager.options.scaleBar.position = .bottomRight
+        XCTAssertTrue(scaleBar.isOnRight, "The scale bar should be on the right after the position has been updated to bottomRight.")
+    }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR updates `MapboxScaleBarOrnamentView.isOnRight` when the ornament options are added. Also adds tests to check for these updates. 

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
