### PR TITLE
Add a distance expression example

### DIFF
--- a/Apps/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Apps/Examples/Examples.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		17B4806426851C6E00CF0D5E /* radar1.gif in Resources */ = {isa = PBXBuildFile; fileRef = 17B4805F26851C6E00CF0D5E /* radar1.gif */; };
 		17B4806526851C6E00CF0D5E /* radar0.gif in Resources */ = {isa = PBXBuildFile; fileRef = 17B4806026851C6E00CF0D5E /* radar0.gif */; };
 		17B4806B268BD91000CF0D5E /* RasterTileSourceExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B4806A268BD91000CF0D5E /* RasterTileSourceExample.swift */; };
+		17B48067268A4E9300CF0D5E /* DistanceExpressionExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B48066268A4E9300CF0D5E /* DistanceExpressionExample.swift */; };
 		17E28C5C2672A1160033DF0F /* SymbolClusteringExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E28C5B2672A1160033DF0F /* SymbolClusteringExample.swift */; };
 		30F095BF270B39AF00F368DC /* GlobeViewExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F095BE270B39AF00F368DC /* GlobeViewExample.swift */; };
 		58248C2F2695FF24009AC598 /* StoryboardMapViewExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58248C2E2695FF24009AC598 /* StoryboardMapViewExample.swift */; };
@@ -160,6 +161,7 @@
 		17B4805F26851C6E00CF0D5E /* radar1.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = radar1.gif; sourceTree = "<group>"; };
 		17B4806026851C6E00CF0D5E /* radar0.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = radar0.gif; sourceTree = "<group>"; };
 		17B4806A268BD91000CF0D5E /* RasterTileSourceExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RasterTileSourceExample.swift; sourceTree = "<group>"; };
+		17B48066268A4E9300CF0D5E /* DistanceExpressionExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceExpressionExample.swift; sourceTree = "<group>"; };
 		17E28C5B2672A1160033DF0F /* SymbolClusteringExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolClusteringExample.swift; sourceTree = "<group>"; };
 		30F095BE270B39AF00F368DC /* GlobeViewExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlobeViewExample.swift; sourceTree = "<group>"; };
 		58248C2E2695FF24009AC598 /* StoryboardMapViewExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryboardMapViewExample.swift; sourceTree = "<group>"; };
@@ -260,6 +262,7 @@
 				A4AC5DEB2542CB2200995E4C /* CustomStyleURLExample.swift */,
 				C69F01EC2543646A001AB49B /* DataDrivenSymbolsExample.swift */,
 				077E3B2B2581810600564A3E /* ExternalVectorSourceExample.swift */,
+				17B48066268A4E9300CF0D5E /* DistanceExpressionExample.swift */,
 				07B0715F254789D6007F2865 /* FeaturesAtPointExample.swift */,
 				0C784D1026D002DC004AE7D0 /* FeatureStateExample.swift */,
 				077E3B8F2581966300564A3E /* FitCameraToGeometryExample.swift */,
@@ -596,6 +599,7 @@
 				CA4F1F7225E815CF00822D2A /* SwiftUIExample.swift in Sources */,
 				CAC195B725AC098A00F69FEA /* CameraAnimatorsExample.swift in Sources */,
 				0C78AC2925BF70E40057F570 /* LineGradientExample.swift in Sources */,
+				17B48067268A4E9300CF0D5E /* DistanceExpressionExample.swift in Sources */,
 				CADCF72B2584990E0065C51B /* FlyToExample.swift in Sources */,
 				0333B84F25ED942600D667C9 /* SceneKitExample.swift in Sources */,
 				CADCF72D2584990E0065C51B /* MultipleGeometriesExample.swift in Sources */,

--- a/Apps/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Apps/Examples/Examples.xcodeproj/project.pbxproj
@@ -261,8 +261,8 @@
 				C64ED3C42540DD6E00ADADFB /* CustomPointAnnotationExample.swift */,
 				A4AC5DEB2542CB2200995E4C /* CustomStyleURLExample.swift */,
 				C69F01EC2543646A001AB49B /* DataDrivenSymbolsExample.swift */,
-				077E3B2B2581810600564A3E /* ExternalVectorSourceExample.swift */,
 				17B48066268A4E9300CF0D5E /* DistanceExpressionExample.swift */,
+				077E3B2B2581810600564A3E /* ExternalVectorSourceExample.swift */,
 				07B0715F254789D6007F2865 /* FeaturesAtPointExample.swift */,
 				0C784D1026D002DC004AE7D0 /* FeatureStateExample.swift */,
 				077E3B8F2581966300564A3E /* FitCameraToGeometryExample.swift */,
@@ -274,6 +274,7 @@
 				17B40D2326A85500000887EF /* LiveDataExample.swift */,
 				C608C106267BC5B1003C86C3 /* LocalizationExample.swift */,
 				07B071CD2547CF2B007F2865 /* MultipleGeometriesExample.swift */,
+				C608C106267BC5B1003C86C3 /* LocalizationExample.swift */,
 				17483DFC2670113300396F8D /* MultiplePointAnnotationsExample.swift */,
 				CA628413262DFD5C00651488 /* OfflineManagerExample.storyboard */,
 				CA03F10E26268DF700673961 /* OfflineManagerExample.swift */,
@@ -296,6 +297,7 @@
 				0706C4A525B1181A008733C0 /* TerrainExample.swift */,
 				73694BD225D4B2CE0064F636 /* TrackingModeExample.swift */,
 				077E3B932581987B00564A3E /* UpdatePointAnnotationPositionExample.swift */,
+				07B071D12547CF50007F2865 /* Sample Data */,
 			);
 			path = "All Examples";
 			sourceTree = "<group>";

--- a/Apps/Examples/Examples/All Examples/DistanceExpressionExample.swift
+++ b/Apps/Examples/Examples/All Examples/DistanceExpressionExample.swift
@@ -4,11 +4,11 @@ import Turf
 @objc(DistanceExpressionExample)
 class DistanceExpressionExample: UIViewController, ExampleProtocol {
     var mapView: MapView!
-    var point: Turf.Point
+    var point: Turf.Feature!
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        
         let center = CLLocationCoordinate2D(latitude: 37.787945, longitude: -122.407522)
         let cameraOptions = CameraOptions(center: center, zoom: 16)
         let mapInitOptions = MapInitOptions(cameraOptions: cameraOptions, styleURI: .streets)
@@ -125,8 +125,8 @@ class DistanceExpressionExample: UIViewController, ExampleProtocol {
     }
 }
 
-extension Turf.Point: ExpressionArgumentConvertible {
-    public var expressionArguments: [Expression.Argument] {
-        <#code#>
-    }
-}
+//extension Turf.Point: ExpressionArgumentConvertible {
+//    public var expressionArguments: [Expression.Argument] {
+//
+//    }
+//}

--- a/Apps/Examples/Examples/All Examples/DistanceExpressionExample.swift
+++ b/Apps/Examples/Examples/All Examples/DistanceExpressionExample.swift
@@ -91,15 +91,32 @@ class DistanceExpressionExample: UIViewController, ExampleProtocol {
 //        let data = try! JSONEncoder().encode(point.self)
 //        let geojson = try! JSONDecoder().decode(GeoJSON.self, from: data)
 
+
+        mapView.mapboxMap.onNext(.styleLoaded) { _ in
+            self.filterPoiLabels()
+        }
+    }
+    
+    func filterPoiLabels() {
+        let style = mapView.mapboxMap.style
+        mapView.mapboxMap.querySourceFeatures(for: "source-id", options: SourceQueryOptions(sourceLayerIds: nil, filter: "")) { result in
+            switch result {
+            case let .success(features):
+                let feature = features.first!
+                var poiLabelLayer: SymbolLayer = try! style.layer(withId: "poi-label")
+                poiLabelLayer.filter = Exp(.distance) {
+                    feature.feature
+                    150
+                }
+            case let .failure(error):
+                print("Error: \(error)")
+            }
+        }
         // Get the `SymbolLayer` with the identifier `poi-label`. This layer is included
         // with the Mapbox Streets v11 style. In order to see all layers included with your
         // style, either inspect the style in Mapbox Studio or inspect the `style.allLayerIdentifiers`
         // property once the style has finished loading.
-//        var poiLabelLayer: SymbolLayer = try! style.layer(withId: "poi-label")
-//        poiLabelLayer.filter = Exp(.distance) {
-//            geojson.decodedFeature?.geometry as! ExpressionArgumentConvertible
-//            150
-//        }
+
     }
 
     func circleRadius(forZoom zoom: CGFloat) -> Double {

--- a/Apps/Examples/Examples/All Examples/DistanceExpressionExample.swift
+++ b/Apps/Examples/Examples/All Examples/DistanceExpressionExample.swift
@@ -21,10 +21,11 @@ class DistanceExpressionExample: UIViewController, ExampleProtocol {
     }
 
     func addCircle() {
+        let style = mapView.mapboxMap.style
         let center = mapView.mapboxMap.cameraState.center
         var source = GeoJSONSource()
         let point = Turf.Point(center)
-        source.data = .geometry(.point(point))
+        source.data = .feature(point)
         var circle = CircleLayer(id: "circle-layer")
         circle.source = "source-id"
         let circleRadiusExp = Exp(.interpolate) {
@@ -38,20 +39,43 @@ class DistanceExpressionExample: UIViewController, ExampleProtocol {
             circleRadius(forZoom: 10)
             15
             circleRadius(forZoom: 15)
+            16
+            circleRadius(forZoom: 16)
+            16.5
+            circleRadius(forZoom: 16.5)
             17
             circleRadius(forZoom: 17)
+            17.5
+            circleRadius(forZoom: 17.5)
             18
             circleRadius(forZoom: 18)
+            18.5
+            circleRadius(forZoom: 18.5)
             19
             circleRadius(forZoom: 19)
+            19.5
+            circleRadius(forZoom: 19.5)
             20
             circleRadius(forZoom: 20)
+            20.5
+            circleRadius(forZoom: 20.5)
+            21
+            circleRadius(forZoom: 21)
+            21.5
+            circleRadius(forZoom: 21.5)
+            22
+            circleRadius(forZoom: 22)
         }
 
         circle.circleRadius = .expression(circleRadiusExp)
         circle.circleOpacity = .constant(0.3)
-        try! mapView.mapboxMap.style.addSource(source, id: "source-id")
-        try! mapView.mapboxMap.style.addLayer(circle)
+        try! style.addSource(source, id: "source-id")
+        try! style.addLayer(circle)
+        
+        let data = JSONEncoder().encode(point.self)
+        var poiLabelLayer: SymbolLayer = try! style.layer(withId: "poi-label")
+        poiLabelLayer.filter = Exp(.distance) {
+        }
     }
 
     func circleRadius(forZoom zoom: CGFloat) -> Double {

--- a/Apps/Examples/Examples/All Examples/DistanceExpressionExample.swift
+++ b/Apps/Examples/Examples/All Examples/DistanceExpressionExample.swift
@@ -17,11 +17,11 @@ class DistanceExpressionExample: UIViewController, ExampleProtocol {
         view.addSubview(mapView)
 
         mapView.mapboxMap.onNext(.mapLoaded) { _ in
-            self.addCircle()
+            self.addCircleLayer()
         }
     }
 
-    func addCircle() {
+    func addCircleLayer() {
         let style = mapView.mapboxMap.style
         let center = mapView.mapboxMap.cameraState.center
 
@@ -88,7 +88,7 @@ class DistanceExpressionExample: UIViewController, ExampleProtocol {
         try! style.addSource(source, id: "source-id")
         try! style.addLayer(circleLayer)
     }
-    
+
     func filterPoiLabels() {
         let style = mapView.mapboxMap.style
 
@@ -111,8 +111,7 @@ class DistanceExpressionExample: UIViewController, ExampleProtocol {
                     150
                 }
             }
-        }
-        catch {
+        } catch {
             print("Updating the layer failed: \(error.localizedDescription)")
         }
 

--- a/Apps/Examples/Examples/All Examples/DistanceExpressionExample.swift
+++ b/Apps/Examples/Examples/All Examples/DistanceExpressionExample.swift
@@ -1,0 +1,63 @@
+import MapboxMaps
+import Turf
+
+@objc(DistanceExpressionExample)
+class DistanceExpressionExample: UIViewController, ExampleProtocol {
+    var mapView: MapView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let center = CLLocationCoordinate2D(latitude: 37.787945, longitude: -122.407522)
+        let cameraOptions = CameraOptions(center: center, zoom: 16)
+        let mapInitOptions = MapInitOptions(cameraOptions: cameraOptions, styleURI: .streets)
+        mapView = MapView(frame: view.bounds, mapInitOptions: mapInitOptions)
+        mapView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+        view.addSubview(mapView)
+
+        mapView.mapboxMap.onNext(.mapLoaded) { _ in
+            self.addCircle()
+        }
+    }
+
+    func addCircle() {
+        let center = mapView.mapboxMap.cameraState.center
+        var source = GeoJSONSource()
+        let point = Turf.Point(center)
+        source.data = .geometry(.point(point))
+        var circle = CircleLayer(id: "circle-layer")
+        circle.source = "source-id"
+        let circleRadiusExp = Exp(.interpolate) {
+            Exp(.linear)
+            Exp(.zoom)
+            0
+            circleRadius(forZoom: 0)
+            5
+            circleRadius(forZoom: 5)
+            10
+            circleRadius(forZoom: 10)
+            15
+            circleRadius(forZoom: 15)
+            17
+            circleRadius(forZoom: 17)
+            18
+            circleRadius(forZoom: 18)
+            19
+            circleRadius(forZoom: 19)
+            20
+            circleRadius(forZoom: 20)
+        }
+
+        circle.circleRadius = .expression(circleRadiusExp)
+        circle.circleOpacity = .constant(0.3)
+        try! mapView.mapboxMap.style.addSource(source, id: "source-id")
+        try! mapView.mapboxMap.style.addLayer(circle)
+    }
+
+    func circleRadius(forZoom zoom: CGFloat) -> Double {
+        let centerLatitude = mapView.cameraState.center.latitude
+        let metersPerPoint = Projection.metersPerPoint(for: centerLatitude, zoom: zoom)
+        let radius = 150 / metersPerPoint
+        return radius
+    }
+}

--- a/Apps/Examples/Examples/Models/Examples.swift
+++ b/Apps/Examples/Examples/Models/Examples.swift
@@ -224,7 +224,8 @@ public struct Examples {
                 type: ShowHideLayerExample.self),
         Example(title: "Add live data",
                 description: "Update feature coordinates from a geoJSON source in real time.",
-                type: LiveDataExample.self)
+                type: LiveDataExample.self),
+        Example(title: "Use a distance expression", description: "", type: DistanceExpressionExample.self)
     ]
 
     // Examples that show use cases related to user interaction with the map.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.

### Summary of changes

![Simulator Screen Shot - iPhone 13 mini - 2021-11-17 at 12 58 48](https://user-images.githubusercontent.com/12474734/142256274-fd6f1365-1e62-4e5e-9584-aaffebea768d.png)


This PR adds an example of using the `distance` operator in an expression. It also shows a workaround for adding a circle whose radius should consistently represent a value in meters. It is based on the [Android example](https://github.com/mapbox/mapbox-maps-android/blob/main/app/src/main/java/com/mapbox/maps/testapp/examples/DistanceExpressionActivity.kt).

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
