### PR TITLE
Accommodate JSONDecoder precision loss in test

### DIFF
--- a/Tests/MapboxMapsTests/Style/StyleColorTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleColorTests.swift
@@ -187,7 +187,11 @@ final class StyleColorTests: XCTestCase {
 
         let color = try JSONDecoder().decode(StyleColor.self, from: expressionData)
 
-        XCTAssertEqual(color, StyleColor(red: red, green: green, blue: blue, alpha: alpha)!)
+        // Accuracy can be removed if https://bugs.swift.org/browse/SR-15172 is fixed
+        XCTAssertEqual(color.red, red!, accuracy: 1e-16)
+        XCTAssertEqual(color.green, green!, accuracy: 1e-16)
+        XCTAssertEqual(color.blue, blue!, accuracy: 1e-16)
+        XCTAssertEqual(color.alpha, alpha!, accuracy: 1e-16)
     }
 
     func testDecodingRGBAString() throws {


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

JSONDecoder doesn't decode doubles identically to the value that was originally serialized. This led to flakiness in a new StyleColor test. This PR updates the test to check for approximate equality.