### PR TITLE
Internalize UIGestureRecognizerDelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 * `BasicCameraAnimator` now keeps animators alive without the user storing the animator. ([#646](https://github.com/mapbox/mapbox-maps-ios/pull/646/))
 * `GestureOptions.hapticFeedbackEnabled` has been removed. ([#663](https://github.com/mapbox/mapbox-maps-ios/pull/663))
 * `GestureManager.decelarationRate` has been removed and `GestureOptions.decelerationRate` is the single source of truth. ([#662](https://github.com/mapbox/mapbox-maps-ios/pull/662))
+* `GestureManager` no longer conforms to `NSObject` and is not a `UIGestureRecognizerDelegate`. ([#669](https://github.com/mapbox/mapbox-maps-ios/pull/669))
 
 ## 10.0.0-rc.8 - Sept 8, 2021
 

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -65,13 +65,12 @@ public final class GestureManager {
     /// Set this delegate to be called back if a gesture begins
     public weak var delegate: GestureManagerDelegate?
 
-    internal let gestureRecognizerDelegate: GestureRecognizerDelegate
+    internal weak var gestureRecognizerDelegate: GestureRecognizerDelegate?
 
     internal init(view: UIView, cameraAnimationsManager: CameraAnimationsManagerProtocol, mapboxMap: MapboxMap) {
         self.view = view
         self.cameraAnimationsManager = cameraAnimationsManager
         self.mapboxMap = mapboxMap
-        self.gestureRecognizerDelegate = GestureRecognizerDelegate(view: view)
         configureGestureHandlers(for: options)
     }
 

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -66,12 +66,14 @@ public final class GestureManager {
     public weak var delegate: GestureManagerDelegate?
 
     /// Internal delegate for gesture recognizers
-    internal weak var gestureRecognizerDelegate: GestureRecognizerDelegate?
+    // swiftlint:disable:next weak_delegate
+    internal let gestureRecognizerDelegate: GestureRecognizerDelegate
 
     internal init(view: UIView, cameraAnimationsManager: CameraAnimationsManagerProtocol, mapboxMap: MapboxMap) {
         self.view = view
         self.cameraAnimationsManager = cameraAnimationsManager
         self.mapboxMap = mapboxMap
+        self.gestureRecognizerDelegate = GestureRecognizerDelegate()
         configureGestureHandlers(for: options)
     }
 

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -65,6 +65,7 @@ public final class GestureManager {
     /// Set this delegate to be called back if a gesture begins
     public weak var delegate: GestureManagerDelegate?
 
+    /// Internal delegate for gesture recognizers
     internal weak var gestureRecognizerDelegate: GestureRecognizerDelegate?
 
     internal init(view: UIView, cameraAnimationsManager: CameraAnimationsManagerProtocol, mapboxMap: MapboxMap) {

--- a/Sources/MapboxMaps/Gestures/GestureRecognizerDelegate.swift
+++ b/Sources/MapboxMaps/Gestures/GestureRecognizerDelegate.swift
@@ -21,11 +21,9 @@ internal class GestureRecognizerDelegate: NSObject, UIGestureRecognizerDelegate 
                 guard let touchPointAngle = GestureUtilities.angleBetweenPoints(leftTouchPoint,
                                                                                 rightTouchPoint) else { return false }
 
-                let horizontalTiltTolerance = 45.0
-
                 // If the angle between the pan touchpoints is greater then the
                 // tolerance specified, don't start the gesture.
-                if fabs(touchPointAngle) > horizontalTiltTolerance {
+                if fabs(touchPointAngle) > 45.0 {
                     return false
                 }
             }

--- a/Sources/MapboxMaps/Gestures/GestureRecognizerDelegate.swift
+++ b/Sources/MapboxMaps/Gestures/GestureRecognizerDelegate.swift
@@ -2,14 +2,8 @@ import UIKit
 
 internal class GestureRecognizerDelegate: NSObject, UIGestureRecognizerDelegate {
 
-    /// The view that all gestures operate on
-    private weak var view: UIView?
-
-    internal init(view: UIView) {
-        self.view = view
-    }
-
     internal func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard let view = gestureRecognizer.view else { return false }
 
         // Handle pitch tilt gesture
         if let panGesture = gestureRecognizer as? UIPanGestureRecognizer {

--- a/Sources/MapboxMaps/Gestures/GestureRecognizerDelegate.swift
+++ b/Sources/MapboxMaps/Gestures/GestureRecognizerDelegate.swift
@@ -1,0 +1,43 @@
+import UIKit
+
+internal class GestureRecognizerDelegate: NSObject, UIGestureRecognizerDelegate {
+
+    /// The view that all gestures operate on
+    private weak var view: UIView?
+
+    internal init(view: UIView) {
+        self.view = view
+    }
+
+    internal func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+
+        // Handle pitch tilt gesture
+        if let panGesture = gestureRecognizer as? UIPanGestureRecognizer {
+            if panGesture.minimumNumberOfTouches == 2 {
+
+                let leftTouchPoint = panGesture.location(ofTouch: 0, in: view)
+                let rightTouchPoint = panGesture.location(ofTouch: 1, in: view)
+
+                guard let touchPointAngle = GestureUtilities.angleBetweenPoints(leftTouchPoint,
+                                                                                rightTouchPoint) else { return false }
+
+                let horizontalTiltTolerance = 45.0
+
+                // If the angle between the pan touchpoints is greater then the
+                // tolerance specified, don't start the gesture.
+                if fabs(touchPointAngle) > horizontalTiltTolerance {
+                    return false
+                }
+            }
+        }
+
+        return true
+    }
+
+    internal func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                                    shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+
+        return (gestureRecognizer is UIPinchGestureRecognizer || gestureRecognizer is UIRotationGestureRecognizer) &&
+            (otherGestureRecognizer is UIPinchGestureRecognizer || otherGestureRecognizer is UIRotationGestureRecognizer)
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -88,7 +88,7 @@ final class GestureManagerTests: XCTestCase {
     func testAllowedSimultaneousGestures() {
         let pinchGestureRecognizer = UIPinchGestureRecognizer()
         let rotateGestureRecognizer = UIRotationGestureRecognizer()
-        XCTAssertTrue(gestureManager.gestureRecognizerDelegate.gestureRecognizer(pinchGestureRecognizer,
+        XCTAssertTrue(gestureManager.gestureRecognizerDelegate!.gestureRecognizer(pinchGestureRecognizer,
                                                                                  shouldRecognizeSimultaneouslyWith: rotateGestureRecognizer))
     }
 
@@ -98,23 +98,23 @@ final class GestureManagerTests: XCTestCase {
         let pinchGestureRecognizer = UIPinchGestureRecognizer()
         let rotateGestureRecognizer = UIRotationGestureRecognizer()
 
-        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(panGestureRecognizer,
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate!.gestureRecognizer(panGestureRecognizer,
                                                                                   shouldRecognizeSimultaneouslyWith: pinchGestureRecognizer))
-        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(panGestureRecognizer,
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate!.gestureRecognizer(panGestureRecognizer,
                                                                                   shouldRecognizeSimultaneouslyWith: rotateGestureRecognizer))
-        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(panGestureRecognizer,
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate!.gestureRecognizer(panGestureRecognizer,
                                                                                   shouldRecognizeSimultaneouslyWith: tapGestureRecognizer))
 
-        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(tapGestureRecognizer,
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate!.gestureRecognizer(tapGestureRecognizer,
                                                                                   shouldRecognizeSimultaneouslyWith: pinchGestureRecognizer))
-        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(tapGestureRecognizer,
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate!.gestureRecognizer(tapGestureRecognizer,
                                                                                   shouldRecognizeSimultaneouslyWith: rotateGestureRecognizer))
     }
 
     func testSimultaneousTapAndPanGestures() {
         let panGestureRecognizer = UIPanGestureRecognizer()
         let tapGestureRecognizer = UITapGestureRecognizer()
-        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(panGestureRecognizer,
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate!.gestureRecognizer(panGestureRecognizer,
                                                                                   shouldRecognizeSimultaneouslyWith: tapGestureRecognizer))
     }
 

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -88,7 +88,7 @@ final class GestureManagerTests: XCTestCase {
     func testAllowedSimultaneousGestures() {
         let pinchGestureRecognizer = UIPinchGestureRecognizer()
         let rotateGestureRecognizer = UIRotationGestureRecognizer()
-        XCTAssertTrue(gestureManager.gestureRecognizerDelegate!.gestureRecognizer(pinchGestureRecognizer,
+        XCTAssertTrue(gestureManager.gestureRecognizerDelegate.gestureRecognizer(pinchGestureRecognizer,
                                                                                  shouldRecognizeSimultaneouslyWith: rotateGestureRecognizer))
     }
 
@@ -98,23 +98,23 @@ final class GestureManagerTests: XCTestCase {
         let pinchGestureRecognizer = UIPinchGestureRecognizer()
         let rotateGestureRecognizer = UIRotationGestureRecognizer()
 
-        XCTAssertFalse(gestureManager.gestureRecognizerDelegate!.gestureRecognizer(panGestureRecognizer,
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(panGestureRecognizer,
                                                                                   shouldRecognizeSimultaneouslyWith: pinchGestureRecognizer))
-        XCTAssertFalse(gestureManager.gestureRecognizerDelegate!.gestureRecognizer(panGestureRecognizer,
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(panGestureRecognizer,
                                                                                   shouldRecognizeSimultaneouslyWith: rotateGestureRecognizer))
-        XCTAssertFalse(gestureManager.gestureRecognizerDelegate!.gestureRecognizer(panGestureRecognizer,
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(panGestureRecognizer,
                                                                                   shouldRecognizeSimultaneouslyWith: tapGestureRecognizer))
 
-        XCTAssertFalse(gestureManager.gestureRecognizerDelegate!.gestureRecognizer(tapGestureRecognizer,
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(tapGestureRecognizer,
                                                                                   shouldRecognizeSimultaneouslyWith: pinchGestureRecognizer))
-        XCTAssertFalse(gestureManager.gestureRecognizerDelegate!.gestureRecognizer(tapGestureRecognizer,
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(tapGestureRecognizer,
                                                                                   shouldRecognizeSimultaneouslyWith: rotateGestureRecognizer))
     }
 
     func testSimultaneousTapAndPanGestures() {
         let panGestureRecognizer = UIPanGestureRecognizer()
         let tapGestureRecognizer = UITapGestureRecognizer()
-        XCTAssertFalse(gestureManager.gestureRecognizerDelegate!.gestureRecognizer(panGestureRecognizer,
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(panGestureRecognizer,
                                                                                   shouldRecognizeSimultaneouslyWith: tapGestureRecognizer))
     }
 

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -88,8 +88,8 @@ final class GestureManagerTests: XCTestCase {
     func testAllowedSimultaneousGestures() {
         let pinchGestureRecognizer = UIPinchGestureRecognizer()
         let rotateGestureRecognizer = UIRotationGestureRecognizer()
-        XCTAssertTrue(gestureManager.gestureRecognizer(pinchGestureRecognizer,
-                                                       shouldRecognizeSimultaneouslyWith: rotateGestureRecognizer))
+        XCTAssertTrue(gestureManager.gestureRecognizerDelegate.gestureRecognizer(pinchGestureRecognizer,
+                                                                                 shouldRecognizeSimultaneouslyWith: rotateGestureRecognizer))
     }
 
     func testDisallowedSimultaneousGestures() {
@@ -98,24 +98,24 @@ final class GestureManagerTests: XCTestCase {
         let pinchGestureRecognizer = UIPinchGestureRecognizer()
         let rotateGestureRecognizer = UIRotationGestureRecognizer()
 
-        XCTAssertFalse(gestureManager.gestureRecognizer(panGestureRecognizer,
-                                                       shouldRecognizeSimultaneouslyWith: pinchGestureRecognizer))
-        XCTAssertFalse(gestureManager.gestureRecognizer(panGestureRecognizer,
-                                                       shouldRecognizeSimultaneouslyWith: rotateGestureRecognizer))
-        XCTAssertFalse(gestureManager.gestureRecognizer(panGestureRecognizer,
-                                                       shouldRecognizeSimultaneouslyWith: tapGestureRecognizer))
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(panGestureRecognizer,
+                                                                                  shouldRecognizeSimultaneouslyWith: pinchGestureRecognizer))
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(panGestureRecognizer,
+                                                                                  shouldRecognizeSimultaneouslyWith: rotateGestureRecognizer))
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(panGestureRecognizer,
+                                                                                  shouldRecognizeSimultaneouslyWith: tapGestureRecognizer))
 
-        XCTAssertFalse(gestureManager.gestureRecognizer(tapGestureRecognizer,
-                                                       shouldRecognizeSimultaneouslyWith: pinchGestureRecognizer))
-        XCTAssertFalse(gestureManager.gestureRecognizer(tapGestureRecognizer,
-                                                       shouldRecognizeSimultaneouslyWith: rotateGestureRecognizer))
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(tapGestureRecognizer,
+                                                                                  shouldRecognizeSimultaneouslyWith: pinchGestureRecognizer))
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(tapGestureRecognizer,
+                                                                                  shouldRecognizeSimultaneouslyWith: rotateGestureRecognizer))
     }
 
     func testSimultaneousTapAndPanGestures() {
         let panGestureRecognizer = UIPanGestureRecognizer()
         let tapGestureRecognizer = UITapGestureRecognizer()
-        XCTAssertFalse(gestureManager.gestureRecognizer(panGestureRecognizer,
-                                                        shouldRecognizeSimultaneouslyWith: tapGestureRecognizer))
+        XCTAssertFalse(gestureManager.gestureRecognizerDelegate.gestureRecognizer(panGestureRecognizer,
+                                                                                  shouldRecognizeSimultaneouslyWith: tapGestureRecognizer))
     }
 
     func testPinchChangedSetsCamera() {


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes
This creates a new class that is a `NSObject` and conforms to `UIGestureRecognizerDelegate`. The `GestureManager` will hold on to this delegate as a single instance. This work was done so that `UIGestureRecognizerDelegate` can be internal instead of public.