### PR TITLE
Fixes a crash in integration test case

### DIFF
--- a/Tests/MapboxMapsTests/Foundation/Integration Tests/MapViewIntegrationTestCase.swift
+++ b/Tests/MapboxMapsTests/Foundation/Integration Tests/MapViewIntegrationTestCase.swift
@@ -31,21 +31,21 @@ internal class MapViewIntegrationTestCase: IntegrationTestCase {
         let view = MapView(frame: window.bounds, mapInitOptions: mapInitOptions)
 
         view.mapboxMap.onEvery(.styleLoaded) { [weak self] _ in
-            guard let self = self else { return }
-            self.didFinishLoadingStyle?(self.mapView!)
+            guard let self = self, let mapView = self.mapView else { return }
+            self.didFinishLoadingStyle?(mapView)
         }
 
         view.mapboxMap.onEvery(.mapIdle) { [weak self] _ in
-            guard let self = self else { return }
-            self.didBecomeIdle?(self.mapView!)
+            guard let self = self, let mapView = self.mapView else { return }
+            self.didBecomeIdle?(mapView)
         }
 
         view.mapboxMap.onEvery(.mapLoadingError) { [weak self] event in
-            guard let self = self else { return }
+            guard let self = self, let mapView = self.mapView else { return }
 
             let userInfo: [String: Any] = (event.data as? [String: Any]) ?? [:]
             let error = NSError(domain: "MapLoadError", code: -1, userInfo: userInfo)
-            self.didFailLoadingMap?(self.mapView!, error)
+            self.didFailLoadingMap?(mapView, error)
         }
 
         style = view.mapboxMap.style


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

Crash could occur due to a `wait` in `tearDownWithError` that allowed
a map event to be delivered to an observer that assumed it was safe to
force-unwrap `mapView`, when in fact `mapView` had already been set to
nil earlier in `tearDownWithError`
