### PR TITLE
Refine OfflineRegionGeometryDefinition for Swift

### DIFF
--- a/Apps/Examples/Examples/All Examples/OfflineRegionManagerExample.swift
+++ b/Apps/Examples/Examples/All Examples/OfflineRegionManagerExample.swift
@@ -46,8 +46,8 @@ public class OfflineRegionManagerExample: UIViewController, ExampleProtocol {
     internal func setupExample() {
         let uriString = mapView.mapboxMap.style.uri!.rawValue
         let offlineRegionDef = OfflineRegionGeometryDefinition(
-            __styleURL: uriString,
-            geometry: MapboxCommon.Geometry(point: CGPoint(x: coord.latitude, y: coord.longitude) as NSValue),
+            styleURL: uriString,
+            geometry: .point(Point(coord)),
             minZoom: zoom - 2,
             maxZoom: zoom + 2,
             pixelRatio: Float(UIScreen.main.scale),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Mapbox welcomes participation and contributions from everyone.
 * `MapboxCoreMaps.Settings` is now deprecated. ([#732](https://github.com/mapbox/mapbox-maps-ios/pull/732))
 * Setting `data` property on a GeoJSON source via `Style.setSourceProperty(for:property:value:)` or `Style.updateGeoJSONSource(withId:geoJSON:)` is now asynchronous and never returns an error. Errors will be reported asynchronously via a `MapEvents.EventKind.mapLoadingError` event instead. ([#732](https://github.com/mapbox/mapbox-maps-ios/pull/732))
 * Core and Common APIs that accept user-defined implementations of protocols now hold strong references to the provided objects. Please audit your usage of the following protocols and make any required changes to avoid memory leaks: `CustomLayerHost`, `ElevationData`, `MapClient`, `MBMMetalViewProvider`, `Observer`, `OfflineRegionObserver`, `HttpServiceInterceptorInterface`, `HttpServiceInterface`, `LogWriterBackend`, `OfflineSwitchObserver`, `ReachabilityInterface`, `TileStoreObserver`. ([#732](https://github.com/mapbox/mapbox-maps-ios/pull/732))
+* Extends `OfflineRegionGeometryDefinition.geometry` to use `Geometry` rather than `MapboxCommon.Geometry`. It also adds a convenience initializer that takes a `Geometry`. ([#706](https://github.com/mapbox/mapbox-maps-ios/pull/706))
 
 ### Features ✨ and improvements 🏁
 

--- a/Sources/MapboxMaps/Annotations/AnnotationOrchestrator.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationOrchestrator.swift
@@ -7,7 +7,7 @@ public protocol Annotation {
     var id: String { get }
 
     /// The geometry that is backing this annotation.
-    var geometry: Turf.Geometry { get }
+    var geometry: Geometry { get }
 
     /// Properties associated with the annotation.
     var userInfo: [String: Any]? { get set }

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
@@ -7,12 +7,12 @@ public struct CircleAnnotation: Annotation {
     public let id: String
 
     /// The geometry backing this annotation
-    public var geometry: Turf.Geometry {
+    public var geometry: Geometry {
         return .point(point)
     }
 
     /// The point backing this annotation
-    public var point: Turf.Point
+    public var point: Point
 
     /// Properties associated with the annotation
     public var userInfo: [String: Any]?
@@ -20,8 +20,8 @@ public struct CircleAnnotation: Annotation {
     /// Storage for layer properties
     internal var layerProperties: [String: Any] = [:]
 
-    internal var feature: Turf.Feature {
-        var feature = Turf.Feature(geometry: geometry)
+    internal var feature: Feature {
+        var feature = Feature(geometry: geometry)
         feature.identifier = .string(id)
         var properties = JSONObject()
         properties["layerProperties"] = JSONValue(rawValue: layerProperties)
@@ -32,8 +32,8 @@ public struct CircleAnnotation: Annotation {
         return feature
     }
 
-    /// Create a circle annotation with a `Turf.Point` and an optional identifier.
-    public init(id: String = UUID().uuidString, point: Turf.Point) {
+    /// Create a circle annotation with a `Point` and an optional identifier.
+    public init(id: String = UUID().uuidString, point: Point) {
         self.id = id
         self.point = point
     }
@@ -43,7 +43,7 @@ public struct CircleAnnotation: Annotation {
     ///   - id: Optional identifier for this annotation
     ///   - coordinate: Coordinate where this circle annotation should be centered
     public init(id: String = UUID().uuidString, centerCoordinate: CLLocationCoordinate2D) {
-        let point = Turf.Point(centerCoordinate)
+        let point = Point(centerCoordinate)
         self.init(id: id, point: point)
     }
 

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -152,7 +152,7 @@ public class CircleAnnotationManager: AnnotationManager {
         }
 
         // build and update the source data
-        let featureCollection = Turf.FeatureCollection(features: annotations.map(\.feature))
+        let featureCollection = FeatureCollection(features: annotations.map(\.feature))
         do {
             let data = try JSONEncoder().encode(featureCollection)
             let jsonObject = try JSONSerialization.jsonObject(with: data) as! [String: Any]

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
@@ -7,12 +7,12 @@ public struct PointAnnotation: Annotation {
     public let id: String
 
     /// The geometry backing this annotation
-    public var geometry: Turf.Geometry {
+    public var geometry: Geometry {
         return .point(point)
     }
 
     /// The point backing this annotation
-    public var point: Turf.Point
+    public var point: Point
 
     /// Properties associated with the annotation
     public var userInfo: [String: Any]?
@@ -20,8 +20,8 @@ public struct PointAnnotation: Annotation {
     /// Storage for layer properties
     internal var layerProperties: [String: Any] = [:]
 
-    internal var feature: Turf.Feature {
-        var feature = Turf.Feature(geometry: geometry)
+    internal var feature: Feature {
+        var feature = Feature(geometry: geometry)
         feature.identifier = .string(id)
         var properties = JSONObject()
         properties["layerProperties"] = JSONValue(rawValue: layerProperties)
@@ -32,8 +32,8 @@ public struct PointAnnotation: Annotation {
         return feature
     }
 
-    /// Create a point annotation with a `Turf.Point` and an optional identifier.
-    public init(id: String = UUID().uuidString, point: Turf.Point) {
+    /// Create a point annotation with a `Point` and an optional identifier.
+    public init(id: String = UUID().uuidString, point: Point) {
         self.id = id
         self.point = point
     }
@@ -43,7 +43,7 @@ public struct PointAnnotation: Annotation {
     ///   - id: Optional identifier for this annotation
     ///   - coordinate: Coordinate where this annotation should be rendered
     public init(id: String = UUID().uuidString, coordinate: CLLocationCoordinate2D) {
-        let point = Turf.Point(coordinate)
+        let point = Point(coordinate)
         self.init(id: id, point: point)
     }
 

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -160,7 +160,7 @@ public class PointAnnotationManager: AnnotationManager {
         }
 
         // build and update the source data
-        let featureCollection = Turf.FeatureCollection(features: annotations.map(\.feature))
+        let featureCollection = FeatureCollection(features: annotations.map(\.feature))
         do {
             let data = try JSONEncoder().encode(featureCollection)
             let jsonObject = try JSONSerialization.jsonObject(with: data) as! [String: Any]

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
@@ -7,12 +7,12 @@ public struct PolygonAnnotation: Annotation {
     public let id: String
 
     /// The geometry backing this annotation
-    public var geometry: Turf.Geometry {
+    public var geometry: Geometry {
         return .polygon(polygon)
     }
 
     /// The polygon backing this annotation
-    public var polygon: Turf.Polygon
+    public var polygon: Polygon
 
     /// Properties associated with the annotation
     public var userInfo: [String: Any]?
@@ -20,8 +20,8 @@ public struct PolygonAnnotation: Annotation {
     /// Storage for layer properties
     internal var layerProperties: [String: Any] = [:]
 
-    internal var feature: Turf.Feature {
-        var feature = Turf.Feature(geometry: geometry)
+    internal var feature: Feature {
+        var feature = Feature(geometry: geometry)
         feature.identifier = .string(id)
         var properties = JSONObject()
         properties["layerProperties"] = JSONValue(rawValue: layerProperties)
@@ -32,8 +32,8 @@ public struct PolygonAnnotation: Annotation {
         return feature
     }
 
-    /// Create a polygon annotation with a `Turf.Polygon` and an optional identifier.
-    public init(id: String = UUID().uuidString, polygon: Turf.Polygon) {
+    /// Create a polygon annotation with a `Polygon` and an optional identifier.
+    public init(id: String = UUID().uuidString, polygon: Polygon) {
         self.id = id
         self.polygon = polygon
     }

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -152,7 +152,7 @@ public class PolygonAnnotationManager: AnnotationManager {
         }
 
         // build and update the source data
-        let featureCollection = Turf.FeatureCollection(features: annotations.map(\.feature))
+        let featureCollection = FeatureCollection(features: annotations.map(\.feature))
         do {
             let data = try JSONEncoder().encode(featureCollection)
             let jsonObject = try JSONSerialization.jsonObject(with: data) as! [String: Any]

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
@@ -7,12 +7,12 @@ public struct PolylineAnnotation: Annotation {
     public let id: String
 
     /// The geometry backing this annotation
-    public var geometry: Turf.Geometry {
+    public var geometry: Geometry {
         return .lineString(lineString)
     }
 
     /// The line string backing this annotation
-    public var lineString: Turf.LineString
+    public var lineString: LineString
 
     /// Properties associated with the annotation
     public var userInfo: [String: Any]?
@@ -20,8 +20,8 @@ public struct PolylineAnnotation: Annotation {
     /// Storage for layer properties
     internal var layerProperties: [String: Any] = [:]
 
-    internal var feature: Turf.Feature {
-        var feature = Turf.Feature(geometry: geometry)
+    internal var feature: Feature {
+        var feature = Feature(geometry: geometry)
         feature.identifier = .string(id)
         var properties = JSONObject()
         properties["layerProperties"] = JSONValue(rawValue: layerProperties)
@@ -32,15 +32,15 @@ public struct PolylineAnnotation: Annotation {
         return feature
     }
 
-    /// Create a polyline annotation with a `Turf.LineString` and an optional identifier.
-    public init(id: String = UUID().uuidString, lineString: Turf.LineString) {
+    /// Create a polyline annotation with a `LineString` and an optional identifier.
+    public init(id: String = UUID().uuidString, lineString: LineString) {
         self.id = id
         self.lineString = lineString
     }
 
     /// Create a polyline annotation with an array of coordinates and an optional identifier.
     public init(id: String = UUID().uuidString, lineCoordinates: [CLLocationCoordinate2D]) {
-        let lineString = Turf.LineString(lineCoordinates)
+        let lineString = LineString(lineCoordinates)
         self.init(id: id, lineString: lineString)
     }
 

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -152,7 +152,7 @@ public class PolylineAnnotationManager: AnnotationManager {
         }
 
         // build and update the source data
-        let featureCollection = Turf.FeatureCollection(features: annotations.map(\.feature))
+        let featureCollection = FeatureCollection(features: annotations.map(\.feature))
         do {
             let data = try JSONEncoder().encode(featureCollection)
             let jsonObject = try JSONSerialization.jsonObject(with: data) as! [String: Any]

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/MBXGeometry.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/MBXGeometry.swift
@@ -10,79 +10,27 @@ extension MapboxCommon.Geometry {
 
     /// Allows a `Geometry` object to be initialized with a `Geometry` object.
     /// - Parameter geometry: The `Geometry` object to transform into the `Geometry` type.
-    internal convenience init(geometry: Geometry) {
+    internal convenience init(_ geometry: Geometry) {
         switch geometry {
         case .point(let point):
-            let coordinate = point.coordinates
-            self.init(coordinate: coordinate)
-
+            self.init(point: point.coordinates.toValue())
         case .lineString(let line):
-            self.init(line: line.coordinates)
-
+            self.init(line: line.coordinates.map { $0.toValue() })
         case .polygon(let polygon):
-            self.init(polygon: polygon.coordinates)
-
+            self.init(polygon: polygon.coordinates.map { $0.map { $0.toValue() } })
         case .multiPoint(let multiPoint):
-            self.init(multiPoint: multiPoint.coordinates)
-
+            self.init(multiPoint: multiPoint.coordinates.map { $0.toValue() })
         case .multiLineString(let multiLine):
-            self.init(multiLine: multiLine.coordinates)
-
+            self.init(multiLine: multiLine.coordinates.map { $0.map { $0.toValue() } })
         case .multiPolygon(let multiPolygon):
-            self.init(multiPolygon: multiPolygon.coordinates)
-
+            self.init(multiPolygon: multiPolygon.coordinates.map { $0.map { $0.map { $0.toValue() } } })
         case .geometryCollection(let geometryCollection):
-            let geometryValues = geometryCollection.geometries.map {( MapboxCommon.Geometry(geometry: $0) )}
-            self.init(geometryCollection: geometryValues)
+            self.init(geometryCollection: geometryCollection.geometries.map(MapboxCommon.Geometry.init(_:)))
 
         #if USING_TURF_WITH_LIBRARY_EVOLUTION
         @unknown default:
             fatalError("Could not determine Geometry from given Turf Geometry")
         #endif
         }
-    }
-
-    /// Initialize a `Geometry` point from a coordinate.
-    /// - Parameter coordinate: The coordinate to represent the `Geometry` point.
-    private convenience init(coordinate: CLLocationCoordinate2D) {
-        let pointValue = coordinate.toValue()
-        self.init(point: pointValue)
-    }
-
-    /// Initialize a `Geometry` line from an array of coordinates.
-    /// - Parameter coordinates: The coordinates to represent the `Geometry` line.
-    private convenience init(line coordinates: [CLLocationCoordinate2D]) {
-        let lineValues = CLLocationCoordinate2D.convertToValues(from: coordinates)
-        self.init(line: lineValues)
-    }
-
-    /// Initialize a `Geometry` polygon from a two-dimensional array of coordinates.
-    /// - Parameter coordinates: The coordinates to represent the `Geometry` polygon.
-    private convenience init(polygon coordinates: [[CLLocationCoordinate2D]]) {
-        let polygons = coordinates.map({ CLLocationCoordinate2D.convertToValues(from: $0) })
-        self.init(polygon: polygons)
-    }
-
-    /// Initialize a `Geometry` multipoint from an array of `CLLocationCoordinate`s.
-    /// - Parameter coordinates: The coordinates to represent the `Geometry` multipoint.
-    private convenience init(multiPoint coordinates: [CLLocationCoordinate2D]) {
-        let multiPointValue = coordinates.map({ $0.toValue() })
-        self.init(multiPoint: multiPointValue)
-    }
-
-    /// Initialize a `Geometry` multiline from a two-dimensional array of `CLLocationCoordinate`s.
-    /// - Parameter coordinates: The coordinates to represent the `Geometry` multiline.
-    private convenience init(multiLine coordinates: [[CLLocationCoordinate2D]]) {
-        let multiLineValues = coordinates.map({ CLLocationCoordinate2D.convertToValues(from: $0) })
-        self.init(multiLine: multiLineValues)
-    }
-
-    /// Initialize a `Geometry` multipolygon from a three-dimensional array of `CLLocationCoordinate`s.
-    /// - Parameter coordinates: The coordinates to represent the `Geometry` multipolygon.
-    private convenience init(multiPolygon coordinates: [[[CLLocationCoordinate2D]]]) {
-        let multiPolygonValues = coordinates.map({
-            $0.map({ CLLocationCoordinate2D.convertToValues(from: $0) })
-        })
-        self.init(multiPolygon: multiPolygonValues)
     }
 }

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/OfflineRegionGeometryDefinition.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/OfflineRegionGeometryDefinition.swift
@@ -9,14 +9,14 @@ extension OfflineRegionGeometryDefinition {
     ///   - maxZoom: The maximum zoom level for the offline region. Must be greater than or equal to the `minZoom`.
     ///   - pixelRatio: The pixel ratio to be accounted for when downloading assets. Must be greater than or equal to `0`. Typically `1.0` or `2.0`.
     ///   - glyphsRasterizationMode: Specifies glyphs rasterization mode. It defines which glyphs will be loaded from the server.
-    public convenience init?(styleURL: String,
-                             geometry: Geometry,
-                             minZoom: Double,
-                             maxZoom: Double,
-                             pixelRatio: Float,
-                             glyphsRasterizationMode: GlyphsRasterizationMode) {
+    public convenience init(styleURL: String,
+                            geometry: Geometry,
+                            minZoom: Double,
+                            maxZoom: Double,
+                            pixelRatio: Float,
+                            glyphsRasterizationMode: GlyphsRasterizationMode) {
         self.init(__styleURL: styleURL,
-                  geometry: MapboxCommon.Geometry(geometry: geometry),
+                  geometry: MapboxCommon.Geometry(geometry),
                   minZoom: minZoom,
                   maxZoom: maxZoom,
                   pixelRatio: pixelRatio,

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/OfflineRegionGeometryDefinition.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/OfflineRegionGeometryDefinition.swift
@@ -1,0 +1,30 @@
+@available(*, deprecated)
+extension OfflineRegionGeometryDefinition {
+
+    /// Initialize a `OfflineRegionGeometryDefinition`.
+    /// - Parameters:
+    ///   - styleURL: The style URL associated with the offline region.
+    ///   - geometry: The geometry that defines the boundary of the offline region.
+    ///   - minZoom: The minimum zoom level for the offline region. Must be greater than or equal to `0`.
+    ///   - maxZoom: The maximum zoom level for the offline region. Must be greater than or equal to the `minZoom`.
+    ///   - pixelRatio: The pixel ratio to be accounted for when downloading assets. Must be greater than or equal to `0`. Typically `1.0` or `2.0`.
+    ///   - glyphsRasterizationMode: Specifies glyphs rasterization mode. It defines which glyphs will be loaded from the server.
+    public convenience init?(styleURL: String,
+                             geometry: Geometry,
+                             minZoom: Double,
+                             maxZoom: Double,
+                             pixelRatio: Float,
+                             glyphsRasterizationMode: GlyphsRasterizationMode) {
+        self.init(__styleURL: styleURL,
+                  geometry: MapboxCommon.Geometry(geometry: geometry),
+                  minZoom: minZoom,
+                  maxZoom: maxZoom,
+                  pixelRatio: pixelRatio,
+                  glyphsRasterizationMode: glyphsRasterizationMode)
+    }
+
+    /// The geometry that defines the boundary of the offline region.
+    public var geometry: Geometry? {
+        return Geometry(__geometry)
+    }
+}

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/QueriedFeature.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/QueriedFeature.swift
@@ -1,7 +1,7 @@
 import MapboxCoreMaps
 
 extension QueriedFeature {
-    public var feature: Turf.Feature? {
-        return Turf.Feature(__feature)
+    public var feature: Feature? {
+        return Feature(__feature)
     }
 }

--- a/Sources/MapboxMaps/Foundation/Extensions/CoreLocation.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/CoreLocation.swift
@@ -52,13 +52,6 @@ extension CLLocationCoordinate2D {
     internal func toValue() -> NSValue {
         return NSValue(cgPoint: CGPoint(x: latitude, y: longitude))
     }
-
-    /// Convert an array of `CLLocationCoordinate`s to an array of `NSValue`s that wrap a `CGPoint`.
-    internal static func convertToValues(from coordinates: [CLLocationCoordinate2D]) -> [NSValue] {
-        return coordinates.map { (coordinate) -> NSValue in
-            return NSValue(cgPoint: CGPoint(x: coordinate.latitude, y: coordinate.longitude))
-        }
-    }
 }
 
 // MARK: - CLLocationDirection

--- a/Sources/MapboxMaps/Foundation/Extensions/Turf/Feature.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Turf/Feature.swift
@@ -8,7 +8,7 @@ extension Turf.Feature {
     /// Initialize a `Turf.Feature` with an `Feature` object.
     /// - Parameter feature: The `Feature` to use to create the `Feature`.
     internal init?(_ feature: MapboxCommon.Feature) {
-        guard let geometry = Turf.Geometry(feature.geometry) else { return nil }
+        guard let geometry = Geometry(feature.geometry) else { return nil }
 
         self.init(geometry: geometry)
 
@@ -31,43 +31,43 @@ extension Turf.Feature {
     /// Initialize a `Turf.Feature` with a `Point`.
     /// - Parameter point: The `Point` to use to create the `Turf.Feature`.
     internal init(_ point: Point) {
-        self.init(geometry: Turf.Geometry.point(point))
+        self.init(geometry: Geometry.point(point))
     }
 
     /// Initialize a `Turf.Feature` with a `LineString`.
     /// - Parameter line: The `LineString` to use to create the `Turf.Feature`.
     internal init(_ line: LineString) {
-        self.init(geometry: Turf.Geometry.lineString(line))
+        self.init(geometry: Geometry.lineString(line))
     }
 
     /// Initialize a `Turf.Feature` with a `Polygon`.
     /// - Parameter polygon: The `Polygon` to use to create the `Turf.Feature`.
     internal init(_ polygon: Turf.Polygon) {
-        self.init(geometry: Turf.Geometry.polygon(polygon))
+        self.init(geometry: Geometry.polygon(polygon))
     }
 
     /// Initialize a `Turf.Feature` with a `MultiPoint`.
     /// - Parameter multiPoint: The `MultiPoint` to use to create the `Turf.Feature`.
     internal init(_ multiPoint: MultiPoint) {
-        self.init(geometry: Turf.Geometry.multiPoint(multiPoint))
+        self.init(geometry: Geometry.multiPoint(multiPoint))
     }
 
     /// Initialize a `Turf.Feature` with a `MultiLineString`.
     /// - Parameter multiLine: The `MultiLineString` to use to create the `Turf.Feature`.
     internal init(_ multiLine: MultiLineString) {
-        self.init(geometry: Turf.Geometry.multiLineString(multiLine))
+        self.init(geometry: Geometry.multiLineString(multiLine))
     }
 
     /// Initialize a `Turf.Feature` with a `MultiPolygon`.
     /// - Parameter multiPolygon: The `MultiPolygon` to use to create the `Turf.Feature`.
     internal init(_ multiPolygon: MultiPolygon) {
-        self.init(geometry: Turf.Geometry.multiPolygon(multiPolygon))
+        self.init(geometry: Geometry.multiPolygon(multiPolygon))
     }
 
     /// Initialize a `Turf.Feature` with a `GeometryCollection`.
     /// - Parameter geometryCollection: The `GeometryCollection` to use to create the `Turf.Feature`.
     internal init(_ geometryCollection: GeometryCollection) {
-        self.init(geometry: Turf.Geometry.geometryCollection(geometryCollection))
+        self.init(geometry: Geometry.geometryCollection(geometryCollection))
     }
 }
 

--- a/Sources/MapboxMaps/Foundation/Extensions/Turf/Feature.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Turf/Feature.swift
@@ -1,12 +1,9 @@
-import Foundation
-import MapboxCommon
-
 public typealias Feature = Turf.Feature
 
-extension Turf.Feature {
+extension Feature {
 
-    /// Initialize a `Turf.Feature` with an `Feature` object.
-    /// - Parameter feature: The `Feature` to use to create the `Feature`.
+    /// Initialize a `Feature` with a `MapboxCommon.Feature` object.
+    /// - Parameter feature: The `MapboxCommon.Feature` to use to create the `Feature`.
     internal init?(_ feature: MapboxCommon.Feature) {
         guard let geometry = Geometry(feature.geometry) else { return nil }
 
@@ -27,53 +24,11 @@ extension Turf.Feature {
 
         properties = JSONObject(rawValue: feature.properties)
     }
-
-    /// Initialize a `Turf.Feature` with a `Point`.
-    /// - Parameter point: The `Point` to use to create the `Turf.Feature`.
-    internal init(_ point: Point) {
-        self.init(geometry: Geometry.point(point))
-    }
-
-    /// Initialize a `Turf.Feature` with a `LineString`.
-    /// - Parameter line: The `LineString` to use to create the `Turf.Feature`.
-    internal init(_ line: LineString) {
-        self.init(geometry: Geometry.lineString(line))
-    }
-
-    /// Initialize a `Turf.Feature` with a `Polygon`.
-    /// - Parameter polygon: The `Polygon` to use to create the `Turf.Feature`.
-    internal init(_ polygon: Turf.Polygon) {
-        self.init(geometry: Geometry.polygon(polygon))
-    }
-
-    /// Initialize a `Turf.Feature` with a `MultiPoint`.
-    /// - Parameter multiPoint: The `MultiPoint` to use to create the `Turf.Feature`.
-    internal init(_ multiPoint: MultiPoint) {
-        self.init(geometry: Geometry.multiPoint(multiPoint))
-    }
-
-    /// Initialize a `Turf.Feature` with a `MultiLineString`.
-    /// - Parameter multiLine: The `MultiLineString` to use to create the `Turf.Feature`.
-    internal init(_ multiLine: MultiLineString) {
-        self.init(geometry: Geometry.multiLineString(multiLine))
-    }
-
-    /// Initialize a `Turf.Feature` with a `MultiPolygon`.
-    /// - Parameter multiPolygon: The `MultiPolygon` to use to create the `Turf.Feature`.
-    internal init(_ multiPolygon: MultiPolygon) {
-        self.init(geometry: Geometry.multiPolygon(multiPolygon))
-    }
-
-    /// Initialize a `Turf.Feature` with a `GeometryCollection`.
-    /// - Parameter geometryCollection: The `GeometryCollection` to use to create the `Turf.Feature`.
-    internal init(_ geometryCollection: GeometryCollection) {
-        self.init(geometry: Geometry.geometryCollection(geometryCollection))
-    }
 }
 
 extension MapboxCommon.Feature {
-    /// Initialize an `Feature` with a `Turf.Feature`
-    internal convenience init(_ feature: Turf.Feature) {
+    /// Initialize a `MapboxCommon.Feature` with a `Feature`
+    internal convenience init(_ feature: Feature) {
 
         let identifier: NSObject
 
@@ -95,7 +50,7 @@ extension MapboxCommon.Feature {
         // A null geometry is valid GeoJSON but not supported by MapboxCommon.
         // The closest thing would be an empty GeometryCollection.
         let nonNullGeometry = feature.geometry ?? .geometryCollection(.init(geometries: []))
-        let geometry = MapboxCommon.Geometry(geometry: nonNullGeometry)
+        let geometry = MapboxCommon.Geometry(nonNullGeometry)
 
         self.init(identifier: identifier,
                   geometry: geometry,

--- a/Sources/MapboxMaps/Foundation/Extensions/Turf/Geometry.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Turf/Geometry.swift
@@ -1,66 +1,45 @@
-import MapboxCommon
-
-// swiftlint:disable cyclomatic_complexity
-
-// MARK: - Geometry
-
 extension Geometry {
 
     /// Allows a Turf object to be initialized with an internal `Geometry` object.
     /// - Parameter geometry: The `Geometry` object to transform.
     internal init?(_ geometry: MapboxCommon.Geometry) {
+        let result: Geometry?
         switch geometry.geometryType {
         case GeometryType_Point:
-            guard let coordinate = geometry.extractLocations()?.coordinateValue() else {
-                return nil
+            result = geometry.extractLocations().map {
+                .point(Point($0.coordinateValue()))
             }
-
-            self = Geometry.point(Point(coordinate))
-
         case GeometryType_Line:
-            guard let coordinates = geometry.extractLocationsArray()?.map({ $0.coordinateValue() }) else {
-                return nil
+            result = geometry.extractLocationsArray().map {
+                .lineString(LineString($0.map { $0.coordinateValue() }))
             }
-
-            self = Geometry.lineString(LineString(coordinates))
-
         case GeometryType_Polygon:
-            guard let coordinates = geometry.extractLocations2DArray()?.map(NSValue.toCoordinates(array:)) else {
-                return nil
+            result = geometry.extractLocations2DArray().map {
+                .polygon(Polygon($0.map(NSValue.toCoordinates(array:))))
             }
-
-            self = Geometry.polygon(Polygon(coordinates))
-
         case GeometryType_MultiPoint:
-            guard let coordinates = geometry.extractLocationsArray()?.map({ $0.coordinateValue() }) else {
-                return nil
+            result = geometry.extractLocationsArray().map {
+                .multiPoint(MultiPoint($0.map({ $0.coordinateValue() })))
             }
-
-            self = Geometry.multiPoint(MultiPoint(coordinates))
-
         case GeometryType_MultiLine:
-            guard let coordinates = geometry.extractLocations2DArray()?.map(NSValue.toCoordinates(array:)) else {
-                return nil
+            result = geometry.extractLocations2DArray().map {
+                .multiLineString(MultiLineString($0.map(NSValue.toCoordinates(array:))))
             }
-
-            self = Geometry.multiLineString(MultiLineString(coordinates))
-
         case GeometryType_MultiPolygon:
-            guard let coordinates = geometry.extractLocations3DArray()?.map(NSValue.toCoordinates2D(array:)) else {
-                return nil
+            result = geometry.extractLocations3DArray().map {
+                .multiPolygon(MultiPolygon($0.map(NSValue.toCoordinates2D(array:))))
             }
-
-            self = Geometry.multiPolygon(MultiPolygon(coordinates))
-
         case GeometryType_GeometryCollection:
-            guard let geometries = geometry.extractGeometriesArray()?.compactMap({ Geometry($0) }) else {
-                return nil
+            result = geometry.extractGeometriesArray().map {
+                .geometryCollection(GeometryCollection(geometries: $0.compactMap(Geometry.init(_:))))
             }
-
-            self = Geometry.geometryCollection(GeometryCollection(geometries: geometries))
-
         default:
+            result = nil
+        }
+
+        guard let result = result else {
             return nil
         }
+        self = result
     }
 }

--- a/Sources/MapboxMaps/Foundation/Extensions/Turf/Geometry.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Turf/Geometry.swift
@@ -3,41 +3,41 @@ extension Geometry {
     /// Allows a Turf object to be initialized with an internal `Geometry` object.
     /// - Parameter geometry: The `Geometry` object to transform.
     internal init?(_ geometry: MapboxCommon.Geometry) {
-        let result: Geometry?
+        let optionalResult: Geometry?
         switch geometry.geometryType {
         case GeometryType_Point:
-            result = geometry.extractLocations().map {
+            optionalResult = geometry.extractLocations().map {
                 .point(Point($0.coordinateValue()))
             }
         case GeometryType_Line:
-            result = geometry.extractLocationsArray().map {
+            optionalResult = geometry.extractLocationsArray().map {
                 .lineString(LineString($0.map { $0.coordinateValue() }))
             }
         case GeometryType_Polygon:
-            result = geometry.extractLocations2DArray().map {
+            optionalResult = geometry.extractLocations2DArray().map {
                 .polygon(Polygon($0.map(NSValue.toCoordinates(array:))))
             }
         case GeometryType_MultiPoint:
-            result = geometry.extractLocationsArray().map {
+            optionalResult = geometry.extractLocationsArray().map {
                 .multiPoint(MultiPoint($0.map({ $0.coordinateValue() })))
             }
         case GeometryType_MultiLine:
-            result = geometry.extractLocations2DArray().map {
+            optionalResult = geometry.extractLocations2DArray().map {
                 .multiLineString(MultiLineString($0.map(NSValue.toCoordinates(array:))))
             }
         case GeometryType_MultiPolygon:
-            result = geometry.extractLocations3DArray().map {
+            optionalResult = geometry.extractLocations3DArray().map {
                 .multiPolygon(MultiPolygon($0.map(NSValue.toCoordinates2D(array:))))
             }
         case GeometryType_GeometryCollection:
-            result = geometry.extractGeometriesArray().map {
+            optionalResult = geometry.extractGeometriesArray().map {
                 .geometryCollection(GeometryCollection(geometries: $0.compactMap(Geometry.init(_:))))
             }
         default:
-            result = nil
+            optionalResult = nil
         }
 
-        guard let result = result else {
+        guard let result = optionalResult else {
             return nil
         }
         self = result

--- a/Sources/MapboxMaps/Foundation/Extensions/Turf/Geometry.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Turf/Geometry.swift
@@ -4,7 +4,7 @@ import MapboxCommon
 
 // MARK: - Geometry
 
-extension Turf.Geometry {
+extension Geometry {
 
     /// Allows a Turf object to be initialized with an internal `Geometry` object.
     /// - Parameter geometry: The `Geometry` object to transform.
@@ -15,49 +15,49 @@ extension Turf.Geometry {
                 return nil
             }
 
-            self = Turf.Geometry.point(Point(coordinate))
+            self = Geometry.point(Point(coordinate))
 
         case GeometryType_Line:
             guard let coordinates = geometry.extractLocationsArray()?.map({ $0.coordinateValue() }) else {
                 return nil
             }
 
-            self = Turf.Geometry.lineString(LineString(coordinates))
+            self = Geometry.lineString(LineString(coordinates))
 
         case GeometryType_Polygon:
             guard let coordinates = geometry.extractLocations2DArray()?.map(NSValue.toCoordinates(array:)) else {
                 return nil
             }
 
-            self = Turf.Geometry.polygon(Polygon(coordinates))
+            self = Geometry.polygon(Polygon(coordinates))
 
         case GeometryType_MultiPoint:
             guard let coordinates = geometry.extractLocationsArray()?.map({ $0.coordinateValue() }) else {
                 return nil
             }
 
-            self = Turf.Geometry.multiPoint(MultiPoint(coordinates))
+            self = Geometry.multiPoint(MultiPoint(coordinates))
 
         case GeometryType_MultiLine:
             guard let coordinates = geometry.extractLocations2DArray()?.map(NSValue.toCoordinates(array:)) else {
                 return nil
             }
 
-            self = Turf.Geometry.multiLineString(MultiLineString(coordinates))
+            self = Geometry.multiLineString(MultiLineString(coordinates))
 
         case GeometryType_MultiPolygon:
             guard let coordinates = geometry.extractLocations3DArray()?.map(NSValue.toCoordinates2D(array:)) else {
                 return nil
             }
 
-            self = Turf.Geometry.multiPolygon(MultiPolygon(coordinates))
+            self = Geometry.multiPolygon(MultiPolygon(coordinates))
 
         case GeometryType_GeometryCollection:
-            guard let geometries = geometry.extractGeometriesArray()?.compactMap({ Turf.Geometry($0) }) else {
+            guard let geometries = geometry.extractGeometriesArray()?.compactMap({ Geometry($0) }) else {
                 return nil
             }
 
-            self = Turf.Geometry.geometryCollection(GeometryCollection(geometries: geometries))
+            self = Geometry.geometryCollection(GeometryCollection(geometries: geometries))
 
         default:
             return nil

--- a/Sources/MapboxMaps/Foundation/MapFeatureQueryable.swift
+++ b/Sources/MapboxMaps/Foundation/MapFeatureQueryable.swift
@@ -19,7 +19,7 @@ internal protocol MapFeatureQueryable: AnyObject {
 
     //swiftlint:disable:next function_parameter_count
     func queryFeatureExtension(for sourceId: String,
-                               feature: Turf.Feature,
+                               feature: Feature,
                                extension: String,
                                extensionField: String,
                                args: [String: Any]?,

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -356,7 +356,7 @@ public final class MapboxMap: MapboxMapProtocol {
                        pitch: CGFloat?) -> CameraOptions {
         return CameraOptions(
             __map.cameraForGeometry(
-                for: MapboxCommon.Geometry(geometry: geometry),
+                for: MapboxCommon.Geometry(geometry),
                 padding: padding.toMBXEdgeInsetsValue(),
                 bearing: bearing?.NSNumber,
                 pitch: pitch?.NSNumber))

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -350,7 +350,7 @@ public final class MapboxMap: MapboxMapProtocol {
     ///   - bearing: The new bearing to be used by the camera.
     ///   - pitch: The new pitch to be used by the camera.
     /// - Returns: A `CameraOptions` that fits the provided constraints
-    public func camera(for geometry: Turf.Geometry,
+    public func camera(for geometry: Geometry,
                        padding: UIEdgeInsets,
                        bearing: CGFloat?,
                        pitch: CGFloat?) -> CameraOptions {

--- a/Sources/MapboxMaps/Offline/TileRegionLoadOptions+MapboxMaps.swift
+++ b/Sources/MapboxMaps/Offline/TileRegionLoadOptions+MapboxMaps.swift
@@ -34,7 +34,7 @@ extension TileRegionLoadOptions {
 
         var commonGeometry: MapboxCommon.Geometry?
         if let geometry = geometry {
-            commonGeometry = MapboxCommon.Geometry(geometry: geometry)
+            commonGeometry = MapboxCommon.Geometry(geometry)
         }
 
         self.init(__geometry: commonGeometry,

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -858,7 +858,7 @@ public class Style {
     ///
     /// - Throws:
     ///     An error describing why the operation was unsuccessful.
-    public func setCustomGeometrySourceTileData(forSourceId sourceId: String, tileId: CanonicalTileID, features: [Turf.Feature]) throws {
+    public func setCustomGeometrySourceTileData(forSourceId sourceId: String, tileId: CanonicalTileID, features: [Feature]) throws {
         let mbxFeatures = features.compactMap { MapboxCommon.Feature($0) }
         return try handleExpected {
             return styleManager.setStyleCustomGeometrySourceTileDataForSourceId(sourceId, tileId: tileId, featureCollection: mbxFeatures)

--- a/Sources/MapboxMaps/Style/Types/GeoJSONSourceData.swift
+++ b/Sources/MapboxMaps/Style/Types/GeoJSONSourceData.swift
@@ -7,10 +7,10 @@ public enum GeoJSONSourceData: Codable {
     case url(URL)
 
     /// The `data` property can be a feature
-    case feature(Turf.Feature)
+    case feature(Feature)
 
     /// The `data` property can be a feature collection
-    case featureCollection(Turf.FeatureCollection)
+    case featureCollection(FeatureCollection)
 
     /// The `data` property can be a geometry with no associated properties.
     case geometry(Geometry)
@@ -26,12 +26,12 @@ public enum GeoJSONSourceData: Codable {
             return
         }
 
-        if let decodedFeature = try? container.decode(Turf.Feature.self) {
+        if let decodedFeature = try? container.decode(Feature.self) {
             self = .feature(decodedFeature)
             return
         }
 
-        if let decodedFeatureCollection = try? container.decode(Turf.FeatureCollection.self) {
+        if let decodedFeatureCollection = try? container.decode(FeatureCollection.self) {
             self = .featureCollection(decodedFeatureCollection)
             return
         }

--- a/Sources/MapboxMaps/Style/Types/GeoJSONSourceData.swift
+++ b/Sources/MapboxMaps/Style/Types/GeoJSONSourceData.swift
@@ -13,7 +13,7 @@ public enum GeoJSONSourceData: Codable {
     case featureCollection(Turf.FeatureCollection)
 
     /// The `data` property can be a geometry with no associated properties.
-    case geometry(Turf.Geometry)
+    case geometry(Geometry)
 
     /// Empty data to be used for initialization
     case empty

--- a/Tests/MapboxMapsTests/Foundation/Extensions/Core/OfflineRegionGeometryDefinitionTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Extensions/Core/OfflineRegionGeometryDefinitionTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import MapboxMaps
+
+class OfflineRegionGeometryDefinitionTests: XCTestCase {
+
+    var coordinate: CLLocationCoordinate2D!
+    var styleUrl: String = "testurl.com"
+    let minZoom: Double = 1
+    let maxZoom: Double = 20
+    let pixelRatio: Float = Float(UIScreen.main.scale)
+    let glyphsRasterizationMode: GlyphsRasterizationMode = .noGlyphsRasterizedLocally
+
+    override func setUp() {
+        super.setUp()
+        coordinate = .random()
+    }
+
+    override func tearDown() {
+        coordinate = nil
+        super.tearDown()
+    }
+
+    func testInitializationWithNonNilAndNonEmptyValues() throws {
+        let offlineRegionGeometryDefinition = try XCTUnwrap(OfflineRegionGeometryDefinition(styleURL: styleUrl,
+                                                                                            geometry: Geometry.point(Point(coordinate)),
+                                                                                            minZoom: minZoom,
+                                                                                            maxZoom: maxZoom,
+                                                                                            pixelRatio: pixelRatio,
+                                                                                            glyphsRasterizationMode: glyphsRasterizationMode))
+
+        XCTAssertEqual(offlineRegionGeometryDefinition.__geometry.geometryType, GeometryType_Point)
+    }
+
+    func testNonNilGeometry() {
+        let offlineRegionGeometryDefinition = OfflineRegionGeometryDefinition(__styleURL: styleUrl,
+                                                                              geometry: MapboxCommon.Geometry(point: CGPoint(x: coordinate.latitude, y: coordinate.longitude) as NSValue),
+                                                                              minZoom: minZoom,
+                                                                              maxZoom: maxZoom,
+                                                                              pixelRatio: pixelRatio,
+                                                                              glyphsRasterizationMode: glyphsRasterizationMode)
+
+        XCTAssertEqual(offlineRegionGeometryDefinition.geometry, .point(.init(coordinate)))
+    }
+}

--- a/Tests/MapboxMapsTests/Foundation/Extensions/Core/OfflineRegionGeometryDefinitionTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Extensions/Core/OfflineRegionGeometryDefinitionTests.swift
@@ -1,44 +1,67 @@
 import XCTest
 @testable import MapboxMaps
 
-class OfflineRegionGeometryDefinitionTests: XCTestCase {
+@available(*, deprecated)
+final class OfflineRegionGeometryDefinitionTests: XCTestCase {
 
+    var styleURL: String!
     var coordinate: CLLocationCoordinate2D!
-    var styleUrl: String = "testurl.com"
-    let minZoom: Double = 1
-    let maxZoom: Double = 20
-    let pixelRatio: Float = Float(UIScreen.main.scale)
-    let glyphsRasterizationMode: GlyphsRasterizationMode = .noGlyphsRasterizedLocally
+    var minZoom: Double!
+    var maxZoom: Double!
+    var pixelRatio: Float!
+    var glyphsRasterizationMode: GlyphsRasterizationMode!
 
     override func setUp() {
         super.setUp()
+        styleURL = .randomASCII(withLength: .random(in: 0...50))
         coordinate = .random()
+        minZoom = .random(in: 0..<10)
+        maxZoom = .random(in: 10...20)
+        // swiftlint:disable:next syntactic_sugar
+        pixelRatio = Array<Float>([1.0, 2.0, 3.0]).randomElement()!
+        glyphsRasterizationMode = [
+            .noGlyphsRasterizedLocally,
+            .ideographsRasterizedLocally,
+            .allGlyphsRasterizedLocally].randomElement()!
     }
 
     override func tearDown() {
+        glyphsRasterizationMode = nil
+        pixelRatio = nil
+        maxZoom = nil
+        minZoom = nil
         coordinate = nil
+        styleURL = nil
         super.tearDown()
     }
 
-    func testInitializationWithNonNilAndNonEmptyValues() throws {
-        let offlineRegionGeometryDefinition = try XCTUnwrap(OfflineRegionGeometryDefinition(styleURL: styleUrl,
-                                                                                            geometry: Geometry.point(Point(coordinate)),
-                                                                                            minZoom: minZoom,
-                                                                                            maxZoom: maxZoom,
-                                                                                            pixelRatio: pixelRatio,
-                                                                                            glyphsRasterizationMode: glyphsRasterizationMode))
+    func testInitialization() {
+        let offlineRegionGeometryDefinition = OfflineRegionGeometryDefinition(
+            styleURL: styleURL,
+            geometry: .point(Point(coordinate)),
+            minZoom: minZoom,
+            maxZoom: maxZoom,
+            pixelRatio: pixelRatio,
+            glyphsRasterizationMode: glyphsRasterizationMode)
 
+        XCTAssertEqual(offlineRegionGeometryDefinition.styleURL, styleURL)
         XCTAssertEqual(offlineRegionGeometryDefinition.__geometry.geometryType, GeometryType_Point)
+        XCTAssertEqual(offlineRegionGeometryDefinition.__geometry.extractLocations()?.coordinateValue(), coordinate)
+        XCTAssertEqual(offlineRegionGeometryDefinition.minZoom, minZoom)
+        XCTAssertEqual(offlineRegionGeometryDefinition.maxZoom, maxZoom)
+        XCTAssertEqual(offlineRegionGeometryDefinition.pixelRatio, pixelRatio)
+        XCTAssertEqual(offlineRegionGeometryDefinition.glyphsRasterizationMode, glyphsRasterizationMode)
     }
 
-    func testNonNilGeometry() {
-        let offlineRegionGeometryDefinition = OfflineRegionGeometryDefinition(__styleURL: styleUrl,
-                                                                              geometry: MapboxCommon.Geometry(point: CGPoint(x: coordinate.latitude, y: coordinate.longitude) as NSValue),
-                                                                              minZoom: minZoom,
-                                                                              maxZoom: maxZoom,
-                                                                              pixelRatio: pixelRatio,
-                                                                              glyphsRasterizationMode: glyphsRasterizationMode)
+    func testGeometry() {
+        let offlineRegionGeometryDefinition = OfflineRegionGeometryDefinition(
+            __styleURL: styleURL,
+            geometry: MapboxCommon.Geometry(point: coordinate.toValue()),
+            minZoom: minZoom,
+            maxZoom: maxZoom,
+            pixelRatio: pixelRatio,
+            glyphsRasterizationMode: glyphsRasterizationMode)
 
-        XCTAssertEqual(offlineRegionGeometryDefinition.geometry, .point(.init(coordinate)))
+        XCTAssertEqual(offlineRegionGeometryDefinition.geometry, .point(Point(coordinate)))
     }
 }

--- a/Tests/MapboxMapsTests/Foundation/Extensions/Turf/FeatureTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Extensions/Turf/FeatureTests.swift
@@ -8,7 +8,7 @@ final class FeatureTests: XCTestCase {
     func testInitializingTurfFeatureFromCommonFeatureNilIdentifier() throws {
         let commonFeature = MapboxCommon.Feature(
             identifier: NSObject(),
-            geometry: MapboxCommon.Geometry(geometry: geometry),
+            geometry: MapboxCommon.Geometry(geometry),
             properties: [:])
 
         let feature = try XCTUnwrap(Feature(commonFeature))
@@ -19,7 +19,7 @@ final class FeatureTests: XCTestCase {
     func testInitializingTurfFeatureFromCommonFeatureNumberIdentifier() throws {
         let commonFeature = MapboxCommon.Feature(
             identifier: NSNumber(value: 2.0),
-            geometry: MapboxCommon.Geometry(geometry: geometry),
+            geometry: MapboxCommon.Geometry(geometry),
             properties: [:])
 
         let feature = try XCTUnwrap(Feature(commonFeature))
@@ -33,7 +33,7 @@ final class FeatureTests: XCTestCase {
     func testInitializingTurfFeatureFromCommonFeatureStringIdentifier() throws {
         let commonFeature = MapboxCommon.Feature(
             identifier: NSString(string: "abc"),
-            geometry: MapboxCommon.Geometry(geometry: geometry),
+            geometry: MapboxCommon.Geometry(geometry),
             properties: [:])
 
         let feature = try XCTUnwrap(Feature(commonFeature))

--- a/Tests/MapboxMapsTests/Foundation/GeoJSON/Geometry+MBXGeometryTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/GeoJSON/Geometry+MBXGeometryTests.swift
@@ -8,7 +8,7 @@ internal class GeometryMBXGeometryTests: XCTestCase {
     func testMBXGeometryToTurfGeometry_Point() {
         // Given
         let coordinate = CLLocationCoordinate2D(latitude: 40, longitude: 40)
-        let mbxGeometry = MapboxCommon.Geometry(geometry: .point(Point(coordinate)))
+        let mbxGeometry = MapboxCommon.Geometry(.point(Point(coordinate)))
 
         // When
         let turfGeometry = Geometry(mbxGeometry)
@@ -30,7 +30,7 @@ internal class GeometryMBXGeometryTests: XCTestCase {
             CLLocationCoordinate2D(latitude: 0, longitude: 2)
         ]
 
-        let mbxGeometry = MapboxCommon.Geometry(geometry: .lineString(LineString(lineCoordinates)))
+        let mbxGeometry = MapboxCommon.Geometry(.lineString(LineString(lineCoordinates)))
 
         // When
         let turfGeometry = Geometry(mbxGeometry)
@@ -53,7 +53,7 @@ internal class GeometryMBXGeometryTests: XCTestCase {
             CLLocationCoordinate2D(latitude: 0, longitude: 0)
         ]
 
-        let mbxGeometry = MapboxCommon.Geometry(geometry: .polygon(Polygon([polygonCoordinates])))
+        let mbxGeometry = MapboxCommon.Geometry(.polygon(Polygon([polygonCoordinates])))
 
         // When
         let turfGeometry = Geometry(mbxGeometry)
@@ -72,7 +72,7 @@ internal class GeometryMBXGeometryTests: XCTestCase {
         let coordinate1 = CLLocationCoordinate2D(latitude: -44, longitude: 30)
         let coordinate2 = CLLocationCoordinate2D(latitude: -50, longitude: 40)
 
-        let mbxGeometry = MapboxCommon.Geometry(geometry: .multiPoint(MultiPoint([coordinate1, coordinate2])))
+        let mbxGeometry = MapboxCommon.Geometry(.multiPoint(MultiPoint([coordinate1, coordinate2])))
 
         // When
         let turfGeometry = Geometry(mbxGeometry)
@@ -98,7 +98,7 @@ internal class GeometryMBXGeometryTests: XCTestCase {
             CLLocationCoordinate2D(latitude: 20, longitude: 31)
         ]
 
-        let mbxGeometry = MapboxCommon.Geometry(geometry: .multiLineString(MultiLineString([line1, line2])))
+        let mbxGeometry = MapboxCommon.Geometry(.multiLineString(MultiLineString([line1, line2])))
 
         // When
         let turfGeometry = Geometry(mbxGeometry)
@@ -130,7 +130,7 @@ internal class GeometryMBXGeometryTests: XCTestCase {
             CLLocationCoordinate2D(latitude: 0, longitude: 0)
         ]
 
-        let mbxGeometry = MapboxCommon.Geometry(geometry: .multiPolygon(MultiPolygon([[polygon1], [polygon2]])))
+        let mbxGeometry = MapboxCommon.Geometry(.multiPolygon(MultiPolygon([[polygon1], [polygon2]])))
 
         // When
         let turfGeometry = Geometry(mbxGeometry)
@@ -154,7 +154,7 @@ internal class GeometryMBXGeometryTests: XCTestCase {
         let geometry = Geometry.point(point)
 
         // When
-        let mbxGeometry = MapboxCommon.Geometry(geometry: geometry)
+        let mbxGeometry = MapboxCommon.Geometry(geometry)
 
         // Then
         guard let mbxLocationValue = mbxGeometry.extractLocations()?.coordinateValue() else {
@@ -176,7 +176,7 @@ internal class GeometryMBXGeometryTests: XCTestCase {
         let geometry = Geometry.lineString(line)
 
         // When
-        let mbxGeometry = MapboxCommon.Geometry(geometry: geometry)
+        let mbxGeometry = MapboxCommon.Geometry(geometry)
 
         // Then
         guard let mbxLocationValues = mbxGeometry.extractLocationsArray() else {
@@ -202,7 +202,7 @@ internal class GeometryMBXGeometryTests: XCTestCase {
         let geometry = Geometry.polygon(polygon)
 
         // When
-        let mbxGeometry = MapboxCommon.Geometry(geometry: geometry)
+        let mbxGeometry = MapboxCommon.Geometry(geometry)
 
         // Then
         guard let mbxLocationValues = mbxGeometry.extractLocations2DArray() else {
@@ -223,7 +223,7 @@ internal class GeometryMBXGeometryTests: XCTestCase {
         let geometry = Geometry.multiPoint(multiPoint)
 
         // When
-        let mbxGeometry = MapboxCommon.Geometry(geometry: geometry)
+        let mbxGeometry = MapboxCommon.Geometry(geometry)
 
         // Then
         guard let mbxLocationValues = mbxGeometry.extractLocationsArray() else {
@@ -252,7 +252,7 @@ internal class GeometryMBXGeometryTests: XCTestCase {
         let geometry = Geometry.multiLineString(multiLineString)
 
         // When
-        let mbxGeometry = MapboxCommon.Geometry(geometry: geometry)
+        let mbxGeometry = MapboxCommon.Geometry(geometry)
 
         // Then
         guard let mbxLocationValues = mbxGeometry.extractLocations2DArray() else {
@@ -285,7 +285,7 @@ internal class GeometryMBXGeometryTests: XCTestCase {
         let geometry = Geometry.multiPolygon(multiPolygon)
 
         // When
-        let mbxGeometry = MapboxCommon.Geometry(geometry: geometry)
+        let mbxGeometry = MapboxCommon.Geometry(geometry)
 
         // Then
         guard let mbxLocationValues = mbxGeometry.extractLocations3DArray() else {
@@ -315,7 +315,7 @@ internal class GeometryMBXGeometryTests: XCTestCase {
         let geometryCollection = Geometry.geometryCollection(geometries)
 
         // When
-        let mbxGeometry = MapboxCommon.Geometry(geometry: geometryCollection)
+        let mbxGeometry = MapboxCommon.Geometry(geometryCollection)
 
         // Then
         guard let mbxLocationValues = mbxGeometry.extractGeometriesArray() else {

--- a/Tests/MapboxMapsTests/Foundation/GeoJSON/MultiPolygonTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/GeoJSON/MultiPolygonTests.swift
@@ -66,7 +66,7 @@ class MultiPolygonTests: XCTestCase {
             ]
         ]
 
-        var multiPolygonFeature = Feature(MultiPolygon(coordinates))
+        var multiPolygonFeature = Feature(geometry: .multiPolygon(MultiPolygon(coordinates)))
         multiPolygonFeature.identifier = FeatureIdentifier.string("uniqueIdentifier")
         multiPolygonFeature.properties = ["some": "var"]
 

--- a/Tests/MapboxMapsTests/Foundation/Integration Tests/FeatureStateIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Integration Tests/FeatureStateIntegrationTests.swift
@@ -83,8 +83,8 @@ internal class FeatureStateIntegrationTests: MapViewIntegrationTestCase {
 
         let coord = CLLocationCoordinate2D(latitude: 14.765625,
                                            longitude: 26.194876675795218)
-        let point = Turf.Point(coord)
-        let feature = Turf.Feature(point)
+        let point = Point(coord)
+        let feature = Feature(geometry: .point(point))
 
         var geojsonSource = GeoJSONSource()
         geojsonSource.generateId = true

--- a/Tests/MapboxMapsTests/Offline/TileRegionLoadOptions+MapboxMaps.swift
+++ b/Tests/MapboxMapsTests/Offline/TileRegionLoadOptions+MapboxMaps.swift
@@ -107,7 +107,7 @@ final class TileRegionLoadOptions_MapboxMapsTests: XCTestCase {
     }
 
     func testNonNilGeometry() {
-        let tileRegionLoadOptions = TileRegionLoadOptions(__geometry: MapboxCommon.Geometry(geometry: .point(Point(coordinate))),
+        let tileRegionLoadOptions = TileRegionLoadOptions(__geometry: MapboxCommon.Geometry(.point(Point(coordinate))),
                                                           descriptors: nil,
                                                           metadata: nil,
                                                           acceptExpired: false,

--- a/Tests/MapboxMapsTests/Style/Fixtures/SourceProperties+Fixtures.swift
+++ b/Tests/MapboxMapsTests/Style/Fixtures/SourceProperties+Fixtures.swift
@@ -28,6 +28,6 @@ extension GeoJSONSourceData: Equatable {
 
     static func testSourceValue() -> GeoJSONSourceData {
         let point = Point(CLLocationCoordinate2D(latitude: 0, longitude: 0))
-        return .feature(.init(point))
+        return .feature(.init(geometry: .point(point)))
     }
 }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.

### Summary of changes
This PR extends `OfflineRegionGeometryDefinition.geometry` to use `Geometry` rather than `MapboxCommon.Geometry`. It also adds a convenience initializer that takes a `Geometry`.