### PR TITLE
Enable show/hide for location puck accuracyRadius

### DIFF
--- a/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
@@ -4,7 +4,7 @@ import MapboxMaps
 @objc(Custom2DPuckExample)
 public class Custom2DPuckExample: UIViewController, ExampleProtocol {
 
-    internal var toggleAccuracyRadiusButton: UIButton? = nil
+    internal var toggleAccuracyRadiusButton: UIButton?
     internal var mapView: MapView!
     internal var shouldToggleAccuracyRadius: Bool = true
 
@@ -55,17 +55,18 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
     }
 
     @objc func showHideAccuracyRadius() {
+        var configuration = Puck2DConfiguration(topImage: UIImage(named: "star"))
         if shouldToggleAccuracyRadius {
-            let configuration = Puck2DConfiguration(topImage: UIImage(named: "star"), showAccuracyRadius: true)
-            mapView.location.options.puckType = .puck2D(configuration)
+            configuration.showAccuracyRadius = true
             shouldToggleAccuracyRadius = false
             self.toggleAccuracyRadiusButton!.setTitle("Disable Accuracy Radius", for: .normal)
         } else {
-            let configuration = Puck2DConfiguration(topImage: UIImage(named: "star"), showAccuracyRadius: false)
-            mapView.location.options.puckType = .puck2D(configuration)
+            configuration.showAccuracyRadius = false
             shouldToggleAccuracyRadius = true
             self.toggleAccuracyRadiusButton!.setTitle("Enable Accuracy Radius", for: .normal)
         }
+
+        mapView.location.options.puckType = .puck2D(configuration)
     }
 
     private func setupToggleShowAccuracyButton() {

--- a/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
@@ -4,7 +4,9 @@ import MapboxMaps
 @objc(Custom2DPuckExample)
 public class Custom2DPuckExample: UIViewController, ExampleProtocol {
 
+    internal var toggleAccuracyRadiusButton: UIButton? = nil
     internal var mapView: MapView!
+    internal var shouldToggleAccuracyRadius: Bool = true
 
     override public func viewDidLoad() {
         super.viewDidLoad()
@@ -17,11 +19,71 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
         let configuration = Puck2DConfiguration(topImage: UIImage(named: "star"))
         mapView.location.options.puckType = .puck2D(configuration)
         mapView.location.options.puckBearingSource = .course
+
+        // Center map over the user's current location
+        mapView.mapboxMap.onNext(.mapLoaded, handler: { [weak self] _ in
+            guard let self = self else { return }
+
+            if let currentLocation = self.mapView.location.latestLocation {
+                let cameraOptions = CameraOptions(center: currentLocation.coordinate, zoom: 17.0)
+                self.mapView.camera.ease(to: cameraOptions, duration: 2.0)
+            }
+        })
+
+        // Setup a toggle button to show how to toggle the accuracy radius
+        mapView.mapboxMap.onEvery(.cameraChanged, handler: { [weak self] _ in
+            guard let self = self else { return }
+
+            if self.mapView.cameraState.zoom >= 17.0 {
+                if let button = self.toggleAccuracyRadiusButton {
+                    button.isHidden = false
+                } else {
+                    self.setupToggleShowAccuracyButton()
+                }
+            } else {
+                if let button = self.toggleAccuracyRadiusButton {
+                    button.isHidden = true
+                }
+            }
+        })
     }
 
     override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         // The below line is used for internal testing purposes only.
         finish()
+    }
+
+    @objc func showHideAccuracyRadius() {
+        if shouldToggleAccuracyRadius {
+            let configuration = Puck2DConfiguration(topImage: UIImage(named: "star"), showAccuracyRadius: true)
+            mapView.location.options.puckType = .puck2D(configuration)
+            shouldToggleAccuracyRadius = false
+            self.toggleAccuracyRadiusButton!.setTitle("Disable Accuracy Radius", for: .normal)
+        } else {
+            let configuration = Puck2DConfiguration(topImage: UIImage(named: "star"), showAccuracyRadius: false)
+            mapView.location.options.puckType = .puck2D(configuration)
+            shouldToggleAccuracyRadius = true
+            self.toggleAccuracyRadiusButton!.setTitle("Enable Accuracy Radius", for: .normal)
+        }
+    }
+
+    private func setupToggleShowAccuracyButton() {
+        // Button setup
+        let button = UIButton(frame: CGRect.zero)
+        button.backgroundColor = .systemBlue
+        button.addTarget(self, action: #selector(self.showHideAccuracyRadius), for: .touchUpInside)
+        button.setTitle("Enable Accuracy Radius", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        self.view.addSubview(button)
+
+        // Constraints
+        button.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 20.0).isActive = true
+        button.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -20.0).isActive = true
+        button.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
+        button.topAnchor.constraint(equalTo: self.view.topAnchor, constant: 650.0).isActive = true
+
+        self.toggleAccuracyRadiusButton = button
     }
 }

--- a/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
@@ -57,11 +57,11 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
     @objc func showHideAccuracyRadius() {
         var configuration = Puck2DConfiguration(topImage: UIImage(named: "star"))
         if shouldToggleAccuracyRadius {
-            configuration.showAccuracyRadius = true
+            configuration.showAccuracyRing = true
             shouldToggleAccuracyRadius = false
             self.toggleAccuracyRadiusButton!.setTitle("Disable Accuracy Radius", for: .normal)
         } else {
-            configuration.showAccuracyRadius = false
+            configuration.showAccuracyRing = false
             shouldToggleAccuracyRadius = true
             self.toggleAccuracyRadiusButton!.setTitle("Enable Accuracy Radius", for: .normal)
         }

--- a/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
@@ -15,6 +15,9 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         view.addSubview(mapView)
 
+        // Setup and create button for toggling accuracy ring
+        self.setupToggleShowAccuracyButton()
+
         // Granularly configure the location puck with a `Puck2DConfiguration`
         let configuration = Puck2DConfiguration(topImage: UIImage(named: "star"))
         mapView.location.options.puckType = .puck2D(configuration)
@@ -25,25 +28,23 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
             guard let self = self else { return }
 
             if let currentLocation = self.mapView.location.latestLocation {
-                let cameraOptions = CameraOptions(center: currentLocation.coordinate, zoom: 17.0)
+                let cameraOptions = CameraOptions(center: currentLocation.coordinate, zoom: 18.0)
                 self.mapView.camera.ease(to: cameraOptions, duration: 2.0)
             }
         })
 
         // Setup a toggle button to show how to toggle the accuracy radius
         mapView.mapboxMap.onEvery(.cameraChanged, handler: { [weak self] _ in
-            guard let self = self else { return }
+            guard let self = self,
+                  let button = self.toggleAccuracyRadiusButton else {
+                return
+            }
 
-            if self.mapView.cameraState.zoom >= 17.0 {
-                if let button = self.toggleAccuracyRadiusButton {
-                    button.isHidden = false
-                } else {
-                    self.setupToggleShowAccuracyButton()
-                }
+            if self.mapView.cameraState.zoom >= 18.0 {
+                button.isHidden = false
+
             } else {
-                if let button = self.toggleAccuracyRadiusButton {
-                    button.isHidden = true
-                }
+                button.isHidden = true
             }
         })
     }
@@ -57,11 +58,11 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
     @objc func showHideAccuracyRadius() {
         var configuration = Puck2DConfiguration(topImage: UIImage(named: "star"))
         if shouldToggleAccuracyRadius {
-            configuration.showAccuracyRing = true
+            configuration.showsAccuracyRing = true
             shouldToggleAccuracyRadius = false
             self.toggleAccuracyRadiusButton!.setTitle("Disable Accuracy Radius", for: .normal)
         } else {
-            configuration.showAccuracyRing = false
+            configuration.showsAccuracyRing = false
             shouldToggleAccuracyRadius = true
             self.toggleAccuracyRadiusButton!.setTitle("Enable Accuracy Radius", for: .normal)
         }
@@ -82,7 +83,6 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
         // Constraints
         button.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 20.0).isActive = true
         button.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -20.0).isActive = true
-        button.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
         button.topAnchor.constraint(equalTo: self.view.topAnchor, constant: 650.0).isActive = true
 
         self.toggleAccuracyRadiusButton = button

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Mapbox welcomes participation and contributions from everyone.
 * Enable instant transitions for data driven paint layer properties ([#628](https://github.com/mapbox/mapbox-maps-ios/pull/628))
 * Offload networking tasks at the init phase ([#631](https://github.com/mapbox/mapbox-maps-ios/pull/631))
 * 3D pucks will now be rendered over other 3D content and occluded by terrain ([#641](https://github.com/mapbox/mapbox-maps-ios/pull/641))
-<<<<<<< HEAD
 * Added a public, failable, component-wise initializer to `StyleColor` ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * Updated `StyleColor`'s `Decodable` support to be able to handle rgba color strings as well as rgba expressions ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * Made generated enums conform to `CaseIterable` ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ Mapbox welcomes participation and contributions from everyone.
 * Added a public, failable, component-wise initializer to `StyleColor` ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * Updated `StyleColor`'s `Decodable` support to be able to handle rgba color strings as well as rgba expressions ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * Made generated enums conform to `CaseIterable` ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
-* Offload networking tasks at the init phase ([#](https://github.com/mapbox/mapbox-maps-ios/pull/))
 * Location puck can now hide the accuracy ring. The default value is to hide the accuracy ring. In order to enable the ring, set the `showAccuracyRing` property in `Puck2DConfiguration` to `true`. [#629](https://github.com/mapbox/mapbox-maps-ios/pull/629)
 
 ### Bug fixes 🐞

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,12 @@ Mapbox welcomes participation and contributions from everyone.
 * Enable instant transitions for data driven paint layer properties ([#628](https://github.com/mapbox/mapbox-maps-ios/pull/628))
 * Offload networking tasks at the init phase ([#631](https://github.com/mapbox/mapbox-maps-ios/pull/631))
 * 3D pucks will now be rendered over other 3D content and occluded by terrain ([#641](https://github.com/mapbox/mapbox-maps-ios/pull/641))
+<<<<<<< HEAD
 * Added a public, failable, component-wise initializer to `StyleColor` ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * Updated `StyleColor`'s `Decodable` support to be able to handle rgba color strings as well as rgba expressions ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * Made generated enums conform to `CaseIterable` ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
+* Offload networking tasks at the init phase ([#](https://github.com/mapbox/mapbox-maps-ios/pull/))
+* Location puck can now hide the accuracy ring. The default value is to hide the accuracy ring. In order to enable the ring, set the `showAccuracyRing` property in `Puck2DConfiguration` to `true`. [#629](https://github.com/mapbox/mapbox-maps-ios/pull/629)
 
 ### Bug fixes 🐞
 

--- a/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
@@ -17,14 +17,19 @@ public struct Puck2DConfiguration: Equatable {
     /// The size of the images, as a scale factor applied to the size of the specified image.
     public var scale: Value<Double>?
 
+    /// Flag determining if the horizontal accuracy ring should be shown arround the Puck. default value is false
+    public var showAccuracyRadius: Bool
+
     public init(topImage: UIImage? = nil,
                 bearingImage: UIImage? = nil,
                 shadowImage: UIImage? = nil,
-                scale: Value<Double>? = nil) {
+                scale: Value<Double>? = nil,
+                showAccuracyRadius: Bool = false) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage
         self.scale = scale
+        self.showAccuracyRadius = showAccuracyRadius
     }
 
     internal var resolvedTopImage: UIImage? {
@@ -181,11 +186,15 @@ internal extension Puck2D {
         layer.topImageSize = configuration.resolvedScale
         layer.bearingImageSize = configuration.resolvedScale
         layer.shadowImageSize = configuration.resolvedScale
-        layer.accuracyRadius = .constant(location.horizontalAccuracy)
         layer.emphasisCircleRadiusTransition = StyleTransition(duration: 0, delay: 0)
         layer.bearingTransition = StyleTransition(duration: 0, delay: 0)
-        layer.accuracyRadiusColor = .constant(StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
-        layer.accuracyRadiusBorderColor = .constant(StyleColor(.lightGray))
+
+        // Horizontal accuracy ring is an optional visual for the 2D Puck
+        if configuration.showAccuracyRadius {
+            layer.accuracyRadius = .constant(location.horizontalAccuracy)
+            layer.accuracyRadiusColor = .constant(ColorRepresentable(color: UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
+            layer.accuracyRadiusBorderColor = .constant(ColorRepresentable(color: .lightGray))
+        }
 
         // Add layer to style
         try style._addPersistentLayer(layer)

--- a/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
@@ -192,8 +192,8 @@ internal extension Puck2D {
         // Horizontal accuracy ring is an optional visual for the 2D Puck
         if configuration.showsAccuracyRing {
             layer.accuracyRadius = .constant(location.horizontalAccuracy)
-            layer.accuracyRadiusColor = .constant(ColorRepresentable(color: UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
-            layer.accuracyRadiusBorderColor = .constant(ColorRepresentable(color: .lightGray))
+            layer.accuracyRadiusColor = .constant(StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
+            layer.accuracyRadiusBorderColor = .constant(StyleColor(.lightGray))
         }
 
         // Add layer to style

--- a/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
@@ -18,18 +18,18 @@ public struct Puck2DConfiguration: Equatable {
     public var scale: Value<Double>?
 
     /// Flag determining if the horizontal accuracy ring should be shown arround the Puck. default value is false
-    public var showAccuracyRadius: Bool
+    public var showAccuracyRing: Bool
 
     public init(topImage: UIImage? = nil,
                 bearingImage: UIImage? = nil,
                 shadowImage: UIImage? = nil,
                 scale: Value<Double>? = nil,
-                showAccuracyRadius: Bool = false) {
+                showAccuracyRing: Bool = false) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage
         self.scale = scale
-        self.showAccuracyRadius = showAccuracyRadius
+        self.showAccuracyRing = showAccuracyRing
     }
 
     internal var resolvedTopImage: UIImage? {
@@ -190,7 +190,7 @@ internal extension Puck2D {
         layer.bearingTransition = StyleTransition(duration: 0, delay: 0)
 
         // Horizontal accuracy ring is an optional visual for the 2D Puck
-        if configuration.showAccuracyRadius {
+        if configuration.showAccuracyRing {
             layer.accuracyRadius = .constant(location.horizontalAccuracy)
             layer.accuracyRadiusColor = .constant(ColorRepresentable(color: UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
             layer.accuracyRadiusBorderColor = .constant(ColorRepresentable(color: .lightGray))

--- a/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
@@ -18,18 +18,18 @@ public struct Puck2DConfiguration: Equatable {
     public var scale: Value<Double>?
 
     /// Flag determining if the horizontal accuracy ring should be shown arround the Puck. default value is false
-    public var showAccuracyRing: Bool
+    public var showsAccuracyRing: Bool
 
     public init(topImage: UIImage? = nil,
                 bearingImage: UIImage? = nil,
                 shadowImage: UIImage? = nil,
                 scale: Value<Double>? = nil,
-                showAccuracyRing: Bool = false) {
+                showsAccuracyRing: Bool = false) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage
         self.scale = scale
-        self.showAccuracyRing = showAccuracyRing
+        self.showsAccuracyRing = showsAccuracyRing
     }
 
     internal var resolvedTopImage: UIImage? {
@@ -190,7 +190,7 @@ internal extension Puck2D {
         layer.bearingTransition = StyleTransition(duration: 0, delay: 0)
 
         // Horizontal accuracy ring is an optional visual for the 2D Puck
-        if configuration.showAccuracyRing {
+        if configuration.showsAccuracyRing {
             layer.accuracyRadius = .constant(location.horizontalAccuracy)
             layer.accuracyRadiusColor = .constant(ColorRepresentable(color: UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
             layer.accuracyRadiusBorderColor = .constant(ColorRepresentable(color: .lightGray))

--- a/Tests/MapboxMapsTests/Location/Pucks/Puck2DIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Location/Pucks/Puck2DIntegrationTests.swift
@@ -139,19 +139,17 @@ class Puck2DIntegrationTests: MapViewIntegrationTestCase {
         didFinishLoadingStyle = { _ in
             let puck = Puck2D(puckStyle: .precise,
                               puckBearingSource: .heading,
-                              locationSupportableMapView: self.mapView!,
                               style: style,
                               configuration: Puck2DConfiguration())
             do {
                 try puck.createPreciseLocationIndicatorLayer(location: location)
+                let layer = try style.layer(withId: "puck") as LocationIndicatorLayer
+                XCTAssertNil(layer.accuracyRadius)
             } catch {
                 XCTFail("Failed to create a precise location indicator layer.")
             }
 
-            let layer = try! style.layer(withId: "puck") as LocationIndicatorLayer
-            if layer.accuracyRadius == nil {
-                accuracyRingIsHiddenExpectation.fulfill()
-            }
+            accuracyRingIsHiddenExpectation.fulfill()
         }
         wait(for: [accuracyRingIsHiddenExpectation], timeout: 5)
     }
@@ -166,19 +164,17 @@ class Puck2DIntegrationTests: MapViewIntegrationTestCase {
         didFinishLoadingStyle = { _ in
             let puck = Puck2D(puckStyle: .precise,
                               puckBearingSource: .heading,
-                              locationSupportableMapView: self.mapView!,
                               style: style,
                               configuration: Puck2DConfiguration(showsAccuracyRing: true))
             do {
                 try puck.createPreciseLocationIndicatorLayer(location: location)
+                let layer = try style.layer(withId: "puck") as LocationIndicatorLayer
+                XCTAssertNotNil(layer.accuracyRadius)
             } catch {
                 XCTFail("Failed to create a precise location indicator layer.")
             }
 
-            let layer = try! style.layer(withId: "puck") as LocationIndicatorLayer
-            if layer.accuracyRadius != nil {
-                accuracyRingIsVisibleExpectation.fulfill()
-            }
+            accuracyRingIsVisibleExpectation.fulfill()
         }
         wait(for: [accuracyRingIsVisibleExpectation], timeout: 5)
     }

--- a/Tests/MapboxMapsTests/Location/Pucks/Puck2DIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Location/Pucks/Puck2DIntegrationTests.swift
@@ -168,7 +168,7 @@ class Puck2DIntegrationTests: MapViewIntegrationTestCase {
                               puckBearingSource: .heading,
                               locationSupportableMapView: self.mapView!,
                               style: style,
-                              configuration: Puck2DConfiguration(showAccuracyRing: true))
+                              configuration: Puck2DConfiguration(showsAccuracyRing: true))
             do {
                 try puck.createPreciseLocationIndicatorLayer(location: location)
             } catch {

--- a/Tests/MapboxMapsTests/Location/Pucks/Puck2DIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Location/Pucks/Puck2DIntegrationTests.swift
@@ -168,7 +168,7 @@ class Puck2DIntegrationTests: MapViewIntegrationTestCase {
                               puckBearingSource: .heading,
                               locationSupportableMapView: self.mapView!,
                               style: style,
-                              configuration: Puck2DConfiguration(showAccuracyRadius: true))
+                              configuration: Puck2DConfiguration(showAccuracyRing: true))
             do {
                 try puck.createPreciseLocationIndicatorLayer(location: location)
             } catch {

--- a/Tests/MapboxMapsTests/Location/Pucks/Puck2DIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Location/Pucks/Puck2DIntegrationTests.swift
@@ -129,6 +129,60 @@ class Puck2DIntegrationTests: MapViewIntegrationTestCase {
         wait(for: [addedPrecisePuckExpectation, removedPrecisePuckExpectation, addedApproximatePuckExpectation], timeout: 5)
     }
 
+    func testAccuracyRadiusIsHidden() throws {
+        let style = try XCTUnwrap(self.style)
+        style.uri = .streets
+
+        let location = Location(with: CLLocation(latitude: 1, longitude: 1))
+        let accuracyRingIsHiddenExpectation = XCTestExpectation(description: "Layer does not contain an accuracy ring")
+
+        didFinishLoadingStyle = { _ in
+            let puck = Puck2D(puckStyle: .precise,
+                              puckBearingSource: .heading,
+                              locationSupportableMapView: self.mapView!,
+                              style: style,
+                              configuration: Puck2DConfiguration())
+            do {
+                try puck.createPreciseLocationIndicatorLayer(location: location)
+            } catch {
+                XCTFail("Failed to create a precise location indicator layer.")
+            }
+
+            let layer = try! style.layer(withId: "puck") as LocationIndicatorLayer
+            if layer.accuracyRadius == nil {
+                accuracyRingIsHiddenExpectation.fulfill()
+            }
+        }
+        wait(for: [accuracyRingIsHiddenExpectation], timeout: 5)
+    }
+
+    func testAccuracyRadiusIsShown() throws {
+        let style = try XCTUnwrap(self.style)
+        style.uri = .streets
+
+        let location = Location(with: CLLocation(latitude: 1, longitude: 1))
+        let accuracyRingIsVisibleExpectation = XCTestExpectation(description: "Layer contains an accuracy ring")
+
+        didFinishLoadingStyle = { _ in
+            let puck = Puck2D(puckStyle: .precise,
+                              puckBearingSource: .heading,
+                              locationSupportableMapView: self.mapView!,
+                              style: style,
+                              configuration: Puck2DConfiguration(showAccuracyRadius: true))
+            do {
+                try puck.createPreciseLocationIndicatorLayer(location: location)
+            } catch {
+                XCTFail("Failed to create a precise location indicator layer.")
+            }
+
+            let layer = try! style.layer(withId: "puck") as LocationIndicatorLayer
+            if layer.accuracyRadius != nil {
+                accuracyRingIsVisibleExpectation.fulfill()
+            }
+        }
+        wait(for: [accuracyRingIsVisibleExpectation], timeout: 5)
+    }
+
     func testLayerPersistence() throws {
         let style = try XCTUnwrap(self.style)
 


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 
### Summary of changes
This PR updates the `Puck2DConfiguration` to have a flag for `accuracyRadius`. This value will be false (disabled) by default. This PR also updates the customization example to bring some clarity to this. 