### PR TITLE
Expose gesture recognizers directly on MapView.GestureManager

### DIFF
--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -19,6 +19,80 @@ public final class GestureManager: NSObject {
     /// Map of GestureType --> GestureHandler. We mantain a map to allow us to remove gestures arbitrarily.
     private(set) var gestureHandlers: [GestureType: GestureHandler] = [:]
 
+    /// The underlying gesture recognizer for the pan gesture
+    public var panGestureRecognizer: UIPanGestureRecognizer? {
+        if let handler = gestureHandlers[.pan],
+           let recognizer = handler.gestureRecognizer as? UIPanGestureRecognizer {
+            return recognizer
+        }
+
+        return nil
+    }
+
+    /// The underlying gesture recognizer for the "double tap to zoom in" gesture
+    public var doubleTapToZoomInGestureRecognizer: UITapGestureRecognizer? {
+        if let handler = gestureHandlers[.tap(numberOfTaps: 2, numberOfTouches: 1)],
+           let recognizer = handler.gestureRecognizer as? UITapGestureRecognizer {
+            return recognizer
+        }
+
+        return nil
+    }
+
+    /// The underlying gesture recognizer for the "double tap to zoom out" gesture
+    public var doubleTapToZoomOutGestureRecognizer: UITapGestureRecognizer? {
+        if let handler = gestureHandlers[.tap(numberOfTaps: 2, numberOfTouches: 2)],
+           let recognizer = handler.gestureRecognizer as? UITapGestureRecognizer {
+            return recognizer
+        }
+
+        return nil
+    }
+
+    /// The underlying gesture recognizer for the quickZoom gesture
+    public var quickZoomGestureRecognizer: UILongPressGestureRecognizer? {
+
+        if let handler = gestureHandlers[.quickZoom],
+           let recognizer = handler.gestureRecognizer as? UILongPressGestureRecognizer {
+            return recognizer
+        }
+
+        return nil
+    }
+
+    /// The underlying gesture recognizer for the pitch gesture
+    public var pitchGestureRecognizer: UIPanGestureRecognizer? {
+
+        if let handler = gestureHandlers[.pitch],
+           let recognizer = handler.gestureRecognizer as? UIPanGestureRecognizer {
+            return recognizer
+        }
+
+        return nil
+    }
+
+    /// The underlying gesture recognizer for the rotate gesture
+    public var rotationGestureRecognizer: UIRotationGestureRecognizer? {
+
+        if let handler = gestureHandlers[.rotate],
+           let recognizer = handler.gestureRecognizer as? UIRotationGestureRecognizer {
+            return recognizer
+        }
+
+        return nil
+    }
+
+    /// The underlying gesture recognizer for the "pinch to zoom" gesture
+    public var pinchGestureRecognizer: UIPinchGestureRecognizer? {
+
+        if let handler = gestureHandlers[.pinch],
+           let recognizer = handler.gestureRecognizer as? UIPinchGestureRecognizer {
+            return recognizer
+        }
+
+        return nil
+    }
+
     /// The view that all gestures operate on
     private weak var view: UIView?
 

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -20,77 +20,38 @@ public final class GestureManager: NSObject {
     private(set) var gestureHandlers: [GestureType: GestureHandler] = [:]
 
     /// The underlying gesture recognizer for the pan gesture
-    public var panGestureRecognizer: UIPanGestureRecognizer? {
-        if let handler = gestureHandlers[.pan],
-           let recognizer = handler.gestureRecognizer as? UIPanGestureRecognizer {
-            return recognizer
-        }
-
-        return nil
+    public var panGestureRecognizer: UIGestureRecognizer? {
+        return gestureHandlers[.pan]?.gestureRecognizer
     }
 
     /// The underlying gesture recognizer for the "double tap to zoom in" gesture
-    public var doubleTapToZoomInGestureRecognizer: UITapGestureRecognizer? {
-        if let handler = gestureHandlers[.tap(numberOfTaps: 2, numberOfTouches: 1)],
-           let recognizer = handler.gestureRecognizer as? UITapGestureRecognizer {
-            return recognizer
-        }
-
-        return nil
+    public var doubleTapToZoomInGestureRecognizer: UIGestureRecognizer? {
+        return gestureHandlers[.tap(numberOfTaps: 2, numberOfTouches: 1)]?.gestureRecognizer
     }
 
     /// The underlying gesture recognizer for the "double tap to zoom out" gesture
-    public var doubleTapToZoomOutGestureRecognizer: UITapGestureRecognizer? {
-        if let handler = gestureHandlers[.tap(numberOfTaps: 2, numberOfTouches: 2)],
-           let recognizer = handler.gestureRecognizer as? UITapGestureRecognizer {
-            return recognizer
-        }
-
-        return nil
+    public var doubleTapToZoomOutGestureRecognizer: UIGestureRecognizer? {
+        return gestureHandlers[.tap(numberOfTaps: 2, numberOfTouches: 2)]?.gestureRecognizer
     }
 
     /// The underlying gesture recognizer for the quickZoom gesture
-    public var quickZoomGestureRecognizer: UILongPressGestureRecognizer? {
-
-        if let handler = gestureHandlers[.quickZoom],
-           let recognizer = handler.gestureRecognizer as? UILongPressGestureRecognizer {
-            return recognizer
-        }
-
-        return nil
+    public var quickZoomGestureRecognizer: UIGestureRecognizer? {
+        return gestureHandlers[.quickZoom]?.gestureRecognizer
     }
 
     /// The underlying gesture recognizer for the pitch gesture
-    public var pitchGestureRecognizer: UIPanGestureRecognizer? {
-
-        if let handler = gestureHandlers[.pitch],
-           let recognizer = handler.gestureRecognizer as? UIPanGestureRecognizer {
-            return recognizer
-        }
-
-        return nil
+    public var pitchGestureRecognizer: UIGestureRecognizer? {
+        return gestureHandlers[.pitch]?.gestureRecognizer
     }
 
     /// The underlying gesture recognizer for the rotate gesture
-    public var rotationGestureRecognizer: UIRotationGestureRecognizer? {
-
-        if let handler = gestureHandlers[.rotate],
-           let recognizer = handler.gestureRecognizer as? UIRotationGestureRecognizer {
-            return recognizer
-        }
-
-        return nil
+    public var rotationGestureRecognizer: UIGestureRecognizer? {
+        return gestureHandlers[.rotate]?.gestureRecognizer
     }
 
     /// The underlying gesture recognizer for the "pinch to zoom" gesture
-    public var pinchGestureRecognizer: UIPinchGestureRecognizer? {
-
-        if let handler = gestureHandlers[.pinch],
-           let recognizer = handler.gestureRecognizer as? UIPinchGestureRecognizer {
-            return recognizer
-        }
-
-        return nil
+    public var pinchGestureRecognizer: UIGestureRecognizer? {
+        return gestureHandlers[.pinch]?.gestureRecognizer
     }
 
     /// The view that all gestures operate on

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -37,6 +37,16 @@ final class GestureManagerTests: XCTestCase {
         XCTAssert(gestureManager.gestureHandlers[.tap(numberOfTaps: 2, numberOfTouches: 2)] is TapGestureHandler)
         XCTAssert(gestureManager.gestureHandlers[.pan] is PanGestureHandler)
     }
+    
+    func testGestureRecognizersReturnedAreSameAsRecognizersPresentInGestureHandlers() {
+        XCTAssertTrue(gestureManager.gestureHandlers[.tap(numberOfTaps: 2, numberOfTouches: 1)]?.gestureRecognizer === gestureManager.doubleTapToZoomInGestureRecognizer)
+        XCTAssertTrue(gestureManager.gestureHandlers[.tap(numberOfTaps: 2, numberOfTouches: 2)]?.gestureRecognizer === gestureManager.doubleTapToZoomOutGestureRecognizer)
+        XCTAssertTrue(gestureManager.gestureHandlers[.pan]?.gestureRecognizer === gestureManager.panGestureRecognizer)
+        XCTAssertTrue(gestureManager.gestureHandlers[.pinch]?.gestureRecognizer === gestureManager.pinchGestureRecognizer)
+        XCTAssertTrue(gestureManager.gestureHandlers[.pitch]?.gestureRecognizer === gestureManager.pitchGestureRecognizer)
+        XCTAssertTrue(gestureManager.gestureHandlers[.quickZoom]?.gestureRecognizer === gestureManager.quickZoomGestureRecognizer)
+        XCTAssertTrue(gestureManager.gestureHandlers[.rotate]?.gestureRecognizer === gestureManager.rotationGestureRecognizer)
+    }
 
     func testTapGesturesTypesAreEqual() {
         let singleTapA = GestureType.tap(numberOfTaps: 1, numberOfTouches: 1)

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -37,7 +37,7 @@ final class GestureManagerTests: XCTestCase {
         XCTAssert(gestureManager.gestureHandlers[.tap(numberOfTaps: 2, numberOfTouches: 2)] is TapGestureHandler)
         XCTAssert(gestureManager.gestureHandlers[.pan] is PanGestureHandler)
     }
-    
+
     func testGestureRecognizersReturnedAreSameAsRecognizersPresentInGestureHandlers() {
         XCTAssertTrue(gestureManager.gestureHandlers[.tap(numberOfTaps: 2, numberOfTouches: 1)]?.gestureRecognizer === gestureManager.doubleTapToZoomInGestureRecognizer)
         XCTAssertTrue(gestureManager.gestureHandlers[.tap(numberOfTaps: 2, numberOfTouches: 2)]?.gestureRecognizer === gestureManager.doubleTapToZoomOutGestureRecognizer)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Gesutre Recognizers added to the mapView are exposed as properties on `mapView.gestures`</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR adds computed vars to the public interface of `MapView.GestureManager` which allow for a developer to inspect (and potentially become the `GestureRecognizerDelegate` of) stock gestures that are set on the map.
