### PR TITLE
Replace syncAnnotations with property setter

### DIFF
--- a/Apps/Examples/Examples/All Examples/CustomPointAnnotationExample.swift
+++ b/Apps/Examples/Examples/All Examples/CustomPointAnnotationExample.swift
@@ -48,7 +48,7 @@ public class CustomPointAnnotationExample: UIViewController, ExampleProtocol {
         customPointAnnotation.image = .custom(image: customImage, name: "my-custom-image-name")
 
         // Add the annotation to the manager in order to render it on the mao.
-        pointAnnotationManager.syncAnnotations([customPointAnnotation])
+        pointAnnotationManager.annotations = [customPointAnnotation]
 
         // The annotations added above will show as long as the `PointAnnotationManager` is alive,
         // so keep a reference to it.

--- a/Apps/Examples/Examples/All Examples/LineAnnotationExample.swift
+++ b/Apps/Examples/Examples/All Examples/LineAnnotationExample.swift
@@ -50,7 +50,7 @@ public class LineAnnotationExample: UIViewController, ExampleProtocol {
         let lineAnnnotationManager = mapView.annotations.makePolylineAnnotationManager()
 
         // Sync the annotation to the manager.
-        lineAnnnotationManager.syncAnnotations([lineAnnotation])
+        lineAnnnotationManager.annotations = [lineAnnotation]
 
         // The annotations added above will show as long as the lineAnnotationManager is alive,
         // so keep a reference to it.

--- a/Apps/Examples/Examples/All Examples/MultiplePointAnnotationsExample.swift
+++ b/Apps/Examples/Examples/All Examples/MultiplePointAnnotationsExample.swift
@@ -48,7 +48,7 @@ public class MultiplePointAnnotationsExample: UIViewController, ExampleProtocol 
 
         // Pass the point annotations into the annotation manager.
         // This will add them to the map.
-        pointAnnotationManager.syncAnnotations([pointAnnotation2, pointAnnotation1])
+        pointAnnotationManager.annotations = [pointAnnotation2, pointAnnotation1]
 
         // The next line is used for internal testing purposes only.
         finish()

--- a/Apps/Examples/Examples/All Examples/OfflineManagerExample.swift
+++ b/Apps/Examples/Examples/All Examples/OfflineManagerExample.swift
@@ -337,7 +337,7 @@ public class OfflineManagerExample: UIViewController, ExampleProtocol {
             pointAnnotation.image = .default
 
             self.pointAnnotationsManager = mapView.annotations.makePointAnnotationManager()
-            self.pointAnnotationsManager?.syncAnnotations([pointAnnotation])
+            self.pointAnnotationsManager?.annotations = [pointAnnotation]
         }
 
         self.mapView = mapView

--- a/Apps/Examples/Examples/All Examples/PointAnnotationExample.swift
+++ b/Apps/Examples/Examples/All Examples/PointAnnotationExample.swift
@@ -46,7 +46,7 @@ public class PointAnnotationExample: UIViewController, ExampleProtocol {
         customPointAnnotation.image = .default
 
         // Add the annotation to the manager in order to render it on the mao.
-        pointAnnotationManager.syncAnnotations([customPointAnnotation])
+        pointAnnotationManager.annotations = [customPointAnnotation]
 
         // The annotations added above will show as long as the `PointAnnotationManager` is alive,
         // so keep a reference to it.

--- a/Apps/Examples/Examples/All Examples/PolygonAnnotationExample.swift
+++ b/Apps/Examples/Examples/All Examples/PolygonAnnotationExample.swift
@@ -41,7 +41,7 @@ public class PolygonAnnotationExample: UIViewController, ExampleProtocol {
         polygonAnnotation.fillOpacity = 0.8
 
         // Add the polygon annotation to the manager
-        polygonAnnotationManager.syncAnnotations([polygonAnnotation])
+        polygonAnnotationManager.annotations = [polygonAnnotation]
 
         // The annotations added above will show as long as the `PolygonAnnotationManager` is alive,
         // so keep a reference to it.

--- a/Apps/Examples/Examples/All Examples/SelectAnnotationExample.swift
+++ b/Apps/Examples/Examples/All Examples/SelectAnnotationExample.swift
@@ -81,7 +81,7 @@ public class SelectAnnotationExample: UIViewController, ExampleProtocol {
         pointAnnotationManager.delegate = self
 
         // Add the annotation to the map.
-        pointAnnotationManager.syncAnnotations([pointAnnotation])
+        pointAnnotationManager.annotations = [pointAnnotation]
 
         // The below line is used for internal testing purposes only.
         finish()

--- a/Apps/Examples/Examples/All Examples/SwiftUIExample.swift
+++ b/Apps/Examples/Examples/All Examples/SwiftUIExample.swift
@@ -117,7 +117,7 @@ internal class SwiftUIMapViewCoordinator {
     /// are set, it synchronizes them to the map
     var annotations = [PointAnnotation]() {
         didSet {
-            syncAnnotations()
+            pointAnnotationManager?.annotations = annotations
         }
     }
 
@@ -195,15 +195,11 @@ internal class SwiftUIMapViewCoordinator {
             /// situation, the warning is expected, and should not cause any runtime problems. We
             /// expect to clean this up as well in an upcoming release.
             pointAnnotationManager = mapView.annotations.makePointAnnotationManager()
-            syncAnnotations()
+            pointAnnotationManager?.annotations = annotations
 
         default:
             break
         }
-    }
-
-    private func syncAnnotations() {
-        pointAnnotationManager?.syncAnnotations(annotations)
     }
 }
 

--- a/Apps/Examples/Examples/All Examples/UpdatePointAnnotationPositionExample.swift
+++ b/Apps/Examples/Examples/All Examples/UpdatePointAnnotationPositionExample.swift
@@ -39,7 +39,7 @@ public class UpdatePointAnnotationPositionExample: UIViewController, ExampleProt
         pointAnnotation.image = .default
 
         // Add the annotation to the map
-        pointAnnotationManager.syncAnnotations([pointAnnotation])
+        pointAnnotationManager.annotations = [pointAnnotation]
 
         // Add a gesture recognizer to the map
         mapView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(updatePosition)))
@@ -55,6 +55,6 @@ public class UpdatePointAnnotationPositionExample: UIViewController, ExampleProt
         pointAnnotation.image = .default
 
         // Update the annotations being managed by the manager
-        pointAnnotationManager.syncAnnotations([pointAnnotation])
+        pointAnnotationManager.annotations = [pointAnnotation]
     }
 }

--- a/Apps/StressTest/StressTest/ViewController.swift
+++ b/Apps/StressTest/StressTest/ViewController.swift
@@ -208,14 +208,14 @@ class ViewController: UIViewController {
 
         // Add the annotation to the map.
         print("Adding line annotation")
-        lineAnnotationManager?.syncAnnotations([lineAnnotation])
+        lineAnnotationManager?.annotations = [lineAnnotation]
 
         let endOptions = CameraOptions(center: end, zoom: 17)
 
         var cancelableAnimator: Cancelable?
         cancelableAnimator = mapView.camera.fly(to: endOptions) { _ in
             print("Removing line annotation for animator \(String(describing: cancelableAnimator))")
-            self.lineAnnotationManager?.syncAnnotations([])
+            self.lineAnnotationManager?.annotations = []
             cancelableAnimator = nil
             completion()
         }
@@ -224,7 +224,7 @@ class ViewController: UIViewController {
     func removeAnnotations() {
         print("Removing \(annotations.count) annotations")
         annotations = []
-        pointAnnotationManager?.syncAnnotations([])
+        pointAnnotationManager?.annotations = []
     }
 
     func addAnnotations(around coord: CLLocationCoordinate2D) {
@@ -237,7 +237,7 @@ class ViewController: UIViewController {
         }
 
         print("Adding \(annotations.count) annotations")
-        pointAnnotationManager?.syncAnnotations(annotations)
+        pointAnnotationManager?.annotations = annotations
     }
 
     func pushColorExpression() {

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -10,16 +10,10 @@ public class CircleAnnotationManager: AnnotationManager {
     // MARK: - Annotations -
 
     /// The collection of CircleAnnotations being managed
-    public private(set) var annotations = [CircleAnnotation]() {
+    public var annotations = [CircleAnnotation]() {
         didSet {
             syncAnnotations()
          }
-    }
-
-    /// Syncs `CircleAnnotation`s to the map
-    /// NOTE: calling this repeatedly results in degraded performance
-    public func syncAnnotations(_ annotations: [CircleAnnotation]) {
-        self.annotations = annotations
     }
 
     // MARK: - AnnotationManager protocol conformance -

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -10,17 +10,11 @@ public class PointAnnotationManager: AnnotationManager {
     // MARK: - Annotations -
 
     /// The collection of PointAnnotations being managed
-    public private(set) var annotations = [PointAnnotation]() {
+    public var annotations = [PointAnnotation]() {
         didSet {
             addImageToStyleIfNeeded(style: style)
             syncAnnotations()
          }
-    }
-
-    /// Syncs `PointAnnotation`s to the map
-    /// NOTE: calling this repeatedly results in degraded performance
-    public func syncAnnotations(_ annotations: [PointAnnotation]) {
-        self.annotations = annotations
     }
 
     // MARK: - AnnotationManager protocol conformance -

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -10,16 +10,10 @@ public class PolygonAnnotationManager: AnnotationManager {
     // MARK: - Annotations -
 
     /// The collection of PolygonAnnotations being managed
-    public private(set) var annotations = [PolygonAnnotation]() {
+    public var annotations = [PolygonAnnotation]() {
         didSet {
             syncAnnotations()
          }
-    }
-
-    /// Syncs `PolygonAnnotation`s to the map
-    /// NOTE: calling this repeatedly results in degraded performance
-    public func syncAnnotations(_ annotations: [PolygonAnnotation]) {
-        self.annotations = annotations
     }
 
     // MARK: - AnnotationManager protocol conformance -

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -10,16 +10,10 @@ public class PolylineAnnotationManager: AnnotationManager {
     // MARK: - Annotations -
 
     /// The collection of PolylineAnnotations being managed
-    public private(set) var annotations = [PolylineAnnotation]() {
+    public var annotations = [PolylineAnnotation]() {
         didSet {
             syncAnnotations()
          }
-    }
-
-    /// Syncs `PolylineAnnotation`s to the map
-    /// NOTE: calling this repeatedly results in degraded performance
-    public func syncAnnotations(_ annotations: [PolylineAnnotation]) {
-        self.annotations = annotations
     }
 
     // MARK: - AnnotationManager protocol conformance -

--- a/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationIntegrationTests.swift
@@ -36,7 +36,7 @@ class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
             annotation.circleStrokeOpacity =  Double.testConstantValue()
             annotation.circleStrokeWidth =  Double.testConstantValue()
 
-            manager.syncAnnotations([annotation])
+            manager.annotations = [annotation]
             self.manager = manager
             successfullyLoadedStyleExpectation.fulfill()
         }
@@ -59,7 +59,7 @@ class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
 
             let annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
 
-            manager.syncAnnotations([annotation])
+            manager.annotations = [annotation]
             self.manager = manager
 
             do {

--- a/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationIntegrationTests.swift
@@ -54,7 +54,7 @@ class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
             annotation.textHaloWidth =  Double.testConstantValue()
             annotation.textOpacity =  Double.testConstantValue()
 
-            manager.syncAnnotations([annotation])
+            manager.annotations = [annotation]
             self.manager = manager
             successfullyLoadedStyleExpectation.fulfill()
         }
@@ -77,7 +77,7 @@ class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
 
             let annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
 
-            manager.syncAnnotations([annotation])
+            manager.annotations = [annotation]
             self.manager = manager
 
             do {

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationIntegrationTests.swift
@@ -40,7 +40,7 @@ class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
             annotation.fillOutlineColor =  ColorRepresentable.testConstantValue()
             annotation.fillPattern =  String.testConstantValue()
 
-            manager.syncAnnotations([annotation])
+            manager.annotations = [annotation]
             self.manager = manager
             successfullyLoadedStyleExpectation.fulfill()
         }
@@ -70,7 +70,7 @@ class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
             ]
             let annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
 
-            manager.syncAnnotations([annotation])
+            manager.annotations = [annotation]
             self.manager = manager
 
             do {

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationIntegrationTests.swift
@@ -38,7 +38,7 @@ class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
             annotation.linePattern =  String.testConstantValue()
             annotation.lineWidth =  Double.testConstantValue()
 
-            manager.syncAnnotations([annotation])
+            manager.annotations = [annotation]
             self.manager = manager
             successfullyLoadedStyleExpectation.fulfill()
         }
@@ -62,7 +62,7 @@ class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
             let annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
 
-            manager.syncAnnotations([annotation])
+            manager.annotations = [annotation]
             self.manager = manager
 
             do {

--- a/Tests/MapboxMapsTests/MigrationGuide/MigrationGuideIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/MigrationGuide/MigrationGuideIntegrationTests.swift
@@ -479,7 +479,7 @@ class MigrationGuideIntegrationTests: IntegrationTestCase {
                     let coordinate = CLLocationCoordinate2DMake(24, -89)
                     var pointAnnotation = PointAnnotation(coordinate: coordinate)
                     pointAnnotation.image = .default
-                    self.pointAnnotationManager.syncAnnotations([pointAnnotation])
+                    self.pointAnnotationManager.annotations = [pointAnnotation]
                 }
             }
 


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Existing tests have been updated
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Update the changelog
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

* The `syncAnnotations(_:)` method on each annotation manager has been replaced by a publicly accessible setter on the `annotations` property.