### PR TITLE
Perform initial camera sync without animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Mapbox welcomes participation and contributions from everyone.
 
 * Allow users to set the map's `MapDebugOptions`. ([#648](https://github.com/mapbox/mapbox-maps-ios/pull/648))
 
+### Bug fixes 🐞
+
+* Fixes animations that are started within an UIKit animation context. ([#684](https://github.com/mapbox/mapbox-maps-ios/pull/684))
+
 ## 10.0.0-rc.8 - Sept 8, 2021
 
 ### Breaking changes ⚠️

--- a/Sources/MapboxMaps/Foundation/Camera/BasicCameraAnimator.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/BasicCameraAnimator.swift
@@ -235,7 +235,9 @@ public class BasicCameraAnimator: NSObject, CameraAnimator, CameraAnimatorInterf
             self.completions.removeAll()
         }
 
-        cameraView.syncLayer(to: transition.fromCameraOptions) // Set up the "from" values for the interpoloation
+        UIView.performWithoutAnimation {
+            cameraView.syncLayer(to: transition.fromCameraOptions) // Set up the "from" values for the interpoloation
+        }
         internalState = .inProgress(transition) // Store the mutated camera transition
     }
 


### PR DESCRIPTION
Fixes #681

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Update the changelog

### Summary of changes

Fixes an issue that caused incorrect animations if the animation was started within a UIKit animation context