### PR TITLE
Use @_spi(Experimental) for experimental methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 ### Breaking changes ⚠️
 
 * `BasicCameraAnimator` now keeps animators alive without the user storing the animator. ([#646](https://github.com/mapbox/mapbox-maps-ios/pull/646/))
+* Experimental style APIs are now marked with `@_spi(Experimental)` and the previously used underscore prefixes have been removed. In order to access these methods, use `@_spi(Experimental)` to annotate the import statement for MapboxMaps. ([#680](https://github.com/mapbox/mapbox-maps-ios/pull/680)) 
 
 ### Features ✨ and improvements 🏁
 

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -103,7 +103,7 @@ public class CircleAnnotationManager: AnnotationManager {
         var layer = CircleLayer(id: layerId)
         layer.source = sourceId
         if shouldPersist {
-            try style._addPersistentLayer(layer, layerPosition: layerPosition)
+            try style.addPersistentLayer(layer, layerPosition: layerPosition)
         } else {
             try style.addLayer(layer, layerPosition: layerPosition)
         }
@@ -145,7 +145,7 @@ public class CircleAnnotationManager: AnnotationManager {
                             category: "Annotations")
                 return (key, ["format", ""])
             } else {
-                return (key, Style._layerPropertyDefaultValue(for: .circle, property: key).value)
+                return (key, Style.layerPropertyDefaultValue(for: .circle, property: key).value)
             }
         })
 

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -109,7 +109,7 @@ public class PointAnnotationManager: AnnotationManager {
         layer.iconIgnorePlacement = .constant(true)
         layer.textIgnorePlacement = .constant(true)
         if shouldPersist {
-            try style._addPersistentLayer(layer, layerPosition: layerPosition)
+            try style.addPersistentLayer(layer, layerPosition: layerPosition)
         } else {
             try style.addLayer(layer, layerPosition: layerPosition)
         }
@@ -153,7 +153,7 @@ public class PointAnnotationManager: AnnotationManager {
                             category: "Annotations")
                 return (key, ["format", ""])
             } else {
-                return (key, Style._layerPropertyDefaultValue(for: .symbol, property: key).value)
+                return (key, Style.layerPropertyDefaultValue(for: .symbol, property: key).value)
             }
         })
 

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -103,7 +103,7 @@ public class PolygonAnnotationManager: AnnotationManager {
         var layer = FillLayer(id: layerId)
         layer.source = sourceId
         if shouldPersist {
-            try style._addPersistentLayer(layer, layerPosition: layerPosition)
+            try style.addPersistentLayer(layer, layerPosition: layerPosition)
         } else {
             try style.addLayer(layer, layerPosition: layerPosition)
         }
@@ -145,7 +145,7 @@ public class PolygonAnnotationManager: AnnotationManager {
                             category: "Annotations")
                 return (key, ["format", ""])
             } else {
-                return (key, Style._layerPropertyDefaultValue(for: .fill, property: key).value)
+                return (key, Style.layerPropertyDefaultValue(for: .fill, property: key).value)
             }
         })
 

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -103,7 +103,7 @@ public class PolylineAnnotationManager: AnnotationManager {
         var layer = LineLayer(id: layerId)
         layer.source = sourceId
         if shouldPersist {
-            try style._addPersistentLayer(layer, layerPosition: layerPosition)
+            try style.addPersistentLayer(layer, layerPosition: layerPosition)
         } else {
             try style.addLayer(layer, layerPosition: layerPosition)
         }
@@ -145,7 +145,7 @@ public class PolylineAnnotationManager: AnnotationManager {
                             category: "Annotations")
                 return (key, ["format", ""])
             } else {
-                return (key, Style._layerPropertyDefaultValue(for: .line, property: key).value)
+                return (key, Style.layerPropertyDefaultValue(for: .line, property: key).value)
             }
         })
 

--- a/Sources/MapboxMaps/Location/LocationStyleProtocol.swift
+++ b/Sources/MapboxMaps/Location/LocationStyleProtocol.swift
@@ -1,5 +1,5 @@
 internal protocol LocationStyleProtocol: AnyObject {
-    func _addPersistentLayer(_ layer: Layer, layerPosition: LayerPosition?) throws
+    func addPersistentLayer(_ layer: Layer, layerPosition: LayerPosition?) throws
     func removeLayer(withId id: String) throws
     func layerExists(withId id: String) -> Bool
     func setLayerProperties(for layerId: String, properties: [String: Any]) throws
@@ -12,8 +12,8 @@ internal protocol LocationStyleProtocol: AnyObject {
 }
 
 extension LocationStyleProtocol {
-    internal func _addPersistentLayer(_ layer: Layer, layerPosition: LayerPosition? = nil) throws {
-        try _addPersistentLayer(layer, layerPosition: layerPosition)
+    internal func addPersistentLayer(_ layer: Layer, layerPosition: LayerPosition? = nil) throws {
+        try addPersistentLayer(layer, layerPosition: layerPosition)
     }
 
     internal func addImage(_ image: UIImage, id: String, sdf: Bool = false, stretchX: [ImageStretches] = [], stretchY: [ImageStretches] = [], content: ImageContent? = nil) throws {

--- a/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck2D.swift
@@ -197,7 +197,7 @@ internal extension Puck2D {
         }
 
         // Add layer to style
-        try style._addPersistentLayer(layer)
+        try style.addPersistentLayer(layer)
 
         locationIndicatorLayer = layer
     }
@@ -237,7 +237,7 @@ internal extension Puck2D {
         layer.accuracyRadiusBorderColor = .constant(StyleColor(.lightGray))
 
         // Add layer to style
-        try style._addPersistentLayer(layer)
+        try style.addPersistentLayer(layer)
 
         locationIndicatorLayer = layer
     }

--- a/Sources/MapboxMaps/Location/Pucks/Puck3D.swift
+++ b/Sources/MapboxMaps/Location/Pucks/Puck3D.swift
@@ -78,7 +78,7 @@ internal class Puck3D: Puck {
 
             // TODO: On first setup "puck-model does not have a uri"
             try? style.addSource(self.modelSource, id: "puck-model-source")
-            try! style._addPersistentLayer(self.modelLayer)
+            try! style.addPersistentLayer(self.modelLayer)
         }
 
         // Do initial setup

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -42,6 +42,7 @@ public class Style {
         let layerJSON = try layer.jsonObject()
         try _addPersistentLayer(with: layerJSON, layerPosition: layerPosition)
     }
+
     /**
      :nodoc:
      Moves a `layer` to a new layer position in the style.
@@ -50,6 +51,7 @@ public class Style {
 
      - Throws: `StyleError` on failure, or `NSError` with a _domain of "com.mapbox.bindgen"
      */
+    @_spi(experimental)
     public func _moveLayer(withId id: String, to position: LayerPosition) throws {
         let properties = try layerProperties(for: id)
         let isPersistent = try _isPersistentLayer(id: id)
@@ -88,6 +90,7 @@ public class Style {
      - Returns: The fully formed `layer` object of type equal to `type`
      - Throws: StyleError or type conversion errors
      */
+    @_spi(experimental)
     public func _layer(withId id: String, type: Layer.Type) throws -> Layer {
         // Get the layer properties from the map
         let properties = try layerProperties(for: id)
@@ -166,6 +169,7 @@ public class Style {
      - Returns: The fully formed `source` object of type equal to `type`.
      - Throws: StyleError or type conversion errors
      */
+    @_spi(experimental)
     public func _source(withId id: String, type: Source.Type) throws  -> Source {
         // Get the source properties for a given identifier
         let sourceProps = try sourceProperties(for: id)
@@ -332,18 +336,21 @@ extension Style: StyleManagerProtocol {
         }
     }
 
+    @_spi(experimental)
     public func _addPersistentLayer(with properties: [String: Any], layerPosition: LayerPosition?) throws {
         return try handleExpected {
             return styleManager.addPersistentStyleLayer(forProperties: properties, layerPosition: layerPosition?.corePosition)
         }
     }
 
+    @_spi(experimental)
     public func _isPersistentLayer(id: String) throws -> Bool {
         return try handleExpected {
             return styleManager.isStyleLayerPersistent(forLayerId: id)
         }
     }
 
+    @_spi(experimental)
     public func _addPersistentCustomLayer(withId id: String, layerHost: CustomLayerHost, layerPosition: LayerPosition?) throws {
         return try handleExpected {
             return styleManager.addPersistentStyleCustomLayer(forLayerId: id, layerHost: layerHost, layerPosition: layerPosition?.corePosition)
@@ -378,6 +385,7 @@ extension Style: StyleManagerProtocol {
 
     // MARK: - Layer Properties
 
+    @_spi(experimental)
     public func _layerProperty(for layerId: String, property: String) -> StylePropertyValue {
         return styleManager.getStyleLayerProperty(forLayerId: layerId, property: property)
     }
@@ -388,6 +396,7 @@ extension Style: StyleManagerProtocol {
         }
     }
 
+    @_spi(experimental)
     public static func _layerPropertyDefaultValue(for layerType: LayerType, property: String) -> StylePropertyValue {
         return StyleManager.getStyleLayerPropertyDefaultValue(forLayerType: layerType.rawValue, property: property)
     }
@@ -434,6 +443,7 @@ extension Style: StyleManagerProtocol {
 
     // MARK: - Source properties
 
+    @_spi(experimental)
     public func _sourceProperty(for sourceId: String, property: String) -> StylePropertyValue {
         return styleManager.getStyleSourceProperty(forSourceId: sourceId, property: property)
     }
@@ -456,6 +466,7 @@ extension Style: StyleManagerProtocol {
         }
     }
 
+    @_spi(experimental)
     public static func _sourcePropertyDefaultValue(for sourceType: String, property: String) -> StylePropertyValue {
         return StyleManager.getStyleSourcePropertyDefaultValue(forSourceType: sourceType, property: property)
     }
@@ -512,6 +523,7 @@ extension Style: StyleManagerProtocol {
         }
     }
 
+    @_spi(experimental)
     public func _lightProperty(_ property: String) -> StylePropertyValue {
         return styleManager.getStyleLightProperty(forProperty: property)
     }
@@ -530,6 +542,7 @@ extension Style: StyleManagerProtocol {
         }
     }
 
+    @_spi(experimental)
     public func _terrainProperty(_ property: String) -> StylePropertyValue {
         return styleManager.getStyleTerrainProperty(forProperty: property)
     }
@@ -548,6 +561,7 @@ extension Style: StyleManagerProtocol {
         }
     }
 
+    @_spi(experimental)
     public func _setCustomGeometrySourceTileData(forSourceId sourceId: String, tileId: CanonicalTileID, features: [Turf.Feature]) throws {
         let mbxFeatures = features.compactMap { MapboxCommon.Feature($0) }
         return try handleExpected {

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -37,10 +37,10 @@ public class Style {
     ///   - layerPosition: Position at which to add the map.
     ///
     /// - Throws: StyleError or type conversion errors
-    internal func _addPersistentLayer(_ layer: Layer, layerPosition: LayerPosition? = nil) throws {
+    internal func addPersistentLayer(_ layer: Layer, layerPosition: LayerPosition? = nil) throws {
         // Attempt to encode the provided layer into JSON and apply it to the map
         let layerJSON = try layer.jsonObject()
-        try _addPersistentLayer(with: layerJSON, layerPosition: layerPosition)
+        try addPersistentLayer(with: layerJSON, layerPosition: layerPosition)
     }
 
     /**
@@ -50,15 +50,16 @@ public class Style {
      - Parameter position: The new position to move the layer to
 
      - Throws: `StyleError` on failure, or `NSError` with a _domain of "com.mapbox.bindgen"
+     - Note: This method is marked as experimental. Annotate the import statement
+     for `MapboxMaps` with `@_spi(Experimental)` in order to use experimental methods.
      */
-    @_spi(experimental)
-    public func _moveLayer(withId id: String, to position: LayerPosition) throws {
+    @_spi(Experimental) public func moveLayer(withId id: String, to position: LayerPosition) throws {
         let properties = try layerProperties(for: id)
-        let isPersistent = try _isPersistentLayer(id: id)
+        let isPersistent = try isPersistentLayer(id: id)
         try removeLayer(withId: id)
 
         if isPersistent {
-            try _addPersistentLayer(with: properties, layerPosition: position)
+            try addPersistentLayer(with: properties, layerPosition: position)
         } else {
             try addLayer(with: properties, layerPosition: position)
         }
@@ -74,7 +75,7 @@ public class Style {
      */
     public func layer<T: Layer>(withId id: String) throws -> T {
         // swiftlint:disable force_cast
-        return try _layer(withId: id, type: T.self) as! T
+        return try layer(withId: id, type: T.self) as! T
         // swiftlint:enable force_cast
     }
 
@@ -89,9 +90,10 @@ public class Style {
 
      - Returns: The fully formed `layer` object of type equal to `type`
      - Throws: StyleError or type conversion errors
+     - Note: This method is marked as experimental. Annotate the import statement
+     for `MapboxMaps` with `@_spi(Experimental)` in order to use experimental methods.
      */
-    @_spi(experimental)
-    public func _layer(withId id: String, type: Layer.Type) throws -> Layer {
+    @_spi(Experimental) public func layer(withId id: String, type: Layer.Type) throws -> Layer {
         // Get the layer properties from the map
         let properties = try layerProperties(for: id)
         return try type.init(jsonObject: properties)
@@ -128,7 +130,7 @@ public class Style {
     /// - Returns:
     ///     The value of the property in the layer with layerId.
     public func layerProperty(for layerId: String, property: String) -> Any {
-        return _layerProperty(for: layerId, property: property).value
+        return layerProperty(for: layerId, property: property).value
     }
 
     // MARK: - Sources
@@ -154,7 +156,7 @@ public class Style {
      */
     public func source<T: Source>(withId id: String) throws -> T {
         // swiftlint:disable force_cast
-        return try _source(withId: id, type: T.self) as! T
+        return try source(withId: id, type: T.self) as! T
         // swiftlint:enable force_cast
     }
 
@@ -168,24 +170,14 @@ public class Style {
      - Parameter type: The type of the source
      - Returns: The fully formed `source` object of type equal to `type`.
      - Throws: StyleError or type conversion errors
+     - Note: This method is marked as experimental. Annotate the import statement
+     for `MapboxMaps` with `@_spi(Experimental)` in order to use experimental methods.
      */
-    @_spi(experimental)
-    public func _source(withId id: String, type: Source.Type) throws  -> Source {
+    @_spi(Experimental) public func source(withId id: String, type: Source.Type) throws  -> Source {
         // Get the source properties for a given identifier
         let sourceProps = try sourceProperties(for: id)
         let source = try type.init(jsonObject: sourceProps)
         return source
-    }
-
-    /// Gets the value of style source property.
-    ///
-    /// - Parameters:
-    ///   - sourceId: Style source identifier.
-    ///   - property: Style source property name.
-    ///
-    /// - Returns: The value of the property in the source with sourceId.
-    public func sourceProperty(for sourceId: String, property: String) -> Any {
-        return _sourceProperty(for: sourceId, property: property).value
     }
 
     /// Updates the `data` property of a given `GeoJSONSource` with a new value
@@ -218,7 +210,7 @@ public class Style {
     ///
     /// - Returns: Style light property value.
     public func lightProperty(_ property: String) -> Any {
-        return _lightProperty(property).value
+        return lightProperty(property).value
     }
 
     // MARK: - Terrain
@@ -244,7 +236,7 @@ public class Style {
     ///
     /// - Returns: Style terrain property value.
     public func terrainProperty(_ property: String) -> Any {
-        return _terrainProperty(property).value
+        return terrainProperty(property).value
     }
 
     // MARK: - Conversion helpers
@@ -336,22 +328,20 @@ extension Style: StyleManagerProtocol {
         }
     }
 
-    @_spi(experimental)
-    public func _addPersistentLayer(with properties: [String: Any], layerPosition: LayerPosition?) throws {
+    @_spi(Experimental)
+    public func addPersistentLayer(with properties: [String: Any], layerPosition: LayerPosition?) throws {
         return try handleExpected {
             return styleManager.addPersistentStyleLayer(forProperties: properties, layerPosition: layerPosition?.corePosition)
         }
     }
 
-    @_spi(experimental)
-    public func _isPersistentLayer(id: String) throws -> Bool {
+    @_spi(Experimental) public func isPersistentLayer(id: String) throws -> Bool {
         return try handleExpected {
             return styleManager.isStyleLayerPersistent(forLayerId: id)
         }
     }
 
-    @_spi(experimental)
-    public func _addPersistentCustomLayer(withId id: String, layerHost: CustomLayerHost, layerPosition: LayerPosition?) throws {
+    @_spi(Experimental) public func addPersistentCustomLayer(withId id: String, layerHost: CustomLayerHost, layerPosition: LayerPosition?) throws {
         return try handleExpected {
             return styleManager.addPersistentStyleCustomLayer(forLayerId: id, layerHost: layerHost, layerPosition: layerPosition?.corePosition)
         }
@@ -385,8 +375,7 @@ extension Style: StyleManagerProtocol {
 
     // MARK: - Layer Properties
 
-    @_spi(experimental)
-    public func _layerProperty(for layerId: String, property: String) -> StylePropertyValue {
+    @_spi(Experimental) public func layerProperty(for layerId: String, property: String) -> StylePropertyValue {
         return styleManager.getStyleLayerProperty(forLayerId: layerId, property: property)
     }
 
@@ -396,8 +385,7 @@ extension Style: StyleManagerProtocol {
         }
     }
 
-    @_spi(experimental)
-    public static func _layerPropertyDefaultValue(for layerType: LayerType, property: String) -> StylePropertyValue {
+    @_spi(Experimental) public static func layerPropertyDefaultValue(for layerType: LayerType, property: String) -> StylePropertyValue {
         return StyleManager.getStyleLayerPropertyDefaultValue(forLayerType: layerType.rawValue, property: property)
     }
 
@@ -443,8 +431,7 @@ extension Style: StyleManagerProtocol {
 
     // MARK: - Source properties
 
-    @_spi(experimental)
-    public func _sourceProperty(for sourceId: String, property: String) -> StylePropertyValue {
+    @_spi(Experimental) public func sourceProperty(for sourceId: String, property: String) -> StylePropertyValue {
         return styleManager.getStyleSourceProperty(forSourceId: sourceId, property: property)
     }
 
@@ -466,8 +453,7 @@ extension Style: StyleManagerProtocol {
         }
     }
 
-    @_spi(experimental)
-    public static func _sourcePropertyDefaultValue(for sourceType: String, property: String) -> StylePropertyValue {
+    @_spi(Experimental) public static func sourcePropertyDefaultValue(for sourceType: String, property: String) -> StylePropertyValue {
         return StyleManager.getStyleSourcePropertyDefaultValue(forSourceType: sourceType, property: property)
     }
 
@@ -523,8 +509,7 @@ extension Style: StyleManagerProtocol {
         }
     }
 
-    @_spi(experimental)
-    public func _lightProperty(_ property: String) -> StylePropertyValue {
+    @_spi(Experimental) public func lightProperty(_ property: String) -> StylePropertyValue {
         return styleManager.getStyleLightProperty(forProperty: property)
     }
 
@@ -542,8 +527,7 @@ extension Style: StyleManagerProtocol {
         }
     }
 
-    @_spi(experimental)
-    public func _terrainProperty(_ property: String) -> StylePropertyValue {
+    @_spi(Experimental) public func terrainProperty(_ property: String) -> StylePropertyValue {
         return styleManager.getStyleTerrainProperty(forProperty: property)
     }
 
@@ -561,8 +545,7 @@ extension Style: StyleManagerProtocol {
         }
     }
 
-    @_spi(experimental)
-    public func _setCustomGeometrySourceTileData(forSourceId sourceId: String, tileId: CanonicalTileID, features: [Turf.Feature]) throws {
+    @_spi(Experimental) public func setCustomGeometrySourceTileData(forSourceId sourceId: String, tileId: CanonicalTileID, features: [Turf.Feature]) throws {
         let mbxFeatures = features.compactMap { MapboxCommon.Feature($0) }
         return try handleExpected {
             return styleManager.setStyleCustomGeometrySourceTileDataForSourceId(sourceId, tileId: tileId, featureCollection: mbxFeatures)
@@ -587,7 +570,7 @@ extension Style: StyleManagerProtocol {
 extension Style {
     internal func sourceAttributions() -> [String] {
         return allSourceIdentifiers.compactMap {
-            sourceProperty(for: $0.id, property: "attribution") as? String
+            sourceProperty(for: $0.id, property: "attribution").value as? String
         }
     }
 }

--- a/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
+++ b/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
@@ -74,15 +74,17 @@ internal protocol StyleManagerProtocol {
     /// - Throws:
     ///     An error describing why the operation was unsuccessful
     ///
-    /// - Note: This API is experimental and can change at any time
-    func _addPersistentLayer(with properties: [String: Any], layerPosition: LayerPosition?) throws
+    /// - Note: This API is experimental and can change at any time. Annotate the import statement
+    /// for `MapboxMaps` with `@_spi(Experimental)` in order to use experimental methods.
+    func addPersistentLayer(with properties: [String: Any], layerPosition: LayerPosition?) throws
 
     /// Returns `true` if the id passed in is associated to a persistent layer
     ///
-    /// - Note: This API is experimental and can change at any time
+    /// - Note: This API is experimental and can change at any time. Annotate the import statement
+    /// for `MapboxMaps` with `@_spi(Experimental)` in order to use experimental methods.
     ///
     /// - Parameter id: The layer identifier to test
-    func _isPersistentLayer(id: String) throws -> Bool
+    func isPersistentLayer(id: String) throws -> Bool
 
     /// Adds a new persistent style custom layer.
     ///
@@ -99,8 +101,9 @@ internal protocol StyleManagerProtocol {
     /// - Throws:
     ///     An error describing why the operation was unsuccessful.
     ///
-    /// - Note: This API is experimental and can change at any time
-    func _addPersistentCustomLayer(withId id: String, layerHost: CustomLayerHost, layerPosition: LayerPosition?) throws
+    /// - Note: This API is experimental and can change at any time. Annotate the import statement
+    /// for `MapboxMaps` with `@_spi(Experimental)` in order to use experimental methods.
+    func addPersistentCustomLayer(withId id: String, layerHost: CustomLayerHost, layerPosition: LayerPosition?) throws
 
     /// Adds a new style custom layer.
     ///
@@ -153,7 +156,9 @@ internal protocol StyleManagerProtocol {
     ///
     /// - Returns:
     ///     The value of the property in the layer with layerId.
-    func _layerProperty(for layerId: String, property: String) -> StylePropertyValue
+    /// - Note: This method is marked as experimental. Annotate the import statement
+    /// for `MapboxMaps` with `@_spi(Experimental)` in order to use experimental methods.
+    func layerProperty(for layerId: String, property: String) -> StylePropertyValue
 
     /// Sets a JSON value to a style layer property.
     ///
@@ -176,7 +181,10 @@ internal protocol StyleManagerProtocol {
     ///
     /// - Returns:
     ///     The default value of the property for the layers with type layerType.
-    static func _layerPropertyDefaultValue(for layerType: LayerType, property: String) -> StylePropertyValue
+    ///
+    /// - Note: This method is marked as experimental. Annotate the import statement
+    /// for `MapboxMaps` with `@_spi(Experimental)` in order to use experimental methods.
+    static func layerPropertyDefaultValue(for layerType: LayerType, property: String) -> StylePropertyValue
 
     /// Gets the properties for a style layer.
     ///
@@ -250,7 +258,10 @@ internal protocol StyleManagerProtocol {
     ///   - property: Style source property name.
     ///
     /// - Returns: The value of the property in the source with sourceId.
-    func _sourceProperty(for sourceId: String, property: String) -> StylePropertyValue
+    ///
+    /// - Note: This method is marked as experimental. Annotate the import statement
+    /// for `MapboxMaps` with `@_spi(Experimental)` in order to use experimental methods.
+    func sourceProperty(for sourceId: String, property: String) -> StylePropertyValue
 
     /// Sets a value to a style source property.
     ///
@@ -300,7 +311,10 @@ internal protocol StyleManagerProtocol {
     ///
     /// - Returns:
     ///     The default value for the named property for the sources with type sourceType.
-    static func _sourcePropertyDefaultValue(for sourceType: String, property: String) -> StylePropertyValue
+    ///
+    /// - Note: This method is marked as experimental. Annotate the import statement
+    /// for `MapboxMaps` with `@_spi(Experimental)` in order to use experimental methods.
+    static func sourcePropertyDefaultValue(for sourceType: String, property: String) -> StylePropertyValue
 
     // MARK: Image source
 
@@ -386,7 +400,10 @@ internal protocol StyleManagerProtocol {
     /// - Parameter property: Style light property name.
     ///
     /// - Returns: Style light property value.
-    func _lightProperty(_ property: String) -> StylePropertyValue
+    ///
+    /// - Note: This method is marked as experimental. Annotate the import statement
+    /// for `MapboxMaps` with `@_spi(Experimental)` in order to use experimental methods.
+    func lightProperty(_ property: String) -> StylePropertyValue
 
     /// Sets a value to the style light property.
     ///
@@ -416,7 +433,10 @@ internal protocol StyleManagerProtocol {
     /// - Parameter property: Style terrain property name.
     ///
     /// - Returns: Style terrain property value.
-    func _terrainProperty(_ property: String) -> StylePropertyValue
+    ///
+    /// - Note: This method is marked as experimental. Annotate the import statement
+    /// for `MapboxMaps` with `@_spi(Experimental)` in order to use experimental methods.
+    func terrainProperty(_ property: String) -> StylePropertyValue
 
     /// Sets a value to the named style terrain property.
     ///
@@ -453,8 +473,11 @@ internal protocol StyleManagerProtocol {
     ///   - features: An array of features to add
     ///
     /// - Throws:
-    ///     An error describing why the operation was unsuccessful.\
-    func _setCustomGeometrySourceTileData(forSourceId sourceId: String, tileId: CanonicalTileID, features: [Turf.Feature]) throws
+    ///     An error describing why the operation was unsuccessful.
+    ///
+    /// - Note: This method is marked as experimental. Annotate the import statement
+    /// for `MapboxMaps` with `@_spi(Experimental)` in order to use experimental methods.
+    func setCustomGeometrySourceTileData(forSourceId sourceId: String, tileId: CanonicalTileID, features: [Turf.Feature]) throws
 
     /// Invalidate tile for provided custom geometry source.
     ///

--- a/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationIntegrationTests.swift
@@ -30,7 +30,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
     internal func testSourceAndLayerSetup() throws {
         let style = try XCTUnwrap(self.style)
         XCTAssertTrue(style.layerExists(withId: manager.layerId))
-        XCTAssertTrue(try style._isPersistentLayer(id: manager.layerId),
+        XCTAssertTrue(try style.isPersistentLayer(id: manager.layerId),
                       "The layer with id \(manager.layerId) should be persistent.")
         XCTAssertTrue(style.sourceExists(withId: manager.sourceId))
     }
@@ -79,7 +79,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.circlePitchAlignment, .constant(CirclePitchAlignment(rawValue: Style._layerPropertyDefaultValue(for: .circle, property: "circle-pitch-alignment").value as! String)!))
+        XCTAssertEqual(layer.circlePitchAlignment, .constant(CirclePitchAlignment(rawValue: Style.layerPropertyDefaultValue(for: .circle, property: "circle-pitch-alignment").value as! String)!))
     }
 
     func testCirclePitchScale() throws {
@@ -101,7 +101,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.circlePitchScale, .constant(CirclePitchScale(rawValue: Style._layerPropertyDefaultValue(for: .circle, property: "circle-pitch-scale").value as! String)!))
+        XCTAssertEqual(layer.circlePitchScale, .constant(CirclePitchScale(rawValue: Style.layerPropertyDefaultValue(for: .circle, property: "circle-pitch-scale").value as! String)!))
     }
 
     func testCircleTranslate() throws {
@@ -123,7 +123,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.circleTranslate, .constant(Style._layerPropertyDefaultValue(for: .circle, property: "circle-translate").value as! [Double]))
+        XCTAssertEqual(layer.circleTranslate, .constant(Style.layerPropertyDefaultValue(for: .circle, property: "circle-translate").value as! [Double]))
     }
 
     func testCircleTranslateAnchor() throws {
@@ -145,7 +145,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.circleTranslateAnchor, .constant(CircleTranslateAnchor(rawValue: Style._layerPropertyDefaultValue(for: .circle, property: "circle-translate-anchor").value as! String)!))
+        XCTAssertEqual(layer.circleTranslateAnchor, .constant(CircleTranslateAnchor(rawValue: Style.layerPropertyDefaultValue(for: .circle, property: "circle-translate-anchor").value as! String)!))
     }
 
     func testCircleSortKey() throws {
@@ -181,7 +181,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.circleSortKey, .constant((Style._layerPropertyDefaultValue(for: .circle, property: "circle-sort-key").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.circleSortKey, .constant((Style.layerPropertyDefaultValue(for: .circle, property: "circle-sort-key").value as! NSNumber).doubleValue))
     }
 
     func testCircleBlur() throws {
@@ -217,7 +217,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.circleBlur, .constant((Style._layerPropertyDefaultValue(for: .circle, property: "circle-blur").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.circleBlur, .constant((Style.layerPropertyDefaultValue(for: .circle, property: "circle-blur").value as! NSNumber).doubleValue))
     }
 
     func testCircleColor() throws {
@@ -253,7 +253,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.circleColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style._layerPropertyDefaultValue(for: .circle, property: "circle-color").value as! [Any], options: []))))
+        XCTAssertEqual(layer.circleColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style.layerPropertyDefaultValue(for: .circle, property: "circle-color").value as! [Any], options: []))))
     }
 
     func testCircleOpacity() throws {
@@ -289,7 +289,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.circleOpacity, .constant((Style._layerPropertyDefaultValue(for: .circle, property: "circle-opacity").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.circleOpacity, .constant((Style.layerPropertyDefaultValue(for: .circle, property: "circle-opacity").value as! NSNumber).doubleValue))
     }
 
     func testCircleRadius() throws {
@@ -325,7 +325,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.circleRadius, .constant((Style._layerPropertyDefaultValue(for: .circle, property: "circle-radius").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.circleRadius, .constant((Style.layerPropertyDefaultValue(for: .circle, property: "circle-radius").value as! NSNumber).doubleValue))
     }
 
     func testCircleStrokeColor() throws {
@@ -361,7 +361,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.circleStrokeColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style._layerPropertyDefaultValue(for: .circle, property: "circle-stroke-color").value as! [Any], options: []))))
+        XCTAssertEqual(layer.circleStrokeColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style.layerPropertyDefaultValue(for: .circle, property: "circle-stroke-color").value as! [Any], options: []))))
     }
 
     func testCircleStrokeOpacity() throws {
@@ -397,7 +397,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.circleStrokeOpacity, .constant((Style._layerPropertyDefaultValue(for: .circle, property: "circle-stroke-opacity").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.circleStrokeOpacity, .constant((Style.layerPropertyDefaultValue(for: .circle, property: "circle-stroke-opacity").value as! NSNumber).doubleValue))
     }
 
     func testCircleStrokeWidth() throws {
@@ -433,7 +433,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.circleStrokeWidth, .constant((Style._layerPropertyDefaultValue(for: .circle, property: "circle-stroke-width").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.circleStrokeWidth, .constant((Style.layerPropertyDefaultValue(for: .circle, property: "circle-stroke-width").value as! NSNumber).doubleValue))
     }
 }
 

--- a/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationIntegrationTests.swift
@@ -30,7 +30,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     internal func testSourceAndLayerSetup() throws {
         let style = try XCTUnwrap(self.style)
         XCTAssertTrue(style.layerExists(withId: manager.layerId))
-        XCTAssertTrue(try style._isPersistentLayer(id: manager.layerId),
+        XCTAssertTrue(try style.isPersistentLayer(id: manager.layerId),
                       "The layer with id \(manager.layerId) should be persistent.")
         XCTAssertTrue(style.sourceExists(withId: manager.sourceId))
     }
@@ -79,7 +79,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconAllowOverlap, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "icon-allow-overlap").value as! NSNumber).boolValue))
+        XCTAssertEqual(layer.iconAllowOverlap, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "icon-allow-overlap").value as! NSNumber).boolValue))
     }
 
     func testIconIgnorePlacement() throws {
@@ -101,7 +101,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconIgnorePlacement, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "icon-ignore-placement").value as! NSNumber).boolValue))
+        XCTAssertEqual(layer.iconIgnorePlacement, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "icon-ignore-placement").value as! NSNumber).boolValue))
     }
 
     func testIconKeepUpright() throws {
@@ -123,7 +123,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconKeepUpright, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "icon-keep-upright").value as! NSNumber).boolValue))
+        XCTAssertEqual(layer.iconKeepUpright, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "icon-keep-upright").value as! NSNumber).boolValue))
     }
 
     func testIconOptional() throws {
@@ -145,7 +145,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconOptional, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "icon-optional").value as! NSNumber).boolValue))
+        XCTAssertEqual(layer.iconOptional, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "icon-optional").value as! NSNumber).boolValue))
     }
 
     func testIconPadding() throws {
@@ -167,7 +167,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconPadding, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "icon-padding").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.iconPadding, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "icon-padding").value as! NSNumber).doubleValue))
     }
 
     func testIconPitchAlignment() throws {
@@ -189,7 +189,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconPitchAlignment, .constant(IconPitchAlignment(rawValue: Style._layerPropertyDefaultValue(for: .symbol, property: "icon-pitch-alignment").value as! String)!))
+        XCTAssertEqual(layer.iconPitchAlignment, .constant(IconPitchAlignment(rawValue: Style.layerPropertyDefaultValue(for: .symbol, property: "icon-pitch-alignment").value as! String)!))
     }
 
     func testIconRotationAlignment() throws {
@@ -211,7 +211,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconRotationAlignment, .constant(IconRotationAlignment(rawValue: Style._layerPropertyDefaultValue(for: .symbol, property: "icon-rotation-alignment").value as! String)!))
+        XCTAssertEqual(layer.iconRotationAlignment, .constant(IconRotationAlignment(rawValue: Style.layerPropertyDefaultValue(for: .symbol, property: "icon-rotation-alignment").value as! String)!))
     }
 
     func testIconTextFit() throws {
@@ -233,7 +233,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconTextFit, .constant(IconTextFit(rawValue: Style._layerPropertyDefaultValue(for: .symbol, property: "icon-text-fit").value as! String)!))
+        XCTAssertEqual(layer.iconTextFit, .constant(IconTextFit(rawValue: Style.layerPropertyDefaultValue(for: .symbol, property: "icon-text-fit").value as! String)!))
     }
 
     func testIconTextFitPadding() throws {
@@ -255,7 +255,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconTextFitPadding, .constant(Style._layerPropertyDefaultValue(for: .symbol, property: "icon-text-fit-padding").value as! [Double]))
+        XCTAssertEqual(layer.iconTextFitPadding, .constant(Style.layerPropertyDefaultValue(for: .symbol, property: "icon-text-fit-padding").value as! [Double]))
     }
 
     func testSymbolAvoidEdges() throws {
@@ -277,7 +277,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.symbolAvoidEdges, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "symbol-avoid-edges").value as! NSNumber).boolValue))
+        XCTAssertEqual(layer.symbolAvoidEdges, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "symbol-avoid-edges").value as! NSNumber).boolValue))
     }
 
     func testSymbolPlacement() throws {
@@ -299,7 +299,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.symbolPlacement, .constant(SymbolPlacement(rawValue: Style._layerPropertyDefaultValue(for: .symbol, property: "symbol-placement").value as! String)!))
+        XCTAssertEqual(layer.symbolPlacement, .constant(SymbolPlacement(rawValue: Style.layerPropertyDefaultValue(for: .symbol, property: "symbol-placement").value as! String)!))
     }
 
     func testSymbolSpacing() throws {
@@ -321,7 +321,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.symbolSpacing, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "symbol-spacing").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.symbolSpacing, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "symbol-spacing").value as! NSNumber).doubleValue))
     }
 
     func testSymbolZOrder() throws {
@@ -343,7 +343,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.symbolZOrder, .constant(SymbolZOrder(rawValue: Style._layerPropertyDefaultValue(for: .symbol, property: "symbol-z-order").value as! String)!))
+        XCTAssertEqual(layer.symbolZOrder, .constant(SymbolZOrder(rawValue: Style.layerPropertyDefaultValue(for: .symbol, property: "symbol-z-order").value as! String)!))
     }
 
     func testTextAllowOverlap() throws {
@@ -365,7 +365,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textAllowOverlap, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-allow-overlap").value as! NSNumber).boolValue))
+        XCTAssertEqual(layer.textAllowOverlap, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-allow-overlap").value as! NSNumber).boolValue))
     }
 
     func testTextFont() throws {
@@ -387,7 +387,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textFont, .constant(Style._layerPropertyDefaultValue(for: .symbol, property: "text-font").value as! [String]))
+        XCTAssertEqual(layer.textFont, .constant(Style.layerPropertyDefaultValue(for: .symbol, property: "text-font").value as! [String]))
     }
 
     func testTextIgnorePlacement() throws {
@@ -409,7 +409,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textIgnorePlacement, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-ignore-placement").value as! NSNumber).boolValue))
+        XCTAssertEqual(layer.textIgnorePlacement, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-ignore-placement").value as! NSNumber).boolValue))
     }
 
     func testTextKeepUpright() throws {
@@ -431,7 +431,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textKeepUpright, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-keep-upright").value as! NSNumber).boolValue))
+        XCTAssertEqual(layer.textKeepUpright, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-keep-upright").value as! NSNumber).boolValue))
     }
 
     func testTextLineHeight() throws {
@@ -453,7 +453,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textLineHeight, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-line-height").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.textLineHeight, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-line-height").value as! NSNumber).doubleValue))
     }
 
     func testTextMaxAngle() throws {
@@ -475,7 +475,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textMaxAngle, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-max-angle").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.textMaxAngle, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-max-angle").value as! NSNumber).doubleValue))
     }
 
     func testTextOptional() throws {
@@ -497,7 +497,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textOptional, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-optional").value as! NSNumber).boolValue))
+        XCTAssertEqual(layer.textOptional, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-optional").value as! NSNumber).boolValue))
     }
 
     func testTextPadding() throws {
@@ -519,7 +519,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textPadding, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-padding").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.textPadding, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-padding").value as! NSNumber).doubleValue))
     }
 
     func testTextPitchAlignment() throws {
@@ -541,7 +541,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textPitchAlignment, .constant(TextPitchAlignment(rawValue: Style._layerPropertyDefaultValue(for: .symbol, property: "text-pitch-alignment").value as! String)!))
+        XCTAssertEqual(layer.textPitchAlignment, .constant(TextPitchAlignment(rawValue: Style.layerPropertyDefaultValue(for: .symbol, property: "text-pitch-alignment").value as! String)!))
     }
 
     func testTextRotationAlignment() throws {
@@ -563,7 +563,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textRotationAlignment, .constant(TextRotationAlignment(rawValue: Style._layerPropertyDefaultValue(for: .symbol, property: "text-rotation-alignment").value as! String)!))
+        XCTAssertEqual(layer.textRotationAlignment, .constant(TextRotationAlignment(rawValue: Style.layerPropertyDefaultValue(for: .symbol, property: "text-rotation-alignment").value as! String)!))
     }
 
     func testTextVariableAnchor() throws {
@@ -585,7 +585,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textVariableAnchor, .constant(Style._layerPropertyDefaultValue(for: .symbol, property: "text-variable-anchor").value as! [TextAnchor]))
+        XCTAssertEqual(layer.textVariableAnchor, .constant(Style.layerPropertyDefaultValue(for: .symbol, property: "text-variable-anchor").value as! [TextAnchor]))
     }
 
     func testTextWritingMode() throws {
@@ -607,7 +607,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textWritingMode, .constant(Style._layerPropertyDefaultValue(for: .symbol, property: "text-writing-mode").value as! [TextWritingMode]))
+        XCTAssertEqual(layer.textWritingMode, .constant(Style.layerPropertyDefaultValue(for: .symbol, property: "text-writing-mode").value as! [TextWritingMode]))
     }
 
     func testIconTranslate() throws {
@@ -629,7 +629,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconTranslate, .constant(Style._layerPropertyDefaultValue(for: .symbol, property: "icon-translate").value as! [Double]))
+        XCTAssertEqual(layer.iconTranslate, .constant(Style.layerPropertyDefaultValue(for: .symbol, property: "icon-translate").value as! [Double]))
     }
 
     func testIconTranslateAnchor() throws {
@@ -651,7 +651,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconTranslateAnchor, .constant(IconTranslateAnchor(rawValue: Style._layerPropertyDefaultValue(for: .symbol, property: "icon-translate-anchor").value as! String)!))
+        XCTAssertEqual(layer.iconTranslateAnchor, .constant(IconTranslateAnchor(rawValue: Style.layerPropertyDefaultValue(for: .symbol, property: "icon-translate-anchor").value as! String)!))
     }
 
     func testTextTranslate() throws {
@@ -673,7 +673,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textTranslate, .constant(Style._layerPropertyDefaultValue(for: .symbol, property: "text-translate").value as! [Double]))
+        XCTAssertEqual(layer.textTranslate, .constant(Style.layerPropertyDefaultValue(for: .symbol, property: "text-translate").value as! [Double]))
     }
 
     func testTextTranslateAnchor() throws {
@@ -695,7 +695,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textTranslateAnchor, .constant(TextTranslateAnchor(rawValue: Style._layerPropertyDefaultValue(for: .symbol, property: "text-translate-anchor").value as! String)!))
+        XCTAssertEqual(layer.textTranslateAnchor, .constant(TextTranslateAnchor(rawValue: Style.layerPropertyDefaultValue(for: .symbol, property: "text-translate-anchor").value as! String)!))
     }
 
     func testIconAnchor() throws {
@@ -731,7 +731,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconAnchor, .constant(IconAnchor(rawValue: Style._layerPropertyDefaultValue(for: .symbol, property: "icon-anchor").value as! String)!))
+        XCTAssertEqual(layer.iconAnchor, .constant(IconAnchor(rawValue: Style.layerPropertyDefaultValue(for: .symbol, property: "icon-anchor").value as! String)!))
     }
 
     func testIconImage() throws {
@@ -767,7 +767,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconImage, .constant(.name(Style._layerPropertyDefaultValue(for: .symbol, property: "icon-image").value as! String)))
+        XCTAssertEqual(layer.iconImage, .constant(.name(Style.layerPropertyDefaultValue(for: .symbol, property: "icon-image").value as! String)))
     }
 
     func testIconOffset() throws {
@@ -805,7 +805,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconOffset, .constant(Style._layerPropertyDefaultValue(for: .symbol, property: "icon-offset").value as! [Double]))
+        XCTAssertEqual(layer.iconOffset, .constant(Style.layerPropertyDefaultValue(for: .symbol, property: "icon-offset").value as! [Double]))
     }
 
     func testIconRotate() throws {
@@ -841,7 +841,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconRotate, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "icon-rotate").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.iconRotate, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "icon-rotate").value as! NSNumber).doubleValue))
     }
 
     func testIconSize() throws {
@@ -877,7 +877,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconSize, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "icon-size").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.iconSize, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "icon-size").value as! NSNumber).doubleValue))
     }
 
     func testSymbolSortKey() throws {
@@ -913,7 +913,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.symbolSortKey, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "symbol-sort-key").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.symbolSortKey, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "symbol-sort-key").value as! NSNumber).doubleValue))
     }
 
     func testTextAnchor() throws {
@@ -949,7 +949,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textAnchor, .constant(TextAnchor(rawValue: Style._layerPropertyDefaultValue(for: .symbol, property: "text-anchor").value as! String)!))
+        XCTAssertEqual(layer.textAnchor, .constant(TextAnchor(rawValue: Style.layerPropertyDefaultValue(for: .symbol, property: "text-anchor").value as! String)!))
     }
 
     func testTextField() throws {
@@ -1025,7 +1025,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textJustify, .constant(TextJustify(rawValue: Style._layerPropertyDefaultValue(for: .symbol, property: "text-justify").value as! String)!))
+        XCTAssertEqual(layer.textJustify, .constant(TextJustify(rawValue: Style.layerPropertyDefaultValue(for: .symbol, property: "text-justify").value as! String)!))
     }
 
     func testTextLetterSpacing() throws {
@@ -1061,7 +1061,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textLetterSpacing, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-letter-spacing").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.textLetterSpacing, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-letter-spacing").value as! NSNumber).doubleValue))
     }
 
     func testTextMaxWidth() throws {
@@ -1097,7 +1097,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textMaxWidth, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-max-width").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.textMaxWidth, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-max-width").value as! NSNumber).doubleValue))
     }
 
     func testTextOffset() throws {
@@ -1135,7 +1135,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textOffset, .constant(Style._layerPropertyDefaultValue(for: .symbol, property: "text-offset").value as! [Double]))
+        XCTAssertEqual(layer.textOffset, .constant(Style.layerPropertyDefaultValue(for: .symbol, property: "text-offset").value as! [Double]))
     }
 
     func testTextRadialOffset() throws {
@@ -1171,7 +1171,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textRadialOffset, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-radial-offset").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.textRadialOffset, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-radial-offset").value as! NSNumber).doubleValue))
     }
 
     func testTextRotate() throws {
@@ -1207,7 +1207,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textRotate, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-rotate").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.textRotate, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-rotate").value as! NSNumber).doubleValue))
     }
 
     func testTextSize() throws {
@@ -1243,7 +1243,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textSize, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-size").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.textSize, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-size").value as! NSNumber).doubleValue))
     }
 
     func testTextTransform() throws {
@@ -1279,7 +1279,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textTransform, .constant(TextTransform(rawValue: Style._layerPropertyDefaultValue(for: .symbol, property: "text-transform").value as! String)!))
+        XCTAssertEqual(layer.textTransform, .constant(TextTransform(rawValue: Style.layerPropertyDefaultValue(for: .symbol, property: "text-transform").value as! String)!))
     }
 
     func testIconColor() throws {
@@ -1315,7 +1315,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style._layerPropertyDefaultValue(for: .symbol, property: "icon-color").value as! [Any], options: []))))
+        XCTAssertEqual(layer.iconColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style.layerPropertyDefaultValue(for: .symbol, property: "icon-color").value as! [Any], options: []))))
     }
 
     func testIconHaloBlur() throws {
@@ -1351,7 +1351,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconHaloBlur, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "icon-halo-blur").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.iconHaloBlur, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "icon-halo-blur").value as! NSNumber).doubleValue))
     }
 
     func testIconHaloColor() throws {
@@ -1387,7 +1387,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconHaloColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style._layerPropertyDefaultValue(for: .symbol, property: "icon-halo-color").value as! [Any], options: []))))
+        XCTAssertEqual(layer.iconHaloColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style.layerPropertyDefaultValue(for: .symbol, property: "icon-halo-color").value as! [Any], options: []))))
     }
 
     func testIconHaloWidth() throws {
@@ -1423,7 +1423,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconHaloWidth, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "icon-halo-width").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.iconHaloWidth, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "icon-halo-width").value as! NSNumber).doubleValue))
     }
 
     func testIconOpacity() throws {
@@ -1459,7 +1459,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.iconOpacity, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "icon-opacity").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.iconOpacity, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "icon-opacity").value as! NSNumber).doubleValue))
     }
 
     func testTextColor() throws {
@@ -1495,7 +1495,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style._layerPropertyDefaultValue(for: .symbol, property: "text-color").value as! [Any], options: []))))
+        XCTAssertEqual(layer.textColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style.layerPropertyDefaultValue(for: .symbol, property: "text-color").value as! [Any], options: []))))
     }
 
     func testTextHaloBlur() throws {
@@ -1531,7 +1531,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textHaloBlur, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-halo-blur").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.textHaloBlur, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-halo-blur").value as! NSNumber).doubleValue))
     }
 
     func testTextHaloColor() throws {
@@ -1567,7 +1567,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textHaloColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style._layerPropertyDefaultValue(for: .symbol, property: "text-halo-color").value as! [Any], options: []))))
+        XCTAssertEqual(layer.textHaloColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style.layerPropertyDefaultValue(for: .symbol, property: "text-halo-color").value as! [Any], options: []))))
     }
 
     func testTextHaloWidth() throws {
@@ -1603,7 +1603,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textHaloWidth, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-halo-width").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.textHaloWidth, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-halo-width").value as! NSNumber).doubleValue))
     }
 
     func testTextOpacity() throws {
@@ -1639,7 +1639,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.textOpacity, .constant((Style._layerPropertyDefaultValue(for: .symbol, property: "text-opacity").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.textOpacity, .constant((Style.layerPropertyDefaultValue(for: .symbol, property: "text-opacity").value as! NSNumber).doubleValue))
     }
 }
 

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationIntegrationTests.swift
@@ -30,7 +30,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
     internal func testSourceAndLayerSetup() throws {
         let style = try XCTUnwrap(self.style)
         XCTAssertTrue(style.layerExists(withId: manager.layerId))
-        XCTAssertTrue(try style._isPersistentLayer(id: manager.layerId),
+        XCTAssertTrue(try style.isPersistentLayer(id: manager.layerId),
                       "The layer with id \(manager.layerId) should be persistent.")
         XCTAssertTrue(style.sourceExists(withId: manager.sourceId))
     }
@@ -86,7 +86,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.fillAntialias, .constant((Style._layerPropertyDefaultValue(for: .fill, property: "fill-antialias").value as! NSNumber).boolValue))
+        XCTAssertEqual(layer.fillAntialias, .constant((Style.layerPropertyDefaultValue(for: .fill, property: "fill-antialias").value as! NSNumber).boolValue))
     }
 
     func testFillTranslate() throws {
@@ -108,7 +108,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.fillTranslate, .constant(Style._layerPropertyDefaultValue(for: .fill, property: "fill-translate").value as! [Double]))
+        XCTAssertEqual(layer.fillTranslate, .constant(Style.layerPropertyDefaultValue(for: .fill, property: "fill-translate").value as! [Double]))
     }
 
     func testFillTranslateAnchor() throws {
@@ -130,7 +130,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.fillTranslateAnchor, .constant(FillTranslateAnchor(rawValue: Style._layerPropertyDefaultValue(for: .fill, property: "fill-translate-anchor").value as! String)!))
+        XCTAssertEqual(layer.fillTranslateAnchor, .constant(FillTranslateAnchor(rawValue: Style.layerPropertyDefaultValue(for: .fill, property: "fill-translate-anchor").value as! String)!))
     }
 
     func testFillSortKey() throws {
@@ -173,7 +173,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.fillSortKey, .constant((Style._layerPropertyDefaultValue(for: .fill, property: "fill-sort-key").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.fillSortKey, .constant((Style.layerPropertyDefaultValue(for: .fill, property: "fill-sort-key").value as! NSNumber).doubleValue))
     }
 
     func testFillColor() throws {
@@ -216,7 +216,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.fillColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style._layerPropertyDefaultValue(for: .fill, property: "fill-color").value as! [Any], options: []))))
+        XCTAssertEqual(layer.fillColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style.layerPropertyDefaultValue(for: .fill, property: "fill-color").value as! [Any], options: []))))
     }
 
     func testFillOpacity() throws {
@@ -259,7 +259,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.fillOpacity, .constant((Style._layerPropertyDefaultValue(for: .fill, property: "fill-opacity").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.fillOpacity, .constant((Style.layerPropertyDefaultValue(for: .fill, property: "fill-opacity").value as! NSNumber).doubleValue))
     }
 
     func testFillOutlineColor() throws {
@@ -302,7 +302,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.fillOutlineColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style._layerPropertyDefaultValue(for: .fill, property: "fill-outline-color").value as! [Any], options: []))))
+        XCTAssertEqual(layer.fillOutlineColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style.layerPropertyDefaultValue(for: .fill, property: "fill-outline-color").value as! [Any], options: []))))
     }
 
     func testFillPattern() throws {
@@ -345,7 +345,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.fillPattern, .constant(.name(Style._layerPropertyDefaultValue(for: .fill, property: "fill-pattern").value as! String)))
+        XCTAssertEqual(layer.fillPattern, .constant(.name(Style.layerPropertyDefaultValue(for: .fill, property: "fill-pattern").value as! String)))
     }
 }
 

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationIntegrationTests.swift
@@ -30,7 +30,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
     internal func testSourceAndLayerSetup() throws {
         let style = try XCTUnwrap(self.style)
         XCTAssertTrue(style.layerExists(withId: manager.layerId))
-        XCTAssertTrue(try style._isPersistentLayer(id: manager.layerId),
+        XCTAssertTrue(try style.isPersistentLayer(id: manager.layerId),
                       "The layer with id \(manager.layerId) should be persistent.")
         XCTAssertTrue(style.sourceExists(withId: manager.sourceId))
     }
@@ -80,7 +80,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.lineCap, .constant(LineCap(rawValue: Style._layerPropertyDefaultValue(for: .line, property: "line-cap").value as! String)!))
+        XCTAssertEqual(layer.lineCap, .constant(LineCap(rawValue: Style.layerPropertyDefaultValue(for: .line, property: "line-cap").value as! String)!))
     }
 
     func testLineMiterLimit() throws {
@@ -102,7 +102,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.lineMiterLimit, .constant((Style._layerPropertyDefaultValue(for: .line, property: "line-miter-limit").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.lineMiterLimit, .constant((Style.layerPropertyDefaultValue(for: .line, property: "line-miter-limit").value as! NSNumber).doubleValue))
     }
 
     func testLineRoundLimit() throws {
@@ -124,7 +124,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.lineRoundLimit, .constant((Style._layerPropertyDefaultValue(for: .line, property: "line-round-limit").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.lineRoundLimit, .constant((Style.layerPropertyDefaultValue(for: .line, property: "line-round-limit").value as! NSNumber).doubleValue))
     }
 
     func testLineDasharray() throws {
@@ -146,7 +146,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.lineDasharray, .constant(Style._layerPropertyDefaultValue(for: .line, property: "line-dasharray").value as! [Double]))
+        XCTAssertEqual(layer.lineDasharray, .constant(Style.layerPropertyDefaultValue(for: .line, property: "line-dasharray").value as! [Double]))
     }
 
     func testLineTranslate() throws {
@@ -168,7 +168,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.lineTranslate, .constant(Style._layerPropertyDefaultValue(for: .line, property: "line-translate").value as! [Double]))
+        XCTAssertEqual(layer.lineTranslate, .constant(Style.layerPropertyDefaultValue(for: .line, property: "line-translate").value as! [Double]))
     }
 
     func testLineTranslateAnchor() throws {
@@ -190,7 +190,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.lineTranslateAnchor, .constant(LineTranslateAnchor(rawValue: Style._layerPropertyDefaultValue(for: .line, property: "line-translate-anchor").value as! String)!))
+        XCTAssertEqual(layer.lineTranslateAnchor, .constant(LineTranslateAnchor(rawValue: Style.layerPropertyDefaultValue(for: .line, property: "line-translate-anchor").value as! String)!))
     }
 
     func testLineJoin() throws {
@@ -227,7 +227,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.lineJoin, .constant(LineJoin(rawValue: Style._layerPropertyDefaultValue(for: .line, property: "line-join").value as! String)!))
+        XCTAssertEqual(layer.lineJoin, .constant(LineJoin(rawValue: Style.layerPropertyDefaultValue(for: .line, property: "line-join").value as! String)!))
     }
 
     func testLineSortKey() throws {
@@ -264,7 +264,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.lineSortKey, .constant((Style._layerPropertyDefaultValue(for: .line, property: "line-sort-key").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.lineSortKey, .constant((Style.layerPropertyDefaultValue(for: .line, property: "line-sort-key").value as! NSNumber).doubleValue))
     }
 
     func testLineBlur() throws {
@@ -301,7 +301,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.lineBlur, .constant((Style._layerPropertyDefaultValue(for: .line, property: "line-blur").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.lineBlur, .constant((Style.layerPropertyDefaultValue(for: .line, property: "line-blur").value as! NSNumber).doubleValue))
     }
 
     func testLineColor() throws {
@@ -338,7 +338,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.lineColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style._layerPropertyDefaultValue(for: .line, property: "line-color").value as! [Any], options: []))))
+        XCTAssertEqual(layer.lineColor, .constant(try! JSONDecoder().decode(StyleColor.self, from: JSONSerialization.data(withJSONObject: Style.layerPropertyDefaultValue(for: .line, property: "line-color").value as! [Any], options: []))))
     }
 
     func testLineGapWidth() throws {
@@ -375,7 +375,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.lineGapWidth, .constant((Style._layerPropertyDefaultValue(for: .line, property: "line-gap-width").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.lineGapWidth, .constant((Style.layerPropertyDefaultValue(for: .line, property: "line-gap-width").value as! NSNumber).doubleValue))
     }
 
     func testLineOffset() throws {
@@ -412,7 +412,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.lineOffset, .constant((Style._layerPropertyDefaultValue(for: .line, property: "line-offset").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.lineOffset, .constant((Style.layerPropertyDefaultValue(for: .line, property: "line-offset").value as! NSNumber).doubleValue))
     }
 
     func testLineOpacity() throws {
@@ -449,7 +449,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.lineOpacity, .constant((Style._layerPropertyDefaultValue(for: .line, property: "line-opacity").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.lineOpacity, .constant((Style.layerPropertyDefaultValue(for: .line, property: "line-opacity").value as! NSNumber).doubleValue))
     }
 
     func testLinePattern() throws {
@@ -486,7 +486,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.linePattern, .constant(.name(Style._layerPropertyDefaultValue(for: .line, property: "line-pattern").value as! String)))
+        XCTAssertEqual(layer.linePattern, .constant(.name(Style.layerPropertyDefaultValue(for: .line, property: "line-pattern").value as! String)))
     }
 
     func testLineWidth() throws {
@@ -523,7 +523,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         // the layer is returned to the default value
         manager.syncSourceAndLayerIfNeeded()
         layer = try XCTUnwrap(self.style?.layer(withId: self.manager.layerId))
-        XCTAssertEqual(layer.lineWidth, .constant((Style._layerPropertyDefaultValue(for: .line, property: "line-width").value as! NSNumber).doubleValue))
+        XCTAssertEqual(layer.lineWidth, .constant((Style.layerPropertyDefaultValue(for: .line, property: "line-width").value as! NSNumber).doubleValue))
     }
 }
 

--- a/Tests/MapboxMapsTests/Location/MockLocationStyle.swift
+++ b/Tests/MapboxMapsTests/Location/MockLocationStyle.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import MapboxMaps
 
 final class MockLocationStyle: LocationStyleProtocol {
-    func _addPersistentLayer(_ layer: Layer, layerPosition: LayerPosition?) throws {}
+    func addPersistentLayer(_ layer: Layer, layerPosition: LayerPosition?) throws {}
     func removeLayer(withId id: String) throws {}
     func layerExists(withId id: String) -> Bool { return false }
     func setLayerProperties(for layerId: String, properties: [String: Any]) throws {}

--- a/Tests/MapboxMapsTests/Location/Pucks/Puck2DIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Location/Pucks/Puck2DIntegrationTests.swift
@@ -192,7 +192,7 @@ class Puck2DIntegrationTests: MapViewIntegrationTestCase {
             } catch {
                 XCTFail("Failed to create an precise location indicator layer.")
             }
-            let isPersistent = try! style._isPersistentLayer(id: "puck")
+            let isPersistent = try! style.isPersistentLayer(id: "puck")
             XCTAssertTrue(isPersistent, "The puck layer should be a persistent layer.")
         })
     }

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LocationIndicatorLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LocationIndicatorLayerIntegrationTests.swift
@@ -54,7 +54,7 @@ final class LocationIndicatorLayerIntegrationTests: MapViewIntegrationTestCase {
 
             // Add the layer
             do {
-                try style._addPersistentLayer(layer)
+                try style.addPersistentLayer(layer)
             successfullyAddedLayerExpectation.fulfill()
             } catch {
                 XCTFail("Failed to add LocationIndicatorLayer because of error: \(error)")

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import MapboxMaps
+@testable @_spi(Experimental) import MapboxMaps
 
 internal class StyleIntegrationTests: MapViewIntegrationTestCase {
 
@@ -77,7 +77,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             do {
                 for step in stride(from: 0, to: layers.count, by: 3) {
 
-                    try style._moveLayer(withId: "test-id", to: .at(step))
+                    try style.moveLayer(withId: "test-id", to: .at(step))
 
                     // Get layer position
                     let layers = style.styleManager.getStyleLayers()
@@ -115,7 +115,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             let newBackgroundLayer = BackgroundLayer(id: layerId)
 
             do {
-                try style._addPersistentLayer(newBackgroundLayer)
+                try style.addPersistentLayer(newBackgroundLayer)
                 addLayerExpectation.fulfill()
             } catch {
                 XCTFail("Could not add background layer due to error: \(error)")
@@ -125,7 +125,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
             do {
                 for step in stride(from: 0, to: layers.count, by: 3) {
 
-                    try style._moveLayer(withId: layerId, to: .at(step))
+                    try style.moveLayer(withId: layerId, to: .at(step))
 
                     // Get layer position
                     let layers = style.styleManager.getStyleLayers()
@@ -134,7 +134,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
                     let position = layerIds.firstIndex(of: layerId)
                     XCTAssertEqual(position, step)
 
-                    let isPersistent = try style._isPersistentLayer(id: layerId)
+                    let isPersistent = try style.isPersistentLayer(id: layerId)
                     XCTAssertTrue(isPersistent)
                 }
 
@@ -163,7 +163,7 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
 
             for layer in layers {
                 do {
-                    _ = try style._layer(withId: layer.id, type: layer.type.layerType)
+                    _ = try style.layer(withId: layer.id, type: layer.type.layerType)
                     expectation.fulfill()
                 } catch {
                     XCTFail("Failed to get line layer with id \(layer.id), error \(error)")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

This PR:
- Uses the `@_spi(Experimental)` annotation to mark style methods as experimental. This means that in order to use these methods, you will need to annotate your import statement for `MapboxMaps` with `@_spi(Experimental)`. (`@_spi(Experimental) import MapboxMaps`).
- Removes the underscore prefix that previously marked these methods as experimental.
### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
