### PR TITLE
Disambiguate Feature in public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ Mapbox welcomes participation and contributions from everyone.
 * Suppresses error notifications on missing volatile tiles in offline mode ([#628](https://github.com/mapbox/mapbox-maps-ios/pull/628))
 * Adapt setBounds to gl-js behavior: constraining of coordinates and zoom level is now stricter to prevent out of bounds map area to be visible in the viewport ([#628](https://github.com/mapbox/mapbox-maps-ios/pull/628))
 * Add HTTP interceptor API - HttpServiceInterface has a new method `setInterceptor` that must be implemented ([#628](https://github.com/mapbox/mapbox-maps-ios/pull/628))
+* `Geometry` now refers to `Turf.Geometry` instead of `MapboxCommon.Geometry`. ([#622](https://github.com/mapbox/mapbox-maps-ios/pull/622))
+* `Feature` now refers to `Turf.Feature` instead of `MapboxCommon.Feature`. ([#642](https://github.com/mapbox/mapbox-maps-ios/pull/642))
 
 ### Features ✨ and improvements 🏁
 
 * It is no longer necessary to `import Turf`. ([#622](https://github.com/mapbox/mapbox-maps-ios/pull/622))
-* `Geometry` now refers to `Turf.Geometry` instead of `MapboxCommon.Geometry`. ([#622](https://github.com/mapbox/mapbox-maps-ios/pull/622))
 * Annotation managers now sync their annotations to their backing source and layer only once per display link. ([#621](https://github.com/mapbox/mapbox-maps-ios/pull/621))
     * Use `syncAnnotationsIfNeeded()` to force the sync to happen earlier if needed.
 * Enable instant transitions for data driven paint layer properties ([#628](https://github.com/mapbox/mapbox-maps-ios/pull/628))

--- a/Sources/MapboxMaps/Foundation/Extensions/Turf/Feature.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Turf/Feature.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MapboxCommon
 
-// MARK: - Feature
+public typealias Feature = Turf.Feature
 
 extension Turf.Feature {
 

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -418,7 +418,7 @@ extension MapboxMap: MapFeatureQueryable {
                                       args: [String: Any]? = nil,
                                       completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void) {
 
-        guard let feature = Feature(feature) else {
+        guard let feature = MapboxCommon.Feature(feature) else {
             completion(.failure(TypeConversionError.unexpectedType))
             return
         }

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -543,7 +543,7 @@ extension Style: StyleManagerProtocol {
     }
 
     public func _setCustomGeometrySourceTileData(forSourceId sourceId: String, tileId: CanonicalTileID, features: [Turf.Feature]) throws {
-        let mbxFeatures = features.compactMap { Feature($0) }
+        let mbxFeatures = features.compactMap { MapboxCommon.Feature($0) }
         return try handleExpected {
             return styleManager.setStyleCustomGeometrySourceTileDataForSourceId(sourceId, tileId: tileId, featureCollection: mbxFeatures)
         }


### PR DESCRIPTION
Fixes #634

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Update the changelog

### Summary of changes

Adds a public typealias defining Feature as Turf.Feature. This fixes an issue where consuming code that referenced the type Feature was ambiguous due to the presence of both MapboxCommon.Feature and Turf.Feature.