### PR TITLE
[examples] Update tile size for 3D terrain examples

### DIFF
--- a/Apps/Examples/Examples/All Examples/SkyLayerExample.swift
+++ b/Apps/Examples/Examples/All Examples/SkyLayerExample.swift
@@ -91,10 +91,10 @@ public class SkyLayerExample: UIViewController, ExampleProtocol {
     }
 
     func addTerrainLayer() {
-        // Add a RasterDEMSource. This will be used to create and add a terrain layer. r
+        // Add a `RasterDEMSource`. This will be used to create and add a terrain layer.
         var demSource = RasterDemSource()
         demSource.url = "mapbox://mapbox.mapbox-terrain-dem-v1"
-        demSource.tileSize = 512
+        demSource.tileSize = 514
         demSource.maxzoom = 14.0
         try! mapView.mapboxMap.style.addSource(demSource, id: "mapbox-dem")
 

--- a/Apps/Examples/Examples/All Examples/TerrainExample.swift
+++ b/Apps/Examples/Examples/All Examples/TerrainExample.swift
@@ -31,6 +31,8 @@ public class TerrainExample: UIViewController, ExampleProtocol {
     func addTerrain() {
         var demSource = RasterDemSource()
         demSource.url = "mapbox://mapbox.mapbox-terrain-dem-v1"
+        // Setting the `tileSize` to 514 provides better performance and adds padding around the outside
+        // of the tiles.
         demSource.tileSize = 514
         demSource.maxzoom = 14.0
         try! mapView.mapboxMap.style.addSource(demSource, id: "mapbox-dem")

--- a/Apps/Examples/Examples/All Examples/TerrainExample.swift
+++ b/Apps/Examples/Examples/All Examples/TerrainExample.swift
@@ -31,7 +31,7 @@ public class TerrainExample: UIViewController, ExampleProtocol {
     func addTerrain() {
         var demSource = RasterDemSource()
         demSource.url = "mapbox://mapbox.mapbox-terrain-dem-v1"
-        demSource.tileSize = 512
+        demSource.tileSize = 514
         demSource.maxzoom = 14.0
         try! mapView.mapboxMap.style.addSource(demSource, id: "mapbox-dem")
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: #470 

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes
This PR updates the tile size for 3D terrain in examples. Previously, `512` was used which led to terrain not displaying.
### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
