### PR TITLE
Fix race condition in annotation integration tests

### DIFF
--- a/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationIntegrationTests.swift
@@ -9,7 +9,6 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         let managerCreatedExpectation = XCTestExpectation(description: "Successfully created annotation manager.")
-        style?.uri = .streets
         didFinishLoadingStyle = { _ in
             guard let mapView = self.mapView else {
                 return
@@ -18,6 +17,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
             managerCreatedExpectation.fulfill()
         }
         continueAfterFailure = false
+        style?.uri = .streets
         wait(for: [managerCreatedExpectation], timeout: 5.0)
         continueAfterFailure = true
     }

--- a/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationIntegrationTests.swift
@@ -9,7 +9,6 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         let managerCreatedExpectation = XCTestExpectation(description: "Successfully created annotation manager.")
-        style?.uri = .streets
         didFinishLoadingStyle = { _ in
             guard let mapView = self.mapView else {
                 return
@@ -18,6 +17,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
             managerCreatedExpectation.fulfill()
         }
         continueAfterFailure = false
+        style?.uri = .streets
         wait(for: [managerCreatedExpectation], timeout: 5.0)
         continueAfterFailure = true
     }

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationIntegrationTests.swift
@@ -9,7 +9,6 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         let managerCreatedExpectation = XCTestExpectation(description: "Successfully created annotation manager.")
-        style?.uri = .streets
         didFinishLoadingStyle = { _ in
             guard let mapView = self.mapView else {
                 return
@@ -18,6 +17,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
             managerCreatedExpectation.fulfill()
         }
         continueAfterFailure = false
+        style?.uri = .streets
         wait(for: [managerCreatedExpectation], timeout: 5.0)
         continueAfterFailure = true
     }

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationIntegrationTests.swift
@@ -9,7 +9,6 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         let managerCreatedExpectation = XCTestExpectation(description: "Successfully created annotation manager.")
-        style?.uri = .streets
         didFinishLoadingStyle = { _ in
             guard let mapView = self.mapView else {
                 return
@@ -18,6 +17,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
             managerCreatedExpectation.fulfill()
         }
         continueAfterFailure = false
+        style?.uri = .streets
         wait(for: [managerCreatedExpectation], timeout: 5.0)
         continueAfterFailure = true
     }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

Addresses the possibility that didFinishLoading could be invoked synchronously when setting style.uri