### PR TITLE
Push loaded event on map view init.

### DIFF
--- a/Apps/DebugApp/DebugApp/Info.plist
+++ b/Apps/DebugApp/DebugApp/Info.plist
@@ -57,7 +57,7 @@
 		<string>Debug App temporarily requires your precise location</string>
 	</dict>
 	<key>MMEDebugLogging</key>
-	<true/>
+	<false/>
 	<key>MMECollectionEnabledInSimulator</key>
 	<false/>
 </dict>

--- a/Apps/DebugApp/DebugApp/Info.plist
+++ b/Apps/DebugApp/DebugApp/Info.plist
@@ -56,5 +56,9 @@
 		<key>LocationAccuracyAuthorizationDescription</key>
 		<string>Debug App temporarily requires your precise location</string>
 	</dict>
+	<key>MMEDebugLogging</key>
+	<true/>
+	<key>MMECollectionEnabledInSimulator</key>
+	<false/>
 </dict>
 </plist>

--- a/Sources/MapboxMaps/Foundation/Events/EventsManager.swift
+++ b/Sources/MapboxMaps/Foundation/Events/EventsManager.swift
@@ -15,6 +15,7 @@ internal class EventsManager: EventsListener {
         mmeEventsManager.initialize(withAccessToken: accessToken,
                                     userAgentBase: Constants.MGLAPIClientUserAgentBase,
                                     hostSDKVersion: sdkVersion)
+        mmeEventsManager.skuId = "00"
     }
 
     init(with telemetry: TelemetryProtocol?) {

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -178,9 +178,6 @@ open class MapView: UIView {
             mapboxMap.setCamera(to: cameraOptions)
         }
 
-//        // Set prefetchZoomDelta
-//        mapboxMap.prefetchZoomDelta = options.prefetchZoomDelta
-
         // Setup Telemetry logging
         setUpTelemetryLogging()
 
@@ -332,6 +329,7 @@ open class MapView: UIView {
 
     @objc func didReceiveMemoryWarning() {
         mapboxMap.reduceMemoryUse()
+        eventsListener.push(event: .memoryWarning)
     }
 
     required public init?(coder: NSCoder) {
@@ -388,10 +386,12 @@ private class BaseMapViewProxy: NSObject {
 extension MapView {
     internal func setUpTelemetryLogging() {
         guard let validResourceOptions = resourceOptions else { return }
-        eventsListener = EventsManager(accessToken: validResourceOptions.accessToken)
+        let eventsListener = EventsManager(accessToken: validResourceOptions.accessToken)
 
-        mapboxMap.onNext(.mapLoaded) { [weak self] _ in
-            self?.eventsListener?.push(event: .map(event: .loaded))
+        DispatchQueue.main.async {
+            eventsListener.push(event: .map(event: .loaded))
         }
+
+        self.eventsListener = eventsListener
     }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

To align with Android, this PR pushes the turnstile & `map.load` event on MapView creation, rather than on the next MapLoaded event.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->
