### PR TITLE
Internalize extensions of Core and Common types

### DIFF
--- a/Apps/Examples/Examples/All Examples/AnimateGeoJSONLineExample.swift
+++ b/Apps/Examples/Examples/All Examples/AnimateGeoJSONLineExample.swift
@@ -38,7 +38,7 @@ public class AnimateGeoJSONLineExample: UIViewController, ExampleProtocol {
 
         // Create a GeoJSON data source.
         routeLineSource = GeoJSONSource()
-        routeLineSource.data = .feature(Feature(LineString([allCoordinates[currentIndex]])))
+        routeLineSource.data = .feature(Feature(geometry: .lineString(LineString([allCoordinates[currentIndex]]))))
 
         // Create a line layer
         var lineLayer = LineLayer(id: "line-layer")
@@ -83,7 +83,7 @@ public class AnimateGeoJSONLineExample: UIViewController, ExampleProtocol {
             // Create a subarray of locations up to the current index.
             currentCoordinates = Array(self.allCoordinates[0..<self.currentIndex - 1])
 
-            let updatedLine = Feature(LineString(currentCoordinates))
+            let updatedLine = Feature(geometry: .lineString(LineString(currentCoordinates)))
             self.routeLineSource.data = .feature(updatedLine)
             try! self.mapView.mapboxMap.style.updateGeoJSONSource(withId: self.sourceIdentifier,
                                                         geoJSON: updatedLine)

--- a/Apps/Examples/Examples/All Examples/AnimateLayerExample.swift
+++ b/Apps/Examples/Examples/All Examples/AnimateLayerExample.swift
@@ -67,7 +67,7 @@ public class AnimateLayerExample: UIViewController, ExampleProtocol {
     public func addLayers(for routeLine: LineString) {
 
         // Define the source data and style layer for the airplane's route line.
-        airplaneRoute.source.data = .feature(Feature(routeLine))
+        airplaneRoute.source.data = .feature(Feature(geometry: .lineString(routeLine)))
         var lineLayer = LineLayer(id: "line-layer")
         lineLayer.source = airplaneRoute.identifier
         lineLayer.lineColor = .constant(ColorRepresentable(color: UIColor.red))
@@ -76,7 +76,7 @@ public class AnimateLayerExample: UIViewController, ExampleProtocol {
 
         // Define the source data and style layer for the airplane symbol.
         let point = Point(routeLine.coordinates[0])
-        airplaneSymbol.source.data = .feature(Feature(point))
+        airplaneSymbol.source.data = .feature(Feature(geometry: .point(point)))
         var airplaneSymbolLayer = SymbolLayer(id: "airplane")
         airplaneSymbolLayer.source = airplaneSymbol.identifier
         // "airport-15" is the name the image that belongs in the style's sprite by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Updated MapboxCoreMaps, MapboxCommon and Turf dependencies. ([#440](https://github.com/mapbox/mapbox-maps-ios/pull/440))
   - Removed `CacheManager`.
   - Changed `ResourceOptions.cachePathURL` to `dataPathURL` and removed `cacheSize`.
+- Internalize extensions of Core and Common types. ([#449](https://github.com/mapbox/mapbox-maps-ios/pull/449))
 
 ### Features ✨ and improvements 🏁
 - Fixed an issue where location updates were only happening via `heading: CLHeading`. You may now specify `mapView.location.options.puckBearingSource = .course` so that location puck will update based on `course: CLDirection`. Note that this value will use `heading: CLHeading` by default. ([#428](https://github.com/mapbox/mapbox-maps-ios/pull/428))

--- a/Sources/MapboxMaps/Foundation/Camera/CameraState.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraState.swift
@@ -38,21 +38,3 @@ public struct CameraState: Hashable {
         hasher.combine(pitch)
     }
 }
-
-extension MapboxCoreMaps.CameraState {
-
-    open override func isEqual(_ object: Any?) -> Bool {
-
-        guard let other = object as? MapboxCoreMaps.CameraState else {
-            return false
-        }
-
-        return
-            center == other.center &&
-            padding.toUIEdgeInsetsValue() == other.padding.toUIEdgeInsetsValue() &&
-            zoom == other.zoom &&
-            pitch == other.pitch &&
-            bearing == other.bearing
-    }
-
-}

--- a/Sources/MapboxMaps/Foundation/Cancelable.swift
+++ b/Sources/MapboxMaps/Foundation/Cancelable.swift
@@ -6,4 +6,20 @@ public protocol Cancelable: AnyObject {
     func cancel()
 }
 
-extension MapboxCommon.Cancelable: Cancelable {}
+internal final class CommonCancelableWrapper: Cancelable {
+    private let cancelable: MapboxCommon.Cancelable
+
+    internal init(_ cancelable: MapboxCommon.Cancelable) {
+        self.cancelable = cancelable
+    }
+
+    internal func cancel() {
+        cancelable.cancel()
+    }
+}
+
+extension MapboxCommon.Cancelable {
+    internal func asCancelable() -> Cancelable {
+        return CommonCancelableWrapper(self)
+    }
+}

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/LayerPosition.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/LayerPosition.swift
@@ -33,23 +33,12 @@ public enum LayerPosition: Equatable {
 
 extension MapboxCoreMaps.LayerPosition {
 
-    public convenience init(above: String? = nil, below: String? = nil, at: Int? = nil) {
+    internal convenience init(above: String? = nil, below: String? = nil, at: Int? = nil) {
         self.init(__above: above, below: below, at: at?.NSNumber)
     }
 
     /// Layer should be positioned at a specified index in the layers stack
-    public var at: UInt32? {
+    internal var at: UInt32? {
         return __at?.uint32Value
-    }
-
-    public override func isEqual(_ object: Any?) -> Bool {
-        guard let object = object as? MapboxCoreMaps.LayerPosition else {
-            return false
-        }
-
-        return
-            (above == object.above) &&
-            (below == object.below) &&
-            (at == object.at)
     }
 }

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/MBXGeometry.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/MBXGeometry.swift
@@ -5,7 +5,9 @@ import Turf
 
 // MARK: - Geometry
 
-extension MapboxCommon.Geometry {
+public typealias Geometry = MapboxCommon.Geometry
+
+extension Geometry {
 
     /// Initialize a `Geometry` point from a coordinate.
     /// - Parameter coordinate: The coordinate to represent the `Geometry` point.

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/MBXGeometry.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/MBXGeometry.swift
@@ -5,7 +5,7 @@ import Turf
 
 // MARK: - Geometry
 
-extension Geometry {
+extension MapboxCommon.Geometry {
 
     /// Initialize a `Geometry` point from a coordinate.
     /// - Parameter coordinate: The coordinate to represent the `Geometry` point.

--- a/Sources/MapboxMaps/Foundation/Extensions/Turf/Feature.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Turf/Feature.swift
@@ -2,15 +2,13 @@ import Foundation
 import MapboxCommon
 import Turf
 
-public typealias Feature = MapboxCommon.Feature
-
 // MARK: - Feature
 
 extension Turf.Feature {
 
     /// Initialize a `Turf.Feature` with an `Feature` object.
     /// - Parameter feature: The `Feature` to use to create the `Feature`.
-    internal init?(_ feature: Feature) {
+    internal init?(_ feature: MapboxCommon.Feature) {
         guard let geometry = Turf.Geometry(feature.geometry) else { return nil }
 
         self.init(geometry: geometry)
@@ -76,7 +74,7 @@ extension Turf.Feature {
     }
 }
 
-extension Feature {
+extension MapboxCommon.Feature {
     /// Initialize an `Feature` with a `Turf.Feature`
     internal convenience init?(_ feature: Turf.Feature) {
 

--- a/Sources/MapboxMaps/Foundation/Extensions/Turf/Feature.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Turf/Feature.swift
@@ -10,7 +10,7 @@ extension Turf.Feature {
 
     /// Initialize a `Turf.Feature` with an `Feature` object.
     /// - Parameter feature: The `Feature` to use to create the `Feature`.
-    public init?(_ feature: Feature) {
+    internal init?(_ feature: Feature) {
         guard let geometry = Turf.Geometry(feature.geometry) else { return nil }
 
         self.init(geometry: geometry)
@@ -35,43 +35,43 @@ extension Turf.Feature {
 
     /// Initialize a `Turf.Feature` with a `Point`.
     /// - Parameter point: The `Point` to use to create the `Turf.Feature`.
-    public init(_ point: Point) {
+    internal init(_ point: Point) {
         self.init(geometry: Turf.Geometry.point(point))
     }
 
     /// Initialize a `Turf.Feature` with a `LineString`.
     /// - Parameter line: The `LineString` to use to create the `Turf.Feature`.
-    public init(_ line: LineString) {
+    internal init(_ line: LineString) {
         self.init(geometry: Turf.Geometry.lineString(line))
     }
 
     /// Initialize a `Turf.Feature` with a `Polygon`.
     /// - Parameter polygon: The `Polygon` to use to create the `Turf.Feature`.
-    public init(_ polygon: Polygon) {
+    internal init(_ polygon: Polygon) {
         self.init(geometry: Turf.Geometry.polygon(polygon))
     }
 
     /// Initialize a `Turf.Feature` with a `MultiPoint`.
     /// - Parameter multiPoint: The `MultiPoint` to use to create the `Turf.Feature`.
-    public init(_ multiPoint: MultiPoint) {
+    internal init(_ multiPoint: MultiPoint) {
         self.init(geometry: Turf.Geometry.multiPoint(multiPoint))
     }
 
     /// Initialize a `Turf.Feature` with a `MultiLineString`.
     /// - Parameter multiLine: The `MultiLineString` to use to create the `Turf.Feature`.
-    public init(_ multiLine: MultiLineString) {
+    internal init(_ multiLine: MultiLineString) {
         self.init(geometry: Turf.Geometry.multiLineString(multiLine))
     }
 
     /// Initialize a `Turf.Feature` with a `MultiPolygon`.
     /// - Parameter multiPolygon: The `MultiPolygon` to use to create the `Turf.Feature`.
-    public init(_ multiPolygon: MultiPolygon) {
+    internal init(_ multiPolygon: MultiPolygon) {
         self.init(geometry: Turf.Geometry.multiPolygon(multiPolygon))
     }
 
     /// Initialize a `Turf.Feature` with a `GeometryCollection`.
     /// - Parameter geometryCollection: The `GeometryCollection` to use to create the `Turf.Feature`.
-    public init(_ geometryCollection: GeometryCollection) {
+    internal init(_ geometryCollection: GeometryCollection) {
         self.init(geometry: Turf.Geometry.geometryCollection(geometryCollection))
     }
 }

--- a/Sources/MapboxMaps/Foundation/Extensions/Turf/Geometry.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Turf/Geometry.swift
@@ -5,13 +5,11 @@ import MapboxCommon
 
 // MARK: - Geometry
 
-public typealias Geometry = MapboxCommon.Geometry
-
 extension Turf.Geometry {
 
     /// Allows a Turf object to be initialized with an internal `Geometry` object.
     /// - Parameter geometry: The `Geometry` object to transform.
-    internal init?(_ geometry: Geometry) {
+    internal init?(_ geometry: MapboxCommon.Geometry) {
         switch geometry.geometryType {
         case GeometryType_Point:
             guard let coordinate = geometry.extractLocations()?.coordinateValue() else {

--- a/Sources/MapboxMaps/Foundation/Extensions/Turf/Geometry.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Turf/Geometry.swift
@@ -11,7 +11,7 @@ extension Turf.Geometry {
 
     /// Allows a Turf object to be initialized with an internal `Geometry` object.
     /// - Parameter geometry: The `Geometry` object to transform.
-    public init?(_ geometry: Geometry) {
+    internal init?(_ geometry: Geometry) {
         switch geometry.geometryType {
         case GeometryType_Point:
             guard let coordinate = geometry.extractLocations()?.coordinateValue() else {

--- a/Sources/MapboxMaps/Offline/OfflineManager+MapboxMaps.swift
+++ b/Sources/MapboxMaps/Offline/OfflineManager+MapboxMaps.swift
@@ -50,13 +50,13 @@ extension MapboxCoreMaps.OfflineManager {
             return __loadStylePack(forStyleURI: styleURI.rawValue,
                                    loadOptions: loadOptions,
                                    onProgress: progress,
-                                   onFinished: offlineManagerClosureAdapter(for: completion, type: StylePack.self))
+                                   onFinished: offlineManagerClosureAdapter(for: completion, type: StylePack.self)).asCancelable()
         }
         // An overloaded version that does not report progess of the loading operation.
         else {
             return __loadStylePack(forStyleURI: styleURI.rawValue,
                                    loadOptions: loadOptions,
-                                   onFinished: offlineManagerClosureAdapter(for: completion, type: StylePack.self))
+                                   onFinished: offlineManagerClosureAdapter(for: completion, type: StylePack.self)).asCancelable()
         }
     }
 

--- a/Sources/MapboxMaps/Offline/TileStore+MapboxMaps.swift
+++ b/Sources/MapboxMaps/Offline/TileStore+MapboxMaps.swift
@@ -78,13 +78,13 @@ extension TileStore {
             return __loadTileRegion(forId: id,
                                     loadOptions: loadOptions,
                                     onProgress: progress,
-                                    onFinished: tileStoreClosureAdapter(for: completion, type: TileRegion.self))
+                                    onFinished: tileStoreClosureAdapter(for: completion, type: TileRegion.self)).asCancelable()
         }
         // Use overloaded version
         else {
             return __loadTileRegion(forId: id,
                                     loadOptions: loadOptions,
-                                    onFinished: tileStoreClosureAdapter(for: completion, type: TileRegion.self))
+                                    onFinished: tileStoreClosureAdapter(for: completion, type: TileRegion.self)).asCancelable()
         }
     }
 

--- a/Tests/MapboxMapsTests/Foundation/Camera/CameraStateTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Camera/CameraStateTests.swift
@@ -146,39 +146,4 @@ final class CameraStateTests: XCTestCase {
                 pitch: Double(pitch + 1)))
         XCTAssertNotEqual(cameraState, other)
     }
-
-    func testEquatabilityOfObjcCameraState() {
-
-        var cameraStateObjc = MapboxCoreMaps.CameraState(
-            center: center,
-            padding: padding,
-            zoom: Double(zoom),
-            bearing: bearing,
-            pitch: Double(pitch))
-
-        var otherCameraStateObjc = MapboxCoreMaps.CameraState(
-            center: center,
-            padding: padding,
-            zoom: Double(zoom),
-            bearing: bearing,
-            pitch: Double(pitch))
-
-        XCTAssertEqual(cameraStateObjc, otherCameraStateObjc)
-
-        cameraStateObjc = MapboxCoreMaps.CameraState(
-            center: center,
-            padding: padding,
-            zoom: Double(zoom),
-            bearing: bearing,
-            pitch: Double(pitch))
-
-        otherCameraStateObjc = MapboxCoreMaps.CameraState(
-            center: center,
-            padding: padding,
-            zoom: Double(zoom + 1),
-            bearing: bearing,
-            pitch: Double(pitch))
-
-        XCTAssertNotEqual(cameraStateObjc, otherCameraStateObjc)
-    }
 }

--- a/Tests/MapboxMapsTests/Foundation/Extensions/Core/LayerPositionTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Extensions/Core/LayerPositionTests.swift
@@ -25,22 +25,4 @@ final class LayerPositionTests: XCTestCase {
         XCTAssertNotEqual(e, f)
         XCTAssertNotEqual(g, h)
     }
-
-    func testCoreMapsPositionEquality() {
-        let a = MapboxCoreMaps.LayerPosition(above: nil, below: nil, at: nil)
-        let b = MapboxCoreMaps.LayerPosition(above: nil, below: nil, at: nil)
-        let c = MapboxCoreMaps.LayerPosition(above: "above", below: nil, at: nil)
-        let d = MapboxCoreMaps.LayerPosition(above: "above", below: "below", at: nil)
-        let e = MapboxCoreMaps.LayerPosition(above: "above", below: "below", at: 3)
-        let f = MapboxCoreMaps.LayerPosition(above: "above", below: "below", at: 3)
-
-        XCTAssertEqual(a, b)
-        XCTAssertEqual(e, f)
-
-        XCTAssertNotEqual(a, c)
-        XCTAssertNotEqual(c, d)
-        XCTAssertNotEqual(d, e)
-
-        XCTAssertEqual(f.at, 3)
-    }
 }


### PR DESCRIPTION
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Changelog updated
 - [x] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

MapboxMaps defined extensions on several types from its dependencies (MapboxCoreMaps, MapboxCommon, Turf) which had the same names as types defined in MapboxMaps. These extensions were written with the dependency module names as prefixes. For example:

```
extension MapboxCoreMaps.CameraState {
```

When MapboxMaps was built as an XCFramework, the generated swiftinterface file dropped the module name prefix from these declarations:

```
extension CameraState {
```

This led to build errors because the compiler then interpreted the declarations as being extensions of the types in MapboxMaps rather than extensions of the types in the dependencies.

To work around this issue, we are avoiding this coding pattern and only using internal and private extensions of such types.

### Breaking changes

- The `isEqual` implementations of `MapboxCoreMaps.CameraState` and `MapboxCoreMaps.LayerPosition` now only check for object identity (the default `NSObject` behavior). Use `MapboxMaps.CameraState` and `MapboxMaps.LayerPosition` instead.
- `MapboxCommon.Cancelable` no longer conforms to `MapboxMaps.Cancelable`.
- `MapboxCoreMaps.LayerPosition`'s `at` property and `init(above:below:at:)` convenience initializer are no longer public. Use `MapboxMaps.LayerPosition` instead or use the unrefined APIs (see the implementations in LayerPosition.swift)
- The convenience initializers added to `Turf.Feature` and `Turf.Geometry` that aid in converting from the `MapboxCommon` counterparts are no longer public. If you need to make these conversions, see the reference implementations in Feature.swift and Geometry.swift
- The convenience initializers added to `Turf.Feature` that aid in creating features from geometries are no longer public. Use the standard Turf APIs instead.