### PR TITLE
Fix StyleColor test that used wrong lower bound

### DIFF
--- a/Tests/MapboxMapsTests/Style/StyleColorTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleColorTests.swift
@@ -111,7 +111,7 @@ final class StyleColorTests: XCTestCase {
     }
 
     func testExpressionInitFailureTooManyArguments() {
-        XCTAssertNil(StyleColor(expression: Exp(operator: .rgba, arguments: Array(repeating: .number(0), count: .random(in: 4...20)))))
+        XCTAssertNil(StyleColor(expression: Exp(operator: .rgba, arguments: Array(repeating: .number(0), count: .random(in: 5...20)))))
     }
 
     func testRGBAStringInit() {


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

Fix StyleColor test that used wrong lower bound