### PR TITLE
Restore Info Button Tests

### DIFF
--- a/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentTests.swift
@@ -1,4 +1,3 @@
-
 import XCTest
 @testable import MapboxMaps
 

--- a/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentTests.swift
@@ -1,0 +1,118 @@
+
+import XCTest
+@testable import MapboxMaps
+
+class MapboxInfoButtonOrnamentTests: XCTestCase {
+
+    func testInfoButtonTapped() throws {
+            let infoButton = MapboxInfoButtonOrnament()
+            let parentViewController = MockParentViewController()
+            parentViewController.view.addSubview(infoButton)
+            infoButton.infoTapped()
+
+            let firstAlert = try XCTUnwrap(parentViewController.currentAlert, "The first alert controller could not be found.")
+            XCTAssertNotNil(firstAlert)
+
+            XCTAssertEqual(firstAlert.actions.count, 2, "There should be two alerts present.")
+            let telemetryTitle = NSLocalizedString("Mapbox Telemetry", comment: "Action in attribution sheet")
+            XCTAssertEqual(firstAlert.actions[0].title!, telemetryTitle)
+
+            let cancelTitle = NSLocalizedString("Cancel", comment: "Title of button for dismissing attribution action sheet")
+            XCTAssertEqual(firstAlert.actions[1].title, cancelTitle)
+        }
+
+        func testTelemetryOptOut() throws {
+            let infoButton = MapboxInfoButtonOrnament()
+            let parentViewController = MockParentViewController()
+            parentViewController.view.addSubview(infoButton)
+            UserDefaults.standard.set(true, forKey: MapboxInfoButtonOrnament.Constants.metricsEnabledKey)
+            infoButton.infoTapped()
+
+            var infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
+            XCTAssertNotNil(infoAlert)
+            infoAlert.tapButton(atIndex: 0)
+
+            var telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
+
+            XCTAssertEqual(telemetryAlert.actions.count, 3, "The telemetry alert should have 3 actions.")
+
+            let participatingTitle = NSLocalizedString("Keep Participating", comment: "Telemetry prompt button")
+            XCTAssertEqual(participatingTitle, telemetryAlert.actions[2].title, "The third action should be a 'Keep Participating' button.")
+
+            XCTAssertTrue(infoButton.isMetricsEnabled)
+
+            let stopParticipatingTitle = NSLocalizedString("Stop Participating", comment: "Telemetry prompt button")
+            XCTAssertEqual(stopParticipatingTitle, telemetryAlert.actions[1].title, "The second action should be a 'Stop Participating' button.")
+
+            telemetryAlert.tapButton(atIndex: 1)
+            XCTAssertFalse(infoButton.isMetricsEnabled, "Metrics should not be enabled after selecting 'Stop participating'.")
+
+            infoButton.infoTapped()
+            infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
+            infoAlert.tapButton(atIndex: 0)
+
+            telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
+            let dontParticipateTitle = NSLocalizedString("Don’t Participate", comment: "Telemetry prompt button")
+            XCTAssertEqual(dontParticipateTitle, telemetryAlert.actions[1].title, "The second action should be a 'Don't Participate' button.")
+            telemetryAlert.tapButton(atIndex: 1)
+            XCTAssertFalse(infoButton.isMetricsEnabled, "Metrics should not be enabled after selecting 'Don't Participate'.")
+        }
+
+        func testTelemetryOptIn() throws {
+            UserDefaults.standard.set(false, forKey: MapboxInfoButtonOrnament.Constants.metricsEnabledKey)
+            let infoButton = MapboxInfoButtonOrnament()
+            let parentViewController = MockParentViewController()
+            parentViewController.view.addSubview(infoButton)
+            infoButton.infoTapped()
+
+            var infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
+            XCTAssertNotNil(infoAlert)
+            infoAlert.tapButton(atIndex: 0)
+
+            var telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
+
+            XCTAssertEqual(telemetryAlert.actions.count, 3, "The telemetry alert should have 3 actions.")
+
+            let participatingTitle = NSLocalizedString("Participate", comment: "Telemetry prompt button")
+            XCTAssertEqual(participatingTitle, telemetryAlert.actions[2].title, "The third action should be a 'Participate' button.")
+
+            XCTAssertFalse(infoButton.isMetricsEnabled)
+
+            let dontParticipateTitle = NSLocalizedString("Don’t Participate", comment: "Telemetry prompt button")
+            XCTAssertEqual(dontParticipateTitle, telemetryAlert.actions[1].title, "The second action should be a 'Don't Participate' button.")
+
+            telemetryAlert.tapButton(atIndex: 2)
+            XCTAssertTrue(infoButton.isMetricsEnabled, "Metrics should be enabled after selecting 'Participate'.")
+
+            infoButton.infoTapped()
+            infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
+            infoAlert.tapButton(atIndex: 0)
+            telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
+            let keepParticipatingTitle = NSLocalizedString("Keep Participating", comment: "Telemetry prompt button")
+            XCTAssertEqual(keepParticipatingTitle, telemetryAlert.actions[2].title, "The third action should be a 'Keep Participating' button.")
+            telemetryAlert.tapButton(atIndex: 2)
+            XCTAssertTrue(infoButton.isMetricsEnabled, "Metrics should be enabled after selecting 'Keep Participating'.")
+        }
+    }
+
+    class MockParentViewController: UIViewController {
+        var currentAlert: UIAlertController?
+
+        override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+            if let vc = viewControllerToPresent as? UIAlertController {
+                currentAlert = vc
+            }
+        }
+    }
+
+    // From https://stackoverflow.com/questions/36173740/trigger-uialertaction-on-uialertcontroller-programmatically
+    extension UIAlertController {
+        typealias AlertHandler = @convention(block) (UIAlertAction) -> Void
+
+        func tapButton(atIndex index: Int) {
+            guard let block = actions[index].value(forKey: "handler") else { return }
+            let handler = unsafeBitCast(block as AnyObject, to: AlertHandler.self)
+            handler(actions[index])
+        }
+
+}

--- a/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentTests.swift
@@ -45,7 +45,7 @@ class MapboxInfoButtonOrnamentTests: XCTestCase {
 
         telemetryAlert.tapButton(atIndex: 1)
         XCTAssertFalse(infoButton.isMetricsEnabled, "Metrics should not be enabled after selecting 'Stop participating'.")
-        
+
         infoButton.infoTapped()
         infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
         infoAlert.tapButton(atIndex: 0)

--- a/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentTests.swift
@@ -4,114 +4,113 @@ import XCTest
 class MapboxInfoButtonOrnamentTests: XCTestCase {
 
     func testInfoButtonTapped() throws {
-            let infoButton = MapboxInfoButtonOrnament()
-            let parentViewController = MockParentViewController()
-            parentViewController.view.addSubview(infoButton)
-            infoButton.infoTapped()
+        let infoButton = MapboxInfoButtonOrnament()
+        let parentViewController = MockParentViewController()
+        parentViewController.view.addSubview(infoButton)
+        infoButton.infoTapped()
 
-            let firstAlert = try XCTUnwrap(parentViewController.currentAlert, "The first alert controller could not be found.")
-            XCTAssertNotNil(firstAlert)
+        let firstAlert = try XCTUnwrap(parentViewController.currentAlert, "The first alert controller could not be found.")
+        XCTAssertNotNil(firstAlert)
 
-            XCTAssertEqual(firstAlert.actions.count, 2, "There should be two alerts present.")
-            let telemetryTitle = NSLocalizedString("Mapbox Telemetry", comment: "Action in attribution sheet")
-            XCTAssertEqual(firstAlert.actions[0].title!, telemetryTitle)
+        XCTAssertEqual(firstAlert.actions.count, 2, "There should be two alerts present.")
+        let telemetryTitle = NSLocalizedString("Mapbox Telemetry", comment: "Action in attribution sheet")
+        XCTAssertEqual(firstAlert.actions[0].title!, telemetryTitle)
 
-            let cancelTitle = NSLocalizedString("Cancel", comment: "Title of button for dismissing attribution action sheet")
-            XCTAssertEqual(firstAlert.actions[1].title, cancelTitle)
-        }
-
-        func testTelemetryOptOut() throws {
-            let infoButton = MapboxInfoButtonOrnament()
-            let parentViewController = MockParentViewController()
-            parentViewController.view.addSubview(infoButton)
-            UserDefaults.standard.set(true, forKey: MapboxInfoButtonOrnament.Constants.metricsEnabledKey)
-            infoButton.infoTapped()
-
-            var infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
-            XCTAssertNotNil(infoAlert)
-            infoAlert.tapButton(atIndex: 0)
-
-            var telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
-
-            XCTAssertEqual(telemetryAlert.actions.count, 3, "The telemetry alert should have 3 actions.")
-
-            let participatingTitle = NSLocalizedString("Keep Participating", comment: "Telemetry prompt button")
-            XCTAssertEqual(participatingTitle, telemetryAlert.actions[2].title, "The third action should be a 'Keep Participating' button.")
-
-            XCTAssertTrue(infoButton.isMetricsEnabled)
-
-            let stopParticipatingTitle = NSLocalizedString("Stop Participating", comment: "Telemetry prompt button")
-            XCTAssertEqual(stopParticipatingTitle, telemetryAlert.actions[1].title, "The second action should be a 'Stop Participating' button.")
-
-            telemetryAlert.tapButton(atIndex: 1)
-            XCTAssertFalse(infoButton.isMetricsEnabled, "Metrics should not be enabled after selecting 'Stop participating'.")
-
-            infoButton.infoTapped()
-            infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
-            infoAlert.tapButton(atIndex: 0)
-
-            telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
-            let dontParticipateTitle = NSLocalizedString("Don’t Participate", comment: "Telemetry prompt button")
-            XCTAssertEqual(dontParticipateTitle, telemetryAlert.actions[1].title, "The second action should be a 'Don't Participate' button.")
-            telemetryAlert.tapButton(atIndex: 1)
-            XCTAssertFalse(infoButton.isMetricsEnabled, "Metrics should not be enabled after selecting 'Don't Participate'.")
-        }
-
-        func testTelemetryOptIn() throws {
-            UserDefaults.standard.set(false, forKey: MapboxInfoButtonOrnament.Constants.metricsEnabledKey)
-            let infoButton = MapboxInfoButtonOrnament()
-            let parentViewController = MockParentViewController()
-            parentViewController.view.addSubview(infoButton)
-            infoButton.infoTapped()
-
-            var infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
-            XCTAssertNotNil(infoAlert)
-            infoAlert.tapButton(atIndex: 0)
-
-            var telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
-
-            XCTAssertEqual(telemetryAlert.actions.count, 3, "The telemetry alert should have 3 actions.")
-
-            let participatingTitle = NSLocalizedString("Participate", comment: "Telemetry prompt button")
-            XCTAssertEqual(participatingTitle, telemetryAlert.actions[2].title, "The third action should be a 'Participate' button.")
-
-            XCTAssertFalse(infoButton.isMetricsEnabled)
-
-            let dontParticipateTitle = NSLocalizedString("Don’t Participate", comment: "Telemetry prompt button")
-            XCTAssertEqual(dontParticipateTitle, telemetryAlert.actions[1].title, "The second action should be a 'Don't Participate' button.")
-
-            telemetryAlert.tapButton(atIndex: 2)
-            XCTAssertTrue(infoButton.isMetricsEnabled, "Metrics should be enabled after selecting 'Participate'.")
-
-            infoButton.infoTapped()
-            infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
-            infoAlert.tapButton(atIndex: 0)
-            telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
-            let keepParticipatingTitle = NSLocalizedString("Keep Participating", comment: "Telemetry prompt button")
-            XCTAssertEqual(keepParticipatingTitle, telemetryAlert.actions[2].title, "The third action should be a 'Keep Participating' button.")
-            telemetryAlert.tapButton(atIndex: 2)
-            XCTAssertTrue(infoButton.isMetricsEnabled, "Metrics should be enabled after selecting 'Keep Participating'.")
-        }
+        let cancelTitle = NSLocalizedString("Cancel", comment: "Title of button for dismissing attribution action sheet")
+        XCTAssertEqual(firstAlert.actions[1].title, cancelTitle)
     }
 
-    class MockParentViewController: UIViewController {
-        var currentAlert: UIAlertController?
+    func testTelemetryOptOut() throws {
+        let infoButton = MapboxInfoButtonOrnament()
+        let parentViewController = MockParentViewController()
+        parentViewController.view.addSubview(infoButton)
+        UserDefaults.standard.set(true, forKey: MapboxInfoButtonOrnament.Constants.metricsEnabledKey)
+        infoButton.infoTapped()
 
-        override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
-            if let vc = viewControllerToPresent as? UIAlertController {
-                currentAlert = vc
-            }
-        }
+        var infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
+        XCTAssertNotNil(infoAlert)
+        infoAlert.tapButton(atIndex: 0)
+
+        var telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
+
+        XCTAssertEqual(telemetryAlert.actions.count, 3, "The telemetry alert should have 3 actions.")
+
+        let participatingTitle = NSLocalizedString("Keep Participating", comment: "Telemetry prompt button")
+        XCTAssertEqual(participatingTitle, telemetryAlert.actions[2].title, "The third action should be a 'Keep Participating' button.")
+
+        XCTAssertTrue(infoButton.isMetricsEnabled)
+
+        let stopParticipatingTitle = NSLocalizedString("Stop Participating", comment: "Telemetry prompt button")
+        XCTAssertEqual(stopParticipatingTitle, telemetryAlert.actions[1].title, "The second action should be a 'Stop Participating' button.")
+
+        telemetryAlert.tapButton(atIndex: 1)
+        XCTAssertFalse(infoButton.isMetricsEnabled, "Metrics should not be enabled after selecting 'Stop participating'.")
+        
+        infoButton.infoTapped()
+        infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
+        infoAlert.tapButton(atIndex: 0)
+
+        telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
+        let dontParticipateTitle = NSLocalizedString("Don’t Participate", comment: "Telemetry prompt button")
+        XCTAssertEqual(dontParticipateTitle, telemetryAlert.actions[1].title, "The second action should be a 'Don't Participate' button.")
+        telemetryAlert.tapButton(atIndex: 1)
+        XCTAssertFalse(infoButton.isMetricsEnabled, "Metrics should not be enabled after selecting 'Don't Participate'.")
     }
 
-    // From https://stackoverflow.com/questions/36173740/trigger-uialertaction-on-uialertcontroller-programmatically
-    extension UIAlertController {
-        typealias AlertHandler = @convention(block) (UIAlertAction) -> Void
+    func testTelemetryOptIn() throws {
+        UserDefaults.standard.set(false, forKey: MapboxInfoButtonOrnament.Constants.metricsEnabledKey)
+        let infoButton = MapboxInfoButtonOrnament()
+        let parentViewController = MockParentViewController()
+        parentViewController.view.addSubview(infoButton)
+        infoButton.infoTapped()
 
-        func tapButton(atIndex index: Int) {
-            guard let block = actions[index].value(forKey: "handler") else { return }
-            let handler = unsafeBitCast(block as AnyObject, to: AlertHandler.self)
-            handler(actions[index])
+        var infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
+        XCTAssertNotNil(infoAlert)
+        infoAlert.tapButton(atIndex: 0)
+
+        var telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
+
+        XCTAssertEqual(telemetryAlert.actions.count, 3, "The telemetry alert should have 3 actions.")
+
+        let participatingTitle = NSLocalizedString("Participate", comment: "Telemetry prompt button")
+        XCTAssertEqual(participatingTitle, telemetryAlert.actions[2].title, "The third action should be a 'Participate' button.")
+
+        XCTAssertFalse(infoButton.isMetricsEnabled)
+
+        let dontParticipateTitle = NSLocalizedString("Don’t Participate", comment: "Telemetry prompt button")
+        XCTAssertEqual(dontParticipateTitle, telemetryAlert.actions[1].title, "The second action should be a 'Don't Participate' button.")
+
+        telemetryAlert.tapButton(atIndex: 2)
+        XCTAssertTrue(infoButton.isMetricsEnabled, "Metrics should be enabled after selecting 'Participate'.")
+
+        infoButton.infoTapped()
+        infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
+        infoAlert.tapButton(atIndex: 0)
+        telemetryAlert = try XCTUnwrap(parentViewController.currentAlert, "The telemetry alert controller could not be found.")
+        let keepParticipatingTitle = NSLocalizedString("Keep Participating", comment: "Telemetry prompt button")
+        XCTAssertEqual(keepParticipatingTitle, telemetryAlert.actions[2].title, "The third action should be a 'Keep Participating' button.")
+        telemetryAlert.tapButton(atIndex: 2)
+        XCTAssertTrue(infoButton.isMetricsEnabled, "Metrics should be enabled after selecting 'Keep Participating'.")
+    }
+}
+
+class MockParentViewController: UIViewController {
+    var currentAlert: UIAlertController?
+
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        if let vc = viewControllerToPresent as? UIAlertController {
+            currentAlert = vc
         }
+    }
+}
 
+// From https://stackoverflow.com/questions/36173740/trigger-uialertaction-on-uialertcontroller-programmatically
+extension UIAlertController {
+    typealias AlertHandler = @convention(block) (UIAlertAction) -> Void
+
+    func tapButton(atIndex index: Int) {
+        guard let block = actions[index].value(forKey: "handler") else { return }
+        let handler = unsafeBitCast(block as AnyObject, to: AlertHandler.self)
+        handler(actions[index])
+    }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR is to restore the info button tests, which were removed in #487 
### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
