### PR TITLE
[testing] Test the attribution button's behavior when tapped

### DIFF
--- a/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
+++ b/Mapbox/MapboxMaps.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		0CE8ED6125890F870066E56C /* ModelSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE8ED6025890F870066E56C /* ModelSource.swift */; };
 		0CECCCCD253491A80000FC64 /* LocationSupportableMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CECCCCC253491A80000FC64 /* LocationSupportableMapView.swift */; };
 		0CF0C42924EB1779000DC118 /* Enums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF0C42824EB1779000DC118 /* Enums.swift */; };
+		172C6FC8267A976E0016B301 /* MapboxInfoButtonOrnamentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172C6FC7267A976E0016B301 /* MapboxInfoButtonOrnamentViewTests.swift */; };
 		174CD9A2266E8E9200EB588A /* ScaleBar in Resources */ = {isa = PBXBuildFile; fileRef = 174CD9A1266E8E9200EB588A /* ScaleBar */; };
 		1FECC9E02474519D00B63910 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FECC9DF2474519D00B63910 /* Expression.swift */; };
 		2B8637D52461601100698135 /* MapboxScaleBarOrnamentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8637D42461601100698135 /* MapboxScaleBarOrnamentView.swift */; };
@@ -570,6 +571,7 @@
 		0CECCCCC253491A80000FC64 /* LocationSupportableMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSupportableMapView.swift; sourceTree = "<group>"; };
 		0CF0C42824EB1779000DC118 /* Enums.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Enums.swift; sourceTree = "<group>"; };
 		0CF118A2243D1C630097779A /* PinchGestureHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchGestureHandler.swift; sourceTree = "<group>"; };
+		172C6FC7267A976E0016B301 /* MapboxInfoButtonOrnamentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxInfoButtonOrnamentViewTests.swift; sourceTree = "<group>"; };
 		174CD9A1266E8E9200EB588A /* ScaleBar */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ScaleBar; sourceTree = "<group>"; };
 		1F11C11C2421B05600F8397B /* MapboxMapsFoundationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxMapsFoundationTests.swift; sourceTree = "<group>"; };
 		1F2AD73C2421C462006592F4 /* GestureManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GestureManagerTests.swift; sourceTree = "<group>"; };
@@ -849,6 +851,7 @@
 		07797F9F242C21BC00229F7D /* MapboxMapsOrnamentsTests */ = {
 			isa = PBXGroup;
 			children = (
+				172C6FC6267A974B0016B301 /* InfoButton */,
 				174CD9A1266E8E9200EB588A /* ScaleBar */,
 				A495048C2666BE8700130A8F /* Compass */,
 				2B8637E72464021500698135 /* DistanceFormatterTests.swift */,
@@ -1237,6 +1240,14 @@
 				0CF0C42824EB1779000DC118 /* Enums.swift */,
 			);
 			path = Enums;
+			sourceTree = "<group>";
+		};
+		172C6FC6267A974B0016B301 /* InfoButton */ = {
+			isa = PBXGroup;
+			children = (
+				172C6FC7267A976E0016B301 /* MapboxInfoButtonOrnamentViewTests.swift */,
+			);
+			path = InfoButton;
 			sourceTree = "<group>";
 		};
 		1F11C1102421B05600F8397B /* MapboxMapsFoundation */ = {
@@ -2154,6 +2165,7 @@
 				CAC1960B25AE98F400F69FEA /* GlyphsRasterizationOptions.swift in Sources */,
 				0706C49225B1128A008733C0 /* Terrain.swift in Sources */,
 				CA03F1132626948300673961 /* StylePackLoadOptions+MapboxMaps.swift in Sources */,
+				172C6FC8267A976E0016B301 /* MapboxInfoButtonOrnamentViewTests.swift in Sources */,
 				CABCDF4B2620E0D800D61635 /* Bool.swift in Sources */,
 				CA5890D6264B00B50060987A /* MapEventHandler.swift in Sources */,
 				0C350D83263278090090FA74 /* FlyToCameraAnimator.swift in Sources */,

--- a/Sources/MapboxMaps/Ornaments/MapboxInfoButtonOrnament.swift
+++ b/Sources/MapboxMaps/Ornaments/MapboxInfoButtonOrnament.swift
@@ -8,7 +8,7 @@ internal class MapboxInfoButtonOrnament: UIView {
         static let telemetryURL = "https://www.mapbox.com/telemetry/"
     }
 
-    private var isMetricsEnabled: Bool {
+    internal var isMetricsEnabled: Bool {
         get {
             UserDefaults.standard.bool(forKey: Constants.metricsEnabledKey)
         }
@@ -57,7 +57,7 @@ internal class MapboxInfoButtonOrnament: UIView {
     }
 
     @objc
-    private func infoTapped() {
+    internal func infoTapped() {
         guard let viewController = parentViewController else { return }
         let alert: UIAlertController
 
@@ -97,7 +97,7 @@ internal class MapboxInfoButtonOrnament: UIView {
     }
 
     //swiftlint:disable function_body_length
-    private func showTelemetryAlertController() {
+    internal func showTelemetryAlertController() {
         guard let viewController = parentViewController else { return }
         let alert: UIAlertController
         let bundle = Bundle.mapboxMaps
@@ -176,7 +176,7 @@ internal class MapboxInfoButtonOrnament: UIView {
     }
 }
 
-private extension UIView {
+internal extension UIView {
     var parentViewController: UIViewController? {
         var parentResponder: UIResponder? = self
         while parentResponder != nil {

--- a/Sources/MapboxMaps/Ornaments/MapboxInfoButtonOrnament.swift
+++ b/Sources/MapboxMaps/Ornaments/MapboxInfoButtonOrnament.swift
@@ -2,7 +2,7 @@ import UIKit
 @_implementationOnly import MapboxCommon_Private
 
 internal class MapboxInfoButtonOrnament: UIView {
-    private enum Constants {
+    internal enum Constants {
         static let localizableTableName = "OrnamentsLocalizable"
         static let metricsEnabledKey = "MGLMapboxMetricsEnabled"
         static let telemetryURL = "https://www.mapbox.com/telemetry/"

--- a/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentViewTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentViewTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import MapboxMaps
+
+class MapboxInfoButtonOrnamentTests: MapViewIntegrationTestCase {
+    func testInfoButton() throws {
+        let mapView = try XCTUnwrap(self.mapView, "There should be a map view present.")
+        
+        let initialSubviews = mapView.subviews.filter { $0 is MapboxInfoButtonOrnament }
+
+        let infoButton = try XCTUnwrap(initialSubviews.first as? MapboxInfoButtonOrnament, "The MapView should include an info button as a subview")
+        
+        let parentViewController = try XCTUnwrap(infoButton.parentViewController, "")
+        
+        infoButton.infoTapped()
+        
+        let expectation = XCTestExpectation(description: "alert controller should exist")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            let alertControllers = parentViewController.children
+    //            parentViewController.children.filter { $0 is UIAlertController }
+            do {
+                let alertController = try XCTUnwrap(alertControllers.first, "There should be an alert controller present.")
+                expectation.fulfill()
+            } catch {
+                print("Couldn't find alert controller.")
+            }
+
+        }
+        wait(for: [expectation], timeout: 5)
+    }
+    
+    func testMetricsEnabled() {
+        let infoButton = MapboxInfoButtonOrnament()
+        
+        XCTAssertFalse(infoButton.isMetricsEnabled, "Metrics should be enabled by default.")
+        
+//        UserDefaults.standard.set(false, forKey: MapboxInfoButton.Constants.metricsEnabledKey)
+    }
+}
+
+class MockMapboxInfoButtonOrnament: MapboxInfoButtonOrnament {
+    var didTapInfoButton: Bool
+    var didShowTelemetryController: Bool
+
+    override func infoTapped() {
+        didTapInfoButton = true
+    }
+    
+    override func showTelemetryAlertController() {
+        
+    }
+}

--- a/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentViewTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentViewTests.swift
@@ -26,11 +26,11 @@ class MapboxInfoButtonOrnamentTests: MapViewIntegrationTestCase {
         parentViewController.view.addSubview(infoButton)
         infoButton.infoTapped()
 
-        let infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The first alert controller could not be found.")
+        var infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
         XCTAssertNotNil(infoAlert)
         infoAlert.tapButton(atIndex: 0)
 
-        let telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The second alert controller could not be found.")
+        var telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
 
         XCTAssertEqual(telemetryAlert.actions.count, 3, "The telemetry alert should have 3 actions.")
 
@@ -44,6 +44,16 @@ class MapboxInfoButtonOrnamentTests: MapViewIntegrationTestCase {
 
         telemetryAlert.tapButton(atIndex: 1)
         XCTAssertFalse(infoButton.isMetricsEnabled, "Metrics should not be enabled after selecting 'Stop participating'.")
+
+        infoButton.infoTapped()
+        infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
+        infoAlert.tapButton(atIndex: 0)
+
+        telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
+        let dontParticipateTitle = NSLocalizedString("Don’t Participate", comment: "Telemetry prompt button")
+        XCTAssertEqual(dontParticipateTitle, telemetryAlert.actions[1].title, "The second action should be a 'Don't Participate' button.")
+        telemetryAlert.tapButton(atIndex: 1)
+        XCTAssertFalse(infoButton.isMetricsEnabled, "Metrics should not be enabled after selecting 'Don't Participate'.")
     }
     
     func testTelemetryOptIn() throws {
@@ -53,11 +63,11 @@ class MapboxInfoButtonOrnamentTests: MapViewIntegrationTestCase {
         parentViewController.view.addSubview(infoButton)
         infoButton.infoTapped()
 
-        let infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The first alert controller could not be found.")
+        var infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
         XCTAssertNotNil(infoAlert)
         infoAlert.tapButton(atIndex: 0)
 
-        let telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The second alert controller could not be found.")
+        var telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
 
         XCTAssertEqual(telemetryAlert.actions.count, 3, "The telemetry alert should have 3 actions.")
 
@@ -71,6 +81,15 @@ class MapboxInfoButtonOrnamentTests: MapViewIntegrationTestCase {
 
         telemetryAlert.tapButton(atIndex: 2)
         XCTAssertTrue(infoButton.isMetricsEnabled, "Metrics should be enabled after selecting 'Participate'.")
+        
+        infoButton.infoTapped()
+        infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
+        infoAlert.tapButton(atIndex: 0)
+        telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
+        let keepParticipatingTitle = NSLocalizedString("Keep Participating", comment: "Telemetry prompt button")
+        XCTAssertEqual(keepParticipatingTitle, telemetryAlert.actions[2].title, "The third action should be a 'Keep Participating' button.")
+        telemetryAlert.tapButton(atIndex: 2)
+        XCTAssertTrue(infoButton.isMetricsEnabled, "Metrics should be enabled after selecting 'Keep Participating'.")
     }
 }
 

--- a/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentViewTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentViewTests.swift
@@ -2,30 +2,43 @@ import XCTest
 @testable import MapboxMaps
 
 class MapboxInfoButtonOrnamentTests: MapViewIntegrationTestCase {
-    func testInfoButton() throws {
-        let mapView = try XCTUnwrap(self.mapView, "There should be a map view present.")
-        
-        let initialSubviews = mapView.subviews.filter { $0 is MapboxInfoButtonOrnament }
-
-        let infoButton = try XCTUnwrap(initialSubviews.first as? MapboxInfoButtonOrnament, "The MapView should include an info button as a subview")
-        
-        let parentViewController = try XCTUnwrap(infoButton.parentViewController, "")
-        
+    func testInfoButtonTapped() throws {
+        let infoButton = MapboxInfoButtonOrnament()
+        let parentViewController = MockParentViewController()
+        parentViewController.view.addSubview(infoButton)
         infoButton.infoTapped()
         
-        let expectation = XCTestExpectation(description: "alert controller should exist")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            let alertControllers = parentViewController.children
-    //            parentViewController.children.filter { $0 is UIAlertController }
-            do {
-                let alertController = try XCTUnwrap(alertControllers.first, "There should be an alert controller present.")
-                expectation.fulfill()
-            } catch {
-                print("Couldn't find alert controller.")
-            }
+        let firstAlert = try XCTUnwrap(parentViewController.currentAlert, "The first alert controller could not be found.")
+        XCTAssertNotNil(firstAlert)
+        
+        XCTAssertEqual(firstAlert.actions.count, 2, "There should be two alerts present.")
+        let telemetryTitle = NSLocalizedString("Mapbox Telemetry", comment: "Action in attribution sheet")
+        XCTAssertEqual(firstAlert.actions[0].title!, telemetryTitle)
+        
+        let cancelTitle = NSLocalizedString("Cancel", comment: "Title of button for dismissing attribution action sheet")
+        XCTAssertEqual(firstAlert.actions[1].title, cancelTitle)
+    }
+    
+    func testTelemetryTapped() throws {
+        
+        UserDefaults.standard.set(true, forKey: MapboxInfoButtonOrnament.Constants.metricsEnabledKey)
+        let infoButton = MapboxInfoButtonOrnament()
+        let parentViewController = MockParentViewController()
+        parentViewController.view.addSubview(infoButton)
+        infoButton.infoTapped()
+        
+        let firstAlert = try XCTUnwrap(parentViewController.currentAlert, "The first alert controller could not be found.")
+        XCTAssertNotNil(firstAlert)
 
-        }
-        wait(for: [expectation], timeout: 5)
+        firstAlert.tapButton(atIndex: 0)
+        let secondAlert = try XCTUnwrap(parentViewController.currentAlert, "The second alert controller could not be found.")
+        
+        XCTAssertEqual(secondAlert.actions.count, 3, "The telemetry alert should have 3 actions.")
+        
+        let cancelTitle = NSLocalizedString( "Keep Participating", comment: "Telemetry prompt button")
+        XCTAssertEqual(cancelTitle, secondAlert.actions[2].title, "The third action should be a cancel button.")
+        
+        XCTAssertTrue(infoButton.isMetricsEnabled)
     }
     
     func testMetricsEnabled() {
@@ -37,15 +50,30 @@ class MapboxInfoButtonOrnamentTests: MapViewIntegrationTestCase {
     }
 }
 
-class MockMapboxInfoButtonOrnament: MapboxInfoButtonOrnament {
-    var didTapInfoButton: Bool
-    var didShowTelemetryController: Bool
+class MockParentViewController: UIViewController {
+    var alertCount = 0
+    var currentAlert: UIAlertController?
 
-    override func infoTapped() {
-        didTapInfoButton = true
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        if let vc = viewControllerToPresent as? UIAlertController {
+            currentAlert = vc
+            alertCount += 1
+        }
+    }
+}
+
+// From https://stackoverflow.com/questions/36173740/trigger-uialertaction-on-uialertcontroller-programmatically
+extension UIAlertController {
+    typealias AlertHandler = @convention(block) (UIAlertAction) -> Void
+
+    func tapButton(atIndex index: Int) {
+        guard let block = actions[index].value(forKey: "handler") else { return }
+        let handler = unsafeBitCast(block as AnyObject, to: AlertHandler.self)
+        handler(actions[index])
     }
     
-    override func showTelemetryAlertController() {
-        
+    override open func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        print("BYE")
+        super.dismiss(animated: flag, completion: completion)
     }
 }

--- a/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentViewTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentViewTests.swift
@@ -1,12 +1,13 @@
 import XCTest
 @testable import MapboxMaps
 
-class MapboxInfoButtonOrnamentTests: MapViewIntegrationTestCase {
+class MapboxInfoButtonOrnamentTests: XCTestCase {
 
     var infoButton: MapboxInfoButtonOrnament!
     var parentViewController: MockParentViewController!
 
     override func setUp() {
+        super.setUp()
         infoButton = MapboxInfoButtonOrnament()
         parentViewController = MockParentViewController()
         parentViewController.view.addSubview(infoButton)

--- a/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentViewTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentViewTests.swift
@@ -2,10 +2,17 @@ import XCTest
 @testable import MapboxMaps
 
 class MapboxInfoButtonOrnamentTests: MapViewIntegrationTestCase {
-    func testInfoButtonTapped() throws {
-        let infoButton = MapboxInfoButtonOrnament()
-        let parentViewController = MockParentViewController()
+
+    var infoButton: MapboxInfoButtonOrnament!
+    var parentViewController: MockParentViewController!
+
+    override func setUp() {
+        infoButton = MapboxInfoButtonOrnament()
+        parentViewController = MockParentViewController()
         parentViewController.view.addSubview(infoButton)
+    }
+
+    func testInfoButtonTapped() throws {
         infoButton.infoTapped()
 
         let firstAlert = try XCTUnwrap(parentViewController.currentAlert, "The first alert controller could not be found.")
@@ -21,9 +28,6 @@ class MapboxInfoButtonOrnamentTests: MapViewIntegrationTestCase {
 
     func testTelemetryOptOut() throws {
         UserDefaults.standard.set(true, forKey: MapboxInfoButtonOrnament.Constants.metricsEnabledKey)
-        let infoButton = MapboxInfoButtonOrnament()
-        let parentViewController = MockParentViewController()
-        parentViewController.view.addSubview(infoButton)
         infoButton.infoTapped()
 
         var infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")

--- a/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentViewTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentViewTests.swift
@@ -55,7 +55,7 @@ class MapboxInfoButtonOrnamentTests: MapViewIntegrationTestCase {
         telemetryAlert.tapButton(atIndex: 1)
         XCTAssertFalse(infoButton.isMetricsEnabled, "Metrics should not be enabled after selecting 'Don't Participate'.")
     }
-    
+
     func testTelemetryOptIn() throws {
         UserDefaults.standard.set(false, forKey: MapboxInfoButtonOrnament.Constants.metricsEnabledKey)
         let infoButton = MapboxInfoButtonOrnament()
@@ -81,7 +81,7 @@ class MapboxInfoButtonOrnamentTests: MapViewIntegrationTestCase {
 
         telemetryAlert.tapButton(atIndex: 2)
         XCTAssertTrue(infoButton.isMetricsEnabled, "Metrics should be enabled after selecting 'Participate'.")
-        
+
         infoButton.infoTapped()
         infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
         infoAlert.tapButton(atIndex: 0)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR:
- Tests the initial info button menu that is presented when the button is first tapped.
- Tests opting into telemetry programmatically, opting out of telemetry, then opting out again.
- Tests opting out of telemetry programmatically, opting into telemetry, then opting in again.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
