### PR TITLE
[examples] Check whether an annotation was selected

### DIFF
--- a/Apps/Examples/Examples/All Examples/SelectAnnotationExample.swift
+++ b/Apps/Examples/Examples/All Examples/SelectAnnotationExample.swift
@@ -92,6 +92,8 @@ public class SelectAnnotationExample: UIViewController, ExampleProtocol {
 extension SelectAnnotationExample: AnnotationInteractionDelegate {
     public func annotationManager(_ manager: AnnotationManager,
                                   didDetectTappedAnnotations annotations: [Annotation]) {
-        annotationSelected.toggle()
+        if annotationSelected || annotations.count > 0 {
+            annotationSelected.toggle()
+        }
     }
 }

--- a/Apps/Examples/Examples/All Examples/SelectAnnotationExample.swift
+++ b/Apps/Examples/Examples/All Examples/SelectAnnotationExample.swift
@@ -92,7 +92,7 @@ public class SelectAnnotationExample: UIViewController, ExampleProtocol {
 extension SelectAnnotationExample: AnnotationInteractionDelegate {
     public func annotationManager(_ manager: AnnotationManager,
                                   didDetectTappedAnnotations annotations: [Annotation]) {
-        if annotationSelected || annotations.count > 0 {
+        if annotationSelected || !annotations.isEmpty {
             annotationSelected.toggle()
         }
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 
### Summary of changes
This fixes an issue where `annotationSelected` would be toggled, regardless of whether an annotation had been tapped.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
