### PR TITLE
Fix issue where tapped annotations were not being detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,11 @@ Mapbox welcomes participation and contributions from everyone.
 * Added a public, failable, component-wise initializer to `StyleColor` ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * Updated `StyleColor`'s `Decodable` support to be able to handle rgba color strings as well as rgba expressions ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * Made generated enums conform to `CaseIterable` ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
+<<<<<<< HEAD
 * Location puck can now hide the accuracy ring. The default value is to hide the accuracy ring. In order to enable the ring, set the `showAccuracyRing` property in `Puck2DConfiguration` to `true`. [#629](https://github.com/mapbox/mapbox-maps-ios/pull/629)
+=======
+* Annotation interaction delegates are only called when at least one annotation is detected to have been tapped ([638](https://github.com/mapbox/mapbox-maps-ios/issues/638))
+>>>>>>> 4431ea67 (add changelog)
 
 ### Bug fixes 🐞
 
@@ -46,7 +50,11 @@ Mapbox welcomes participation and contributions from everyone.
 * Updated annotations to use `rgbaString` and `init(rgbaString:)` when serializing and deserializing `StyleColor`s ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * Annotation managers now properly restore the default values of any annotation or common style properties that are reset to nil, with the exception of `text-field` and `line-gradient` for which there are currently issues to resolve between mapbox-maps-ios and mapbox-core-maps-ios. ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * Fixed Expression decoding when second array element could be an operator ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
+<<<<<<< HEAD
 * Fixed an issue where layer persistence was not maintained after calling `Style._moveLayer`. ([#643](https://github.com/mapbox/mapbox-maps-ios/pull/643))
+=======
+* Fix issue where annotations were not being returned to annotation interaction delegates ([638](https://github.com/mapbox/mapbox-maps-ios/issues/638))
+>>>>>>> 4431ea67 (add changelog)
 
 ## 10.0.0-rc.7 - August 25, 2021
 

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -254,9 +254,24 @@ public class CircleAnnotationManager: AnnotationManager {
             switch result {
 
             case .success(let queriedFeatures):
-                if let annotationIds = queriedFeatures.compactMap({ $0.feature?.properties?["annotation-id"] }) as? [String] {
-
-                    let tappedAnnotations = self.annotations.filter { annotationIds.contains($0.id) }
+                
+                // Get the identifiers of all the queried features
+                let queriedFeatureIds: [String] = queriedFeatures.compactMap {
+                    guard let feature = $0.feature,
+                          let identifier = feature.identifier,
+                          case let FeatureIdentifier.string(featureId) = identifier else {
+                    
+                        return nil
+                    }
+                    
+                    return featureId
+                }
+                
+                // Find if any `queriedFeatureIds` match an annotation's `id`
+                let tappedAnnotations = self.annotations.filter { queriedFeatureIds.contains($0.id) }
+                
+                // If `tappedAnnotations` is not empty, call delegate
+                if !tappedAnnotations.isEmpty {
                     self.delegate?.annotationManager(
                         self,
                         didDetectTappedAnnotations: tappedAnnotations)

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -254,22 +254,22 @@ public class CircleAnnotationManager: AnnotationManager {
             switch result {
 
             case .success(let queriedFeatures):
-                
+
                 // Get the identifiers of all the queried features
                 let queriedFeatureIds: [String] = queriedFeatures.compactMap {
                     guard let feature = $0.feature,
                           let identifier = feature.identifier,
                           case let FeatureIdentifier.string(featureId) = identifier else {
-                    
+
                         return nil
                     }
-                    
+
                     return featureId
                 }
-                
+
                 // Find if any `queriedFeatureIds` match an annotation's `id`
                 let tappedAnnotations = self.annotations.filter { queriedFeatureIds.contains($0.id) }
-                
+
                 // If `tappedAnnotations` is not empty, call delegate
                 if !tappedAnnotations.isEmpty {
                     self.delegate?.annotationManager(

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -512,9 +512,24 @@ public class PointAnnotationManager: AnnotationManager {
             switch result {
 
             case .success(let queriedFeatures):
-                if let annotationIds = queriedFeatures.compactMap({ $0.feature?.properties?["annotation-id"] }) as? [String] {
-
-                    let tappedAnnotations = self.annotations.filter { annotationIds.contains($0.id) }
+                
+                // Get the identifiers of all the queried features
+                let queriedFeatureIds: [String] = queriedFeatures.compactMap {
+                    guard let feature = $0.feature,
+                          let identifier = feature.identifier,
+                          case let FeatureIdentifier.string(featureId) = identifier else {
+                    
+                        return nil
+                    }
+                    
+                    return featureId
+                }
+                
+                // Find if any `queriedFeatureIds` match an annotation's `id`
+                let tappedAnnotations = self.annotations.filter { queriedFeatureIds.contains($0.id) }
+                
+                // If `tappedAnnotations` is not empty, call delegate
+                if !tappedAnnotations.isEmpty {
                     self.delegate?.annotationManager(
                         self,
                         didDetectTappedAnnotations: tappedAnnotations)

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -512,22 +512,22 @@ public class PointAnnotationManager: AnnotationManager {
             switch result {
 
             case .success(let queriedFeatures):
-                
+
                 // Get the identifiers of all the queried features
                 let queriedFeatureIds: [String] = queriedFeatures.compactMap {
                     guard let feature = $0.feature,
                           let identifier = feature.identifier,
                           case let FeatureIdentifier.string(featureId) = identifier else {
-                    
+
                         return nil
                     }
-                    
+
                     return featureId
                 }
-                
+
                 // Find if any `queriedFeatureIds` match an annotation's `id`
                 let tappedAnnotations = self.annotations.filter { queriedFeatureIds.contains($0.id) }
-                
+
                 // If `tappedAnnotations` is not empty, call delegate
                 if !tappedAnnotations.isEmpty {
                     self.delegate?.annotationManager(

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -244,9 +244,24 @@ public class PolygonAnnotationManager: AnnotationManager {
             switch result {
 
             case .success(let queriedFeatures):
-                if let annotationIds = queriedFeatures.compactMap({ $0.feature?.properties?["annotation-id"] }) as? [String] {
-
-                    let tappedAnnotations = self.annotations.filter { annotationIds.contains($0.id) }
+                
+                // Get the identifiers of all the queried features
+                let queriedFeatureIds: [String] = queriedFeatures.compactMap {
+                    guard let feature = $0.feature,
+                          let identifier = feature.identifier,
+                          case let FeatureIdentifier.string(featureId) = identifier else {
+                    
+                        return nil
+                    }
+                    
+                    return featureId
+                }
+                
+                // Find if any `queriedFeatureIds` match an annotation's `id`
+                let tappedAnnotations = self.annotations.filter { queriedFeatureIds.contains($0.id) }
+                
+                // If `tappedAnnotations` is not empty, call delegate
+                if !tappedAnnotations.isEmpty {
                     self.delegate?.annotationManager(
                         self,
                         didDetectTappedAnnotations: tappedAnnotations)

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -244,22 +244,22 @@ public class PolygonAnnotationManager: AnnotationManager {
             switch result {
 
             case .success(let queriedFeatures):
-                
+
                 // Get the identifiers of all the queried features
                 let queriedFeatureIds: [String] = queriedFeatures.compactMap {
                     guard let feature = $0.feature,
                           let identifier = feature.identifier,
                           case let FeatureIdentifier.string(featureId) = identifier else {
-                    
+
                         return nil
                     }
-                    
+
                     return featureId
                 }
-                
+
                 // Find if any `queriedFeatureIds` match an annotation's `id`
                 let tappedAnnotations = self.annotations.filter { queriedFeatureIds.contains($0.id) }
-                
+
                 // If `tappedAnnotations` is not empty, call delegate
                 if !tappedAnnotations.isEmpty {
                     self.delegate?.annotationManager(

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -274,9 +274,24 @@ public class PolylineAnnotationManager: AnnotationManager {
             switch result {
 
             case .success(let queriedFeatures):
-                if let annotationIds = queriedFeatures.compactMap({ $0.feature?.properties?["annotation-id"] }) as? [String] {
-
-                    let tappedAnnotations = self.annotations.filter { annotationIds.contains($0.id) }
+                
+                // Get the identifiers of all the queried features
+                let queriedFeatureIds: [String] = queriedFeatures.compactMap {
+                    guard let feature = $0.feature,
+                          let identifier = feature.identifier,
+                          case let FeatureIdentifier.string(featureId) = identifier else {
+                    
+                        return nil
+                    }
+                    
+                    return featureId
+                }
+                
+                // Find if any `queriedFeatureIds` match an annotation's `id`
+                let tappedAnnotations = self.annotations.filter { queriedFeatureIds.contains($0.id) }
+                
+                // If `tappedAnnotations` is not empty, call delegate
+                if !tappedAnnotations.isEmpty {
                     self.delegate?.annotationManager(
                         self,
                         didDetectTappedAnnotations: tappedAnnotations)

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -274,22 +274,22 @@ public class PolylineAnnotationManager: AnnotationManager {
             switch result {
 
             case .success(let queriedFeatures):
-                
+
                 // Get the identifiers of all the queried features
                 let queriedFeatureIds: [String] = queriedFeatures.compactMap {
                     guard let feature = $0.feature,
                           let identifier = feature.identifier,
                           case let FeatureIdentifier.string(featureId) = identifier else {
-                    
+
                         return nil
                     }
-                    
+
                     return featureId
                 }
-                
+
                 // Find if any `queriedFeatureIds` match an annotation's `id`
                 let tappedAnnotations = self.annotations.filter { queriedFeatureIds.contains($0.id) }
-                
+
                 // If `tappedAnnotations` is not empty, call delegate
                 if !tappedAnnotations.isEmpty {
                     self.delegate?.annotationManager(


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes https://github.com/mapbox/mapbox-maps-ios/issues/638

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR fixes an issue where tapped annotations were not being detected. The `handleTap` method in each annotation manager was testing for `annotation-id` instead of `Turf.Feature.identifier` in the queried features.

This PR also makes it so that `AnnotationInteractionDelegate`s are only called when at least one annotation is detected to have been tapped.