### PR TITLE
Rework snapshot approach

### DIFF
--- a/Apps/DebugApp/DebugApp.xcodeproj/xcshareddata/xcschemes/DebugApp.xcscheme
+++ b/Apps/DebugApp/DebugApp.xcodeproj/xcshareddata/xcschemes/DebugApp.xcscheme
@@ -92,6 +92,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
@@ -109,13 +110,6 @@
             isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-         <AdditionalOption
-            key = "MallocStackLogging"
-            value = ""
-            isEnabled = "YES">
-         </AdditionalOption>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"

--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -112,10 +112,13 @@ public class DebugViewController: UIViewController {
             guard let mapView = self?.mapView else {
                 return
             }
-
-            mapView.snapshot { image in
-                if image != nil {
+            
+            mapView.snapshot { imageResult in
+                switch imageResult {
+                case .success(let image):
                     imageView.image = image
+                case .failure(let error):
+                    print("Error: \(error)")
                 }
             }
         }

--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -1,5 +1,5 @@
 import UIKit
-import MapboxMaps
+@_spi(Experimental) import MapboxMaps
 import Turf
 
 /**
@@ -22,6 +22,10 @@ public class DebugViewController: UIViewController {
         mapView.location.options.puckType = .puck2D()
 
         view.addSubview(mapView)
+
+        let imageView = UIImageView(frame: CGRect(x: 20, y: 20, width: 100, height: 200))
+        imageView.backgroundColor = .red
+        view.addSubview(imageView)
 
         // Convenience that takes a closure that's called when the style
         // is loaded or fails to load.
@@ -102,6 +106,18 @@ public class DebugViewController: UIViewController {
             }
 
             print("The map failed to load.. \(type) = \(message)")
+        }
+
+        mapView.mapboxMap.onEvery(.mapIdle) { [weak self] _ in
+            guard let mapView = self?.mapView else {
+                return
+            }
+
+            mapView.snapshot() { snapshot in
+                if snapshot != nil {
+                    imageView.image = snapshot
+                }
+            }
         }
     }
 }

--- a/Apps/DebugApp/DebugApp/DebugViewController.swift
+++ b/Apps/DebugApp/DebugApp/DebugViewController.swift
@@ -113,9 +113,9 @@ public class DebugViewController: UIViewController {
                 return
             }
 
-            mapView.snapshot() { snapshot in
-                if snapshot != nil {
-                    imageView.image = snapshot
+            mapView.snapshot { image in
+                if image != nil {
+                    imageView.image = image
                 }
             }
         }

--- a/Sources/MapboxMaps/Foundation/Extensions/CoreGraphics.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/CoreGraphics.swift
@@ -76,10 +76,8 @@ extension CGImage {
         let data: UnsafePointer<UInt8> = CFDataGetBytePtr(pixelData)
         let uint32Pointer = UnsafeRawPointer(data).bindMemory(to: UInt32.self, capacity: size)
 
-        for x in 0..<size {
-            if uint32Pointer[x] != 0 {
-                return false
-            }
+        for x in 0..<size where uint32Pointer[x] != 0 {
+            return false
         }
 
         return true

--- a/Sources/MapboxMaps/Foundation/Extensions/CoreGraphics.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/CoreGraphics.swift
@@ -63,3 +63,25 @@ extension CGRect {
         return rect
     }
 }
+
+extension CGImage {
+    internal func isEmpty() -> Bool {
+        let size = width * height
+
+        guard let dataProvider = dataProvider, size > 0 else {
+            return true
+        }
+
+        let pixelData = dataProvider.data
+        let data: UnsafePointer<UInt8> = CFDataGetBytePtr(pixelData)
+        let uint32Pointer = UnsafeRawPointer(data).bindMemory(to: UInt32.self, capacity: size)
+
+        for x in 0..<size {
+            if uint32Pointer[x] != 0 {
+                return false
+            }
+        }
+
+        return true
+    }
+}

--- a/Sources/MapboxMaps/Foundation/MapView+Snapshot.swift
+++ b/Sources/MapboxMaps/Foundation/MapView+Snapshot.swift
@@ -1,0 +1,68 @@
+@_implementationOnly import MapboxCommon_Private
+
+@available(iOSApplicationExtension, unavailable)
+extension MapView {
+    /// :nodoc:
+    ///
+    /// Schedules the capturing of the "last rendered map view" (if available),
+    /// generation of a UIImage and passes the result to the completion handler.
+    ///
+    /// Currently the image passed to the closure has a slightly washed out
+    /// appearance compared with the main map view.
+    /// 
+    /// - Parameter completion: Closure that is passed a snapshot image if available
+    ///
+    /// - Note: This is an experimental API and subject to change.
+    @_spi(Experimental) public func snapshot(completion: @escaping (UIImage?) -> Void ) {
+
+        // Calling mapView.layer.render(in:) isn't sufficient for
+        // capturing the Metal rendering. This is modified from
+        // https://stackoverflow.com/a/47632198 and might not be
+        // sufficient.
+        guard let metalView = subviews.first as? MTKView else {
+            completion(nil)
+            return
+        }
+
+        // If Metal API validation is enabled, the call to CIContext().createCGImage
+        // below will crash with the following message:
+        //
+        //  -[MTLDebugComputeCommandEncoder setTexture:atIndex:]:373: failed
+        //  assertion `frameBufferOnly texture not supported for compute.'
+        guard getenv("METAL_DEVICE_WRAPPER_TYPE") == nil else {
+            Log.warning(forMessage: "Metal API validation is enabled - MapView snapshot is being skipped.", category: "MapView")
+            completion(nil)
+            return
+        }
+
+        // This needs to be captured on the main thread
+        let scale = metalView.contentScaleFactor
+
+        DispatchQueue.global().async {
+            var snapshot: UIImage?
+
+            defer {
+                DispatchQueue.main.async {
+                    completion(snapshot)
+                }
+            }
+
+            // May need to schedule this for after rendering has occurred
+            guard let texture = metalView.currentDrawable?.texture else {
+                return
+            }
+
+            // This results in an image where the colors appear slightly washed
+            // out.
+            guard let ciImage = CIImage(mtlTexture: texture, options: nil),
+                  let cgImage = CIContext().createCGImage(ciImage, from: ciImage.extent) else {
+                return
+            }
+
+            // Sometimes (observed on simulator) the image returned is blank
+            if !cgImage.isEmpty() {
+                snapshot = UIImage(cgImage: cgImage, scale: scale, orientation: .downMirrored)
+            }
+        }
+    }
+}

--- a/Sources/MapboxMaps/Foundation/MapView+Snapshot.swift
+++ b/Sources/MapboxMaps/Foundation/MapView+Snapshot.swift
@@ -52,8 +52,7 @@ extension MapView {
                 return
             }
 
-            // This results in an image where the colors appear slightly washed
-            // out.
+            // This results in an image where the colors appear slightly washed out
             guard let ciImage = CIImage(mtlTexture: texture, options: nil),
                   let cgImage = CIContext().createCGImage(ciImage, from: ciImage.extent) else {
                 return

--- a/Tests/MapboxMapsTests/Foundation/Integration Tests/MapViewIntegrationTestCase.swift
+++ b/Tests/MapboxMapsTests/Foundation/Integration Tests/MapViewIntegrationTestCase.swift
@@ -85,36 +85,3 @@ internal class MapViewIntegrationTestCase: IntegrationTestCase {
         try super.tearDownWithError()
     }
 }
-
-// TODO: Cleanup & move the follow somewhere more appropriate
-extension MapView {
-    func snapshot() -> UIImage? {
-        // Calling mapView.layer.render(in:) isn't sufficient for
-        // capturing the Metal rendering. This is modified from
-        // https://stackoverflow.com/a/47632198 and might not be
-        // sufficient.
-
-        guard let metalView = subviews.first as? MTKView,
-              let texture = metalView.currentDrawable?.texture else {
-            return nil
-        }
-
-        guard let ciImage = CIImage(mtlTexture: texture, options: nil),
-              let cgImage = CIContext().createCGImage(ciImage, from: ciImage.extent) else {
-            return nil
-        }
-
-        // Need to check what the metal view is setting for scale.
-        let mapViewSnapshot = UIImage(cgImage: cgImage, scale: 2.0, orientation: .downMirrored)
-
-        // For other subviews, we *can* use render(in:). Again, check scale factor.
-        UIGraphicsBeginImageContextWithOptions(bounds.size, false, 1.0)
-        let context = UIGraphicsGetCurrentContext()
-        mapViewSnapshot.draw(at: .zero)
-        layer.render(in: context!)
-        let snapshot = UIGraphicsGetImageFromCurrentImageContext()!
-        UIGraphicsEndImageContext()
-
-        return snapshot
-    }
-}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR reworks the changes in #581 :

- We no longer call `CIContext().createCGImage(...) ` to create the `CGImageRef` and rely on constructing it directly from the raw bytes backing the texture. Colors are no longer washed out.
- Metal validation being an issue is no longer a problem.
- The completion closure is now based on a new result type : `Result<UIImage, RenderedSnapshotError>`.
- Corrects the assumption that the first subview is the MTKView.

