### PR TITLE
Make gestureOptions.decelarationRate the source of truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Mapbox welcomes participation and contributions from everyone.
 * `PointAnnotationManager.textVariableAnchor` is now of type `[TextAnchor]?` instead of `[String]?` ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * `PointAnnotationManager.textWritingMode` is now of type `[TextWritingMode]?` instead of `[String]?` ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * `GestureOptions.hapticFeedbackEnabled` has been removed. ([#663](https://github.com/mapbox/mapbox-maps-ios/pull/663))
+* `GestureManager.decelarationRate` has been removed and `GestureOptions.decelerationRate` is the single source of truth. ([#]())
 
 ### Features ✨ and improvements 🏁
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Mapbox welcomes participation and contributions from everyone.
 * `PointAnnotationManager.textVariableAnchor` is now of type `[TextAnchor]?` instead of `[String]?` ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * `PointAnnotationManager.textWritingMode` is now of type `[TextWritingMode]?` instead of `[String]?` ([#650](https://github.com/mapbox/mapbox-maps-ios/pull/650))
 * `GestureOptions.hapticFeedbackEnabled` has been removed. ([#663](https://github.com/mapbox/mapbox-maps-ios/pull/663))
-* `GestureManager.decelarationRate` has been removed and `GestureOptions.decelerationRate` is the single source of truth. ([#]())
+* `GestureManager.decelarationRate` has been removed and `GestureOptions.decelerationRate` is the single source of truth. ([#662](https://github.com/mapbox/mapbox-maps-ios/pull/662))
 
 ### Features ✨ and improvements 🏁
 

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -233,7 +233,7 @@ extension GestureManager: GestureHandlerDelegate {
             let driftCameraOptions = mapboxMap.dragCameraOptions(from: endPoint, to: driftEndPoint)
             _ = cameraAnimationsManager.ease(
                     to: driftCameraOptions,
-                duration: Double(options.decelerationRate),
+                    duration: Double(options.decelerationRate),
                     curve: .easeOut,
                     completion: nil)
         }

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -65,10 +65,6 @@ public final class GestureManager: NSObject {
     /// Set this delegate to be called back if a gesture begins
     public weak var delegate: GestureManagerDelegate?
 
-    /// A floating-point value that determines the rate of deceleration after the
-    /// user lifts their finger.
-    public var decelerationRate: CGFloat = UIScrollView.DecelerationRate.normal.rawValue
-
     internal init(view: UIView, cameraAnimationsManager: CameraAnimationsManagerProtocol, mapboxMap: MapboxMap) {
         self.view = view
         self.cameraAnimationsManager = cameraAnimationsManager
@@ -237,7 +233,7 @@ extension GestureManager: GestureHandlerDelegate {
             let driftCameraOptions = mapboxMap.dragCameraOptions(from: endPoint, to: driftEndPoint)
             _ = cameraAnimationsManager.ease(
                     to: driftCameraOptions,
-                    duration: Double(decelerationRate),
+                duration: Double(options.decelerationRate),
                     curve: .easeOut,
                     completion: nil)
         }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes
This updates gestures to treat the `GestureOptions.decelarationRate` as the source of truth