### PR TITLE
Fit MTLView to MapView bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+* Fixed an issue where MapView positioning wasn't correct when used in containers such as UIStackView ([#533](https://github.com/mapbox/mapbox-maps-ios/pull/533)) 
+
 ## 10.0.0-rc.4 - July 14, 2021
 
 ### Features ✨ and improvements 🏁

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -362,7 +362,7 @@ extension MapView: DelegatingMapClientDelegate {
     }
 
     internal func getMetalView(for metalDevice: MTLDevice?) -> MTKView? {
-        let metalView = dependencyProvider.makeMetalView(frame: frame, device: metalDevice)
+        let metalView = dependencyProvider.makeMetalView(frame: bounds, device: metalDevice)
         displayCallback = {
             metalView.setNeedsDisplay()
         }

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -111,4 +111,17 @@ final class MapViewTests: XCTestCase {
 
         XCTAssertEqual(metalView.setNeedsDisplayStub.invocations.count, 1)
     }
+
+    func testMetalViewDoesFitMapView() {
+        let mapView = MapView(frame: .init(x: 50, y: 50, width: 100, height: 100))
+
+        XCTAssertEqual(mapView.bounds, mapView.metalView?.frame)
+    }
+
+    func testMetalViewDoesResizeToFitMapView() {
+        let mapView = MapView(frame: .init(x: 50, y: 50, width: 100, height: 100))
+        mapView.frame = .init(x: 0, y: 0, width: 100, height: 100)
+
+        XCTAssertEqual(mapView.bounds, mapView.metalView?.frame)
+    }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: https://github.com/mapbox/mapbox-maps-ios/issues/528

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

This change uses the bounds, instead of the frame, when position the MTLView in the MapView. This should accommodate a number of scenarios where the MapView frame is not positioned at origin (0,0).

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


![bounds](https://user-images.githubusercontent.com/1672024/125640036-ec078ee5-0d32-4458-a62e-ef0654c51b77.png)
