### PR TITLE
Test using CocoaImageHashing for image comparisons

### DIFF
--- a/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "CocoaImageHashing",
+        "repositoryURL": "https://github.com/ameingast/cocoaimagehashing",
+        "state": {
+          "branch": null,
+          "revision": "ad01eee3c3f91bd181f7f4eba7f48f7cb211b51c",
+          "version": "1.9.0"
+        }
+      },
+      {
         "package": "MapboxCommon",
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", .exact("1.0.2")),
         .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("16.2.0")),
         .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", .exact("2.0.0-rc.1")),
+        .package(name: "CocoaImageHashing", url: "https://github.com/ameingast/cocoaimagehashing", .exact("1.9.0"))
     ],
     targets: [
         .target(
@@ -28,7 +29,7 @@ let package = Package(
         ),
         .testTarget(
             name: "MapboxMapsTests",
-            dependencies: ["MapboxMaps"],
+            dependencies: ["MapboxMaps", "CocoaImageHashing"],
             exclude: [
                 "Info.plist",
                 "Foundation/Integration Tests/HTTP/HTTPIntegrationTests.swift",

--- a/Tests/MapboxMapsTests/Helpers/XCTestCase+MapboxMaps.swift
+++ b/Tests/MapboxMapsTests/Helpers/XCTestCase+MapboxMaps.swift
@@ -41,6 +41,10 @@ extension XCTestCase {
         return try validated(token: token()).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private var imageComparisonHashDistanceMax: OSHashDistanceType {
+        return 2
+    }
+
     func compare(observedImage: UIImage, expectedImageNamed expectedImageName: String, expectedImageScale: CGFloat, attachmentName: String? = nil) -> Bool {
 
         var equal = false
@@ -73,16 +77,14 @@ extension XCTestCase {
 
         // See https://github.com/ameingast/cocoaimagehashing, http://phash.org
         // and https://github.com/aetilius/pHash
-        let start = CACurrentMediaTime()
         let imageHashing = OSImageHashing.sharedInstance()
         let observedHash = imageHashing.hashImage(observedImage, with: .pHash)
         let expectedHash = imageHashing.hashImage(expectedImage, with: .pHash)
         let imageDistance = imageHashing.hashDistance(observedHash, to: expectedHash, with: .pHash)
-        let end = CACurrentMediaTime()
 
-        equal = (imageDistance <= 2)
+        equal = (imageDistance <= imageComparisonHashDistanceMax)
 
-        print("Image comparison took \(end-start) seconds, distance = \(imageDistance)")
+        print("Image comparison distance = \(imageDistance)")
 
         return equal
     }

--- a/Tests/MapboxMapsTests/Snapshot/MapboxMapsSnapshotTests.swift
+++ b/Tests/MapboxMapsTests/Snapshot/MapboxMapsSnapshotTests.swift
@@ -96,7 +96,7 @@ class MapboxMapsSnapshotTests: XCTestCase {
                 XCTAssertNotNil(result)
                 print(snapshotter)
             }
-            wait(for: [expectation], timeout: 10)
+            wait(for: [expectation], timeout: 15)
         }
         XCTAssertNil(weakSnapshotter)
     }

--- a/project.yml
+++ b/project.yml
@@ -100,3 +100,6 @@ targets:
       - path: MapboxTestHost
     dependencies:
       - package: MapboxMaps
+        product: MapboxMaps
+      - package: MapboxMaps
+        product: CocoaImageHashing


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [X] Briefly describe the changes in this PR.
 - [X] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

This PR uses [cocoaimagehashing](https://github.com/ameingast/cocoaimagehashing) for image comparison tests, where [pixelmatch-cpp](https://github.com/mapbox/pixelmatch-cpp) needed a unusably high tolerance factor.

More understanding of the meaning of the distance returned by `hashDistance` is needed before this PR can really be merged. The tests currently uses the maximum distance (2) returned by diffing the same rendered scheme on different iOS versions - the main difference were in the CG context drawing and text rendering; map rendering did not change. 

This change was tested by added some variation to the source reference images, and appeared to behave well.