### PR TITLE
Expose display link duration and timestamp for metrics purposes

### DIFF
--- a/Sources/MapboxMaps/Foundation/DisplayLinkProtocol.swift
+++ b/Sources/MapboxMaps/Foundation/DisplayLinkProtocol.swift
@@ -1,6 +1,8 @@
 import QuartzCore
 
 internal protocol DisplayLinkProtocol: AnyObject {
+    var timestamp: CFTimeInterval { get }
+    var duration: CFTimeInterval { get }
     var preferredFramesPerSecond: Int { get set }
     func add(to runloop: RunLoop, forMode mode: RunLoop.Mode)
     func invalidate()

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -100,12 +100,12 @@ open class MapView: UIView {
     }
 
     /// The `timestamp` from the underlying `CADisplayLink` if it exists, otherwise `nil`
-    public var displayLinkTimestamp: CFTimeInterval? {
+    @_spi(Metrics) public var displayLinkTimestamp: CFTimeInterval? {
         return displayLink?.timestamp
     }
 
     /// The `duration` from the underlying `CADisplayLink` if it exists, otherwise `nil`
-    public var displayLinkDuration: CFTimeInterval? {
+    @_spi(Metrics) public var displayLinkDuration: CFTimeInterval? {
         return displayLink?.duration
     }
 

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -99,6 +99,16 @@ open class MapView: UIView {
         }
     }
 
+    /// The `timestamp` from the underlying `CADisplayLink` if it exists, otherwise `nil`
+    public var displayLinkTimestamp: CFTimeInterval? {
+        return displayLink?.timestamp
+    }
+
+    /// The `duration` from the underlying `CADisplayLink` if it exists, otherwise `nil`
+    public var displayLinkDuration: CFTimeInterval? {
+        return displayLink?.duration
+    }
+
     /// The map's current camera
     public var cameraState: CameraState {
         return mapboxMap.cameraState

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -80,6 +80,30 @@ final class MapViewTests: XCTestCase {
         XCTAssertEqual(displayLink.preferredFramesPerSecond, 23)
     }
 
+    func testDisplayLinkTimestampIsNilWhenDisplayLinkIsNil() {
+        mapView.removeFromSuperview()
+
+        XCTAssertNil(mapView.displayLinkTimestamp)
+    }
+
+    func testDisplayLinkTimestampWhenDisplayLinkIsNonNil() {
+        displayLink.timestamp = .random(in: 0..<CFTimeInterval.greatestFiniteMagnitude)
+
+        XCTAssertEqual(mapView.displayLinkTimestamp, displayLink.timestamp)
+    }
+
+    func testDisplayLinkDurationIsNilWhenDisplayLinkIsNil() {
+        mapView.removeFromSuperview()
+
+        XCTAssertNil(mapView.displayLinkDuration)
+    }
+
+    func testDisplayLinkDurationWhenDisplayLinkIsNonNil() {
+        displayLink.duration = .random(in: 0..<CFTimeInterval.greatestFiniteMagnitude)
+
+        XCTAssertEqual(mapView.displayLinkDuration, displayLink.duration)
+    }
+
     func testMetalViewSetNeedsDisplayIsTriggeredByScheduleRepaint() throws {
         mapView.scheduleRepaint()
 

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -1,5 +1,6 @@
 import XCTest
-@testable import MapboxMaps
+@testable @_spi(Metrics) import MapboxMaps
+
 
 final class MapViewTests: XCTestCase {
 

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable @_spi(Metrics) import MapboxMaps
 
-
 final class MapViewTests: XCTestCase {
 
     var displayLink: MockDisplayLink!

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockDisplayLink.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockDisplayLink.swift
@@ -2,6 +2,11 @@ import Foundation
 @testable import MapboxMaps
 
 final class MockDisplayLink: DisplayLinkProtocol {
+
+    var timestamp: CFTimeInterval = 0
+
+    var duration: CFTimeInterval = 0
+
     var preferredFramesPerSecond: Int = 0
 
     struct AddParams {


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

Exposes two new properties on `MapView` to enable metrics collection