### PR TITLE
Ensure MapView CameraState has been updated before triggering ease

### DIFF
--- a/Apps/Examples/Examples/All Examples/FlyToExample.swift
+++ b/Apps/Examples/Examples/All Examples/FlyToExample.swift
@@ -36,11 +36,6 @@ public class FlyToExample: UIViewController, ExampleProtocol {
             // The below line is used for internal testing purposes only.
             self?.finish()
         }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            cancelable?.cancel()
-        }
-
     }
 }
 

--- a/Sources/MapboxMaps/Gestures/GestureManager+GestureHandlerDelegate.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager+GestureHandlerDelegate.swift
@@ -52,11 +52,22 @@ extension GestureManager: GestureHandlerDelegate {
         if endPoint != driftEndPoint,
            let driftCameraOptions = cameraManager.mapView?.mapboxMap.dragCameraOptions(from: endPoint, to: driftEndPoint) {
 
-            _ = cameraManager.ease(
-                    to: driftCameraOptions,
-                    duration: Double(decelerationRate),
-                    curve: .easeOut,
-                    completion: nil)
+            // Wait until the animator's delete's camera state has been updated
+            if let mapView = cameraManager.mapView {
+                let completion = { [weak self] (_: UIViewAnimatingPosition) in
+                    guard let self = self else {
+                        return
+                    }
+
+                    _ = self.cameraManager.ease(
+                        to: driftCameraOptions,
+                        duration: Double(self.decelerationRate),
+                        curve: .easeOut,
+                        completion: nil)
+                }
+
+                mapView.pendingAnimatorCompletionBlocks.append((completion, .current))
+            }
         }
         cameraManager.mapView?.mapboxMap.dragEnd()
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
  
### Summary of changes

This PR adds a workaround to fix a [bug](https://github.com/mapbox/mapbox-maps-ios/issues/493) where the camera momentarily jumps when drifting to a stop after panning.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
