### PR TITLE
Move check for simulator to the beginning of `checkForMetalSupport`

### DIFF
--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -228,20 +228,20 @@ open class MapView: UIView {
     }
 
     private func checkForMetalSupport() {
+        #if targetEnvironment(simulator)
         guard MTLCreateSystemDefaultDevice() == nil else {
             return
         }
 
         // Metal is unavailable on older simulators
-        #if targetEnvironment(simulator)
         guard ProcessInfo().isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 13, minorVersion: 0, patchVersion: 0)) else {
             Log.warning(forMessage: "Metal rendering is not supported on iOS versions < iOS 13. Please test on device or on iOS version >= 13.", category: "MapView")
             return
         }
-        #endif
 
         // Metal is unavailable for a different reason
-        Log.error(forMessage: "No suitable Metal device or simulator can be found.", category: "MapView")
+        Log.error(forMessage: "No suitable Metal simulator can be found.", category: "MapView")
+        #endif
     }
 
     class internal func parseIBString(ibString: String) -> String? {

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -235,7 +235,7 @@ open class MapView: UIView {
 
         // Metal is unavailable on older simulators
         guard ProcessInfo().isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 13, minorVersion: 0, patchVersion: 0)) else {
-            Log.warning(forMessage: "Metal rendering is not supported on iOS versions < iOS 13. Please test on device or on iOS version >= 13.", category: "MapView")
+            Log.warning(forMessage: "Metal rendering is not supported on iOS versions < iOS 13. Please test on device or on iOS simulators version >= 13.", category: "MapView")
             return
         }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

This PR moves the check for simulator to before `MTLCreateSystemDefaultDevice()` is called in `checkForMetalSupport`. This is intended to help performance when initializing a `MapView`.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
