### PR TITLE
Update *Annotations to get/set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+### Bug fixes 🐞
+* Update all Annotation files to use `get/set` instead of `didSet`. This fixes an issue where properties were not being set at `init`. ([#590](https://github.com/mapbox/mapbox-maps-ios/pull/590))
+
 ## 10.0.0-rc.6 - August 11, 2021
 
 ### Features ✨ and improvements 🏁

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
@@ -44,7 +44,7 @@ public struct CircleAnnotation: Annotation {
     /// Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
     public var circleSortKey: Double? {
         get {
-            return feature.properties?[""circle-sort-key""] as? Double 
+            return feature.properties?["circle-sort-key"] as? Double 
         }
         set {
             feature.properties?["circle-sort-key"] = newValue
@@ -59,7 +59,7 @@ public struct CircleAnnotation: Annotation {
     /// Amount to blur the circle. 1 blurs the circle such that only the centerpoint is full opacity.
     public var circleBlur: Double? {
         get {
-            return feature.properties?[""circle-blur""] as? Double 
+            return feature.properties?["circle-blur"] as? Double 
         }
         set {
             feature.properties?["circle-blur"] = newValue
@@ -74,7 +74,7 @@ public struct CircleAnnotation: Annotation {
     /// The fill color of the circle.
     public var circleColor: ColorRepresentable? {
         get {
-            return feature.properties?[""circle-color""] as? ColorRepresentable 
+            return feature.properties?["circle-color"] as? ColorRepresentable 
         }
         set {
             feature.properties?["circle-color"] = newValue
@@ -89,7 +89,7 @@ public struct CircleAnnotation: Annotation {
     /// The opacity at which the circle will be drawn.
     public var circleOpacity: Double? {
         get {
-            return feature.properties?[""circle-opacity""] as? Double 
+            return feature.properties?["circle-opacity"] as? Double 
         }
         set {
             feature.properties?["circle-opacity"] = newValue
@@ -104,7 +104,7 @@ public struct CircleAnnotation: Annotation {
     /// Circle radius.
     public var circleRadius: Double? {
         get {
-            return feature.properties?[""circle-radius""] as? Double 
+            return feature.properties?["circle-radius"] as? Double 
         }
         set {
             feature.properties?["circle-radius"] = newValue
@@ -119,7 +119,7 @@ public struct CircleAnnotation: Annotation {
     /// The stroke color of the circle.
     public var circleStrokeColor: ColorRepresentable? {
         get {
-            return feature.properties?[""circle-stroke-color""] as? ColorRepresentable 
+            return feature.properties?["circle-stroke-color"] as? ColorRepresentable 
         }
         set {
             feature.properties?["circle-stroke-color"] = newValue
@@ -134,7 +134,7 @@ public struct CircleAnnotation: Annotation {
     /// The opacity of the circle's stroke.
     public var circleStrokeOpacity: Double? {
         get {
-            return feature.properties?[""circle-stroke-opacity""] as? Double 
+            return feature.properties?["circle-stroke-opacity"] as? Double 
         }
         set {
             feature.properties?["circle-stroke-opacity"] = newValue
@@ -149,7 +149,7 @@ public struct CircleAnnotation: Annotation {
     /// The width of the circle's stroke. Strokes are placed outside of the `circle-radius`.
     public var circleStrokeWidth: Double? {
         get {
-            return feature.properties?[""circle-stroke-width""] as? Double 
+            return feature.properties?["circle-stroke-width"] as? Double 
         }
         set {
             feature.properties?["circle-stroke-width"] = newValue

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
@@ -43,80 +43,120 @@ public struct CircleAnnotation: Annotation {
     
     /// Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
     public var circleSortKey: Double? {
-        didSet {
-            feature.properties?["circle-sort-key"] = circleSortKey 
-            if circleSortKey != nil {
+        get {
+            return feature.properties?[""circle-sort-key""] as? Double 
+        }
+        set {
+            feature.properties?["circle-sort-key"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-sort-key")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("circle-sort-key")
             }
         }
     }
     
     /// Amount to blur the circle. 1 blurs the circle such that only the centerpoint is full opacity.
     public var circleBlur: Double? {
-        didSet {
-            feature.properties?["circle-blur"] = circleBlur 
-            if circleBlur != nil {
+        get {
+            return feature.properties?[""circle-blur""] as? Double 
+        }
+        set {
+            feature.properties?["circle-blur"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-blur")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("circle-blur")
             }
         }
     }
     
     /// The fill color of the circle.
     public var circleColor: ColorRepresentable? {
-        didSet {
-            feature.properties?["circle-color"] = circleColor?.rgbaDescription 
-            if circleColor != nil {
+        get {
+            return feature.properties?[""circle-color""] as? ColorRepresentable 
+        }
+        set {
+            feature.properties?["circle-color"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-color")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("circle-color")
             }
         }
     }
     
     /// The opacity at which the circle will be drawn.
     public var circleOpacity: Double? {
-        didSet {
-            feature.properties?["circle-opacity"] = circleOpacity 
-            if circleOpacity != nil {
+        get {
+            return feature.properties?[""circle-opacity""] as? Double 
+        }
+        set {
+            feature.properties?["circle-opacity"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-opacity")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("circle-opacity")
             }
         }
     }
     
     /// Circle radius.
     public var circleRadius: Double? {
-        didSet {
-            feature.properties?["circle-radius"] = circleRadius 
-            if circleRadius != nil {
+        get {
+            return feature.properties?[""circle-radius""] as? Double 
+        }
+        set {
+            feature.properties?["circle-radius"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-radius")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("circle-radius")
             }
         }
     }
     
     /// The stroke color of the circle.
     public var circleStrokeColor: ColorRepresentable? {
-        didSet {
-            feature.properties?["circle-stroke-color"] = circleStrokeColor?.rgbaDescription 
-            if circleStrokeColor != nil {
+        get {
+            return feature.properties?[""circle-stroke-color""] as? ColorRepresentable 
+        }
+        set {
+            feature.properties?["circle-stroke-color"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-stroke-color")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("circle-stroke-color")
             }
         }
     }
     
     /// The opacity of the circle's stroke.
     public var circleStrokeOpacity: Double? {
-        didSet {
-            feature.properties?["circle-stroke-opacity"] = circleStrokeOpacity 
-            if circleStrokeOpacity != nil {
+        get {
+            return feature.properties?[""circle-stroke-opacity""] as? Double 
+        }
+        set {
+            feature.properties?["circle-stroke-opacity"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-stroke-opacity")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("circle-stroke-opacity")
             }
         }
     }
     
     /// The width of the circle's stroke. Strokes are placed outside of the `circle-radius`.
     public var circleStrokeWidth: Double? {
-        didSet {
-            feature.properties?["circle-stroke-width"] = circleStrokeWidth 
-            if circleStrokeWidth != nil {
+        get {
+            return feature.properties?[""circle-stroke-width""] as? Double 
+        }
+        set {
+            feature.properties?["circle-stroke-width"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-stroke-width")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("circle-stroke-width")
             }
         }
     }

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
@@ -47,7 +47,7 @@ public struct CircleAnnotation: Annotation {
             return feature.properties?["circle-sort-key"] as? Double 
         }
         set {
-            feature.properties?["circle-sort-key"] = newValue
+            feature.properties?["circle-sort-key"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-sort-key")
             } else {
@@ -62,7 +62,7 @@ public struct CircleAnnotation: Annotation {
             return feature.properties?["circle-blur"] as? Double 
         }
         set {
-            feature.properties?["circle-blur"] = newValue
+            feature.properties?["circle-blur"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-blur")
             } else {
@@ -77,7 +77,7 @@ public struct CircleAnnotation: Annotation {
             return feature.properties?["circle-color"] as? ColorRepresentable 
         }
         set {
-            feature.properties?["circle-color"] = newValue
+            feature.properties?["circle-color"] = newValue?.rgbaDescription 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-color")
             } else {
@@ -92,7 +92,7 @@ public struct CircleAnnotation: Annotation {
             return feature.properties?["circle-opacity"] as? Double 
         }
         set {
-            feature.properties?["circle-opacity"] = newValue
+            feature.properties?["circle-opacity"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-opacity")
             } else {
@@ -107,7 +107,7 @@ public struct CircleAnnotation: Annotation {
             return feature.properties?["circle-radius"] as? Double 
         }
         set {
-            feature.properties?["circle-radius"] = newValue
+            feature.properties?["circle-radius"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-radius")
             } else {
@@ -122,7 +122,7 @@ public struct CircleAnnotation: Annotation {
             return feature.properties?["circle-stroke-color"] as? ColorRepresentable 
         }
         set {
-            feature.properties?["circle-stroke-color"] = newValue
+            feature.properties?["circle-stroke-color"] = newValue?.rgbaDescription 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-stroke-color")
             } else {
@@ -137,7 +137,7 @@ public struct CircleAnnotation: Annotation {
             return feature.properties?["circle-stroke-opacity"] as? Double 
         }
         set {
-            feature.properties?["circle-stroke-opacity"] = newValue
+            feature.properties?["circle-stroke-opacity"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-stroke-opacity")
             } else {
@@ -152,7 +152,7 @@ public struct CircleAnnotation: Annotation {
             return feature.properties?["circle-stroke-width"] as? Double 
         }
         set {
-            feature.properties?["circle-stroke-width"] = newValue
+            feature.properties?["circle-stroke-width"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("circle-stroke-width")
             } else {

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
@@ -44,7 +44,7 @@ public struct PointAnnotation: Annotation {
     /// Part of the icon placed closest to the anchor.
     public var iconAnchor: IconAnchor? {
         get {
-            return feature.properties?[""icon-anchor""] as? IconAnchor 
+            return feature.properties?["icon-anchor"] as? IconAnchor 
         }
         set {
             feature.properties?["icon-anchor"] = newValue
@@ -59,7 +59,7 @@ public struct PointAnnotation: Annotation {
     /// Name of image in sprite to use for drawing an image background.
     public var iconImage: String? {
         get {
-            return feature.properties?[""icon-image""] as? String 
+            return feature.properties?["icon-image"] as? String 
         }
         set {
             feature.properties?["icon-image"] = newValue
@@ -74,7 +74,7 @@ public struct PointAnnotation: Annotation {
     /// Offset distance of icon from its anchor. Positive values indicate right and down, while negative values indicate left and up. Each component is multiplied by the value of `icon-size` to obtain the final offset in pixels. When combined with `icon-rotate` the offset will be as if the rotated direction was up.
     public var iconOffset: [Double]? {
         get {
-            return feature.properties?[""icon-offset""] as? [Double] 
+            return feature.properties?["icon-offset"] as? [Double] 
         }
         set {
             feature.properties?["icon-offset"] = newValue
@@ -89,7 +89,7 @@ public struct PointAnnotation: Annotation {
     /// Rotates the icon clockwise.
     public var iconRotate: Double? {
         get {
-            return feature.properties?[""icon-rotate""] as? Double 
+            return feature.properties?["icon-rotate"] as? Double 
         }
         set {
             feature.properties?["icon-rotate"] = newValue
@@ -104,7 +104,7 @@ public struct PointAnnotation: Annotation {
     /// Scales the original size of the icon by the provided factor. The new pixel size of the image will be the original pixel size multiplied by `icon-size`. 1 is the original size; 3 triples the size of the image.
     public var iconSize: Double? {
         get {
-            return feature.properties?[""icon-size""] as? Double 
+            return feature.properties?["icon-size"] as? Double 
         }
         set {
             feature.properties?["icon-size"] = newValue
@@ -119,7 +119,7 @@ public struct PointAnnotation: Annotation {
     /// Sorts features in ascending order based on this value. Features with lower sort keys are drawn and placed first.  When `icon-allow-overlap` or `text-allow-overlap` is `false`, features with a lower sort key will have priority during placement. When `icon-allow-overlap` or `text-allow-overlap` is set to `true`, features with a higher sort key will overlap over features with a lower sort key.
     public var symbolSortKey: Double? {
         get {
-            return feature.properties?[""symbol-sort-key""] as? Double 
+            return feature.properties?["symbol-sort-key"] as? Double 
         }
         set {
             feature.properties?["symbol-sort-key"] = newValue
@@ -134,7 +134,7 @@ public struct PointAnnotation: Annotation {
     /// Part of the text placed closest to the anchor.
     public var textAnchor: TextAnchor? {
         get {
-            return feature.properties?[""text-anchor""] as? TextAnchor 
+            return feature.properties?["text-anchor"] as? TextAnchor 
         }
         set {
             feature.properties?["text-anchor"] = newValue
@@ -149,7 +149,7 @@ public struct PointAnnotation: Annotation {
     /// Value to use for a text label. If a plain `string` is provided, it will be treated as a `formatted` with default/inherited formatting options.
     public var textField: String? {
         get {
-            return feature.properties?[""text-field""] as? String 
+            return feature.properties?["text-field"] as? String 
         }
         set {
             feature.properties?["text-field"] = newValue
@@ -164,7 +164,7 @@ public struct PointAnnotation: Annotation {
     /// Text justification options.
     public var textJustify: TextJustify? {
         get {
-            return feature.properties?[""text-justify""] as? TextJustify 
+            return feature.properties?["text-justify"] as? TextJustify 
         }
         set {
             feature.properties?["text-justify"] = newValue
@@ -179,7 +179,7 @@ public struct PointAnnotation: Annotation {
     /// Text tracking amount.
     public var textLetterSpacing: Double? {
         get {
-            return feature.properties?[""text-letter-spacing""] as? Double 
+            return feature.properties?["text-letter-spacing"] as? Double 
         }
         set {
             feature.properties?["text-letter-spacing"] = newValue
@@ -194,7 +194,7 @@ public struct PointAnnotation: Annotation {
     /// The maximum line width for text wrapping.
     public var textMaxWidth: Double? {
         get {
-            return feature.properties?[""text-max-width""] as? Double 
+            return feature.properties?["text-max-width"] as? Double 
         }
         set {
             feature.properties?["text-max-width"] = newValue
@@ -209,7 +209,7 @@ public struct PointAnnotation: Annotation {
     /// Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up. If used with text-variable-anchor, input values will be taken as absolute values. Offsets along the x- and y-axis will be applied automatically based on the anchor position.
     public var textOffset: [Double]? {
         get {
-            return feature.properties?[""text-offset""] as? [Double] 
+            return feature.properties?["text-offset"] as? [Double] 
         }
         set {
             feature.properties?["text-offset"] = newValue
@@ -224,7 +224,7 @@ public struct PointAnnotation: Annotation {
     /// Radial offset of text, in the direction of the symbol's anchor. Useful in combination with `text-variable-anchor`, which defaults to using the two-dimensional `text-offset` if present.
     public var textRadialOffset: Double? {
         get {
-            return feature.properties?[""text-radial-offset""] as? Double 
+            return feature.properties?["text-radial-offset"] as? Double 
         }
         set {
             feature.properties?["text-radial-offset"] = newValue
@@ -239,7 +239,7 @@ public struct PointAnnotation: Annotation {
     /// Rotates the text clockwise.
     public var textRotate: Double? {
         get {
-            return feature.properties?[""text-rotate""] as? Double 
+            return feature.properties?["text-rotate"] as? Double 
         }
         set {
             feature.properties?["text-rotate"] = newValue
@@ -254,7 +254,7 @@ public struct PointAnnotation: Annotation {
     /// Font size.
     public var textSize: Double? {
         get {
-            return feature.properties?[""text-size""] as? Double 
+            return feature.properties?["text-size"] as? Double 
         }
         set {
             feature.properties?["text-size"] = newValue
@@ -269,7 +269,7 @@ public struct PointAnnotation: Annotation {
     /// Specifies how to capitalize text, similar to the CSS `text-transform` property.
     public var textTransform: TextTransform? {
         get {
-            return feature.properties?[""text-transform""] as? TextTransform 
+            return feature.properties?["text-transform"] as? TextTransform 
         }
         set {
             feature.properties?["text-transform"] = newValue
@@ -284,7 +284,7 @@ public struct PointAnnotation: Annotation {
     /// The color of the icon. This can only be used with sdf icons.
     public var iconColor: ColorRepresentable? {
         get {
-            return feature.properties?[""icon-color""] as? ColorRepresentable 
+            return feature.properties?["icon-color"] as? ColorRepresentable 
         }
         set {
             feature.properties?["icon-color"] = newValue
@@ -299,7 +299,7 @@ public struct PointAnnotation: Annotation {
     /// Fade out the halo towards the outside.
     public var iconHaloBlur: Double? {
         get {
-            return feature.properties?[""icon-halo-blur""] as? Double 
+            return feature.properties?["icon-halo-blur"] as? Double 
         }
         set {
             feature.properties?["icon-halo-blur"] = newValue
@@ -314,7 +314,7 @@ public struct PointAnnotation: Annotation {
     /// The color of the icon's halo. Icon halos can only be used with SDF icons.
     public var iconHaloColor: ColorRepresentable? {
         get {
-            return feature.properties?[""icon-halo-color""] as? ColorRepresentable 
+            return feature.properties?["icon-halo-color"] as? ColorRepresentable 
         }
         set {
             feature.properties?["icon-halo-color"] = newValue
@@ -329,7 +329,7 @@ public struct PointAnnotation: Annotation {
     /// Distance of halo to the icon outline.
     public var iconHaloWidth: Double? {
         get {
-            return feature.properties?[""icon-halo-width""] as? Double 
+            return feature.properties?["icon-halo-width"] as? Double 
         }
         set {
             feature.properties?["icon-halo-width"] = newValue
@@ -344,7 +344,7 @@ public struct PointAnnotation: Annotation {
     /// The opacity at which the icon will be drawn.
     public var iconOpacity: Double? {
         get {
-            return feature.properties?[""icon-opacity""] as? Double 
+            return feature.properties?["icon-opacity"] as? Double 
         }
         set {
             feature.properties?["icon-opacity"] = newValue
@@ -359,7 +359,7 @@ public struct PointAnnotation: Annotation {
     /// The color with which the text will be drawn.
     public var textColor: ColorRepresentable? {
         get {
-            return feature.properties?[""text-color""] as? ColorRepresentable 
+            return feature.properties?["text-color"] as? ColorRepresentable 
         }
         set {
             feature.properties?["text-color"] = newValue
@@ -374,7 +374,7 @@ public struct PointAnnotation: Annotation {
     /// The halo's fadeout distance towards the outside.
     public var textHaloBlur: Double? {
         get {
-            return feature.properties?[""text-halo-blur""] as? Double 
+            return feature.properties?["text-halo-blur"] as? Double 
         }
         set {
             feature.properties?["text-halo-blur"] = newValue
@@ -389,7 +389,7 @@ public struct PointAnnotation: Annotation {
     /// The color of the text's halo, which helps it stand out from backgrounds.
     public var textHaloColor: ColorRepresentable? {
         get {
-            return feature.properties?[""text-halo-color""] as? ColorRepresentable 
+            return feature.properties?["text-halo-color"] as? ColorRepresentable 
         }
         set {
             feature.properties?["text-halo-color"] = newValue
@@ -404,7 +404,7 @@ public struct PointAnnotation: Annotation {
     /// Distance of halo to the font outline. Max text halo width is 1/4 of the font-size.
     public var textHaloWidth: Double? {
         get {
-            return feature.properties?[""text-halo-width""] as? Double 
+            return feature.properties?["text-halo-width"] as? Double 
         }
         set {
             feature.properties?["text-halo-width"] = newValue
@@ -419,7 +419,7 @@ public struct PointAnnotation: Annotation {
     /// The opacity at which the text will be drawn.
     public var textOpacity: Double? {
         get {
-            return feature.properties?[""text-opacity""] as? Double 
+            return feature.properties?["text-opacity"] as? Double 
         }
         set {
             feature.properties?["text-opacity"] = newValue

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
@@ -43,260 +43,390 @@ public struct PointAnnotation: Annotation {
     
     /// Part of the icon placed closest to the anchor.
     public var iconAnchor: IconAnchor? {
-        didSet {
-            feature.properties?["icon-anchor"] = iconAnchor?.rawValue 
-            if iconAnchor != nil {
+        get {
+            return feature.properties?[""icon-anchor""] as? IconAnchor 
+        }
+        set {
+            feature.properties?["icon-anchor"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-anchor")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("icon-anchor")
             }
         }
     }
     
     /// Name of image in sprite to use for drawing an image background.
     public var iconImage: String? {
-        didSet {
-            feature.properties?["icon-image"] = iconImage 
-            if iconImage != nil {
+        get {
+            return feature.properties?[""icon-image""] as? String 
+        }
+        set {
+            feature.properties?["icon-image"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-image")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("icon-image")
             }
         }
     }
     
     /// Offset distance of icon from its anchor. Positive values indicate right and down, while negative values indicate left and up. Each component is multiplied by the value of `icon-size` to obtain the final offset in pixels. When combined with `icon-rotate` the offset will be as if the rotated direction was up.
     public var iconOffset: [Double]? {
-        didSet {
-            feature.properties?["icon-offset"] = iconOffset 
-            if iconOffset != nil {
+        get {
+            return feature.properties?[""icon-offset""] as? [Double] 
+        }
+        set {
+            feature.properties?["icon-offset"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-offset")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("icon-offset")
             }
         }
     }
     
     /// Rotates the icon clockwise.
     public var iconRotate: Double? {
-        didSet {
-            feature.properties?["icon-rotate"] = iconRotate 
-            if iconRotate != nil {
+        get {
+            return feature.properties?[""icon-rotate""] as? Double 
+        }
+        set {
+            feature.properties?["icon-rotate"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-rotate")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("icon-rotate")
             }
         }
     }
     
     /// Scales the original size of the icon by the provided factor. The new pixel size of the image will be the original pixel size multiplied by `icon-size`. 1 is the original size; 3 triples the size of the image.
     public var iconSize: Double? {
-        didSet {
-            feature.properties?["icon-size"] = iconSize 
-            if iconSize != nil {
+        get {
+            return feature.properties?[""icon-size""] as? Double 
+        }
+        set {
+            feature.properties?["icon-size"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-size")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("icon-size")
             }
         }
     }
     
     /// Sorts features in ascending order based on this value. Features with lower sort keys are drawn and placed first.  When `icon-allow-overlap` or `text-allow-overlap` is `false`, features with a lower sort key will have priority during placement. When `icon-allow-overlap` or `text-allow-overlap` is set to `true`, features with a higher sort key will overlap over features with a lower sort key.
     public var symbolSortKey: Double? {
-        didSet {
-            feature.properties?["symbol-sort-key"] = symbolSortKey 
-            if symbolSortKey != nil {
+        get {
+            return feature.properties?[""symbol-sort-key""] as? Double 
+        }
+        set {
+            feature.properties?["symbol-sort-key"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("symbol-sort-key")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("symbol-sort-key")
             }
         }
     }
     
     /// Part of the text placed closest to the anchor.
     public var textAnchor: TextAnchor? {
-        didSet {
-            feature.properties?["text-anchor"] = textAnchor?.rawValue 
-            if textAnchor != nil {
+        get {
+            return feature.properties?[""text-anchor""] as? TextAnchor 
+        }
+        set {
+            feature.properties?["text-anchor"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-anchor")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-anchor")
             }
         }
     }
     
     /// Value to use for a text label. If a plain `string` is provided, it will be treated as a `formatted` with default/inherited formatting options.
     public var textField: String? {
-        didSet {
-            feature.properties?["text-field"] = textField 
-            if textField != nil {
+        get {
+            return feature.properties?[""text-field""] as? String 
+        }
+        set {
+            feature.properties?["text-field"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-field")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-field")
             }
         }
     }
     
     /// Text justification options.
     public var textJustify: TextJustify? {
-        didSet {
-            feature.properties?["text-justify"] = textJustify?.rawValue 
-            if textJustify != nil {
+        get {
+            return feature.properties?[""text-justify""] as? TextJustify 
+        }
+        set {
+            feature.properties?["text-justify"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-justify")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-justify")
             }
         }
     }
     
     /// Text tracking amount.
     public var textLetterSpacing: Double? {
-        didSet {
-            feature.properties?["text-letter-spacing"] = textLetterSpacing 
-            if textLetterSpacing != nil {
+        get {
+            return feature.properties?[""text-letter-spacing""] as? Double 
+        }
+        set {
+            feature.properties?["text-letter-spacing"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-letter-spacing")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-letter-spacing")
             }
         }
     }
     
     /// The maximum line width for text wrapping.
     public var textMaxWidth: Double? {
-        didSet {
-            feature.properties?["text-max-width"] = textMaxWidth 
-            if textMaxWidth != nil {
+        get {
+            return feature.properties?[""text-max-width""] as? Double 
+        }
+        set {
+            feature.properties?["text-max-width"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-max-width")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-max-width")
             }
         }
     }
     
     /// Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up. If used with text-variable-anchor, input values will be taken as absolute values. Offsets along the x- and y-axis will be applied automatically based on the anchor position.
     public var textOffset: [Double]? {
-        didSet {
-            feature.properties?["text-offset"] = textOffset 
-            if textOffset != nil {
+        get {
+            return feature.properties?[""text-offset""] as? [Double] 
+        }
+        set {
+            feature.properties?["text-offset"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-offset")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-offset")
             }
         }
     }
     
     /// Radial offset of text, in the direction of the symbol's anchor. Useful in combination with `text-variable-anchor`, which defaults to using the two-dimensional `text-offset` if present.
     public var textRadialOffset: Double? {
-        didSet {
-            feature.properties?["text-radial-offset"] = textRadialOffset 
-            if textRadialOffset != nil {
+        get {
+            return feature.properties?[""text-radial-offset""] as? Double 
+        }
+        set {
+            feature.properties?["text-radial-offset"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-radial-offset")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-radial-offset")
             }
         }
     }
     
     /// Rotates the text clockwise.
     public var textRotate: Double? {
-        didSet {
-            feature.properties?["text-rotate"] = textRotate 
-            if textRotate != nil {
+        get {
+            return feature.properties?[""text-rotate""] as? Double 
+        }
+        set {
+            feature.properties?["text-rotate"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-rotate")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-rotate")
             }
         }
     }
     
     /// Font size.
     public var textSize: Double? {
-        didSet {
-            feature.properties?["text-size"] = textSize 
-            if textSize != nil {
+        get {
+            return feature.properties?[""text-size""] as? Double 
+        }
+        set {
+            feature.properties?["text-size"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-size")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-size")
             }
         }
     }
     
     /// Specifies how to capitalize text, similar to the CSS `text-transform` property.
     public var textTransform: TextTransform? {
-        didSet {
-            feature.properties?["text-transform"] = textTransform?.rawValue 
-            if textTransform != nil {
+        get {
+            return feature.properties?[""text-transform""] as? TextTransform 
+        }
+        set {
+            feature.properties?["text-transform"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-transform")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-transform")
             }
         }
     }
     
     /// The color of the icon. This can only be used with sdf icons.
     public var iconColor: ColorRepresentable? {
-        didSet {
-            feature.properties?["icon-color"] = iconColor?.rgbaDescription 
-            if iconColor != nil {
+        get {
+            return feature.properties?[""icon-color""] as? ColorRepresentable 
+        }
+        set {
+            feature.properties?["icon-color"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-color")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("icon-color")
             }
         }
     }
     
     /// Fade out the halo towards the outside.
     public var iconHaloBlur: Double? {
-        didSet {
-            feature.properties?["icon-halo-blur"] = iconHaloBlur 
-            if iconHaloBlur != nil {
+        get {
+            return feature.properties?[""icon-halo-blur""] as? Double 
+        }
+        set {
+            feature.properties?["icon-halo-blur"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-halo-blur")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("icon-halo-blur")
             }
         }
     }
     
     /// The color of the icon's halo. Icon halos can only be used with SDF icons.
     public var iconHaloColor: ColorRepresentable? {
-        didSet {
-            feature.properties?["icon-halo-color"] = iconHaloColor?.rgbaDescription 
-            if iconHaloColor != nil {
+        get {
+            return feature.properties?[""icon-halo-color""] as? ColorRepresentable 
+        }
+        set {
+            feature.properties?["icon-halo-color"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-halo-color")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("icon-halo-color")
             }
         }
     }
     
     /// Distance of halo to the icon outline.
     public var iconHaloWidth: Double? {
-        didSet {
-            feature.properties?["icon-halo-width"] = iconHaloWidth 
-            if iconHaloWidth != nil {
+        get {
+            return feature.properties?[""icon-halo-width""] as? Double 
+        }
+        set {
+            feature.properties?["icon-halo-width"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-halo-width")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("icon-halo-width")
             }
         }
     }
     
     /// The opacity at which the icon will be drawn.
     public var iconOpacity: Double? {
-        didSet {
-            feature.properties?["icon-opacity"] = iconOpacity 
-            if iconOpacity != nil {
+        get {
+            return feature.properties?[""icon-opacity""] as? Double 
+        }
+        set {
+            feature.properties?["icon-opacity"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-opacity")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("icon-opacity")
             }
         }
     }
     
     /// The color with which the text will be drawn.
     public var textColor: ColorRepresentable? {
-        didSet {
-            feature.properties?["text-color"] = textColor?.rgbaDescription 
-            if textColor != nil {
+        get {
+            return feature.properties?[""text-color""] as? ColorRepresentable 
+        }
+        set {
+            feature.properties?["text-color"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-color")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-color")
             }
         }
     }
     
     /// The halo's fadeout distance towards the outside.
     public var textHaloBlur: Double? {
-        didSet {
-            feature.properties?["text-halo-blur"] = textHaloBlur 
-            if textHaloBlur != nil {
+        get {
+            return feature.properties?[""text-halo-blur""] as? Double 
+        }
+        set {
+            feature.properties?["text-halo-blur"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-halo-blur")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-halo-blur")
             }
         }
     }
     
     /// The color of the text's halo, which helps it stand out from backgrounds.
     public var textHaloColor: ColorRepresentable? {
-        didSet {
-            feature.properties?["text-halo-color"] = textHaloColor?.rgbaDescription 
-            if textHaloColor != nil {
+        get {
+            return feature.properties?[""text-halo-color""] as? ColorRepresentable 
+        }
+        set {
+            feature.properties?["text-halo-color"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-halo-color")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-halo-color")
             }
         }
     }
     
     /// Distance of halo to the font outline. Max text halo width is 1/4 of the font-size.
     public var textHaloWidth: Double? {
-        didSet {
-            feature.properties?["text-halo-width"] = textHaloWidth 
-            if textHaloWidth != nil {
+        get {
+            return feature.properties?[""text-halo-width""] as? Double 
+        }
+        set {
+            feature.properties?["text-halo-width"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-halo-width")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-halo-width")
             }
         }
     }
     
     /// The opacity at which the text will be drawn.
     public var textOpacity: Double? {
-        didSet {
-            feature.properties?["text-opacity"] = textOpacity 
-            if textOpacity != nil {
+        get {
+            return feature.properties?[""text-opacity""] as? Double 
+        }
+        set {
+            feature.properties?["text-opacity"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-opacity")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("text-opacity")
             }
         }
     }

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
@@ -47,7 +47,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["icon-anchor"] as? IconAnchor 
         }
         set {
-            feature.properties?["icon-anchor"] = newValue
+            feature.properties?["icon-anchor"] = newValue?.rawValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-anchor")
             } else {
@@ -62,7 +62,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["icon-image"] as? String 
         }
         set {
-            feature.properties?["icon-image"] = newValue
+            feature.properties?["icon-image"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-image")
             } else {
@@ -77,7 +77,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["icon-offset"] as? [Double] 
         }
         set {
-            feature.properties?["icon-offset"] = newValue
+            feature.properties?["icon-offset"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-offset")
             } else {
@@ -92,7 +92,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["icon-rotate"] as? Double 
         }
         set {
-            feature.properties?["icon-rotate"] = newValue
+            feature.properties?["icon-rotate"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-rotate")
             } else {
@@ -107,7 +107,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["icon-size"] as? Double 
         }
         set {
-            feature.properties?["icon-size"] = newValue
+            feature.properties?["icon-size"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-size")
             } else {
@@ -122,7 +122,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["symbol-sort-key"] as? Double 
         }
         set {
-            feature.properties?["symbol-sort-key"] = newValue
+            feature.properties?["symbol-sort-key"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("symbol-sort-key")
             } else {
@@ -137,7 +137,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-anchor"] as? TextAnchor 
         }
         set {
-            feature.properties?["text-anchor"] = newValue
+            feature.properties?["text-anchor"] = newValue?.rawValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-anchor")
             } else {
@@ -152,7 +152,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-field"] as? String 
         }
         set {
-            feature.properties?["text-field"] = newValue
+            feature.properties?["text-field"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-field")
             } else {
@@ -167,7 +167,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-justify"] as? TextJustify 
         }
         set {
-            feature.properties?["text-justify"] = newValue
+            feature.properties?["text-justify"] = newValue?.rawValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-justify")
             } else {
@@ -182,7 +182,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-letter-spacing"] as? Double 
         }
         set {
-            feature.properties?["text-letter-spacing"] = newValue
+            feature.properties?["text-letter-spacing"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-letter-spacing")
             } else {
@@ -197,7 +197,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-max-width"] as? Double 
         }
         set {
-            feature.properties?["text-max-width"] = newValue
+            feature.properties?["text-max-width"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-max-width")
             } else {
@@ -212,7 +212,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-offset"] as? [Double] 
         }
         set {
-            feature.properties?["text-offset"] = newValue
+            feature.properties?["text-offset"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-offset")
             } else {
@@ -227,7 +227,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-radial-offset"] as? Double 
         }
         set {
-            feature.properties?["text-radial-offset"] = newValue
+            feature.properties?["text-radial-offset"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-radial-offset")
             } else {
@@ -242,7 +242,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-rotate"] as? Double 
         }
         set {
-            feature.properties?["text-rotate"] = newValue
+            feature.properties?["text-rotate"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-rotate")
             } else {
@@ -257,7 +257,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-size"] as? Double 
         }
         set {
-            feature.properties?["text-size"] = newValue
+            feature.properties?["text-size"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-size")
             } else {
@@ -272,7 +272,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-transform"] as? TextTransform 
         }
         set {
-            feature.properties?["text-transform"] = newValue
+            feature.properties?["text-transform"] = newValue?.rawValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-transform")
             } else {
@@ -287,7 +287,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["icon-color"] as? ColorRepresentable 
         }
         set {
-            feature.properties?["icon-color"] = newValue
+            feature.properties?["icon-color"] = newValue?.rgbaDescription 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-color")
             } else {
@@ -302,7 +302,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["icon-halo-blur"] as? Double 
         }
         set {
-            feature.properties?["icon-halo-blur"] = newValue
+            feature.properties?["icon-halo-blur"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-halo-blur")
             } else {
@@ -317,7 +317,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["icon-halo-color"] as? ColorRepresentable 
         }
         set {
-            feature.properties?["icon-halo-color"] = newValue
+            feature.properties?["icon-halo-color"] = newValue?.rgbaDescription 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-halo-color")
             } else {
@@ -332,7 +332,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["icon-halo-width"] as? Double 
         }
         set {
-            feature.properties?["icon-halo-width"] = newValue
+            feature.properties?["icon-halo-width"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-halo-width")
             } else {
@@ -347,7 +347,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["icon-opacity"] as? Double 
         }
         set {
-            feature.properties?["icon-opacity"] = newValue
+            feature.properties?["icon-opacity"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("icon-opacity")
             } else {
@@ -362,7 +362,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-color"] as? ColorRepresentable 
         }
         set {
-            feature.properties?["text-color"] = newValue
+            feature.properties?["text-color"] = newValue?.rgbaDescription 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-color")
             } else {
@@ -377,7 +377,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-halo-blur"] as? Double 
         }
         set {
-            feature.properties?["text-halo-blur"] = newValue
+            feature.properties?["text-halo-blur"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-halo-blur")
             } else {
@@ -392,7 +392,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-halo-color"] as? ColorRepresentable 
         }
         set {
-            feature.properties?["text-halo-color"] = newValue
+            feature.properties?["text-halo-color"] = newValue?.rgbaDescription 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-halo-color")
             } else {
@@ -407,7 +407,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-halo-width"] as? Double 
         }
         set {
-            feature.properties?["text-halo-width"] = newValue
+            feature.properties?["text-halo-width"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-halo-width")
             } else {
@@ -422,7 +422,7 @@ public struct PointAnnotation: Annotation {
             return feature.properties?["text-opacity"] as? Double 
         }
         set {
-            feature.properties?["text-opacity"] = newValue
+            feature.properties?["text-opacity"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("text-opacity")
             } else {

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
@@ -34,50 +34,75 @@ public struct PolygonAnnotation: Annotation {
     
     /// Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
     public var fillSortKey: Double? {
-        didSet {
-            feature.properties?["fill-sort-key"] = fillSortKey 
-            if fillSortKey != nil {
+        get {
+            return feature.properties?[""fill-sort-key""] as? Double 
+        }
+        set {
+            feature.properties?["fill-sort-key"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("fill-sort-key")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("fill-sort-key")
             }
         }
     }
     
     /// The color of the filled part of this layer. This color can be specified as `rgba` with an alpha component and the color's opacity will not affect the opacity of the 1px stroke, if it is used.
     public var fillColor: ColorRepresentable? {
-        didSet {
-            feature.properties?["fill-color"] = fillColor?.rgbaDescription 
-            if fillColor != nil {
+        get {
+            return feature.properties?[""fill-color""] as? ColorRepresentable 
+        }
+        set {
+            feature.properties?["fill-color"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("fill-color")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("fill-color")
             }
         }
     }
     
     /// The opacity of the entire fill layer. In contrast to the `fill-color`, this value will also affect the 1px stroke around the fill, if the stroke is used.
     public var fillOpacity: Double? {
-        didSet {
-            feature.properties?["fill-opacity"] = fillOpacity 
-            if fillOpacity != nil {
+        get {
+            return feature.properties?[""fill-opacity""] as? Double 
+        }
+        set {
+            feature.properties?["fill-opacity"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("fill-opacity")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("fill-opacity")
             }
         }
     }
     
     /// The outline color of the fill. Matches the value of `fill-color` if unspecified.
     public var fillOutlineColor: ColorRepresentable? {
-        didSet {
-            feature.properties?["fill-outline-color"] = fillOutlineColor?.rgbaDescription 
-            if fillOutlineColor != nil {
+        get {
+            return feature.properties?[""fill-outline-color""] as? ColorRepresentable 
+        }
+        set {
+            feature.properties?["fill-outline-color"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("fill-outline-color")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("fill-outline-color")
             }
         }
     }
     
     /// Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
     public var fillPattern: String? {
-        didSet {
-            feature.properties?["fill-pattern"] = fillPattern 
-            if fillPattern != nil {
+        get {
+            return feature.properties?[""fill-pattern""] as? String 
+        }
+        set {
+            feature.properties?["fill-pattern"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("fill-pattern")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("fill-pattern")
             }
         }
     }

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
@@ -35,7 +35,7 @@ public struct PolygonAnnotation: Annotation {
     /// Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
     public var fillSortKey: Double? {
         get {
-            return feature.properties?[""fill-sort-key""] as? Double 
+            return feature.properties?["fill-sort-key"] as? Double 
         }
         set {
             feature.properties?["fill-sort-key"] = newValue
@@ -50,7 +50,7 @@ public struct PolygonAnnotation: Annotation {
     /// The color of the filled part of this layer. This color can be specified as `rgba` with an alpha component and the color's opacity will not affect the opacity of the 1px stroke, if it is used.
     public var fillColor: ColorRepresentable? {
         get {
-            return feature.properties?[""fill-color""] as? ColorRepresentable 
+            return feature.properties?["fill-color"] as? ColorRepresentable 
         }
         set {
             feature.properties?["fill-color"] = newValue
@@ -65,7 +65,7 @@ public struct PolygonAnnotation: Annotation {
     /// The opacity of the entire fill layer. In contrast to the `fill-color`, this value will also affect the 1px stroke around the fill, if the stroke is used.
     public var fillOpacity: Double? {
         get {
-            return feature.properties?[""fill-opacity""] as? Double 
+            return feature.properties?["fill-opacity"] as? Double 
         }
         set {
             feature.properties?["fill-opacity"] = newValue
@@ -80,7 +80,7 @@ public struct PolygonAnnotation: Annotation {
     /// The outline color of the fill. Matches the value of `fill-color` if unspecified.
     public var fillOutlineColor: ColorRepresentable? {
         get {
-            return feature.properties?[""fill-outline-color""] as? ColorRepresentable 
+            return feature.properties?["fill-outline-color"] as? ColorRepresentable 
         }
         set {
             feature.properties?["fill-outline-color"] = newValue
@@ -95,7 +95,7 @@ public struct PolygonAnnotation: Annotation {
     /// Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
     public var fillPattern: String? {
         get {
-            return feature.properties?[""fill-pattern""] as? String 
+            return feature.properties?["fill-pattern"] as? String 
         }
         set {
             feature.properties?["fill-pattern"] = newValue

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
@@ -38,7 +38,7 @@ public struct PolygonAnnotation: Annotation {
             return feature.properties?["fill-sort-key"] as? Double 
         }
         set {
-            feature.properties?["fill-sort-key"] = newValue
+            feature.properties?["fill-sort-key"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("fill-sort-key")
             } else {
@@ -53,7 +53,7 @@ public struct PolygonAnnotation: Annotation {
             return feature.properties?["fill-color"] as? ColorRepresentable 
         }
         set {
-            feature.properties?["fill-color"] = newValue
+            feature.properties?["fill-color"] = newValue?.rgbaDescription 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("fill-color")
             } else {
@@ -68,7 +68,7 @@ public struct PolygonAnnotation: Annotation {
             return feature.properties?["fill-opacity"] as? Double 
         }
         set {
-            feature.properties?["fill-opacity"] = newValue
+            feature.properties?["fill-opacity"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("fill-opacity")
             } else {
@@ -83,7 +83,7 @@ public struct PolygonAnnotation: Annotation {
             return feature.properties?["fill-outline-color"] as? ColorRepresentable 
         }
         set {
-            feature.properties?["fill-outline-color"] = newValue
+            feature.properties?["fill-outline-color"] = newValue?.rgbaDescription 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("fill-outline-color")
             } else {
@@ -98,7 +98,7 @@ public struct PolygonAnnotation: Annotation {
             return feature.properties?["fill-pattern"] as? String 
         }
         set {
-            feature.properties?["fill-pattern"] = newValue
+            feature.properties?["fill-pattern"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("fill-pattern")
             } else {

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
@@ -44,7 +44,7 @@ public struct PolylineAnnotation: Annotation {
             return feature.properties?["line-join"] as? LineJoin 
         }
         set {
-            feature.properties?["line-join"] = newValue
+            feature.properties?["line-join"] = newValue?.rawValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-join")
             } else {
@@ -59,7 +59,7 @@ public struct PolylineAnnotation: Annotation {
             return feature.properties?["line-sort-key"] as? Double 
         }
         set {
-            feature.properties?["line-sort-key"] = newValue
+            feature.properties?["line-sort-key"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-sort-key")
             } else {
@@ -74,7 +74,7 @@ public struct PolylineAnnotation: Annotation {
             return feature.properties?["line-blur"] as? Double 
         }
         set {
-            feature.properties?["line-blur"] = newValue
+            feature.properties?["line-blur"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-blur")
             } else {
@@ -89,7 +89,7 @@ public struct PolylineAnnotation: Annotation {
             return feature.properties?["line-color"] as? ColorRepresentable 
         }
         set {
-            feature.properties?["line-color"] = newValue
+            feature.properties?["line-color"] = newValue?.rgbaDescription 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-color")
             } else {
@@ -104,7 +104,7 @@ public struct PolylineAnnotation: Annotation {
             return feature.properties?["line-gap-width"] as? Double 
         }
         set {
-            feature.properties?["line-gap-width"] = newValue
+            feature.properties?["line-gap-width"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-gap-width")
             } else {
@@ -119,7 +119,7 @@ public struct PolylineAnnotation: Annotation {
             return feature.properties?["line-offset"] as? Double 
         }
         set {
-            feature.properties?["line-offset"] = newValue
+            feature.properties?["line-offset"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-offset")
             } else {
@@ -134,7 +134,7 @@ public struct PolylineAnnotation: Annotation {
             return feature.properties?["line-opacity"] as? Double 
         }
         set {
-            feature.properties?["line-opacity"] = newValue
+            feature.properties?["line-opacity"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-opacity")
             } else {
@@ -149,7 +149,7 @@ public struct PolylineAnnotation: Annotation {
             return feature.properties?["line-pattern"] as? String 
         }
         set {
-            feature.properties?["line-pattern"] = newValue
+            feature.properties?["line-pattern"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-pattern")
             } else {
@@ -164,7 +164,7 @@ public struct PolylineAnnotation: Annotation {
             return feature.properties?["line-width"] as? Double 
         }
         set {
-            feature.properties?["line-width"] = newValue
+            feature.properties?["line-width"] = newValue 
             if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-width")
             } else {

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
@@ -40,90 +40,135 @@ public struct PolylineAnnotation: Annotation {
     
     /// The display of lines when joining.
     public var lineJoin: LineJoin? {
-        didSet {
-            feature.properties?["line-join"] = lineJoin?.rawValue 
-            if lineJoin != nil {
+        get {
+            return feature.properties?[""line-join""] as? LineJoin 
+        }
+        set {
+            feature.properties?["line-join"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-join")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("line-join")
             }
         }
     }
     
     /// Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
     public var lineSortKey: Double? {
-        didSet {
-            feature.properties?["line-sort-key"] = lineSortKey 
-            if lineSortKey != nil {
+        get {
+            return feature.properties?[""line-sort-key""] as? Double 
+        }
+        set {
+            feature.properties?["line-sort-key"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-sort-key")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("line-sort-key")
             }
         }
     }
     
     /// Blur applied to the line, in pixels.
     public var lineBlur: Double? {
-        didSet {
-            feature.properties?["line-blur"] = lineBlur 
-            if lineBlur != nil {
+        get {
+            return feature.properties?[""line-blur""] as? Double 
+        }
+        set {
+            feature.properties?["line-blur"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-blur")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("line-blur")
             }
         }
     }
     
     /// The color with which the line will be drawn.
     public var lineColor: ColorRepresentable? {
-        didSet {
-            feature.properties?["line-color"] = lineColor?.rgbaDescription 
-            if lineColor != nil {
+        get {
+            return feature.properties?[""line-color""] as? ColorRepresentable 
+        }
+        set {
+            feature.properties?["line-color"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-color")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("line-color")
             }
         }
     }
     
     /// Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
     public var lineGapWidth: Double? {
-        didSet {
-            feature.properties?["line-gap-width"] = lineGapWidth 
-            if lineGapWidth != nil {
+        get {
+            return feature.properties?[""line-gap-width""] as? Double 
+        }
+        set {
+            feature.properties?["line-gap-width"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-gap-width")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("line-gap-width")
             }
         }
     }
     
     /// The line's offset. For linear features, a positive value offsets the line to the right, relative to the direction of the line, and a negative value to the left. For polygon features, a positive value results in an inset, and a negative value results in an outset.
     public var lineOffset: Double? {
-        didSet {
-            feature.properties?["line-offset"] = lineOffset 
-            if lineOffset != nil {
+        get {
+            return feature.properties?[""line-offset""] as? Double 
+        }
+        set {
+            feature.properties?["line-offset"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-offset")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("line-offset")
             }
         }
     }
     
     /// The opacity at which the line will be drawn.
     public var lineOpacity: Double? {
-        didSet {
-            feature.properties?["line-opacity"] = lineOpacity 
-            if lineOpacity != nil {
+        get {
+            return feature.properties?[""line-opacity""] as? Double 
+        }
+        set {
+            feature.properties?["line-opacity"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-opacity")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("line-opacity")
             }
         }
     }
     
     /// Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
     public var linePattern: String? {
-        didSet {
-            feature.properties?["line-pattern"] = linePattern 
-            if linePattern != nil {
+        get {
+            return feature.properties?[""line-pattern""] as? String 
+        }
+        set {
+            feature.properties?["line-pattern"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-pattern")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("line-pattern")
             }
         }
     }
     
     /// Stroke thickness.
     public var lineWidth: Double? {
-        didSet {
-            feature.properties?["line-width"] = lineWidth 
-            if lineWidth != nil {
+        get {
+            return feature.properties?[""line-width""] as? Double 
+        }
+        set {
+            feature.properties?["line-width"] = newValue
+            if newValue != nil {
                 dataDrivenPropertiesUsedSet.insert("line-width")
+            } else {
+                dataDrivenPropertiesUsedSet.remove("line-width")
             }
         }
     }

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
@@ -41,7 +41,7 @@ public struct PolylineAnnotation: Annotation {
     /// The display of lines when joining.
     public var lineJoin: LineJoin? {
         get {
-            return feature.properties?[""line-join""] as? LineJoin 
+            return feature.properties?["line-join"] as? LineJoin 
         }
         set {
             feature.properties?["line-join"] = newValue
@@ -56,7 +56,7 @@ public struct PolylineAnnotation: Annotation {
     /// Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
     public var lineSortKey: Double? {
         get {
-            return feature.properties?[""line-sort-key""] as? Double 
+            return feature.properties?["line-sort-key"] as? Double 
         }
         set {
             feature.properties?["line-sort-key"] = newValue
@@ -71,7 +71,7 @@ public struct PolylineAnnotation: Annotation {
     /// Blur applied to the line, in pixels.
     public var lineBlur: Double? {
         get {
-            return feature.properties?[""line-blur""] as? Double 
+            return feature.properties?["line-blur"] as? Double 
         }
         set {
             feature.properties?["line-blur"] = newValue
@@ -86,7 +86,7 @@ public struct PolylineAnnotation: Annotation {
     /// The color with which the line will be drawn.
     public var lineColor: ColorRepresentable? {
         get {
-            return feature.properties?[""line-color""] as? ColorRepresentable 
+            return feature.properties?["line-color"] as? ColorRepresentable 
         }
         set {
             feature.properties?["line-color"] = newValue
@@ -101,7 +101,7 @@ public struct PolylineAnnotation: Annotation {
     /// Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
     public var lineGapWidth: Double? {
         get {
-            return feature.properties?[""line-gap-width""] as? Double 
+            return feature.properties?["line-gap-width"] as? Double 
         }
         set {
             feature.properties?["line-gap-width"] = newValue
@@ -116,7 +116,7 @@ public struct PolylineAnnotation: Annotation {
     /// The line's offset. For linear features, a positive value offsets the line to the right, relative to the direction of the line, and a negative value to the left. For polygon features, a positive value results in an inset, and a negative value results in an outset.
     public var lineOffset: Double? {
         get {
-            return feature.properties?[""line-offset""] as? Double 
+            return feature.properties?["line-offset"] as? Double 
         }
         set {
             feature.properties?["line-offset"] = newValue
@@ -131,7 +131,7 @@ public struct PolylineAnnotation: Annotation {
     /// The opacity at which the line will be drawn.
     public var lineOpacity: Double? {
         get {
-            return feature.properties?[""line-opacity""] as? Double 
+            return feature.properties?["line-opacity"] as? Double 
         }
         set {
             feature.properties?["line-opacity"] = newValue
@@ -146,7 +146,7 @@ public struct PolylineAnnotation: Annotation {
     /// Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
     public var linePattern: String? {
         get {
-            return feature.properties?[""line-pattern""] as? String 
+            return feature.properties?["line-pattern"] as? String 
         }
         set {
             feature.properties?["line-pattern"] = newValue
@@ -161,7 +161,7 @@ public struct PolylineAnnotation: Annotation {
     /// Stroke thickness.
     public var lineWidth: Double? {
         get {
-            return feature.properties?[""line-width""] as? Double 
+            return feature.properties?["line-width"] as? Double 
         }
         set {
             feature.properties?["line-width"] = newValue


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: https://github.com/mapbox/mapbox-maps-ios/issues/565

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes
This PR will update all the Annotation structs by using `get/set` for properties instead of `didSet`. The existing `didSet` solution prevented custom initializers from being used. `didSet` is not called at `init`. 