### PR TITLE
Embed MME framework in test host

### DIFF
--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -308,6 +308,8 @@
 		CA6245E42627F20B00C79547 /* TileStore+MapboxMaps.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6245E32627F20B00C79547 /* TileStore+MapboxMaps.swift */; };
 		CA6245E92627F37B00C79547 /* OfflineManager+MapboxMaps.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6245E82627F37B00C79547 /* OfflineManager+MapboxMaps.swift */; };
 		CA62460026289D6400C79547 /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6245FF26289D6400C79547 /* Cancelable.swift */; };
+		CA867D05266EE80A0012DBD4 /* MapboxMobileEvents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA867D04266EE80A0012DBD4 /* MapboxMobileEvents.framework */; };
+		CA867D06266EE82B0012DBD4 /* MapboxMobileEvents.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CA867D04266EE80A0012DBD4 /* MapboxMobileEvents.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CA8CBA352668A2F800D50553 /* CameraBounds.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8CBA342668A2F800D50553 /* CameraBounds.swift */; };
 		CA9481572554AA9E00D93C3C /* TestConveniences.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9481552554AA9E00D93C3C /* TestConveniences.swift */; };
 		CA952ECD251C30B80099C080 /* MapboxMaps.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CD34FCE242AADDB00943687 /* MapboxMaps.framework */; };
@@ -390,6 +392,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				CA867D06266EE82B0012DBD4 /* MapboxMobileEvents.framework in Embed Frameworks */,
 				CA952ECE251C30B80099C080 /* MapboxMaps.framework in Embed Frameworks */,
 				58EFAD15265FF4EE007FC1FF /* MapboxCommon.framework in Embed Frameworks */,
 				58EFAD16265FF4EE007FC1FF /* MapboxCoreMaps.framework in Embed Frameworks */,
@@ -738,6 +741,7 @@
 		CA6245E32627F20B00C79547 /* TileStore+MapboxMaps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TileStore+MapboxMaps.swift"; sourceTree = "<group>"; };
 		CA6245E82627F37B00C79547 /* OfflineManager+MapboxMaps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OfflineManager+MapboxMaps.swift"; sourceTree = "<group>"; };
 		CA6245FF26289D6400C79547 /* Cancelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancelable.swift; sourceTree = "<group>"; };
+		CA867D04266EE80A0012DBD4 /* MapboxMobileEvents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = MapboxMobileEvents.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA8CBA342668A2F800D50553 /* CameraBounds.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraBounds.swift; sourceTree = "<group>"; };
 		CA9481552554AA9E00D93C3C /* TestConveniences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConveniences.swift; sourceTree = "<group>"; };
 		CA952F4A251C36CD0099C080 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -791,6 +795,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CA867D05266EE80A0012DBD4 /* MapboxMobileEvents.framework in Frameworks */,
 				CA952ECD251C30B80099C080 /* MapboxMaps.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1376,6 +1381,7 @@
 		1FEE79BC2421AC7C00337895 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				CA867D04266EE80A0012DBD4 /* MapboxMobileEvents.framework */,
 				58EFAD13265FF4C2007FC1FF /* MapboxCommon.framework */,
 				58EFAD14265FF4C3007FC1FF /* MapboxCoreMaps.framework */,
 			);

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -98,7 +98,7 @@ final class GestureManagerTests: XCTestCase {
         XCTAssertNotEqual(mapView.cameraState.zoom, zoom, "The map's zoom should not equal `zoom` before it is provided to the gesture manager.")
         gestureManager.pinchScaleChanged(with: zoom, andAnchor: .zero)
 
-        XCTAssertEqual(mapView.cameraState.zoom, zoom, "The map's zoom should equal the zoom level provided by the gesture manager.")
+        XCTAssertEqual(mapView.cameraState.zoom, zoom, accuracy: 0.00001, "The map's zoom should equal the zoom level provided by the gesture manager.")
     }
 
     func testPinchEnded_SetsCamera() {
@@ -107,6 +107,6 @@ final class GestureManagerTests: XCTestCase {
         XCTAssertNotEqual(mapView.cameraState.zoom, zoom, "The map's zoom should not equal `zoom` before it is provided to the gesture manager.")
         gestureManager.pinchEnded(with: zoom, andDrift: true, andAnchor: .zero)
 
-        XCTAssertEqual(mapView.cameraState.zoom, zoom, "The map's zoom should equal the zoom level provided by the gesture manager after the drift.")
+        XCTAssertEqual(mapView.cameraState.zoom, zoom, accuracy: 0.00001, "The map's zoom should equal the zoom level provided by the gesture manager after the drift.")
     }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

Adds MME to TestHost as an embedded framework. This is required due to code-signing, and the change of MME being included as a binary.