### PR TITLE
Mark overridden designated initializers as unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+### Bug fixes 🐞
+
+* Fixed a crash at runtime, when an application is built with the xcframework (direct download) rather than from source (i.e. Swift Package Manager). ([#497](https://github.com/mapbox/mapbox-maps-ios/pull/497))
+
 ## 10.0.0-rc.2 - June 23, 2021
 
 ### Features ✨ and improvements 🏁

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -136,9 +136,11 @@ open class MapView: UIView {
         commonInit(mapInitOptions: mapInitOptions, overridingStyleURI: nil)
     }
 
+    /// :nodoc:
+    /// See https://developer.apple.com/forums/thread/650054 for context
     @available(*, unavailable)
-    public override init(frame: CGRect) {
-        fatalError()
+    internal override init(frame: CGRect) {
+        fatalError("This initializer should not be called.")
     }
 
     private func commonInit(mapInitOptions: MapInitOptions, overridingStyleURI: URL?) {

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -136,6 +136,11 @@ open class MapView: UIView {
         commonInit(mapInitOptions: mapInitOptions, overridingStyleURI: nil)
     }
 
+    @available(*, unavailable)
+    public override init(frame: CGRect) {
+        fatalError()
+    }
+
     private func commonInit(mapInitOptions: MapInitOptions, overridingStyleURI: URL?) {
         checkForMetalSupport()
 

--- a/Sources/MapboxMaps/MapView/Configuration/MapInitOptions.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/MapInitOptions.swift
@@ -44,9 +44,11 @@ public final class MapInitOptions: NSObject {
         self.styleURI        = styleURI
     }
 
+    /// :nodoc:
+    /// See https://developer.apple.com/forums/thread/650054 for context
     @available(*, unavailable)
-    public override init() {
-        fatalError()
+    internal override init() {
+        fatalError("This initializer should not be called.")
     }
 
     /// :nodoc:

--- a/Sources/MapboxMaps/MapView/Configuration/MapInitOptions.swift
+++ b/Sources/MapboxMaps/MapView/Configuration/MapInitOptions.swift
@@ -44,6 +44,11 @@ public final class MapInitOptions: NSObject {
         self.styleURI        = styleURI
     }
 
+    @available(*, unavailable)
+    public override init() {
+        fatalError()
+    }
+
     /// :nodoc:
     public override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? MapInitOptions else {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

This PR adds (and overrides) designated initializers for `MapView.init(frame:)` and `MapInitOptions()` and marks them as unavailable. 

This fixes an issue when using the binary xcframework, where the expected designated initializers are called instead of the initializer with all default parameters, causing a run-time crash:

```
Fatal error: Use of unimplemented initializer 'init(frame:)' for class 'MapboxMaps.MapView'
```


#### Initializer snippets from `swiftinterface` file before PR:

MapView:

```
  public init(frame: CoreGraphics.CGRect, mapInitOptions: MapboxMaps.MapInitOptions = MapInitOptions())
  @objc required dynamic public init?(coder: Foundation.NSCoder)
  @objc override dynamic public init(frame: CoreGraphics.CGRect)
```

MapInitOptions:

```
  public init(resourceOptions: MapboxMaps.ResourceOptions = ResourceOptionsManager.default.resourceOptions, mapOptions: MapboxCoreMaps.MapOptions = MapOptions(), cameraOptions: MapboxMaps.CameraOptions? = nil, styleURI: MapboxMaps.StyleURI? = .streets)
  @objc override dynamic public init()
```

#### After PR - overridden designated initializers are not present.

MapView:

```
  public init(frame: CoreGraphics.CGRect, mapInitOptions: MapboxMaps.MapInitOptions = MapInitOptions())
  @objc required dynamic public init?(coder: Foundation.NSCoder)
```

MapInitOptions:

```
  public init(resourceOptions: MapboxMaps.ResourceOptions = ResourceOptionsManager.default.resourceOptions, mapOptions: MapboxCoreMaps.MapOptions = MapOptions(), cameraOptions: MapboxMaps.CameraOptions? = nil, styleURI: MapboxMaps.StyleURI? = .streets)
```


