### PR TITLE
Check whether a layer is persistent in Style._moveLayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Updated annotations to use `rgbaString` and `init(rgbaString:)` when serializing and deserializing `StyleColor`s ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * Annotation managers now properly restore the default values of any annotation or common style properties that are reset to nil, with the exception of `text-field` and `line-gradient` for which there are currently issues to resolve between mapbox-maps-ios and mapbox-core-maps-ios. ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * Fixed Expression decoding when second array element could be an operator ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
+* Fixed an issue where layer persistence was not maintained after calling `Style._moveLayer`. ([#643](https://github.com/mapbox/mapbox-maps-ios/pull/643))
 
 ## 10.0.0-rc.7 - August 25, 2021
 
@@ -86,7 +87,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## 10.0.0-rc.5 - July 28, 2021
 
-* Fixed an issue where `MapView` positioning wasn't correct when used in containers such as UIStackView. ([#533](https://github.com/mapbox/mapbox-maps-ios/pull/533)) 
+* Fixed an issue where `MapView` positioning wasn't correct when used in containers such as UIStackView. ([#533](https://github.com/mapbox/mapbox-maps-ios/pull/533))
 
 ### Features ✨ and improvements 🏁
 * Added new options to `MapSnapshotOptions`

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -52,8 +52,14 @@ public class Style {
      */
     public func _moveLayer(withId id: String, to position: LayerPosition) throws {
         let properties = try layerProperties(for: id)
+        let isPersistent = try _isPersistentLayer(id: id)
         try removeLayer(withId: id)
-        try addLayer(with: properties, layerPosition: position)
+
+        if isPersistent {
+            try _addPersistentLayer(with: properties, layerPosition: position)
+        } else {
+            try addLayer(with: properties, layerPosition: position)
+        }
     }
 
     /**

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -103,20 +103,20 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             return
         }
 
-        let expectation = XCTestExpectation(description: "Move persistent style layer succeeded")
-        expectation.expectedFulfillmentCount = 2
+        let addLayerExpectation = XCTestExpectation(description: "Adding a persistent style layer succeeded.")
+        let persistenceExpectation = XCTestExpectation(description: "The layer should still be persistent after repeatedly moving.")
 
         let layerId = "test-id"
         style.uri = .streets
 
         didFinishLoadingStyle = { _ in
 
-            let layers = style.styleManager.getStyleLayers()
+            let layers = style.allLayerIdentifiers
             let newBackgroundLayer = BackgroundLayer(id: layerId)
 
             do {
                 try style._addPersistentLayer(newBackgroundLayer)
-                expectation.fulfill()
+                addLayerExpectation.fulfill()
             } catch {
                 XCTFail("Could not add background layer due to error: \(error)")
             }
@@ -138,13 +138,13 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                     XCTAssertTrue(isPersistent)
                 }
 
-                expectation.fulfill()
+                persistenceExpectation.fulfill()
             } catch {
                 XCTFail("_moveLayer failed with \(error)")
             }
         }
 
-        wait(for: [expectation], timeout: 5.0)
+        wait(for: [addLayerExpectation, persistenceExpectation], timeout: 5.0)
     }
 
     func testDecodingOfAllLayersInStreetsv11() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Fixed an issue where layer persistence was not maintained after calling `Style._moveLayer`.</changelog>`.

### Summary of changes
This PR checks whether a layer is a persistent layer, then calls the appropriate method to add the layer to its new position.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
