### PR TITLE
Add iOSApplicationExtension unavailable annotations to fix compilation on Xcode 13b3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+### Features ✨ and improvements 🏁
+
+* Added support for building with Xcode 13b3. ([#564](https://github.com/mapbox/mapbox-maps-ios/pull/564))
+
 ## 10.0.0-rc.5 - July 28, 2021
 
 ### Bug fixes 🐞
 
-* Fixed an issue where `MapView` positioning wasn't correct when used in containers such as UIStackView ([#533](https://github.com/mapbox/mapbox-maps-ios/pull/533)) 
+* Fixed an issue where `MapView` positioning wasn't correct when used in containers such as UIStackView. ([#533](https://github.com/mapbox/mapbox-maps-ios/pull/533)) 
 
 ## 10.0.0-rc.4 - July 14, 2021
 

--- a/Sources/MapboxMaps/Foundation/MapView+Supportable.swift
+++ b/Sources/MapboxMaps/Foundation/MapView+Supportable.swift
@@ -1,6 +1,7 @@
 import UIKit
 import CoreLocation
 
+@available(iOSApplicationExtension, unavailable)
 extension MapView: OrnamentSupportableView {
     // User has tapped on an ornament
     internal func tapped() {
@@ -30,6 +31,7 @@ extension MapView: OrnamentSupportableView {
     }
 }
 
+@available(iOSApplicationExtension, unavailable)
 extension MapView: LocationSupportableMapView {
 
     public func point(for coordinate: CLLocationCoordinate2D) -> CGPoint {

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Turf
 
+@available(iOSApplicationExtension, unavailable)
 open class MapView: UIView {
 
     // mapbox map depends on MapInitOptions, which is not available until
@@ -352,6 +353,7 @@ open class MapView: UIView {
     }
 }
 
+@available(iOSApplicationExtension, unavailable)
 extension MapView: DelegatingMapClientDelegate {
     internal func scheduleRepaint() {
         needsDisplayRefresh = true

--- a/Sources/MapboxMaps/Location/LocationManager.swift
+++ b/Sources/MapboxMaps/Location/LocationManager.swift
@@ -103,6 +103,7 @@ public class LocationManager: NSObject {
 }
 
 // MARK: LocationProviderDelegate functions
+@available(iOSApplicationExtension, unavailable)
 extension LocationManager: LocationProviderDelegate {
 
     public func locationProvider(_ provider: LocationProvider, didUpdateLocations locations: [CLLocation]) {

--- a/Sources/MapboxMaps/Ornaments/MapboxInfoButtonOrnament.swift
+++ b/Sources/MapboxMaps/Ornaments/MapboxInfoButtonOrnament.swift
@@ -1,6 +1,7 @@
 import UIKit
 @_implementationOnly import MapboxCommon_Private
 
+@available(iOSApplicationExtension, unavailable)
 internal class MapboxInfoButtonOrnament: UIView {
     internal enum Constants {
         static let localizableTableName = "OrnamentsLocalizable"

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -14,6 +14,7 @@ public enum OrnamentVisibility: String, Equatable {
     case visible
 }
 
+@available(iOSApplicationExtension, unavailable)
 public class OrnamentsManager: NSObject {
 
     /// The `OrnamentOptions` object that is used to set up and update the required ornaments on the map.


### PR DESCRIPTION
Xcode 13b4 still has this rule and it is unclear if it will be fixed at all. It turns out the the amount of changes is minimal, so why not support Xcode 13 right now.

This is a regression due to a new rule in Xcode 13b3:

Linking Swift packages from application extension targets or watchOS applications no longer emits unresolvable warnings about linking to libraries not safe for use in application extensions. This means that code referencing APIs annotated as unavailable for use in app extensions must now themselves be annotated as unavailable for use in application extensions, in order to allow that code to be used in both apps and app extensions. (66928265)

https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes
