### PR TITLE
Add scroll edge appearance for iOS 15

### DIFF
--- a/Apps/Examples/Examples/AppDelegate.swift
+++ b/Apps/Examples/Examples/AppDelegate.swift
@@ -13,7 +13,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let examplesTableViewController = ExampleTableViewController()
         let navigationController = UINavigationController(rootViewController: examplesTableViewController)
-        navigationController.navigationBar.prefersLargeTitles = true
+
+        let appearance = UINavigationBar.appearance()
+        appearance.prefersLargeTitles = true
+
+        if #available(iOS 13.0, *) {
+            appearance.scrollEdgeAppearance = UINavigationBarAppearance()
+        }
+
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

Adds scroll edge appearance for UINavigationBar to ensure bar is visible on iOS 15.