### PR TITLE
Fixes leak in creating UIImage from MBMImage

### DIFF
--- a/Sources/MapboxMaps/Foundation/Extensions/UIImage.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/UIImage.swift
@@ -9,7 +9,7 @@ extension UIImage {
     ///   - mbxImage: The internal `Image` type to use for the `UIImage`.
     ///   - scale: The scale of the new `UIImage`.
     internal convenience init?(mbxImage: Image, scale: CGFloat = UIScreen.main.scale) {
-        let cgImage = mbxImage.cgImage().takeUnretainedValue()
+        let cgImage = mbxImage.cgImage().takeRetainedValue()
 
         let size = CGSize(width: CGFloat(CGFloat(mbxImage.width) / scale),
                           height: CGFloat(CGFloat(mbxImage.height) / scale))


### PR DESCRIPTION
`MBMImage.cgImage()` returns `CGImage` with +1 retain count.
The caller is responsible for releasing this image.

`Unmanaged.takeRetainedValue()` says: This is useful when a function
returns an unmanaged reference and you know that you're responsible for
releasing the result.

So this is a perfect method for this situation.

Similar fix was applied in Mapbox NavSDK for iOS: https://github.com/mapbox/mapbox-navigation-ios/pull/2880/files

The issue was found in Memory Leak Xcode tool: 
<img width="1273" alt="Screenshot 2021-07-26 at 13 55 12" src="https://user-images.githubusercontent.com/413986/126978065-ce046e1f-40f6-42b4-9cb3-ead3578f2d8f.png">

After applying the fix, the issue disappeared. 