### PR TITLE
Remove if canImport checks

### DIFF
--- a/Sources/MapboxMaps/Ornaments/Compass/MapboxCompassOrnamentView.swift
+++ b/Sources/MapboxMaps/Ornaments/Compass/MapboxCompassOrnamentView.swift
@@ -1,10 +1,6 @@
 import CoreLocation
 import UIKit
 
-#if canImport(MapboxMapsFoundation)
-import MapboxMapsFoundation
-#endif
-
 internal class MapboxCompassOrnamentView: UIButton {
     private enum Constants {
         static let localizableTableName = "OrnamentsLocalizable"

--- a/Sources/MapboxMaps/Ornaments/OrnamentSupportableView.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentSupportableView.swift
@@ -1,9 +1,5 @@
 import UIKit
 
-#if canImport(MapboxMapsFoundation)
-import MapboxMapsFoundation
-#endif
-
 /// The `OrnamentSupportableView` protocol supports communication
 /// from the MapboxMapsOrnaments module to the `MapView`.
 internal protocol OrnamentSupportableView: UIView {

--- a/Sources/MapboxMaps/Ornaments/ScaleBar/MapboxScaleBarOrnamentView.swift
+++ b/Sources/MapboxMaps/Ornaments/ScaleBar/MapboxScaleBarOrnamentView.swift
@@ -1,10 +1,6 @@
 import UIKit
 import CoreLocation
 
-#if canImport(MapboxMapsFoundation)
-import MapboxMapsFoundation
-#endif
-
 //swiftlint:disable type_body_length
 internal class MapboxScaleBarOrnamentView: UIView {
 

--- a/Tests/MapboxMapsTests/Foundation/Camera/FlyToTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Camera/FlyToTests.swift
@@ -1,11 +1,6 @@
 import XCTest
 import Turf
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
 
 internal class FlyToTests: XCTestCase {
 

--- a/Tests/MapboxMapsTests/Foundation/Comparable+ClampedTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Comparable+ClampedTests.swift
@@ -1,9 +1,5 @@
 import XCTest
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
 
 final class Comparable_ClampedTests: XCTestCase {
     func testClampedWithValueLessThanLowerBound() throws {

--- a/Tests/MapboxMapsTests/Foundation/Extensions/Core/LayerPositionTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Extensions/Core/LayerPositionTests.swift
@@ -1,10 +1,5 @@
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
 
 final class LayerPositionTests: XCTestCase {
 

--- a/Tests/MapboxMapsTests/Foundation/GeoJSON/FeatureCollectionTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/GeoJSON/FeatureCollectionTests.swift
@@ -1,12 +1,7 @@
 import XCTest
 import CoreLocation
 import Turf
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
 
 // Disabling rules against force casting for test file.
 // swiftlint:disable explicit_top_level_acl explicit_acl force_try force_cast

--- a/Tests/MapboxMapsTests/Foundation/GeoJSON/Geometry+MBXGeometryTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/GeoJSON/Geometry+MBXGeometryTests.swift
@@ -3,7 +3,6 @@ import Turf
 import CoreLocation
 @testable import MapboxMaps
 
-
 internal class GeometryMBXGeometryTests: XCTestCase {
 
     // MARK: - Geometry → Turf Geometry

--- a/Tests/MapboxMapsTests/Foundation/GeoJSON/Geometry+MBXGeometryTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/GeoJSON/Geometry+MBXGeometryTests.swift
@@ -1,12 +1,8 @@
 import XCTest
 import Turf
 import CoreLocation
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
+
 
 internal class GeometryMBXGeometryTests: XCTestCase {
 

--- a/Tests/MapboxMapsTests/Foundation/GeoJSON/GeometryCollectionTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/GeoJSON/GeometryCollectionTests.swift
@@ -1,12 +1,7 @@
 import XCTest
 import CoreLocation
 import Turf
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
 
 // Disabling rules against force try for test file.
 // swiftlint:disable explicit_top_level_acl explicit_acl force_try

--- a/Tests/MapboxMapsTests/Foundation/GeoJSON/LineStringTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/GeoJSON/LineStringTests.swift
@@ -1,12 +1,7 @@
 import XCTest
 import CoreLocation
 import Turf
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
 
 // swiftlint:disable explicit_top_level_acl explicit_acl force_try force_cast
 let metersPerMile: CLLocationDistance = 1_609.344

--- a/Tests/MapboxMapsTests/Foundation/GeoJSON/MultiLineStringTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/GeoJSON/MultiLineStringTests.swift
@@ -1,12 +1,7 @@
 import XCTest
 import CoreLocation
 import Turf
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
 
 // Disabling rules against force try for this test file.
 // swiftlint:disable explicit_top_level_acl explicit_acl force_try

--- a/Tests/MapboxMapsTests/Foundation/GeoJSON/MultiPointTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/GeoJSON/MultiPointTests.swift
@@ -1,12 +1,7 @@
 import XCTest
 import CoreLocation
 import Turf
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
 
 // Disabling rules against force try for test file.
 // swiftlint:disable explicit_top_level_acl explicit_acl force_try

--- a/Tests/MapboxMapsTests/Foundation/GeoJSON/MultiPolygonTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/GeoJSON/MultiPolygonTests.swift
@@ -1,12 +1,7 @@
 import XCTest
 import CoreLocation
 import Turf
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
 
 // Disabling rules against force try for test file.
 // swiftlint:disable explicit_top_level_acl explicit_acl force_try

--- a/Tests/MapboxMapsTests/Foundation/GeoJSON/PointTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/GeoJSON/PointTests.swift
@@ -1,12 +1,7 @@
 import XCTest
 import CoreLocation
 import Turf
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
 
 // Disabling rules against force casting for test file.
 // swiftlint:disable explicit_top_level_acl explicit_acl force_try force_cast

--- a/Tests/MapboxMapsTests/Foundation/GeoJSON/PolygonTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/GeoJSON/PolygonTests.swift
@@ -1,12 +1,7 @@
 import XCTest
 import CoreLocation
 import Turf
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
 
 // Disabling rules against force casting for test file.
 // swiftlint:disable explicit_top_level_acl explicit_acl force_try force_cast

--- a/Tests/MapboxMapsTests/Foundation/Glyphs/GlyphsRasterizationOptionsTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Glyphs/GlyphsRasterizationOptionsTests.swift
@@ -1,10 +1,5 @@
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
 
 // swiftlint:disable explicit_top_level_acl explicit_acl
 class GlyphsRasterizationOptionsTests: XCTestCase {

--- a/Tests/MapboxMapsTests/Foundation/MapboxMapsFoundationTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapboxMapsFoundationTests.swift
@@ -1,12 +1,7 @@
 import XCTest
 import CoreLocation
 import UIKit
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
 
 // swiftlint:disable explicit_top_level_acl explicit_acl
 class MapboxMapsFoundationTests: XCTestCase {

--- a/Tests/MapboxMapsTests/Foundation/Mocks/LocationProviderMock.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/LocationProviderMock.swift
@@ -1,10 +1,5 @@
 import CoreLocation
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsLocation
-#endif
 
 class LocationProviderMock: LocationProvider {
     var locationProviderOptions: LocationOptions

--- a/Tests/MapboxMapsTests/Foundation/UtilsTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/UtilsTests.swift
@@ -1,9 +1,5 @@
 import XCTest
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsFoundation
-#endif
 
 class UtilsTests: XCTestCase {
 

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -1,12 +1,6 @@
 import XCTest
 import UIKit
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsGestures
-import MapboxMapsFoundation
-#endif
 
 //swiftlint:disable explicit_acl explicit_top_level_acl
 final class GestureManagerTests: XCTestCase {

--- a/Tests/MapboxMapsTests/Gestures/GestureSupportableViewMock.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureSupportableViewMock.swift
@@ -1,9 +1,5 @@
 import UIKit
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsGestures
-#endif
 
 //swiftlint:disable explicit_acl explicit_top_level_acl large_tuple
 // Mock class that flags true when `GestureSupportableView` protocol methods have been called on it

--- a/Tests/MapboxMapsTests/Gestures/GestureUtilitiesTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureUtilitiesTests.swift
@@ -1,14 +1,5 @@
-//
-//  GestureUtilitiesTests.swift
-//  MapboxMapsGesturesTests
-//
-
 import XCTest
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsGestures
-#endif
 
 //swiftlint:disable explicit_acl explicit_top_level_acl
 class GestureUtilitiesTests: XCTestCase {

--- a/Tests/MapboxMapsTests/Gestures/PanGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/PanGestureHandlerTests.swift
@@ -1,9 +1,6 @@
 import XCTest
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsGestures
-#endif
+
 
 //swiftlint:disable explicit_acl explicit_top_level_acl
 class PanGestureHandlerTests: XCTestCase {

--- a/Tests/MapboxMapsTests/Gestures/PanGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/PanGestureHandlerTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import MapboxMaps
 
-
 //swiftlint:disable explicit_acl explicit_top_level_acl
 class PanGestureHandlerTests: XCTestCase {
 

--- a/Tests/MapboxMapsTests/Gestures/PinchGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/PinchGestureHandlerTests.swift
@@ -1,10 +1,5 @@
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsGestures
-#endif
 
 //swiftlint:disable explicit_acl explicit_top_level_acl
 class PinchGestureHandlerTests: XCTestCase {

--- a/Tests/MapboxMapsTests/Gestures/PitchGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/PitchGestureHandlerTests.swift
@@ -1,9 +1,5 @@
 import XCTest
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsGestures
-#endif
 
 //swiftlint:disable explicit_acl explicit_top_level_acl
 class PitchGestureHandlerTests: XCTestCase {

--- a/Tests/MapboxMapsTests/Gestures/QuickZoomGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/QuickZoomGestureHandlerTests.swift
@@ -1,9 +1,5 @@
 import XCTest
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsGestures
-#endif
 
 //swiftlint:disable explicit_acl explicit_top_level_acl
 final class QuickZoomGestureHandlerTest: XCTestCase {

--- a/Tests/MapboxMapsTests/Gestures/RotateGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/RotateGestureHandlerTests.swift
@@ -1,9 +1,5 @@
 import XCTest
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsGestures
-#endif
 
 //swiftlint:disable explicit_top_level_acl explicit_acl
 class RotateGestureHandlerTests: XCTestCase {

--- a/Tests/MapboxMapsTests/Gestures/TapGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/TapGestureHandlerTests.swift
@@ -1,9 +1,5 @@
 import XCTest
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsGestures
-#endif
 
 //swiftlint:disable explicit_acl explicit_top_level_acl
 class TapGestureHandlerTests: XCTestCase {

--- a/Tests/MapboxMapsTests/Location/LocationConsumerMock.swift
+++ b/Tests/MapboxMapsTests/Location/LocationConsumerMock.swift
@@ -1,10 +1,5 @@
 import UIKit
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsLocation
-#endif
 
 internal class LocationConsumerMock: LocationConsumer {
     func locationUpdate(newLocation: Location) {

--- a/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
@@ -1,11 +1,5 @@
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsLocation
-import MapboxMapsFoundation
-#endif
 
 internal class LocationManagerTests: XCTestCase {
 

--- a/Tests/MapboxMapsTests/Location/LocationOptionsTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationOptionsTests.swift
@@ -1,11 +1,5 @@
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsLocation
-import MapboxMapsFoundation
-#endif
 
 final class LocationOptionsTests: XCTestCase {
     func testLocationOptionsPuckTypeDefaultIsNil() {

--- a/Tests/MapboxMapsTests/Location/LocationSupportableMapViewMock.swift
+++ b/Tests/MapboxMapsTests/Location/LocationSupportableMapViewMock.swift
@@ -1,16 +1,6 @@
 import MapboxCoreMaps
 import UIKit
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsLocation
-@testable import MapboxMapsStyle
-#endif
-
-#if canImport(MapboxMapsStyle)
-@testable import MapboxMapsStyle
-#endif
 
 class LocationSupportableMapViewMock: UIView, LocationSupportableMapView {
 

--- a/Tests/MapboxMapsTests/Location/PuckTypeTests.swift
+++ b/Tests/MapboxMapsTests/Location/PuckTypeTests.swift
@@ -1,12 +1,5 @@
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsLocation
-import MapboxMapsFoundation
-import MapboxMapsStyle
-#endif
 
 internal class PuckTypeTests: XCTestCase {
 

--- a/Tests/MapboxMapsTests/Ornaments/Compass/MapboxCompassOrnamentViewTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/Compass/MapboxCompassOrnamentViewTests.swift
@@ -1,11 +1,6 @@
 import CoreLocation
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsOrnaments
-#endif
 
 //swiftlint:disable explicit_acl explicit_top_level_acl
 class MapboxCompassOrnamentViewTests: XCTestCase {

--- a/Tests/MapboxMapsTests/Ornaments/DistanceFormatterTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/DistanceFormatterTests.swift
@@ -1,9 +1,5 @@
 import XCTest
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsOrnaments
-#endif
 
 class DistanceFormatterTests: XCTestCase {
 

--- a/Tests/MapboxMapsTests/Ornaments/OrnamentManagerTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/OrnamentManagerTests.swift
@@ -1,10 +1,5 @@
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsOrnaments
-#endif
 
 //swiftlint:disable explicit_acl explicit_top_level_acl
 class OrnamentManagerTests: XCTestCase, AttributionDataSource {

--- a/Tests/MapboxMapsTests/Ornaments/OrnamentSupportableViewMock.swift
+++ b/Tests/MapboxMapsTests/Ornaments/OrnamentSupportableViewMock.swift
@@ -1,11 +1,5 @@
 import UIKit
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-import MapboxMapsFoundation
-@testable import MapboxMapsOrnaments
-#endif
 
 //swiftlint:disable explicit_acl explicit_top_level_acl
 // Mock class that flags true when `OrnamentSupportableView` protocol methods have been called on it

--- a/Tests/MapboxMapsTests/Style/ColorTests.swift
+++ b/Tests/MapboxMapsTests/Style/ColorTests.swift
@@ -1,9 +1,5 @@
 import XCTest
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 internal class ColorTests: XCTestCase {
 

--- a/Tests/MapboxMapsTests/Style/ExpressionTests/ExpressionBuilderTests.swift
+++ b/Tests/MapboxMapsTests/Style/ExpressionTests/ExpressionBuilderTests.swift
@@ -1,9 +1,5 @@
 import XCTest
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 internal class ExpressionBuilderTests: XCTestCase {
 

--- a/Tests/MapboxMapsTests/Style/ExpressionTests/ExpressionTests.swift
+++ b/Tests/MapboxMapsTests/Style/ExpressionTests/ExpressionTests.swift
@@ -1,9 +1,5 @@
 import XCTest
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 internal class ExpressionTests: XCTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Fixtures/Enums+Fixtures.swift
+++ b/Tests/MapboxMapsTests/Style/Fixtures/Enums+Fixtures.swift
@@ -20,7 +20,7 @@ extension Visibility {
 // MARK: LINE_CAP
 
 extension Value where T == LineCap {
-    
+
     static func testConstantValue() -> Value<LineCap> {
        return .constant(LineCap.testConstantValue())
     }
@@ -28,7 +28,7 @@ extension Value where T == LineCap {
 }
 
 extension LineCap {
-    
+
   static func testConstantValue() -> LineCap {
      return LineCap.init(rawValue: "butt")!
   }
@@ -37,7 +37,7 @@ extension LineCap {
 // MARK: LINE_JOIN
 
 extension Value where T == LineJoin {
-    
+
     static func testConstantValue() -> Value<LineJoin> {
        return .constant(LineJoin.testConstantValue())
     }
@@ -45,7 +45,7 @@ extension Value where T == LineJoin {
 }
 
 extension LineJoin {
-    
+
   static func testConstantValue() -> LineJoin {
      return LineJoin.init(rawValue: "bevel")!
   }
@@ -54,7 +54,7 @@ extension LineJoin {
 // MARK: ICON_ANCHOR
 
 extension Value where T == IconAnchor {
-    
+
     static func testConstantValue() -> Value<IconAnchor> {
        return .constant(IconAnchor.testConstantValue())
     }
@@ -62,7 +62,7 @@ extension Value where T == IconAnchor {
 }
 
 extension IconAnchor {
-    
+
   static func testConstantValue() -> IconAnchor {
      return IconAnchor.init(rawValue: "center")!
   }
@@ -71,7 +71,7 @@ extension IconAnchor {
 // MARK: ICON_PITCH_ALIGNMENT
 
 extension Value where T == IconPitchAlignment {
-    
+
     static func testConstantValue() -> Value<IconPitchAlignment> {
        return .constant(IconPitchAlignment.testConstantValue())
     }
@@ -79,7 +79,7 @@ extension Value where T == IconPitchAlignment {
 }
 
 extension IconPitchAlignment {
-    
+
   static func testConstantValue() -> IconPitchAlignment {
      return IconPitchAlignment.init(rawValue: "map")!
   }
@@ -88,7 +88,7 @@ extension IconPitchAlignment {
 // MARK: ICON_ROTATION_ALIGNMENT
 
 extension Value where T == IconRotationAlignment {
-    
+
     static func testConstantValue() -> Value<IconRotationAlignment> {
        return .constant(IconRotationAlignment.testConstantValue())
     }
@@ -96,7 +96,7 @@ extension Value where T == IconRotationAlignment {
 }
 
 extension IconRotationAlignment {
-    
+
   static func testConstantValue() -> IconRotationAlignment {
      return IconRotationAlignment.init(rawValue: "map")!
   }
@@ -105,7 +105,7 @@ extension IconRotationAlignment {
 // MARK: ICON_TEXT_FIT
 
 extension Value where T == IconTextFit {
-    
+
     static func testConstantValue() -> Value<IconTextFit> {
        return .constant(IconTextFit.testConstantValue())
     }
@@ -113,7 +113,7 @@ extension Value where T == IconTextFit {
 }
 
 extension IconTextFit {
-    
+
   static func testConstantValue() -> IconTextFit {
      return IconTextFit.init(rawValue: "none")!
   }
@@ -122,7 +122,7 @@ extension IconTextFit {
 // MARK: SYMBOL_PLACEMENT
 
 extension Value where T == SymbolPlacement {
-    
+
     static func testConstantValue() -> Value<SymbolPlacement> {
        return .constant(SymbolPlacement.testConstantValue())
     }
@@ -130,7 +130,7 @@ extension Value where T == SymbolPlacement {
 }
 
 extension SymbolPlacement {
-    
+
   static func testConstantValue() -> SymbolPlacement {
      return SymbolPlacement.init(rawValue: "point")!
   }
@@ -139,7 +139,7 @@ extension SymbolPlacement {
 // MARK: SYMBOL_Z_ORDER
 
 extension Value where T == SymbolZOrder {
-    
+
     static func testConstantValue() -> Value<SymbolZOrder> {
        return .constant(SymbolZOrder.testConstantValue())
     }
@@ -147,7 +147,7 @@ extension Value where T == SymbolZOrder {
 }
 
 extension SymbolZOrder {
-    
+
   static func testConstantValue() -> SymbolZOrder {
      return SymbolZOrder.init(rawValue: "auto")!
   }
@@ -156,7 +156,7 @@ extension SymbolZOrder {
 // MARK: TEXT_ANCHOR
 
 extension Value where T == TextAnchor {
-    
+
     static func testConstantValue() -> Value<TextAnchor> {
        return .constant(TextAnchor.testConstantValue())
     }
@@ -164,7 +164,7 @@ extension Value where T == TextAnchor {
 }
 
 extension TextAnchor {
-    
+
   static func testConstantValue() -> TextAnchor {
      return TextAnchor.init(rawValue: "center")!
   }
@@ -173,7 +173,7 @@ extension TextAnchor {
 // MARK: TEXT_JUSTIFY
 
 extension Value where T == TextJustify {
-    
+
     static func testConstantValue() -> Value<TextJustify> {
        return .constant(TextJustify.testConstantValue())
     }
@@ -181,7 +181,7 @@ extension Value where T == TextJustify {
 }
 
 extension TextJustify {
-    
+
   static func testConstantValue() -> TextJustify {
      return TextJustify.init(rawValue: "auto")!
   }
@@ -190,7 +190,7 @@ extension TextJustify {
 // MARK: TEXT_PITCH_ALIGNMENT
 
 extension Value where T == TextPitchAlignment {
-    
+
     static func testConstantValue() -> Value<TextPitchAlignment> {
        return .constant(TextPitchAlignment.testConstantValue())
     }
@@ -198,7 +198,7 @@ extension Value where T == TextPitchAlignment {
 }
 
 extension TextPitchAlignment {
-    
+
   static func testConstantValue() -> TextPitchAlignment {
      return TextPitchAlignment.init(rawValue: "map")!
   }
@@ -207,7 +207,7 @@ extension TextPitchAlignment {
 // MARK: TEXT_ROTATION_ALIGNMENT
 
 extension Value where T == TextRotationAlignment {
-    
+
     static func testConstantValue() -> Value<TextRotationAlignment> {
        return .constant(TextRotationAlignment.testConstantValue())
     }
@@ -215,7 +215,7 @@ extension Value where T == TextRotationAlignment {
 }
 
 extension TextRotationAlignment {
-    
+
   static func testConstantValue() -> TextRotationAlignment {
      return TextRotationAlignment.init(rawValue: "map")!
   }
@@ -224,7 +224,7 @@ extension TextRotationAlignment {
 // MARK: TEXT_TRANSFORM
 
 extension Value where T == TextTransform {
-    
+
     static func testConstantValue() -> Value<TextTransform> {
        return .constant(TextTransform.testConstantValue())
     }
@@ -232,7 +232,7 @@ extension Value where T == TextTransform {
 }
 
 extension TextTransform {
-    
+
   static func testConstantValue() -> TextTransform {
      return TextTransform.init(rawValue: "none")!
   }
@@ -241,7 +241,7 @@ extension TextTransform {
 // MARK: FILL_TRANSLATE_ANCHOR
 
 extension Value where T == FillTranslateAnchor {
-    
+
     static func testConstantValue() -> Value<FillTranslateAnchor> {
        return .constant(FillTranslateAnchor.testConstantValue())
     }
@@ -249,7 +249,7 @@ extension Value where T == FillTranslateAnchor {
 }
 
 extension FillTranslateAnchor {
-    
+
   static func testConstantValue() -> FillTranslateAnchor {
      return FillTranslateAnchor.init(rawValue: "map")!
   }
@@ -258,7 +258,7 @@ extension FillTranslateAnchor {
 // MARK: LINE_TRANSLATE_ANCHOR
 
 extension Value where T == LineTranslateAnchor {
-    
+
     static func testConstantValue() -> Value<LineTranslateAnchor> {
        return .constant(LineTranslateAnchor.testConstantValue())
     }
@@ -266,7 +266,7 @@ extension Value where T == LineTranslateAnchor {
 }
 
 extension LineTranslateAnchor {
-    
+
   static func testConstantValue() -> LineTranslateAnchor {
      return LineTranslateAnchor.init(rawValue: "map")!
   }
@@ -275,7 +275,7 @@ extension LineTranslateAnchor {
 // MARK: ICON_TRANSLATE_ANCHOR
 
 extension Value where T == IconTranslateAnchor {
-    
+
     static func testConstantValue() -> Value<IconTranslateAnchor> {
        return .constant(IconTranslateAnchor.testConstantValue())
     }
@@ -283,7 +283,7 @@ extension Value where T == IconTranslateAnchor {
 }
 
 extension IconTranslateAnchor {
-    
+
   static func testConstantValue() -> IconTranslateAnchor {
      return IconTranslateAnchor.init(rawValue: "map")!
   }
@@ -292,7 +292,7 @@ extension IconTranslateAnchor {
 // MARK: TEXT_TRANSLATE_ANCHOR
 
 extension Value where T == TextTranslateAnchor {
-    
+
     static func testConstantValue() -> Value<TextTranslateAnchor> {
        return .constant(TextTranslateAnchor.testConstantValue())
     }
@@ -300,7 +300,7 @@ extension Value where T == TextTranslateAnchor {
 }
 
 extension TextTranslateAnchor {
-    
+
   static func testConstantValue() -> TextTranslateAnchor {
      return TextTranslateAnchor.init(rawValue: "map")!
   }
@@ -309,7 +309,7 @@ extension TextTranslateAnchor {
 // MARK: CIRCLE_PITCH_ALIGNMENT
 
 extension Value where T == CirclePitchAlignment {
-    
+
     static func testConstantValue() -> Value<CirclePitchAlignment> {
        return .constant(CirclePitchAlignment.testConstantValue())
     }
@@ -317,7 +317,7 @@ extension Value where T == CirclePitchAlignment {
 }
 
 extension CirclePitchAlignment {
-    
+
   static func testConstantValue() -> CirclePitchAlignment {
      return CirclePitchAlignment.init(rawValue: "map")!
   }
@@ -326,7 +326,7 @@ extension CirclePitchAlignment {
 // MARK: CIRCLE_PITCH_SCALE
 
 extension Value where T == CirclePitchScale {
-    
+
     static func testConstantValue() -> Value<CirclePitchScale> {
        return .constant(CirclePitchScale.testConstantValue())
     }
@@ -334,7 +334,7 @@ extension Value where T == CirclePitchScale {
 }
 
 extension CirclePitchScale {
-    
+
   static func testConstantValue() -> CirclePitchScale {
      return CirclePitchScale.init(rawValue: "map")!
   }
@@ -343,7 +343,7 @@ extension CirclePitchScale {
 // MARK: CIRCLE_TRANSLATE_ANCHOR
 
 extension Value where T == CircleTranslateAnchor {
-    
+
     static func testConstantValue() -> Value<CircleTranslateAnchor> {
        return .constant(CircleTranslateAnchor.testConstantValue())
     }
@@ -351,7 +351,7 @@ extension Value where T == CircleTranslateAnchor {
 }
 
 extension CircleTranslateAnchor {
-    
+
   static func testConstantValue() -> CircleTranslateAnchor {
      return CircleTranslateAnchor.init(rawValue: "map")!
   }
@@ -360,7 +360,7 @@ extension CircleTranslateAnchor {
 // MARK: FILL_EXTRUSION_TRANSLATE_ANCHOR
 
 extension Value where T == FillExtrusionTranslateAnchor {
-    
+
     static func testConstantValue() -> Value<FillExtrusionTranslateAnchor> {
        return .constant(FillExtrusionTranslateAnchor.testConstantValue())
     }
@@ -368,7 +368,7 @@ extension Value where T == FillExtrusionTranslateAnchor {
 }
 
 extension FillExtrusionTranslateAnchor {
-    
+
   static func testConstantValue() -> FillExtrusionTranslateAnchor {
      return FillExtrusionTranslateAnchor.init(rawValue: "map")!
   }
@@ -377,7 +377,7 @@ extension FillExtrusionTranslateAnchor {
 // MARK: RASTER_RESAMPLING
 
 extension Value where T == RasterResampling {
-    
+
     static func testConstantValue() -> Value<RasterResampling> {
        return .constant(RasterResampling.testConstantValue())
     }
@@ -385,7 +385,7 @@ extension Value where T == RasterResampling {
 }
 
 extension RasterResampling {
-    
+
   static func testConstantValue() -> RasterResampling {
      return RasterResampling.init(rawValue: "linear")!
   }
@@ -394,7 +394,7 @@ extension RasterResampling {
 // MARK: HILLSHADE_ILLUMINATION_ANCHOR
 
 extension Value where T == HillshadeIlluminationAnchor {
-    
+
     static func testConstantValue() -> Value<HillshadeIlluminationAnchor> {
        return .constant(HillshadeIlluminationAnchor.testConstantValue())
     }
@@ -402,7 +402,7 @@ extension Value where T == HillshadeIlluminationAnchor {
 }
 
 extension HillshadeIlluminationAnchor {
-    
+
   static func testConstantValue() -> HillshadeIlluminationAnchor {
      return HillshadeIlluminationAnchor.init(rawValue: "map")!
   }
@@ -411,7 +411,7 @@ extension HillshadeIlluminationAnchor {
 // MARK: SKY_TYPE
 
 extension Value where T == SkyType {
-    
+
     static func testConstantValue() -> Value<SkyType> {
        return .constant(SkyType.testConstantValue())
     }
@@ -419,7 +419,7 @@ extension Value where T == SkyType {
 }
 
 extension SkyType {
-    
+
   static func testConstantValue() -> SkyType {
      return SkyType.init(rawValue: "gradient")!
   }
@@ -428,7 +428,7 @@ extension SkyType {
 // MARK: ANCHOR
 
 extension Value where T == Anchor {
-    
+
     static func testConstantValue() -> Value<Anchor> {
        return .constant(Anchor.testConstantValue())
     }
@@ -436,7 +436,7 @@ extension Value where T == Anchor {
 }
 
 extension Anchor {
-    
+
   static func testConstantValue() -> Anchor {
      return Anchor.init(rawValue: "map")!
   }
@@ -445,7 +445,7 @@ extension Anchor {
 // MARK: TEXT_WRITING_MODE
 
 extension Value where T == TextWritingMode {
-    
+
     static func testConstantValue() -> Value<TextWritingMode> {
        return .constant(TextWritingMode.testConstantValue())
     }
@@ -453,7 +453,7 @@ extension Value where T == TextWritingMode {
 }
 
 extension TextWritingMode {
-    
+
   static func testConstantValue() -> TextWritingMode {
      return TextWritingMode.init(rawValue: "horizontal")!
   }

--- a/Tests/MapboxMapsTests/Style/Fixtures/Enums+Fixtures.swift
+++ b/Tests/MapboxMapsTests/Style/Fixtures/Enums+Fixtures.swift
@@ -1,12 +1,7 @@
 // swiftlint:disable all
 // This file is generated.
 import Foundation
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 extension Value where T == Visibility {
 

--- a/Tests/MapboxMapsTests/Style/Fixtures/SouceProperties+Fixtures.swift
+++ b/Tests/MapboxMapsTests/Style/Fixtures/SouceProperties+Fixtures.swift
@@ -1,12 +1,7 @@
 import Foundation
 import Turf
 import CoreLocation
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 internal extension Scheme {
     static func testSourceValue() -> Scheme {

--- a/Tests/MapboxMapsTests/Style/Fixtures/Value+Fixtures.swift
+++ b/Tests/MapboxMapsTests/Style/Fixtures/Value+Fixtures.swift
@@ -1,7 +1,6 @@
 import UIKit
 @testable import MapboxMaps
 
-
 internal extension Value where T == Double {
     static func testConstantValue() -> Value<Double> {
         return .constant(1.0)

--- a/Tests/MapboxMapsTests/Style/Fixtures/Value+Fixtures.swift
+++ b/Tests/MapboxMapsTests/Style/Fixtures/Value+Fixtures.swift
@@ -1,9 +1,6 @@
 import UIKit
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
+
 
 internal extension Value where T == Double {
     static func testConstantValue() -> Value<Double> {

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/BackgroundLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/BackgroundLayerIntegrationTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class BackgroundLayerIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/CircleLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/CircleLayerIntegrationTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class CircleLayerIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/FillExtrusionLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/FillExtrusionLayerIntegrationTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class FillExtrusionLayerIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/FillLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/FillLayerIntegrationTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class FillLayerIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/HeatmapLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/HeatmapLayerIntegrationTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class HeatmapLayerIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/HillshadeLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/HillshadeLayerIntegrationTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class HillshadeLayerIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LineLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LineLayerIntegrationTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class LineLayerIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LocationIndicatorLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LocationIndicatorLayerIntegrationTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class LocationIndicatorLayerIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/ModelLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/ModelLayerIntegrationTests.swift
@@ -1,11 +1,6 @@
 // This file is NOT CURRENTLY generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class ModelLayerIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/RasterLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/RasterLayerIntegrationTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class RasterLayerIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/SkyLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/SkyLayerIntegrationTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class SkyLayerIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/SymbolLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/SymbolLayerIntegrationTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class SymbolLayerIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/GeoJsonSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/GeoJsonSourceIntegrationTests.swift
@@ -2,14 +2,11 @@
 
 import XCTest
 import Turf
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
+
 
 class GeoJSONSourceIntegrationTests: MapViewIntegrationTestCase {
-    
+
     func testAdditionAndRemovalOfSource() throws {
         let style = try XCTUnwrap(self.style)
 
@@ -34,7 +31,7 @@ class GeoJSONSourceIntegrationTests: MapViewIntegrationTestCase {
             source.lineMetrics = Bool.testSourceValue()
             source.generateId = Bool.testSourceValue()
             source.prefetchZoomDelta = Double.testSourceValue()
-            
+
             // Add the source
             do {
                 try style.addSource(source, id: "test-source")

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/ImageSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/ImageSourceIntegrationTests.swift
@@ -2,14 +2,11 @@
 
 import XCTest
 import Turf
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
+
 
 class ImageSourceIntegrationTests: MapViewIntegrationTestCase {
-    
+
     func testAdditionAndRemovalOfSource() throws {
         let style = try XCTUnwrap(self.style)
 
@@ -26,7 +23,7 @@ class ImageSourceIntegrationTests: MapViewIntegrationTestCase {
             source.url = String.testSourceValue()
             source.coordinates = [[Double]].testSourceValue()
             source.prefetchZoomDelta = Double.testSourceValue()
-            
+
             // Add the source
             do {
                 try style.addSource(source, id: "test-source")

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterDemSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterDemSourceIntegrationTests.swift
@@ -2,14 +2,11 @@
 
 import XCTest
 import Turf
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
+
 
 class RasterDemSourceIntegrationTests: MapViewIntegrationTestCase {
-    
+
     func testAdditionAndRemovalOfSource() throws {
         let style = try XCTUnwrap(self.style)
 
@@ -35,7 +32,7 @@ class RasterDemSourceIntegrationTests: MapViewIntegrationTestCase {
             source.prefetchZoomDelta = Double.testSourceValue()
             source.minimumTileUpdateInterval = Double.testSourceValue()
             source.maxOverscaleFactorForParentTiles = Double.testSourceValue()
-            
+
             // Add the source
             do {
                 try style.addSource(source, id: "test-source")

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterSourceIntegrationTests.swift
@@ -2,14 +2,11 @@
 
 import XCTest
 import Turf
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
+
 
 class RasterSourceIntegrationTests: MapViewIntegrationTestCase {
-    
+
     func testAdditionAndRemovalOfSource() throws {
         let style = try XCTUnwrap(self.style)
 
@@ -35,7 +32,7 @@ class RasterSourceIntegrationTests: MapViewIntegrationTestCase {
             source.prefetchZoomDelta = Double.testSourceValue()
             source.minimumTileUpdateInterval = Double.testSourceValue()
             source.maxOverscaleFactorForParentTiles = Double.testSourceValue()
-            
+
             // Add the source
             do {
                 try style.addSource(source, id: "test-source")

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/VectorSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/VectorSourceIntegrationTests.swift
@@ -2,14 +2,11 @@
 
 import XCTest
 import Turf
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
+
 
 class VectorSourceIntegrationTests: MapViewIntegrationTestCase {
-    
+
     func testAdditionAndRemovalOfSource() throws {
         let style = try XCTUnwrap(self.style)
 
@@ -34,7 +31,7 @@ class VectorSourceIntegrationTests: MapViewIntegrationTestCase {
             source.prefetchZoomDelta = Double.testSourceValue()
             source.minimumTileUpdateInterval = Double.testSourceValue()
             source.maxOverscaleFactorForParentTiles = Double.testSourceValue()
-            
+
             // Add the source
             do {
                 try style.addSource(source, id: "test-source")

--- a/Tests/MapboxMapsTests/Style/Generated/Layers/BackgroundLayerTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Layers/BackgroundLayerTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class BackgroundLayerTests: XCTestCase {
 
@@ -61,7 +56,7 @@ class BackgroundLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfLayoutProperties() {
 
-       var layer = BackgroundLayer(id: "test-id")	
+       var layer = BackgroundLayer(id: "test-id")
        layer.visibility = .constant(.visible)
 
        var data: Data?
@@ -79,7 +74,6 @@ class BackgroundLayerTests: XCTestCase {
        do {
            let decodedLayer = try JSONDecoder().decode(BackgroundLayer.self, from: validData)
            XCTAssert(decodedLayer.visibility == .constant(.visible))
- 
        } catch {
            XCTFail("Failed to decode BackgroundLayer")
        }
@@ -87,7 +81,7 @@ class BackgroundLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfPaintProperties() {
 
-       var layer = BackgroundLayer(id: "test-id")	
+       var layer = BackgroundLayer(id: "test-id")
        layer.backgroundColor = Value<ColorRepresentable>.testConstantValue()
        layer.backgroundColorTransition = StyleTransition(duration: 10.0, delay: 10.0)
        layer.backgroundOpacity = Value<Double>.testConstantValue()
@@ -113,7 +107,6 @@ class BackgroundLayerTests: XCTestCase {
        	   XCTAssert(layer.backgroundColor == Value<ColorRepresentable>.testConstantValue())
        	   XCTAssert(layer.backgroundOpacity == Value<Double>.testConstantValue())
        	   XCTAssert(layer.backgroundPattern == Value<ResolvedImage>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode BackgroundLayer")
        }

--- a/Tests/MapboxMapsTests/Style/Generated/Layers/CircleLayerTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Layers/CircleLayerTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class CircleLayerTests: XCTestCase {
 
@@ -61,7 +56,7 @@ class CircleLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfLayoutProperties() {
 
-       var layer = CircleLayer(id: "test-id")	
+       var layer = CircleLayer(id: "test-id")
        layer.visibility = .constant(.visible)
        layer.circleSortKey = Value<Double>.testConstantValue()
 
@@ -81,7 +76,6 @@ class CircleLayerTests: XCTestCase {
            let decodedLayer = try JSONDecoder().decode(CircleLayer.self, from: validData)
            XCTAssert(decodedLayer.visibility == .constant(.visible))
        	   XCTAssert(layer.circleSortKey == Value<Double>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode CircleLayer")
        }
@@ -89,7 +83,7 @@ class CircleLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfPaintProperties() {
 
-       var layer = CircleLayer(id: "test-id")	
+       var layer = CircleLayer(id: "test-id")
        layer.circleBlur = Value<Double>.testConstantValue()
        layer.circleBlurTransition = StyleTransition(duration: 10.0, delay: 10.0)
        layer.circleColor = Value<ColorRepresentable>.testConstantValue()
@@ -136,7 +130,6 @@ class CircleLayerTests: XCTestCase {
        	   XCTAssert(layer.circleStrokeWidth == Value<Double>.testConstantValue())
        	   XCTAssert(layer.circleTranslate == Value<[Double]>.testConstantValue())
        	   XCTAssert(layer.circleTranslateAnchor == Value<CircleTranslateAnchor>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode CircleLayer")
        }

--- a/Tests/MapboxMapsTests/Style/Generated/Layers/FillExtrusionLayerTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Layers/FillExtrusionLayerTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class FillExtrusionLayerTests: XCTestCase {
 
@@ -61,7 +56,7 @@ class FillExtrusionLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfLayoutProperties() {
 
-       var layer = FillExtrusionLayer(id: "test-id")	
+       var layer = FillExtrusionLayer(id: "test-id")
        layer.visibility = .constant(.visible)
 
        var data: Data?
@@ -79,7 +74,6 @@ class FillExtrusionLayerTests: XCTestCase {
        do {
            let decodedLayer = try JSONDecoder().decode(FillExtrusionLayer.self, from: validData)
            XCTAssert(decodedLayer.visibility == .constant(.visible))
- 
        } catch {
            XCTFail("Failed to decode FillExtrusionLayer")
        }
@@ -87,7 +81,7 @@ class FillExtrusionLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfPaintProperties() {
 
-       var layer = FillExtrusionLayer(id: "test-id")	
+       var layer = FillExtrusionLayer(id: "test-id")
        layer.fillExtrusionBase = Value<Double>.testConstantValue()
        layer.fillExtrusionBaseTransition = StyleTransition(duration: 10.0, delay: 10.0)
        layer.fillExtrusionColor = Value<ColorRepresentable>.testConstantValue()
@@ -126,7 +120,6 @@ class FillExtrusionLayerTests: XCTestCase {
        	   XCTAssert(layer.fillExtrusionTranslate == Value<[Double]>.testConstantValue())
        	   XCTAssert(layer.fillExtrusionTranslateAnchor == Value<FillExtrusionTranslateAnchor>.testConstantValue())
        	   XCTAssert(layer.fillExtrusionVerticalGradient == Value<Bool>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode FillExtrusionLayer")
        }

--- a/Tests/MapboxMapsTests/Style/Generated/Layers/FillLayerTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Layers/FillLayerTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class FillLayerTests: XCTestCase {
 
@@ -61,7 +56,7 @@ class FillLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfLayoutProperties() {
 
-       var layer = FillLayer(id: "test-id")	
+       var layer = FillLayer(id: "test-id")
        layer.visibility = .constant(.visible)
        layer.fillSortKey = Value<Double>.testConstantValue()
 
@@ -81,7 +76,6 @@ class FillLayerTests: XCTestCase {
            let decodedLayer = try JSONDecoder().decode(FillLayer.self, from: validData)
            XCTAssert(decodedLayer.visibility == .constant(.visible))
        	   XCTAssert(layer.fillSortKey == Value<Double>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode FillLayer")
        }
@@ -89,7 +83,7 @@ class FillLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfPaintProperties() {
 
-       var layer = FillLayer(id: "test-id")	
+       var layer = FillLayer(id: "test-id")
        layer.fillAntialias = Value<Bool>.testConstantValue()
        layer.fillColor = Value<ColorRepresentable>.testConstantValue()
        layer.fillColorTransition = StyleTransition(duration: 10.0, delay: 10.0)
@@ -125,7 +119,6 @@ class FillLayerTests: XCTestCase {
        	   XCTAssert(layer.fillPattern == Value<ResolvedImage>.testConstantValue())
        	   XCTAssert(layer.fillTranslate == Value<[Double]>.testConstantValue())
        	   XCTAssert(layer.fillTranslateAnchor == Value<FillTranslateAnchor>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode FillLayer")
        }

--- a/Tests/MapboxMapsTests/Style/Generated/Layers/HeatmapLayerTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Layers/HeatmapLayerTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class HeatmapLayerTests: XCTestCase {
 
@@ -61,7 +56,7 @@ class HeatmapLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfLayoutProperties() {
 
-       var layer = HeatmapLayer(id: "test-id")	
+       var layer = HeatmapLayer(id: "test-id")
        layer.visibility = .constant(.visible)
 
        var data: Data?
@@ -79,7 +74,6 @@ class HeatmapLayerTests: XCTestCase {
        do {
            let decodedLayer = try JSONDecoder().decode(HeatmapLayer.self, from: validData)
            XCTAssert(decodedLayer.visibility == .constant(.visible))
- 
        } catch {
            XCTFail("Failed to decode HeatmapLayer")
        }
@@ -87,7 +81,7 @@ class HeatmapLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfPaintProperties() {
 
-       var layer = HeatmapLayer(id: "test-id")	
+       var layer = HeatmapLayer(id: "test-id")
        layer.heatmapColor = Value<ColorRepresentable>.testConstantValue()
        layer.heatmapIntensity = Value<Double>.testConstantValue()
        layer.heatmapIntensityTransition = StyleTransition(duration: 10.0, delay: 10.0)
@@ -117,7 +111,6 @@ class HeatmapLayerTests: XCTestCase {
        	   XCTAssert(layer.heatmapOpacity == Value<Double>.testConstantValue())
        	   XCTAssert(layer.heatmapRadius == Value<Double>.testConstantValue())
        	   XCTAssert(layer.heatmapWeight == Value<Double>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode HeatmapLayer")
        }

--- a/Tests/MapboxMapsTests/Style/Generated/Layers/HillshadeLayerTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Layers/HillshadeLayerTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class HillshadeLayerTests: XCTestCase {
 
@@ -61,7 +56,7 @@ class HillshadeLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfLayoutProperties() {
 
-       var layer = HillshadeLayer(id: "test-id")	
+       var layer = HillshadeLayer(id: "test-id")
        layer.visibility = .constant(.visible)
 
        var data: Data?
@@ -79,7 +74,6 @@ class HillshadeLayerTests: XCTestCase {
        do {
            let decodedLayer = try JSONDecoder().decode(HillshadeLayer.self, from: validData)
            XCTAssert(decodedLayer.visibility == .constant(.visible))
- 
        } catch {
            XCTFail("Failed to decode HillshadeLayer")
        }
@@ -87,7 +81,7 @@ class HillshadeLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfPaintProperties() {
 
-       var layer = HillshadeLayer(id: "test-id")	
+       var layer = HillshadeLayer(id: "test-id")
        layer.hillshadeAccentColor = Value<ColorRepresentable>.testConstantValue()
        layer.hillshadeAccentColorTransition = StyleTransition(duration: 10.0, delay: 10.0)
        layer.hillshadeExaggeration = Value<Double>.testConstantValue()
@@ -120,7 +114,6 @@ class HillshadeLayerTests: XCTestCase {
        	   XCTAssert(layer.hillshadeIlluminationAnchor == Value<HillshadeIlluminationAnchor>.testConstantValue())
        	   XCTAssert(layer.hillshadeIlluminationDirection == Value<Double>.testConstantValue())
        	   XCTAssert(layer.hillshadeShadowColor == Value<ColorRepresentable>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode HillshadeLayer")
        }

--- a/Tests/MapboxMapsTests/Style/Generated/Layers/LineLayerTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Layers/LineLayerTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class LineLayerTests: XCTestCase {
 
@@ -61,7 +56,7 @@ class LineLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfLayoutProperties() {
 
-       var layer = LineLayer(id: "test-id")	
+       var layer = LineLayer(id: "test-id")
        layer.visibility = .constant(.visible)
        layer.lineCap = Value<LineCap>.testConstantValue()
        layer.lineJoin = Value<LineJoin>.testConstantValue()
@@ -89,7 +84,6 @@ class LineLayerTests: XCTestCase {
        	   XCTAssert(layer.lineMiterLimit == Value<Double>.testConstantValue())
        	   XCTAssert(layer.lineRoundLimit == Value<Double>.testConstantValue())
        	   XCTAssert(layer.lineSortKey == Value<Double>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode LineLayer")
        }
@@ -97,7 +91,7 @@ class LineLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfPaintProperties() {
 
-       var layer = LineLayer(id: "test-id")	
+       var layer = LineLayer(id: "test-id")
        layer.lineBlur = Value<Double>.testConstantValue()
        layer.lineBlurTransition = StyleTransition(duration: 10.0, delay: 10.0)
        layer.lineColor = Value<ColorRepresentable>.testConstantValue()
@@ -145,7 +139,6 @@ class LineLayerTests: XCTestCase {
        	   XCTAssert(layer.lineTranslate == Value<[Double]>.testConstantValue())
        	   XCTAssert(layer.lineTranslateAnchor == Value<LineTranslateAnchor>.testConstantValue())
        	   XCTAssert(layer.lineWidth == Value<Double>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode LineLayer")
        }

--- a/Tests/MapboxMapsTests/Style/Generated/Layers/LocationIndicatorLayerTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Layers/LocationIndicatorLayerTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class LocationIndicatorLayerTests: XCTestCase {
 
@@ -61,7 +56,7 @@ class LocationIndicatorLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfLayoutProperties() {
 
-       var layer = LocationIndicatorLayer(id: "test-id")	
+       var layer = LocationIndicatorLayer(id: "test-id")
        layer.visibility = .constant(.visible)
        layer.bearingImage = Value<ResolvedImage>.testConstantValue()
        layer.shadowImage = Value<ResolvedImage>.testConstantValue()
@@ -85,7 +80,6 @@ class LocationIndicatorLayerTests: XCTestCase {
        	   XCTAssert(layer.bearingImage == Value<ResolvedImage>.testConstantValue())
        	   XCTAssert(layer.shadowImage == Value<ResolvedImage>.testConstantValue())
        	   XCTAssert(layer.topImage == Value<ResolvedImage>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode LocationIndicatorLayer")
        }
@@ -93,7 +87,7 @@ class LocationIndicatorLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfPaintProperties() {
 
-       var layer = LocationIndicatorLayer(id: "test-id")	
+       var layer = LocationIndicatorLayer(id: "test-id")
        layer.accuracyRadius = Value<Double>.testConstantValue()
        layer.accuracyRadiusTransition = StyleTransition(duration: 10.0, delay: 10.0)
        layer.accuracyRadiusBorderColor = Value<ColorRepresentable>.testConstantValue()
@@ -143,7 +137,6 @@ class LocationIndicatorLayerTests: XCTestCase {
        	   XCTAssert(layer.perspectiveCompensation == Value<Double>.testConstantValue())
        	   XCTAssert(layer.shadowImageSize == Value<Double>.testConstantValue())
        	   XCTAssert(layer.topImageSize == Value<Double>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode LocationIndicatorLayer")
        }

--- a/Tests/MapboxMapsTests/Style/Generated/Layers/ModelLayerTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Layers/ModelLayerTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class ModelLayerTests: XCTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Generated/Layers/RasterLayerTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Layers/RasterLayerTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class RasterLayerTests: XCTestCase {
 
@@ -61,7 +56,7 @@ class RasterLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfLayoutProperties() {
 
-       var layer = RasterLayer(id: "test-id")	
+       var layer = RasterLayer(id: "test-id")
        layer.visibility = .constant(.visible)
 
        var data: Data?
@@ -79,7 +74,6 @@ class RasterLayerTests: XCTestCase {
        do {
            let decodedLayer = try JSONDecoder().decode(RasterLayer.self, from: validData)
            XCTAssert(decodedLayer.visibility == .constant(.visible))
- 
        } catch {
            XCTFail("Failed to decode RasterLayer")
        }
@@ -87,7 +81,7 @@ class RasterLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfPaintProperties() {
 
-       var layer = RasterLayer(id: "test-id")	
+       var layer = RasterLayer(id: "test-id")
        layer.rasterBrightnessMax = Value<Double>.testConstantValue()
        layer.rasterBrightnessMaxTransition = StyleTransition(duration: 10.0, delay: 10.0)
        layer.rasterBrightnessMin = Value<Double>.testConstantValue()
@@ -126,7 +120,6 @@ class RasterLayerTests: XCTestCase {
        	   XCTAssert(layer.rasterOpacity == Value<Double>.testConstantValue())
        	   XCTAssert(layer.rasterResampling == Value<RasterResampling>.testConstantValue())
        	   XCTAssert(layer.rasterSaturation == Value<Double>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode RasterLayer")
        }

--- a/Tests/MapboxMapsTests/Style/Generated/Layers/SkyLayerTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Layers/SkyLayerTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class SkyLayerTests: XCTestCase {
 
@@ -61,7 +56,7 @@ class SkyLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfLayoutProperties() {
 
-       var layer = SkyLayer(id: "test-id")	
+       var layer = SkyLayer(id: "test-id")
        layer.visibility = .constant(.visible)
 
        var data: Data?
@@ -79,7 +74,6 @@ class SkyLayerTests: XCTestCase {
        do {
            let decodedLayer = try JSONDecoder().decode(SkyLayer.self, from: validData)
            XCTAssert(decodedLayer.visibility == .constant(.visible))
- 
        } catch {
            XCTFail("Failed to decode SkyLayer")
        }
@@ -87,7 +81,7 @@ class SkyLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfPaintProperties() {
 
-       var layer = SkyLayer(id: "test-id")	
+       var layer = SkyLayer(id: "test-id")
        layer.skyAtmosphereColor = Value<ColorRepresentable>.testConstantValue()
        layer.skyAtmosphereHaloColor = Value<ColorRepresentable>.testConstantValue()
        layer.skyAtmosphereSun = Value<[Double]>.testConstantValue()
@@ -123,7 +117,6 @@ class SkyLayerTests: XCTestCase {
        	   XCTAssert(layer.skyGradientRadius == Value<Double>.testConstantValue())
        	   XCTAssert(layer.skyOpacity == Value<Double>.testConstantValue())
        	   XCTAssert(layer.skyType == Value<SkyType>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode SkyLayer")
        }

--- a/Tests/MapboxMapsTests/Style/Generated/Layers/SymbolLayerTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Layers/SymbolLayerTests.swift
@@ -1,11 +1,6 @@
 // This file is generated
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class SymbolLayerTests: XCTestCase {
 
@@ -61,7 +56,7 @@ class SymbolLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfLayoutProperties() {
 
-       var layer = SymbolLayer(id: "test-id")	
+       var layer = SymbolLayer(id: "test-id")
        layer.visibility = .constant(.visible)
        layer.iconAllowOverlap = Value<Bool>.testConstantValue()
        layer.iconAnchor = Value<IconAnchor>.testConstantValue()
@@ -161,7 +156,6 @@ class SymbolLayerTests: XCTestCase {
        	   XCTAssert(layer.textTransform == Value<TextTransform>.testConstantValue())
        	   XCTAssert(layer.textVariableAnchor == Value<[TextAnchor]>.testConstantValue())
        	   XCTAssert(layer.textWritingMode == Value<[TextWritingMode]>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode SymbolLayer")
        }
@@ -169,7 +163,7 @@ class SymbolLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfPaintProperties() {
 
-       var layer = SymbolLayer(id: "test-id")	
+       var layer = SymbolLayer(id: "test-id")
        layer.iconColor = Value<ColorRepresentable>.testConstantValue()
        layer.iconColorTransition = StyleTransition(duration: 10.0, delay: 10.0)
        layer.iconHaloBlur = Value<Double>.testConstantValue()
@@ -226,7 +220,6 @@ class SymbolLayerTests: XCTestCase {
        	   XCTAssert(layer.textOpacity == Value<Double>.testConstantValue())
        	   XCTAssert(layer.textTranslate == Value<[Double]>.testConstantValue())
        	   XCTAssert(layer.textTranslateAnchor == Value<TextTranslateAnchor>.testConstantValue())
- 
        } catch {
            XCTFail("Failed to decode SymbolLayer")
        }

--- a/Tests/MapboxMapsTests/Style/Generated/Sources/GeoJsonSourceTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Sources/GeoJsonSourceTests.swift
@@ -1,16 +1,12 @@
 // This file is generated.
 
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
 import Turf
-#endif
+
 
 class GeoJSONSourceTests: XCTestCase {
-    
+
     func testEncodingAndDecoding() {
         var source = GeoJSONSource()
         source.data = GeoJSONSourceData.testSourceValue()

--- a/Tests/MapboxMapsTests/Style/Generated/Sources/ImageSourceTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Sources/ImageSourceTests.swift
@@ -1,16 +1,12 @@
 // This file is generated.
 
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
 import Turf
-#endif
+
 
 class ImageSourceTests: XCTestCase {
-    
+
     func testEncodingAndDecoding() {
         var source = ImageSource()
         source.url = String.testSourceValue()

--- a/Tests/MapboxMapsTests/Style/Generated/Sources/RasterDemSourceTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Sources/RasterDemSourceTests.swift
@@ -1,16 +1,12 @@
 // This file is generated.
 
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
 import Turf
-#endif
+
 
 class RasterDemSourceTests: XCTestCase {
-    
+
     func testEncodingAndDecoding() {
         var source = RasterDemSource()
         source.url = String.testSourceValue()

--- a/Tests/MapboxMapsTests/Style/Generated/Sources/RasterSourceTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Sources/RasterSourceTests.swift
@@ -1,16 +1,12 @@
 // This file is generated.
 
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
 import Turf
-#endif
+
 
 class RasterSourceTests: XCTestCase {
-    
+
     func testEncodingAndDecoding() {
         var source = RasterSource()
         source.url = String.testSourceValue()

--- a/Tests/MapboxMapsTests/Style/Generated/Sources/VectorSourceTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Sources/VectorSourceTests.swift
@@ -1,16 +1,12 @@
 // This file is generated.
 
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
 import Turf
-#endif
+
 
 class VectorSourceTests: XCTestCase {
-    
+
     func testEncodingAndDecoding() {
         var source = VectorSource()
         source.url = String.testSourceValue()

--- a/Tests/MapboxMapsTests/Style/GeoJSONSourceDataTests.swift
+++ b/Tests/MapboxMapsTests/Style/GeoJSONSourceDataTests.swift
@@ -1,12 +1,7 @@
 import CoreLocation
 import XCTest
 import Turf
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 //swiftlint:disable explicit_acl explicit_top_level_acl
 class GeoJSONSourceDataTests: XCTestCase {

--- a/Tests/MapboxMapsTests/Style/LightTests.swift
+++ b/Tests/MapboxMapsTests/Style/LightTests.swift
@@ -1,11 +1,6 @@
 import XCTest
 import Turf
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 class LightTests: XCTestCase {
 

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -1,10 +1,5 @@
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 internal class StyleIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/StyleURITests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleURITests.swift
@@ -1,10 +1,5 @@
 import XCTest
-
-#if canImport(MapboxMaps)
 @testable import MapboxMaps
-#else
-@testable import MapboxMapsStyle
-#endif
 
 //swiftlint:disable explicit_top_level_acl explicit_acl
 class StyleURITests: XCTestCase {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR moves `#if canImport` checks. These should no longer be necessary with the current SDK structure. 

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
