### PR TITLE
Make tap gesture recognizer public on annotation managers + clean up

### DIFF
--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
@@ -18,7 +18,6 @@ public struct CircleAnnotation: Annotation {
         }
     }
 
-    public var type: AnnotationType = .circle
 
     /// Create a circle annotation with a `Turf.Point` and an optional identifier.
     public init(id: String = UUID().uuidString, point: Turf.Point) {

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -187,8 +187,8 @@ public class CircleAnnotationManager: AnnotationManager {
         }
     }
 
-    /// The `UITapGestureRecognizer` that's listening to touch events on the map
-    private var tapRecognizer: UITapGestureRecognizer?
+    /// The `UITapGestureRecognizer` that's listening to touch events on the map for the annotations present in this manager
+    public var tapRecognizer: UITapGestureRecognizer?
 
     internal func setupTapRecognizer() {
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
@@ -223,6 +223,7 @@ public class CircleAnnotationManager: AnnotationManager {
             }
         }
     }
+
 } 
 // End of generated file.
 // swiftlint:enable all

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
@@ -18,7 +18,6 @@ public struct PointAnnotation: Annotation {
         }
     }
 
-    public var type: AnnotationType = .point
 
     /// Create a point annotation with a `Turf.Point` and an optional identifier.
     public init(id: String = UUID().uuidString, point: Turf.Point) {
@@ -303,7 +302,18 @@ public struct PointAnnotation: Annotation {
     }
 
     // MARK: - Image Convenience -
-    public var image: Image? {
+    
+    public struct NamedImage {
+        public init(image: UIImage, name: String) {
+            self.image = image
+            self.name = name
+        }
+        
+        public let image: UIImage
+        public let name: String
+    }
+    
+    public var image: NamedImage? {
         didSet {
             self.iconImage = image?.name
         }

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -12,7 +12,7 @@ public class PointAnnotationManager: AnnotationManager {
     /// The collection of PointAnnotations being managed
     public private(set) var annotations = [PointAnnotation]() {
         didSet {
-            addImageToStyleIfNeeded(style: style)
+            addImageToStyleIfNeeded()
             syncAnnotations()
          }
     }
@@ -495,8 +495,8 @@ public class PointAnnotationManager: AnnotationManager {
         }
     }
 
-    /// The `UITapGestureRecognizer` that's listening to touch events on the map
-    private var tapRecognizer: UITapGestureRecognizer?
+    /// The `UITapGestureRecognizer` that's listening to touch events on the map for the annotations present in this manager
+    public var tapRecognizer: UITapGestureRecognizer?
 
     internal func setupTapRecognizer() {
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
@@ -528,6 +528,23 @@ public class PointAnnotationManager: AnnotationManager {
             case .failure(let error):
                 Log.warning(forMessage: "Failed to query map for annotations due to error: \(error)", 
                             category: "Annotations")
+            }
+        }
+    }
+
+    // MARK: - Image Convenience -
+    
+    func addImageToStyleIfNeeded() {
+        guard let style = style else { return }
+        let namedImages = annotations.compactMap(\.image)
+        for namedImage in namedImages {
+            do {
+                let image = style.image(withId: namedImage.name)
+                if image == nil {
+                    try style.addImage(namedImage.image, id: namedImage.name)
+                } 
+            } catch {
+                Log.warning(forMessage: "Could not add image to style in PointAnnotationManager", category: "Annnotations")
             }
         }
     }

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
@@ -18,7 +18,6 @@ public struct PolygonAnnotation: Annotation {
         }
     }
 
-    public var type: AnnotationType = .polygon
 
     /// Create a polygon annotation with a `Turf.Polygon` and an optional identifier.
     public init(id: String = UUID().uuidString, polygon: Turf.Polygon) {

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -175,8 +175,8 @@ public class PolygonAnnotationManager: AnnotationManager {
         }
     }
 
-    /// The `UITapGestureRecognizer` that's listening to touch events on the map
-    private var tapRecognizer: UITapGestureRecognizer?
+    /// The `UITapGestureRecognizer` that's listening to touch events on the map for the annotations present in this manager
+    public var tapRecognizer: UITapGestureRecognizer?
 
     internal func setupTapRecognizer() {
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
@@ -211,6 +211,7 @@ public class PolygonAnnotationManager: AnnotationManager {
             }
         }
     }
+
 } 
 // End of generated file.
 // swiftlint:enable all

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
@@ -18,7 +18,6 @@ public struct PolylineAnnotation: Annotation {
         }
     }
 
-    public var type: AnnotationType = .polyline
 
     /// Create a polyline annotation with a `Turf.Polyline` and an optional identifier.
     public init(id: String = UUID().uuidString, line: Turf.LineString) {

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -223,8 +223,8 @@ public class PolylineAnnotationManager: AnnotationManager {
         }
     }
 
-    /// The `UITapGestureRecognizer` that's listening to touch events on the map
-    private var tapRecognizer: UITapGestureRecognizer?
+    /// The `UITapGestureRecognizer` that's listening to touch events on the map for the annotations present in this manager
+    public var tapRecognizer: UITapGestureRecognizer?
 
     internal func setupTapRecognizer() {
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
@@ -259,6 +259,7 @@ public class PolylineAnnotationManager: AnnotationManager {
             }
         }
     }
+
 } 
 // End of generated file.
 // swiftlint:enable all


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR makes the following changes:

- The `tapRecognizer` on annotation managers is now public. It can be used to coordinate with custom gestures that a developer may want to add on the map.
- Annotations no longer have a `type` var since it's redundant.
