### PR TITLE
Ensure that animations / completion blocks are honored even when scheduleRepaint() isn't called

### DIFF
--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -267,7 +267,9 @@ open class MapView: UIView {
             return
         }
 
-        if needsDisplayRefresh {
+        if needsDisplayRefresh
+            || cameraAnimatorsSet.allObjects.count > 0
+            || !pendingAnimatorCompletionBlocks.isEmpty {
             needsDisplayRefresh = false
 
             for animator in cameraAnimatorsSet.allObjects {


### PR DESCRIPTION
…
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: https://github.com/mapbox/mapbox-maps-ios/issues/357

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Fix issue where animations are not honored sometimes</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR fixes a subtle bug that happens with animations where they don't always get honored.

#### Root cause

The core issue is that animations are contrary to the regular rendering loop. Let's first consider the regular case of how a setCamera() call results in a render call.

If a developer calls `setCamera(..)` with some valid camera option, the renderer processes that as a request and eventually calls `scheduleRepaint()`. In [`scheduleRepaint()`, the platform SDK sets the `needsDisplayRefresh` flag.](https://github.com/mapbox/mapbox-maps-ios/blob/24e43136030cddda830817548007a5e3fbbb5633/Sources/MapboxMaps/Foundation/MapView.swift#L343-L345) This flag is [eventually referenced](https://github.com/mapbox/mapbox-maps-ios/blob/24e43136030cddda830817548007a5e3fbbb5633/Sources/MapboxMaps/Foundation/MapView.swift#L270) in `updateFromDisplayLink()`. Only if the flag is true (which it will be in the scenario where a `setCamera` had been previously called), does the `metalView` invoke `setNeedsDisplay` .

In the case of animations however, animators don't call `setCamera` ever(!).. Rather they return the `CameraOptions` that must be set for that particular time in the duration of the animation ( i.e. the interpolated camera options value).

So in the scenario, where the developer loads the mapView and immediately makes a call to something like `fly(to:)`, the `needsDisplayRefresh` flag is never set since the renderer will never call `scheduleRepaint()` (which in turn doesn't happen since setCamera is never called by an animator!).


#### Fix

This flow definitely needs some work so we can make this easier to work with in the future. I'll be opening up a ticket for it.

For now, however, this PR point fixes the issue by checking for the presence of a camera animator in the `cameraAnimatorsSet` in `updateFromDisplayLink()`.
