### PR TITLE
Add specific geometry types to annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 ### Breaking changes ⚠️
 
 * Removed GeoJSONManager. Please use Turf directly instead to serialize and deserialize GeoJSON. ([#603](https://github.com/mapbox/mapbox-maps-ios/pull/603))
+* Add specific geometry types to annotations. ([#612](https://github.com/mapbox/mapbox-maps-ios/pull/612))
 
 ### Bug fixes 🐞
 

--- a/Sources/MapboxMaps/Annotations/AnnotationOrchestrator.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationOrchestrator.swift
@@ -7,8 +7,8 @@ public protocol Annotation {
     /// The unique identifier of the annotation.
     var id: String { get }
 
-    /// The feature that is backing this annotation.
-    var feature: Turf.Feature { get }
+    /// The geometry that is backing this annotation.
+    var geometry: Turf.Geometry { get }
 
     /// Properties associated with the annotation.
     var userInfo: [String: Any]? { get set }

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
@@ -8,22 +8,34 @@ public struct CircleAnnotation: Annotation {
     /// Identifier for this annotation
     public let id: String
 
-    /// The feature backing this annotation
-    public internal(set) var feature: Turf.Feature
+    /// The geometry backing this annotation
+    public var geometry: Turf.Geometry {
+        return .point(point)
+    }
+
+    /// The point backing this annotation
+    public var point: Turf.Point
 
     /// Properties associated with the annotation
-    public var userInfo: [String: Any]? { 
-        didSet {
-            feature.properties?["userInfo"] = userInfo
-        }
+    public var userInfo: [String: Any]?
+
+    internal private(set) var styles: [String: Any] = [:]
+
+    internal var feature: Turf.Feature {
+        var feature = Turf.Feature(geometry: geometry)
+        feature.identifier = .string(id)
+        var properties = [String: Any?]()
+        properties["styles"] = styles
+        properties["userInfo"] = userInfo
+        feature.properties = properties
+        return feature
     }
 
 
     /// Create a circle annotation with a `Turf.Point` and an optional identifier.
     public init(id: String = UUID().uuidString, point: Turf.Point) {
         self.id = id
-        self.feature = Turf.Feature(point)
-        self.feature.properties = ["annotation-id": id]
+        self.point = point
     }
 
     /// Create a circle annotation with a center coordinate and an optional identifier
@@ -35,129 +47,86 @@ public struct CircleAnnotation: Annotation {
         self.init(id: id, point: point)
     }
 
-    // MARK: - Properties -
-
-    /// Set of used data driven properties
-    internal var dataDrivenPropertiesUsedSet: Set<String> = []
+    // MARK: - Style Properties -
 
     
     /// Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
     public var circleSortKey: Double? {
         get {
-            return feature.properties?["circle-sort-key"] as? Double
+            return styles["circle-sort-key"] as? Double
         }
         set {
-            feature.properties?["circle-sort-key"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("circle-sort-key")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("circle-sort-key")
-            }
+            styles["circle-sort-key"] = newValue
         }
     }
     
     /// Amount to blur the circle. 1 blurs the circle such that only the centerpoint is full opacity.
     public var circleBlur: Double? {
         get {
-            return feature.properties?["circle-blur"] as? Double
+            return styles["circle-blur"] as? Double
         }
         set {
-            feature.properties?["circle-blur"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("circle-blur")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("circle-blur")
-            }
+            styles["circle-blur"] = newValue
         }
     }
     
     /// The fill color of the circle.
     public var circleColor: ColorRepresentable? {
         get {
-            return feature.properties?["circle-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
+            return styles["circle-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
         }
         set {
-            feature.properties?["circle-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("circle-color")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("circle-color")
-            }
+            styles["circle-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
         }
     }
     
     /// The opacity at which the circle will be drawn.
     public var circleOpacity: Double? {
         get {
-            return feature.properties?["circle-opacity"] as? Double
+            return styles["circle-opacity"] as? Double
         }
         set {
-            feature.properties?["circle-opacity"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("circle-opacity")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("circle-opacity")
-            }
+            styles["circle-opacity"] = newValue
         }
     }
     
     /// Circle radius.
     public var circleRadius: Double? {
         get {
-            return feature.properties?["circle-radius"] as? Double
+            return styles["circle-radius"] as? Double
         }
         set {
-            feature.properties?["circle-radius"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("circle-radius")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("circle-radius")
-            }
+            styles["circle-radius"] = newValue
         }
     }
     
     /// The stroke color of the circle.
     public var circleStrokeColor: ColorRepresentable? {
         get {
-            return feature.properties?["circle-stroke-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
+            return styles["circle-stroke-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
         }
         set {
-            feature.properties?["circle-stroke-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("circle-stroke-color")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("circle-stroke-color")
-            }
+            styles["circle-stroke-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
         }
     }
     
     /// The opacity of the circle's stroke.
     public var circleStrokeOpacity: Double? {
         get {
-            return feature.properties?["circle-stroke-opacity"] as? Double
+            return styles["circle-stroke-opacity"] as? Double
         }
         set {
-            feature.properties?["circle-stroke-opacity"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("circle-stroke-opacity")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("circle-stroke-opacity")
-            }
+            styles["circle-stroke-opacity"] = newValue
         }
     }
     
     /// The width of the circle's stroke. Strokes are placed outside of the `circle-radius`.
     public var circleStrokeWidth: Double? {
         get {
-            return feature.properties?["circle-stroke-width"] as? Double
+            return styles["circle-stroke-width"] as? Double
         }
         set {
-            feature.properties?["circle-stroke-width"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("circle-stroke-width")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("circle-stroke-width")
-            }
+            styles["circle-stroke-width"] = newValue
         }
     }
 

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -105,10 +105,10 @@ public class CircleAnnotationManager: AnnotationManager {
             return
         }
 
-        let allDataDrivenPropertiesUsed = Set(annotations.flatMap(\.dataDrivenPropertiesUsedSet))
+        let allDataDrivenPropertiesUsed = Set(annotations.flatMap { $0.styles.keys })
         for property in allDataDrivenPropertiesUsed {
             do {
-                try style.setLayerProperty(for: layerId, property: property, value: ["get", property] )
+                try style.setLayerProperty(for: layerId, property: property, value: ["get", property, ["get", "styles"]] )
             } catch {
                 Log.error(forMessage: "Could not set layer property \(property) in CircleAnnotationManager",
                             category: "Annotations")

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
@@ -8,22 +8,34 @@ public struct PointAnnotation: Annotation {
     /// Identifier for this annotation
     public let id: String
 
-    /// The feature backing this annotation
-    public internal(set) var feature: Turf.Feature
+    /// The geometry backing this annotation
+    public var geometry: Turf.Geometry {
+        return .point(point)
+    }
+
+    /// The point backing this annotation
+    public var point: Turf.Point
 
     /// Properties associated with the annotation
-    public var userInfo: [String: Any]? { 
-        didSet {
-            feature.properties?["userInfo"] = userInfo
-        }
+    public var userInfo: [String: Any]?
+
+    internal private(set) var styles: [String: Any] = [:]
+
+    internal var feature: Turf.Feature {
+        var feature = Turf.Feature(geometry: geometry)
+        feature.identifier = .string(id)
+        var properties = [String: Any?]()
+        properties["styles"] = styles
+        properties["userInfo"] = userInfo
+        feature.properties = properties
+        return feature
     }
 
 
     /// Create a point annotation with a `Turf.Point` and an optional identifier.
     public init(id: String = UUID().uuidString, point: Turf.Point) {
         self.id = id
-        self.feature = Turf.Feature(point)
-        self.feature.properties = ["annotation-id": id]
+        self.point = point
     }
 
     /// Create a point annotation with a coordinate and an optional identifier
@@ -35,399 +47,266 @@ public struct PointAnnotation: Annotation {
         self.init(id: id, point: point)
     }
 
-    // MARK: - Properties -
-
-    /// Set of used data driven properties
-    internal var dataDrivenPropertiesUsedSet: Set<String> = []
+    // MARK: - Style Properties -
 
     
     /// Part of the icon placed closest to the anchor.
     public var iconAnchor: IconAnchor? {
         get {
-            return feature.properties?["icon-anchor"].flatMap { $0 as? String }.flatMap { IconAnchor(rawValue: $0) }
+            return styles["icon-anchor"].flatMap { $0 as? String }.flatMap { IconAnchor(rawValue: $0) }
         }
         set {
-            feature.properties?["icon-anchor"] = newValue?.rawValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("icon-anchor")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("icon-anchor")
-            }
+            styles["icon-anchor"] = newValue?.rawValue
         }
     }
     
     /// Name of image in sprite to use for drawing an image background.
     public var iconImage: String? {
         get {
-            return feature.properties?["icon-image"] as? String
+            return styles["icon-image"] as? String
         }
         set {
-            feature.properties?["icon-image"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("icon-image")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("icon-image")
-            }
+            styles["icon-image"] = newValue
         }
     }
     
     /// Offset distance of icon from its anchor. Positive values indicate right and down, while negative values indicate left and up. Each component is multiplied by the value of `icon-size` to obtain the final offset in pixels. When combined with `icon-rotate` the offset will be as if the rotated direction was up.
     public var iconOffset: [Double]? {
         get {
-            return feature.properties?["icon-offset"] as? [Double]
+            return styles["icon-offset"] as? [Double]
         }
         set {
-            feature.properties?["icon-offset"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("icon-offset")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("icon-offset")
-            }
+            styles["icon-offset"] = newValue
         }
     }
     
     /// Rotates the icon clockwise.
     public var iconRotate: Double? {
         get {
-            return feature.properties?["icon-rotate"] as? Double
+            return styles["icon-rotate"] as? Double
         }
         set {
-            feature.properties?["icon-rotate"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("icon-rotate")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("icon-rotate")
-            }
+            styles["icon-rotate"] = newValue
         }
     }
     
     /// Scales the original size of the icon by the provided factor. The new pixel size of the image will be the original pixel size multiplied by `icon-size`. 1 is the original size; 3 triples the size of the image.
     public var iconSize: Double? {
         get {
-            return feature.properties?["icon-size"] as? Double
+            return styles["icon-size"] as? Double
         }
         set {
-            feature.properties?["icon-size"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("icon-size")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("icon-size")
-            }
+            styles["icon-size"] = newValue
         }
     }
     
     /// Sorts features in ascending order based on this value. Features with lower sort keys are drawn and placed first.  When `icon-allow-overlap` or `text-allow-overlap` is `false`, features with a lower sort key will have priority during placement. When `icon-allow-overlap` or `text-allow-overlap` is set to `true`, features with a higher sort key will overlap over features with a lower sort key.
     public var symbolSortKey: Double? {
         get {
-            return feature.properties?["symbol-sort-key"] as? Double
+            return styles["symbol-sort-key"] as? Double
         }
         set {
-            feature.properties?["symbol-sort-key"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("symbol-sort-key")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("symbol-sort-key")
-            }
+            styles["symbol-sort-key"] = newValue
         }
     }
     
     /// Part of the text placed closest to the anchor.
     public var textAnchor: TextAnchor? {
         get {
-            return feature.properties?["text-anchor"].flatMap { $0 as? String }.flatMap { TextAnchor(rawValue: $0) }
+            return styles["text-anchor"].flatMap { $0 as? String }.flatMap { TextAnchor(rawValue: $0) }
         }
         set {
-            feature.properties?["text-anchor"] = newValue?.rawValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-anchor")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-anchor")
-            }
+            styles["text-anchor"] = newValue?.rawValue
         }
     }
     
     /// Value to use for a text label. If a plain `string` is provided, it will be treated as a `formatted` with default/inherited formatting options.
     public var textField: String? {
         get {
-            return feature.properties?["text-field"] as? String
+            return styles["text-field"] as? String
         }
         set {
-            feature.properties?["text-field"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-field")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-field")
-            }
+            styles["text-field"] = newValue
         }
     }
     
     /// Text justification options.
     public var textJustify: TextJustify? {
         get {
-            return feature.properties?["text-justify"].flatMap { $0 as? String }.flatMap { TextJustify(rawValue: $0) }
+            return styles["text-justify"].flatMap { $0 as? String }.flatMap { TextJustify(rawValue: $0) }
         }
         set {
-            feature.properties?["text-justify"] = newValue?.rawValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-justify")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-justify")
-            }
+            styles["text-justify"] = newValue?.rawValue
         }
     }
     
     /// Text tracking amount.
     public var textLetterSpacing: Double? {
         get {
-            return feature.properties?["text-letter-spacing"] as? Double
+            return styles["text-letter-spacing"] as? Double
         }
         set {
-            feature.properties?["text-letter-spacing"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-letter-spacing")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-letter-spacing")
-            }
+            styles["text-letter-spacing"] = newValue
         }
     }
     
     /// The maximum line width for text wrapping.
     public var textMaxWidth: Double? {
         get {
-            return feature.properties?["text-max-width"] as? Double
+            return styles["text-max-width"] as? Double
         }
         set {
-            feature.properties?["text-max-width"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-max-width")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-max-width")
-            }
+            styles["text-max-width"] = newValue
         }
     }
     
     /// Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up. If used with text-variable-anchor, input values will be taken as absolute values. Offsets along the x- and y-axis will be applied automatically based on the anchor position.
     public var textOffset: [Double]? {
         get {
-            return feature.properties?["text-offset"] as? [Double]
+            return styles["text-offset"] as? [Double]
         }
         set {
-            feature.properties?["text-offset"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-offset")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-offset")
-            }
+            styles["text-offset"] = newValue
         }
     }
     
     /// Radial offset of text, in the direction of the symbol's anchor. Useful in combination with `text-variable-anchor`, which defaults to using the two-dimensional `text-offset` if present.
     public var textRadialOffset: Double? {
         get {
-            return feature.properties?["text-radial-offset"] as? Double
+            return styles["text-radial-offset"] as? Double
         }
         set {
-            feature.properties?["text-radial-offset"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-radial-offset")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-radial-offset")
-            }
+            styles["text-radial-offset"] = newValue
         }
     }
     
     /// Rotates the text clockwise.
     public var textRotate: Double? {
         get {
-            return feature.properties?["text-rotate"] as? Double
+            return styles["text-rotate"] as? Double
         }
         set {
-            feature.properties?["text-rotate"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-rotate")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-rotate")
-            }
+            styles["text-rotate"] = newValue
         }
     }
     
     /// Font size.
     public var textSize: Double? {
         get {
-            return feature.properties?["text-size"] as? Double
+            return styles["text-size"] as? Double
         }
         set {
-            feature.properties?["text-size"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-size")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-size")
-            }
+            styles["text-size"] = newValue
         }
     }
     
     /// Specifies how to capitalize text, similar to the CSS `text-transform` property.
     public var textTransform: TextTransform? {
         get {
-            return feature.properties?["text-transform"].flatMap { $0 as? String }.flatMap { TextTransform(rawValue: $0) }
+            return styles["text-transform"].flatMap { $0 as? String }.flatMap { TextTransform(rawValue: $0) }
         }
         set {
-            feature.properties?["text-transform"] = newValue?.rawValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-transform")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-transform")
-            }
+            styles["text-transform"] = newValue?.rawValue
         }
     }
     
     /// The color of the icon. This can only be used with sdf icons.
     public var iconColor: ColorRepresentable? {
         get {
-            return feature.properties?["icon-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
+            return styles["icon-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
         }
         set {
-            feature.properties?["icon-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("icon-color")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("icon-color")
-            }
+            styles["icon-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
         }
     }
     
     /// Fade out the halo towards the outside.
     public var iconHaloBlur: Double? {
         get {
-            return feature.properties?["icon-halo-blur"] as? Double
+            return styles["icon-halo-blur"] as? Double
         }
         set {
-            feature.properties?["icon-halo-blur"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("icon-halo-blur")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("icon-halo-blur")
-            }
+            styles["icon-halo-blur"] = newValue
         }
     }
     
     /// The color of the icon's halo. Icon halos can only be used with SDF icons.
     public var iconHaloColor: ColorRepresentable? {
         get {
-            return feature.properties?["icon-halo-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
+            return styles["icon-halo-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
         }
         set {
-            feature.properties?["icon-halo-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("icon-halo-color")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("icon-halo-color")
-            }
+            styles["icon-halo-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
         }
     }
     
     /// Distance of halo to the icon outline.
     public var iconHaloWidth: Double? {
         get {
-            return feature.properties?["icon-halo-width"] as? Double
+            return styles["icon-halo-width"] as? Double
         }
         set {
-            feature.properties?["icon-halo-width"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("icon-halo-width")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("icon-halo-width")
-            }
+            styles["icon-halo-width"] = newValue
         }
     }
     
     /// The opacity at which the icon will be drawn.
     public var iconOpacity: Double? {
         get {
-            return feature.properties?["icon-opacity"] as? Double
+            return styles["icon-opacity"] as? Double
         }
         set {
-            feature.properties?["icon-opacity"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("icon-opacity")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("icon-opacity")
-            }
+            styles["icon-opacity"] = newValue
         }
     }
     
     /// The color with which the text will be drawn.
     public var textColor: ColorRepresentable? {
         get {
-            return feature.properties?["text-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
+            return styles["text-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
         }
         set {
-            feature.properties?["text-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-color")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-color")
-            }
+            styles["text-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
         }
     }
     
     /// The halo's fadeout distance towards the outside.
     public var textHaloBlur: Double? {
         get {
-            return feature.properties?["text-halo-blur"] as? Double
+            return styles["text-halo-blur"] as? Double
         }
         set {
-            feature.properties?["text-halo-blur"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-halo-blur")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-halo-blur")
-            }
+            styles["text-halo-blur"] = newValue
         }
     }
     
     /// The color of the text's halo, which helps it stand out from backgrounds.
     public var textHaloColor: ColorRepresentable? {
         get {
-            return feature.properties?["text-halo-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
+            return styles["text-halo-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
         }
         set {
-            feature.properties?["text-halo-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-halo-color")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-halo-color")
-            }
+            styles["text-halo-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
         }
     }
     
     /// Distance of halo to the font outline. Max text halo width is 1/4 of the font-size.
     public var textHaloWidth: Double? {
         get {
-            return feature.properties?["text-halo-width"] as? Double
+            return styles["text-halo-width"] as? Double
         }
         set {
-            feature.properties?["text-halo-width"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-halo-width")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-halo-width")
-            }
+            styles["text-halo-width"] = newValue
         }
     }
     
     /// The opacity at which the text will be drawn.
     public var textOpacity: Double? {
         get {
-            return feature.properties?["text-opacity"] as? Double
+            return styles["text-opacity"] as? Double
         }
         set {
-            feature.properties?["text-opacity"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("text-opacity")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("text-opacity")
-            }
+            styles["text-opacity"] = newValue
         }
     }
 

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -112,10 +112,10 @@ public class PointAnnotationManager: AnnotationManager {
             return
         }
 
-        let allDataDrivenPropertiesUsed = Set(annotations.flatMap(\.dataDrivenPropertiesUsedSet))
+        let allDataDrivenPropertiesUsed = Set(annotations.flatMap { $0.styles.keys })
         for property in allDataDrivenPropertiesUsed {
             do {
-                try style.setLayerProperty(for: layerId, property: property, value: ["get", property] )
+                try style.setLayerProperty(for: layerId, property: property, value: ["get", property, ["get", "styles"]] )
             } catch {
                 Log.error(forMessage: "Could not set layer property \(property) in PointAnnotationManager",
                             category: "Annotations")

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
@@ -8,102 +8,86 @@ public struct PolygonAnnotation: Annotation {
     /// Identifier for this annotation
     public let id: String
 
-    /// The feature backing this annotation
-    public internal(set) var feature: Turf.Feature
+    /// The geometry backing this annotation
+    public var geometry: Turf.Geometry {
+        return .polygon(polygon)
+    }
+
+    /// The polygon backing this annotation
+    public var polygon: Turf.Polygon
 
     /// Properties associated with the annotation
-    public var userInfo: [String: Any]? { 
-        didSet {
-            feature.properties?["userInfo"] = userInfo
-        }
+    public var userInfo: [String: Any]?
+
+    internal private(set) var styles: [String: Any] = [:]
+
+    internal var feature: Turf.Feature {
+        var feature = Turf.Feature(geometry: geometry)
+        feature.identifier = .string(id)
+        var properties = [String: Any?]()
+        properties["styles"] = styles
+        properties["userInfo"] = userInfo
+        feature.properties = properties
+        return feature
     }
 
 
     /// Create a polygon annotation with a `Turf.Polygon` and an optional identifier.
     public init(id: String = UUID().uuidString, polygon: Turf.Polygon) {
         self.id = id
-        self.feature = Turf.Feature(polygon)
-        self.feature.properties = ["annotation-id": id]
+        self.polygon = polygon
     }
 
-    // MARK: - Properties -
-
-    /// Set of used data driven properties
-    internal var dataDrivenPropertiesUsedSet: Set<String> = []
+    // MARK: - Style Properties -
 
     
     /// Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
     public var fillSortKey: Double? {
         get {
-            return feature.properties?["fill-sort-key"] as? Double
+            return styles["fill-sort-key"] as? Double
         }
         set {
-            feature.properties?["fill-sort-key"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("fill-sort-key")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("fill-sort-key")
-            }
+            styles["fill-sort-key"] = newValue
         }
     }
     
     /// The color of the filled part of this layer. This color can be specified as `rgba` with an alpha component and the color's opacity will not affect the opacity of the 1px stroke, if it is used.
     public var fillColor: ColorRepresentable? {
         get {
-            return feature.properties?["fill-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
+            return styles["fill-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
         }
         set {
-            feature.properties?["fill-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("fill-color")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("fill-color")
-            }
+            styles["fill-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
         }
     }
     
     /// The opacity of the entire fill layer. In contrast to the `fill-color`, this value will also affect the 1px stroke around the fill, if the stroke is used.
     public var fillOpacity: Double? {
         get {
-            return feature.properties?["fill-opacity"] as? Double
+            return styles["fill-opacity"] as? Double
         }
         set {
-            feature.properties?["fill-opacity"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("fill-opacity")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("fill-opacity")
-            }
+            styles["fill-opacity"] = newValue
         }
     }
     
     /// The outline color of the fill. Matches the value of `fill-color` if unspecified.
     public var fillOutlineColor: ColorRepresentable? {
         get {
-            return feature.properties?["fill-outline-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
+            return styles["fill-outline-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
         }
         set {
-            feature.properties?["fill-outline-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("fill-outline-color")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("fill-outline-color")
-            }
+            styles["fill-outline-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
         }
     }
     
     /// Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
     public var fillPattern: String? {
         get {
-            return feature.properties?["fill-pattern"] as? String
+            return styles["fill-pattern"] as? String
         }
         set {
-            feature.properties?["fill-pattern"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("fill-pattern")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("fill-pattern")
-            }
+            styles["fill-pattern"] = newValue
         }
     }
 

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -105,10 +105,10 @@ public class PolygonAnnotationManager: AnnotationManager {
             return
         }
 
-        let allDataDrivenPropertiesUsed = Set(annotations.flatMap(\.dataDrivenPropertiesUsedSet))
+        let allDataDrivenPropertiesUsed = Set(annotations.flatMap { $0.styles.keys })
         for property in allDataDrivenPropertiesUsed {
             do {
-                try style.setLayerProperty(for: layerId, property: property, value: ["get", property] )
+                try style.setLayerProperty(for: layerId, property: property, value: ["get", property, ["get", "styles"]] )
             } catch {
                 Log.error(forMessage: "Could not set layer property \(property) in PolygonAnnotationManager",
                             category: "Annotations")

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
@@ -8,168 +8,132 @@ public struct PolylineAnnotation: Annotation {
     /// Identifier for this annotation
     public let id: String
 
-    /// The feature backing this annotation
-    public internal(set) var feature: Turf.Feature
+    /// The geometry backing this annotation
+    public var geometry: Turf.Geometry {
+        return .lineString(lineString)
+    }
+
+    /// The line string backing this annotation
+    public var lineString: Turf.LineString
 
     /// Properties associated with the annotation
-    public var userInfo: [String: Any]? { 
-        didSet {
-            feature.properties?["userInfo"] = userInfo
-        }
+    public var userInfo: [String: Any]?
+
+    internal private(set) var styles: [String: Any] = [:]
+
+    internal var feature: Turf.Feature {
+        var feature = Turf.Feature(geometry: geometry)
+        feature.identifier = .string(id)
+        var properties = [String: Any?]()
+        properties["styles"] = styles
+        properties["userInfo"] = userInfo
+        feature.properties = properties
+        return feature
     }
 
 
-    /// Create a polyline annotation with a `Turf.Polyline` and an optional identifier.
-    public init(id: String = UUID().uuidString, line: Turf.LineString) {
+    /// Create a polyline annotation with a `Turf.LineString` and an optional identifier.
+    public init(id: String = UUID().uuidString, lineString: Turf.LineString) {
         self.id = id
-        self.feature = Turf.Feature(line)
-        self.feature.properties = ["annotation-id": id]
+        self.lineString = lineString
     }
 
     /// Create a polyline annotation with an array of coordinates and an optional identifier.
     public init(id: String = UUID().uuidString, lineCoordinates: [CLLocationCoordinate2D]) {
-        let line = Turf.LineString(lineCoordinates)
-        self.init(id: id, line: line)
+        let lineString = Turf.LineString(lineCoordinates)
+        self.init(id: id, lineString: lineString)
     }
 
-    // MARK: - Properties -
-
-    /// Set of used data driven properties
-    internal var dataDrivenPropertiesUsedSet: Set<String> = []
+    // MARK: - Style Properties -
 
     
     /// The display of lines when joining.
     public var lineJoin: LineJoin? {
         get {
-            return feature.properties?["line-join"].flatMap { $0 as? String }.flatMap { LineJoin(rawValue: $0) }
+            return styles["line-join"].flatMap { $0 as? String }.flatMap { LineJoin(rawValue: $0) }
         }
         set {
-            feature.properties?["line-join"] = newValue?.rawValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("line-join")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("line-join")
-            }
+            styles["line-join"] = newValue?.rawValue
         }
     }
     
     /// Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
     public var lineSortKey: Double? {
         get {
-            return feature.properties?["line-sort-key"] as? Double
+            return styles["line-sort-key"] as? Double
         }
         set {
-            feature.properties?["line-sort-key"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("line-sort-key")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("line-sort-key")
-            }
+            styles["line-sort-key"] = newValue
         }
     }
     
     /// Blur applied to the line, in pixels.
     public var lineBlur: Double? {
         get {
-            return feature.properties?["line-blur"] as? Double
+            return styles["line-blur"] as? Double
         }
         set {
-            feature.properties?["line-blur"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("line-blur")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("line-blur")
-            }
+            styles["line-blur"] = newValue
         }
     }
     
     /// The color with which the line will be drawn.
     public var lineColor: ColorRepresentable? {
         get {
-            return feature.properties?["line-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
+            return styles["line-color"].flatMap { $0 as? String }.flatMap { try? JSONDecoder().decode(ColorRepresentable.self, from: $0.data(using: .utf8)!) }
         }
         set {
-            feature.properties?["line-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("line-color")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("line-color")
-            }
+            styles["line-color"] = newValue.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
         }
     }
     
     /// Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
     public var lineGapWidth: Double? {
         get {
-            return feature.properties?["line-gap-width"] as? Double
+            return styles["line-gap-width"] as? Double
         }
         set {
-            feature.properties?["line-gap-width"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("line-gap-width")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("line-gap-width")
-            }
+            styles["line-gap-width"] = newValue
         }
     }
     
     /// The line's offset. For linear features, a positive value offsets the line to the right, relative to the direction of the line, and a negative value to the left. For polygon features, a positive value results in an inset, and a negative value results in an outset.
     public var lineOffset: Double? {
         get {
-            return feature.properties?["line-offset"] as? Double
+            return styles["line-offset"] as? Double
         }
         set {
-            feature.properties?["line-offset"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("line-offset")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("line-offset")
-            }
+            styles["line-offset"] = newValue
         }
     }
     
     /// The opacity at which the line will be drawn.
     public var lineOpacity: Double? {
         get {
-            return feature.properties?["line-opacity"] as? Double
+            return styles["line-opacity"] as? Double
         }
         set {
-            feature.properties?["line-opacity"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("line-opacity")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("line-opacity")
-            }
+            styles["line-opacity"] = newValue
         }
     }
     
     /// Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
     public var linePattern: String? {
         get {
-            return feature.properties?["line-pattern"] as? String
+            return styles["line-pattern"] as? String
         }
         set {
-            feature.properties?["line-pattern"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("line-pattern")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("line-pattern")
-            }
+            styles["line-pattern"] = newValue
         }
     }
     
     /// Stroke thickness.
     public var lineWidth: Double? {
         get {
-            return feature.properties?["line-width"] as? Double
+            return styles["line-width"] as? Double
         }
         set {
-            feature.properties?["line-width"] = newValue
-            if newValue != nil {
-                dataDrivenPropertiesUsedSet.insert("line-width")
-            } else {
-                dataDrivenPropertiesUsedSet.remove("line-width")
-            }
+            styles["line-width"] = newValue
         }
     }
 

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -105,10 +105,10 @@ public class PolylineAnnotationManager: AnnotationManager {
             return
         }
 
-        let allDataDrivenPropertiesUsed = Set(annotations.flatMap(\.dataDrivenPropertiesUsedSet))
+        let allDataDrivenPropertiesUsed = Set(annotations.flatMap { $0.styles.keys })
         for property in allDataDrivenPropertiesUsed {
             do {
-                try style.setLayerProperty(for: layerId, property: property, value: ["get", property] )
+                try style.setLayerProperty(for: layerId, property: property, value: ["get", property, ["get", "styles"]] )
             } catch {
                 Log.error(forMessage: "Could not set layer property \(property) in PolylineAnnotationManager",
                             category: "Annotations")

--- a/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationTests.swift
@@ -14,7 +14,7 @@ final class CircleAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["circle-sort-key"] as? Double, annotation.circleSortKey)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["circle-sort-key"] as? Double, annotation.circleSortKey)
     }
 
     func testCircleBlur() {
@@ -25,7 +25,7 @@ final class CircleAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["circle-blur"] as? Double, annotation.circleBlur)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["circle-blur"] as? Double, annotation.circleBlur)
     }
 
     func testCircleColor() {
@@ -36,7 +36,7 @@ final class CircleAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["circle-color"] as? String, annotation.circleColor.flatMap { try? $0.jsonString() })
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["circle-color"] as? String, annotation.circleColor.flatMap { try? $0.jsonString() })
     }
 
     func testCircleOpacity() {
@@ -47,7 +47,7 @@ final class CircleAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["circle-opacity"] as? Double, annotation.circleOpacity)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["circle-opacity"] as? Double, annotation.circleOpacity)
     }
 
     func testCircleRadius() {
@@ -58,7 +58,7 @@ final class CircleAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["circle-radius"] as? Double, annotation.circleRadius)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["circle-radius"] as? Double, annotation.circleRadius)
     }
 
     func testCircleStrokeColor() {
@@ -69,7 +69,7 @@ final class CircleAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["circle-stroke-color"] as? String, annotation.circleStrokeColor.flatMap { try? $0.jsonString() })
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["circle-stroke-color"] as? String, annotation.circleStrokeColor.flatMap { try? $0.jsonString() })
     }
 
     func testCircleStrokeOpacity() {
@@ -80,7 +80,7 @@ final class CircleAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["circle-stroke-opacity"] as? Double, annotation.circleStrokeOpacity)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["circle-stroke-opacity"] as? Double, annotation.circleStrokeOpacity)
     }
 
     func testCircleStrokeWidth() {
@@ -91,7 +91,7 @@ final class CircleAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["circle-stroke-width"] as? Double, annotation.circleStrokeWidth)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["circle-stroke-width"] as? Double, annotation.circleStrokeWidth)
     }
 }
 

--- a/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationTests.swift
@@ -14,7 +14,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["icon-anchor"] as? String, annotation.iconAnchor?.rawValue)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["icon-anchor"] as? String, annotation.iconAnchor?.rawValue)
     }
 
     func testIconImage() {
@@ -25,7 +25,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["icon-image"] as? String, annotation.iconImage)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["icon-image"] as? String, annotation.iconImage)
     }
 
     func testIconOffset() {
@@ -36,7 +36,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["icon-offset"] as? [Double], annotation.iconOffset)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["icon-offset"] as? [Double], annotation.iconOffset)
     }
 
     func testIconRotate() {
@@ -47,7 +47,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["icon-rotate"] as? Double, annotation.iconRotate)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["icon-rotate"] as? Double, annotation.iconRotate)
     }
 
     func testIconSize() {
@@ -58,7 +58,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["icon-size"] as? Double, annotation.iconSize)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["icon-size"] as? Double, annotation.iconSize)
     }
 
     func testSymbolSortKey() {
@@ -69,7 +69,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["symbol-sort-key"] as? Double, annotation.symbolSortKey)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["symbol-sort-key"] as? Double, annotation.symbolSortKey)
     }
 
     func testTextAnchor() {
@@ -80,7 +80,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-anchor"] as? String, annotation.textAnchor?.rawValue)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-anchor"] as? String, annotation.textAnchor?.rawValue)
     }
 
     func testTextField() {
@@ -91,7 +91,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-field"] as? String, annotation.textField)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-field"] as? String, annotation.textField)
     }
 
     func testTextJustify() {
@@ -102,7 +102,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-justify"] as? String, annotation.textJustify?.rawValue)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-justify"] as? String, annotation.textJustify?.rawValue)
     }
 
     func testTextLetterSpacing() {
@@ -113,7 +113,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-letter-spacing"] as? Double, annotation.textLetterSpacing)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-letter-spacing"] as? Double, annotation.textLetterSpacing)
     }
 
     func testTextMaxWidth() {
@@ -124,7 +124,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-max-width"] as? Double, annotation.textMaxWidth)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-max-width"] as? Double, annotation.textMaxWidth)
     }
 
     func testTextOffset() {
@@ -135,7 +135,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-offset"] as? [Double], annotation.textOffset)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-offset"] as? [Double], annotation.textOffset)
     }
 
     func testTextRadialOffset() {
@@ -146,7 +146,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-radial-offset"] as? Double, annotation.textRadialOffset)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-radial-offset"] as? Double, annotation.textRadialOffset)
     }
 
     func testTextRotate() {
@@ -157,7 +157,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-rotate"] as? Double, annotation.textRotate)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-rotate"] as? Double, annotation.textRotate)
     }
 
     func testTextSize() {
@@ -168,7 +168,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-size"] as? Double, annotation.textSize)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-size"] as? Double, annotation.textSize)
     }
 
     func testTextTransform() {
@@ -179,7 +179,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-transform"] as? String, annotation.textTransform?.rawValue)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-transform"] as? String, annotation.textTransform?.rawValue)
     }
 
     func testIconColor() {
@@ -190,7 +190,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["icon-color"] as? String, annotation.iconColor.flatMap { try? $0.jsonString() })
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["icon-color"] as? String, annotation.iconColor.flatMap { try? $0.jsonString() })
     }
 
     func testIconHaloBlur() {
@@ -201,7 +201,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["icon-halo-blur"] as? Double, annotation.iconHaloBlur)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["icon-halo-blur"] as? Double, annotation.iconHaloBlur)
     }
 
     func testIconHaloColor() {
@@ -212,7 +212,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["icon-halo-color"] as? String, annotation.iconHaloColor.flatMap { try? $0.jsonString() })
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["icon-halo-color"] as? String, annotation.iconHaloColor.flatMap { try? $0.jsonString() })
     }
 
     func testIconHaloWidth() {
@@ -223,7 +223,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["icon-halo-width"] as? Double, annotation.iconHaloWidth)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["icon-halo-width"] as? Double, annotation.iconHaloWidth)
     }
 
     func testIconOpacity() {
@@ -234,7 +234,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["icon-opacity"] as? Double, annotation.iconOpacity)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["icon-opacity"] as? Double, annotation.iconOpacity)
     }
 
     func testTextColor() {
@@ -245,7 +245,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-color"] as? String, annotation.textColor.flatMap { try? $0.jsonString() })
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-color"] as? String, annotation.textColor.flatMap { try? $0.jsonString() })
     }
 
     func testTextHaloBlur() {
@@ -256,7 +256,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-halo-blur"] as? Double, annotation.textHaloBlur)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-halo-blur"] as? Double, annotation.textHaloBlur)
     }
 
     func testTextHaloColor() {
@@ -267,7 +267,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-halo-color"] as? String, annotation.textHaloColor.flatMap { try? $0.jsonString() })
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-halo-color"] as? String, annotation.textHaloColor.flatMap { try? $0.jsonString() })
     }
 
     func testTextHaloWidth() {
@@ -278,7 +278,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-halo-width"] as? Double, annotation.textHaloWidth)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-halo-width"] as? Double, annotation.textHaloWidth)
     }
 
     func testTextOpacity() {
@@ -289,7 +289,7 @@ final class PointAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["text-opacity"] as? Double, annotation.textOpacity)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["text-opacity"] as? Double, annotation.textOpacity)
     }
 }
 

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationTests.swift
@@ -21,7 +21,7 @@ final class PolygonAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["fill-sort-key"] as? Double, annotation.fillSortKey)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["fill-sort-key"] as? Double, annotation.fillSortKey)
     }
 
     func testFillColor() {
@@ -39,7 +39,7 @@ final class PolygonAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["fill-color"] as? String, annotation.fillColor.flatMap { try? $0.jsonString() })
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["fill-color"] as? String, annotation.fillColor.flatMap { try? $0.jsonString() })
     }
 
     func testFillOpacity() {
@@ -57,7 +57,7 @@ final class PolygonAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["fill-opacity"] as? Double, annotation.fillOpacity)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["fill-opacity"] as? Double, annotation.fillOpacity)
     }
 
     func testFillOutlineColor() {
@@ -75,7 +75,7 @@ final class PolygonAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["fill-outline-color"] as? String, annotation.fillOutlineColor.flatMap { try? $0.jsonString() })
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["fill-outline-color"] as? String, annotation.fillOutlineColor.flatMap { try? $0.jsonString() })
     }
 
     func testFillPattern() {
@@ -93,7 +93,7 @@ final class PolygonAnnotationTests: XCTestCase {
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["fill-pattern"] as? String, annotation.fillPattern)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["fill-pattern"] as? String, annotation.fillPattern)
     }
 }
 

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationIntegrationTests.swift
@@ -26,7 +26,7 @@ class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
             XCTAssertTrue(style.sourceExists(withId: manager.sourceId))
 
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-            var annotation = PolylineAnnotation(line: .init(lineCoordinates))
+            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
 
             annotation.lineJoin =  LineJoin.testConstantValue()
             annotation.lineSortKey =  Double.testConstantValue()
@@ -60,7 +60,7 @@ class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
             XCTAssertTrue(style.sourceExists(withId: manager.sourceId))
 
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-            let annotation = PolylineAnnotation(line: .init(lineCoordinates))
+            let annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
 
             manager.syncAnnotations([annotation])
             self.manager = manager

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationTests.swift
@@ -8,110 +8,110 @@ final class PolylineAnnotationTests: XCTestCase {
 
     func testLineJoin() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(line: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
 
         annotation.lineJoin =  LineJoin.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["line-join"] as? String, annotation.lineJoin?.rawValue)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["line-join"] as? String, annotation.lineJoin?.rawValue)
     }
 
     func testLineSortKey() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(line: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
 
         annotation.lineSortKey =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["line-sort-key"] as? Double, annotation.lineSortKey)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["line-sort-key"] as? Double, annotation.lineSortKey)
     }
 
     func testLineBlur() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(line: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
 
         annotation.lineBlur =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["line-blur"] as? Double, annotation.lineBlur)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["line-blur"] as? Double, annotation.lineBlur)
     }
 
     func testLineColor() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(line: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
 
         annotation.lineColor =  ColorRepresentable.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["line-color"] as? String, annotation.lineColor.flatMap { try? $0.jsonString() })
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["line-color"] as? String, annotation.lineColor.flatMap { try? $0.jsonString() })
     }
 
     func testLineGapWidth() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(line: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
 
         annotation.lineGapWidth =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["line-gap-width"] as? Double, annotation.lineGapWidth)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["line-gap-width"] as? Double, annotation.lineGapWidth)
     }
 
     func testLineOffset() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(line: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
 
         annotation.lineOffset =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["line-offset"] as? Double, annotation.lineOffset)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["line-offset"] as? Double, annotation.lineOffset)
     }
 
     func testLineOpacity() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(line: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
 
         annotation.lineOpacity =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["line-opacity"] as? Double, annotation.lineOpacity)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["line-opacity"] as? Double, annotation.lineOpacity)
     }
 
     func testLinePattern() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(line: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
 
         annotation.linePattern =  String.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["line-pattern"] as? String, annotation.linePattern)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["line-pattern"] as? String, annotation.linePattern)
     }
 
     func testLineWidth() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(line: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
 
         annotation.lineWidth =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
             return
         }
-        XCTAssertEqual(featureProperties["line-width"] as? Double, annotation.lineWidth)
+        XCTAssertEqual((featureProperties["styles"] as! [String: Any])["line-width"] as? Double, annotation.lineWidth)
     }
 }
 


### PR DESCRIPTION
Fixes #595

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Update the changelog
 - [x] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

* The `Annotation` protocol now has `var geometry: Turf.Geometry { get }` instead of `var feature: Turf.Feature { get }`
* Types conforming to `Annotation` additionally have read/write properties of the underlying geometry type. This makes it much easier to access the underlying geometry data.
* The initializer for the `LineString` argument of `PolylineAnnotation` has been renamed from `line` to `lineString`
* Annotation types' internal storage has been refactored and simplified.