### PR TITLE
Fix Map Events Docs

### DIFF
--- a/Sources/MapboxMaps/Foundation/Extensions/Core/MapEvents.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/MapEvents.swift
@@ -2,11 +2,7 @@ import Foundation
 
 // MARK: - MapEvents
 
-/**
-* List of supported event types by the MapView and Snapshotter objects,
-* and event data format specification for each event.
-*
-* Simplified diagram for events emitted by the Map object.
+/* Simplified diagram for events emitted by the Map object.
 *
 * ┌─────────────┐               ┌─────────┐                   ┌──────────────┐
 * │ Application │               │   Map   │                   │ResourceLoader│
@@ -70,6 +66,11 @@ import Foundation
 *        │                           │ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘  │
 *        │                           │                                │
 *
+*/
+
+/**
+* List of supported event types by the MapView and Snapshotter objects,
+* and event data format specification for each event.
 */
 public extension MapEvents {
     /// Events emitted by the SDK


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes
This PR spilts up a comment in side of the `MapEvents` extension so that the graph is removed from the jazzy generated docs. The docs were poorly formatted using the jazzy style comments in Xcode. In general, this type of ascii chart did not appear to be an effective doc for the api reference.

Before: https://docs.mapbox.com/ios/maps/api/10.0.0-rc.5/Extensions/MapEvents.html

After: 
![Screen Shot 2021-08-04 at 4 14 40 PM](https://user-images.githubusercontent.com/5885209/128248963-acbcc836-76e2-4825-a818-4aa82ab911f6.png)
