### PR TITLE
Redesign single tap event handling for annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,10 @@ Mapbox welcomes participation and contributions from everyone.
 * `public func source<T: Source>(withId id: String) throws -> T` has been updated to `public func source<T>(withId id: String, type: T.Type) throws -> T where T: Source`. ([#694](https://github.com/mapbox/mapbox-maps-ios/pull/694))
 * `@_spi(Experimental) public func layer(withId id: String, type: Layer.Type) throws -> Layer` is no longer experimental and has been updated to `public func layer(withId id: String) throws -> Layer`. ([#694](https://github.com/mapbox/mapbox-maps-ios/pull/694))
 * `@_spi(Experimental) public func source(withId id: String, type: Source.Type) throws  -> Source` is no longer experimental and has been updated to `public func source(withId id: String) throws  -> Source`. ([#694](https://github.com/mapbox/mapbox-maps-ios/pull/694))
-<<<<<<< HEAD
 * Converts `PointAnnotation.Image` from an `enum` to a `struct`. ([#707](https://github.com/mapbox/mapbox-maps-ios/pull/707))
 * Removes `PointAnnotation.Image.default`. ([#707](https://github.com/mapbox/mapbox-maps-ios/pull/707))
 * Replaces `PointAnnotation.Image.custom` with `PointAnnotation.Image.init(image:name:)`. ([#707](https://github.com/mapbox/mapbox-maps-ios/pull/707))
-=======
 * The `tapGestureRecognizer` var on each `*AnnotationManager` has been removed in favor of a unified tap gesture recognizer available at `GestureManager.singleTapGestureRecognizer`([#709](https://github.com/mapbox/mapbox-maps-ios/pull/709)).
->>>>>>> 466b6edc (changelog)
 
 ## 10.0.0-rc.9 - Sept 22, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ Mapbox welcomes participation and contributions from everyone.
 * `public func source<T: Source>(withId id: String) throws -> T` has been updated to `public func source<T>(withId id: String, type: T.Type) throws -> T where T: Source`. ([#694](https://github.com/mapbox/mapbox-maps-ios/pull/694))
 * `@_spi(Experimental) public func layer(withId id: String, type: Layer.Type) throws -> Layer` is no longer experimental and has been updated to `public func layer(withId id: String) throws -> Layer`. ([#694](https://github.com/mapbox/mapbox-maps-ios/pull/694))
 * `@_spi(Experimental) public func source(withId id: String, type: Source.Type) throws  -> Source` is no longer experimental and has been updated to `public func source(withId id: String) throws  -> Source`. ([#694](https://github.com/mapbox/mapbox-maps-ios/pull/694))
+<<<<<<< HEAD
 * Converts `PointAnnotation.Image` from an `enum` to a `struct`. ([#707](https://github.com/mapbox/mapbox-maps-ios/pull/707))
 * Removes `PointAnnotation.Image.default`. ([#707](https://github.com/mapbox/mapbox-maps-ios/pull/707))
 * Replaces `PointAnnotation.Image.custom` with `PointAnnotation.Image.init(image:name:)`. ([#707](https://github.com/mapbox/mapbox-maps-ios/pull/707))
+=======
+* The `tapGestureRecognizer` var on each `*AnnotationManager` has been removed in favor of a unified tap gesture recognizer available at `GestureManager.singleTapGestureRecognizer`([#709](https://github.com/mapbox/mapbox-maps-ios/pull/709)).
+>>>>>>> 466b6edc (changelog)
 
 ## 10.0.0-rc.9 - Sept 22, 2021
 

--- a/Sources/MapboxMaps/Annotations/AnnotationOrchestrator.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationOrchestrator.swift
@@ -39,7 +39,7 @@ public protocol AnnotationInteractionDelegate: AnyObject {
 
 public class AnnotationOrchestrator {
 
-    private weak var view: UIView?
+    private weak var singleTapGestureRecognizer: UIGestureRecognizer?
 
     private let style: Style
 
@@ -47,8 +47,11 @@ public class AnnotationOrchestrator {
 
     private weak var displayLinkCoordinator: DisplayLinkCoordinator?
 
-    internal init(view: UIView, mapFeatureQueryable: MapFeatureQueryable, style: Style, displayLinkCoordinator: DisplayLinkCoordinator) {
-        self.view = view
+    internal init(singleTapGestureRecognizer: UIGestureRecognizer,
+                  mapFeatureQueryable: MapFeatureQueryable,
+                  style: Style,
+                  displayLinkCoordinator: DisplayLinkCoordinator) {
+        self.singleTapGestureRecognizer = singleTapGestureRecognizer
         self.mapFeatureQueryable = mapFeatureQueryable
         self.style = style
         self.displayLinkCoordinator = displayLinkCoordinator
@@ -62,14 +65,14 @@ public class AnnotationOrchestrator {
     public func makePointAnnotationManager(id: String = String(UUID().uuidString.prefix(5)),
                                            layerPosition: LayerPosition? = nil) -> PointAnnotationManager {
 
-        guard let view = view,
+        guard let singleTapGestureRecognizer = singleTapGestureRecognizer,
               let displayLinkCoordinator = displayLinkCoordinator else {
-            fatalError("View and displayLinkCoordinator must be present when creating an annotation manager")
+            fatalError("SingleTapGestureRecognizer and displayLinkCoordinator must be present when creating an annotation manager")
         }
 
         return PointAnnotationManager(id: id,
                                       style: style,
-                                      view: view,
+                                      singleTapGestureRecognizer: singleTapGestureRecognizer,
                                       mapFeatureQueryable: mapFeatureQueryable,
                                       shouldPersist: true,
                                       layerPosition: layerPosition,
@@ -84,14 +87,14 @@ public class AnnotationOrchestrator {
     public func makePolygonAnnotationManager(id: String = String(UUID().uuidString.prefix(5)),
                                              layerPosition: LayerPosition? = nil) -> PolygonAnnotationManager {
 
-        guard let view = view,
+        guard let singleTapGestureRecognizer = singleTapGestureRecognizer,
               let displayLinkCoordinator = displayLinkCoordinator else {
-            fatalError("View and displayLinkCoordinator must be present when creating an annotation manager")
+            fatalError("SingleTapGestureRecognizer and displayLinkCoordinator must be present when creating an annotation manager")
         }
 
         return PolygonAnnotationManager(id: id,
                                         style: style,
-                                        view: view,
+                                        singleTapGestureRecognizer: singleTapGestureRecognizer,
                                         mapFeatureQueryable: mapFeatureQueryable,
                                         shouldPersist: true,
                                         layerPosition: layerPosition,
@@ -106,14 +109,14 @@ public class AnnotationOrchestrator {
     public func makePolylineAnnotationManager(id: String = String(UUID().uuidString.prefix(5)),
                                               layerPosition: LayerPosition? = nil) -> PolylineAnnotationManager {
 
-        guard let view = view,
+        guard let singleTapGestureRecognizer = singleTapGestureRecognizer,
               let displayLinkCoordinator = displayLinkCoordinator else {
-            fatalError("View and displayLinkCoordinator must be present when creating an annotation manager")
+            fatalError("SingleTapGestureRecognizer and displayLinkCoordinator must be present when creating an annotation manager")
         }
 
         return PolylineAnnotationManager(id: id,
                                          style: style,
-                                         view: view,
+                                         singleTapGestureRecognizer: singleTapGestureRecognizer,
                                          mapFeatureQueryable: mapFeatureQueryable,
                                          shouldPersist: true,
                                          layerPosition: layerPosition,
@@ -128,14 +131,14 @@ public class AnnotationOrchestrator {
     public func makeCircleAnnotationManager(id: String = String(UUID().uuidString.prefix(5)),
                                             layerPosition: LayerPosition? = nil) -> CircleAnnotationManager {
 
-        guard let view = view,
+        guard let singleTapGestureRecognizer = singleTapGestureRecognizer,
               let displayLinkCoordinator = displayLinkCoordinator else {
-            fatalError("View and displayLinkCoordinator must be present when creating an annotation manager")
+            fatalError("SingleTapGestureRecognizer and displayLinkCoordinator must be present when creating an annotation manager")
         }
 
         return CircleAnnotationManager(id: id,
                                        style: style,
-                                       view: view,
+                                       singleTapGestureRecognizer: singleTapGestureRecognizer,
                                        mapFeatureQueryable: mapFeatureQueryable,
                                        shouldPersist: true,
                                        layerPosition: layerPosition,

--- a/Sources/MapboxMaps/Annotations/AnnotationOrchestrator.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationOrchestrator.swift
@@ -39,7 +39,7 @@ public protocol AnnotationInteractionDelegate: AnyObject {
 
 public class AnnotationOrchestrator {
 
-    private weak var singleTapGestureRecognizer: UIGestureRecognizer?
+    private let singleTapGestureRecognizer: UIGestureRecognizer
 
     private let style: Style
 
@@ -65,9 +65,8 @@ public class AnnotationOrchestrator {
     public func makePointAnnotationManager(id: String = String(UUID().uuidString.prefix(5)),
                                            layerPosition: LayerPosition? = nil) -> PointAnnotationManager {
 
-        guard let singleTapGestureRecognizer = singleTapGestureRecognizer,
-              let displayLinkCoordinator = displayLinkCoordinator else {
-            fatalError("SingleTapGestureRecognizer and displayLinkCoordinator must be present when creating an annotation manager")
+        guard let displayLinkCoordinator = displayLinkCoordinator else {
+            fatalError("DisplayLinkCoordinator must be present when creating an annotation manager")
         }
 
         return PointAnnotationManager(id: id,
@@ -87,9 +86,8 @@ public class AnnotationOrchestrator {
     public func makePolygonAnnotationManager(id: String = String(UUID().uuidString.prefix(5)),
                                              layerPosition: LayerPosition? = nil) -> PolygonAnnotationManager {
 
-        guard let singleTapGestureRecognizer = singleTapGestureRecognizer,
-              let displayLinkCoordinator = displayLinkCoordinator else {
-            fatalError("SingleTapGestureRecognizer and displayLinkCoordinator must be present when creating an annotation manager")
+        guard let displayLinkCoordinator = displayLinkCoordinator else {
+            fatalError("DisplayLinkCoordinator must be present when creating an annotation manager")
         }
 
         return PolygonAnnotationManager(id: id,
@@ -109,9 +107,8 @@ public class AnnotationOrchestrator {
     public func makePolylineAnnotationManager(id: String = String(UUID().uuidString.prefix(5)),
                                               layerPosition: LayerPosition? = nil) -> PolylineAnnotationManager {
 
-        guard let singleTapGestureRecognizer = singleTapGestureRecognizer,
-              let displayLinkCoordinator = displayLinkCoordinator else {
-            fatalError("SingleTapGestureRecognizer and displayLinkCoordinator must be present when creating an annotation manager")
+        guard let displayLinkCoordinator = displayLinkCoordinator else {
+            fatalError("DisplayLinkCoordinator must be present when creating an annotation manager")
         }
 
         return PolylineAnnotationManager(id: id,
@@ -131,9 +128,8 @@ public class AnnotationOrchestrator {
     public func makeCircleAnnotationManager(id: String = String(UUID().uuidString.prefix(5)),
                                             layerPosition: LayerPosition? = nil) -> CircleAnnotationManager {
 
-        guard let singleTapGestureRecognizer = singleTapGestureRecognizer,
-              let displayLinkCoordinator = displayLinkCoordinator else {
-            fatalError("SingleTapGestureRecognizer and displayLinkCoordinator must be present when creating an annotation manager")
+        guard let displayLinkCoordinator = displayLinkCoordinator else {
+            fatalError("DisplayLinkCoordinator must be present when creating an annotation manager")
         }
 
         return CircleAnnotationManager(id: id,

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -242,7 +242,7 @@ public class CircleAnnotationManager: AnnotationManager {
 
                 // If `tappedAnnotations` is not empty, call delegate
                 if !tappedAnnotations.isEmpty {
-                    delegate.annotationManager(
+                    self.delegate?.annotationManager(
                         self,
                         didDetectTappedAnnotations: tappedAnnotations)
                 }

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -33,7 +33,7 @@ public class CircleAnnotationManager: AnnotationManager {
     private let mapFeatureQueryable: MapFeatureQueryable
 
     /// Dependency required to add gesture recognizer to the MapView
-    private weak var view: UIView?
+    private weak var singleTapGestureRecognizer: UIGestureRecognizer?
 
     /// Storage for common layer properties
     private var layerProperties: [String: Any] = [:] {
@@ -54,7 +54,7 @@ public class CircleAnnotationManager: AnnotationManager {
 
     internal init(id: String,
                   style: Style,
-                  view: UIView,
+                  singleTapGestureRecognizer: UIGestureRecognizer,
                   mapFeatureQueryable: MapFeatureQueryable,
                   shouldPersist: Bool,
                   layerPosition: LayerPosition?,
@@ -63,7 +63,7 @@ public class CircleAnnotationManager: AnnotationManager {
         self.style = style
         self.sourceId = id + "-source"
         self.layerId = id + "-layer"
-        self.view = view
+        self.singleTapGestureRecognizer = singleTapGestureRecognizer
         self.mapFeatureQueryable = mapFeatureQueryable
         self.shouldPersist = shouldPersist
 
@@ -206,36 +206,23 @@ public class CircleAnnotationManager: AnnotationManager {
         }
     }
 
-    // MARK: - Selection Handling -
+    // MARK: - Tap Handling -
 
     /// Set this delegate in order to be called back if a tap occurs on an annotation being managed by this manager.
     public weak var delegate: AnnotationInteractionDelegate? {
         didSet {
-            if delegate != nil {
-                setupTapRecognizer()
-            } else {
-                guard let view = view, let recognizer = tapGestureRecognizer else { return }
-                view.removeGestureRecognizer(recognizer)
-                tapGestureRecognizer = nil
+            if delegate != nil && oldValue == nil {
+                singleTapGestureRecognizer?.addTarget(self, action: #selector(handleTap(_:)))
+            } else if delegate == nil && oldValue != nil {
+                singleTapGestureRecognizer?.removeTarget(self, action: #selector(handleTap(_:)))
             }
         }
-    }
-
-    /// The `UITapGestureRecognizer` that's listening to touch events on the map for the annotations present in this manager
-    public var tapGestureRecognizer: UITapGestureRecognizer?
-
-    internal func setupTapRecognizer() {
-        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
-        tapRecognizer.numberOfTapsRequired = 1
-        tapRecognizer.numberOfTouchesRequired = 1
-        view?.addGestureRecognizer(tapRecognizer)
-        tapGestureRecognizer = tapRecognizer
     }
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {
         let options = RenderedQueryOptions(layerIds: [layerId], filter: nil)
         mapFeatureQueryable.queryRenderedFeatures(
-            at: tap.location(in: view),
+            at: tap.location(in: tap.view),
             options: options) { [weak self] (result) in
 
             guard let self = self else { return }

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -32,9 +32,6 @@ public class CircleAnnotationManager: AnnotationManager {
     /// Dependency Required to query for rendered features on tap
     private let mapFeatureQueryable: MapFeatureQueryable
 
-    /// Dependency required to add gesture recognizer to the MapView
-    private weak var singleTapGestureRecognizer: UIGestureRecognizer?
-
     /// Storage for common layer properties
     private var layerProperties: [String: Any] = [:] {
         didSet {
@@ -63,9 +60,11 @@ public class CircleAnnotationManager: AnnotationManager {
         self.style = style
         self.sourceId = id + "-source"
         self.layerId = id + "-layer"
-        self.singleTapGestureRecognizer = singleTapGestureRecognizer
         self.mapFeatureQueryable = mapFeatureQueryable
         self.shouldPersist = shouldPersist
+
+        // Add target-action for tap handling
+        singleTapGestureRecognizer.addTarget(self, action: #selector(handleTap(_:)))
 
         do {
             try makeSourceAndLayer(layerPosition: layerPosition)
@@ -209,17 +208,12 @@ public class CircleAnnotationManager: AnnotationManager {
     // MARK: - Tap Handling -
 
     /// Set this delegate in order to be called back if a tap occurs on an annotation being managed by this manager.
-    public weak var delegate: AnnotationInteractionDelegate? {
-        didSet {
-            if delegate != nil && oldValue == nil {
-                singleTapGestureRecognizer?.addTarget(self, action: #selector(handleTap(_:)))
-            } else if delegate == nil && oldValue != nil {
-                singleTapGestureRecognizer?.removeTarget(self, action: #selector(handleTap(_:)))
-            }
-        }
-    }
+    public weak var delegate: AnnotationInteractionDelegate?
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {
+
+        guard let delegate = delegate else { return }
+
         let options = RenderedQueryOptions(layerIds: [layerId], filter: nil)
         mapFeatureQueryable.queryRenderedFeatures(
             at: tap.location(in: tap.view),
@@ -248,7 +242,7 @@ public class CircleAnnotationManager: AnnotationManager {
 
                 // If `tappedAnnotations` is not empty, call delegate
                 if !tappedAnnotations.isEmpty {
-                    self.delegate?.annotationManager(
+                    delegate.annotationManager(
                         self,
                         didDetectTappedAnnotations: tappedAnnotations)
                 }

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -212,7 +212,7 @@ public class CircleAnnotationManager: AnnotationManager {
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {
 
-        guard let delegate = delegate else { return }
+        guard delegate != nil else { return }
 
         let options = RenderedQueryOptions(layerIds: [layerId], filter: nil)
         mapFeatureQueryable.queryRenderedFeatures(

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -208,6 +208,7 @@ public class CircleAnnotationManager: AnnotationManager {
     // MARK: - Tap Handling -
 
     /// Set this delegate in order to be called back if a tap occurs on an annotation being managed by this manager.
+    /// - NOTE: This annotation manager listens to tap events via the `GestureManager.singleTapGestureRecognizer`.
     public weak var delegate: AnnotationInteractionDelegate?
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -500,7 +500,7 @@ public class PointAnnotationManager: AnnotationManager {
 
                 // If `tappedAnnotations` is not empty, call delegate
                 if !tappedAnnotations.isEmpty {
-                    delegate.annotationManager(
+                    self.delegate?.annotationManager(
                         self,
                         didDetectTappedAnnotations: tappedAnnotations)
                 }

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -33,7 +33,7 @@ public class PointAnnotationManager: AnnotationManager {
     private let mapFeatureQueryable: MapFeatureQueryable
 
     /// Dependency required to add gesture recognizer to the MapView
-    private weak var view: UIView?
+    private weak var singleTapGestureRecognizer: UIGestureRecognizer?
 
     /// Storage for common layer properties
     private var layerProperties: [String: Any] = [:] {
@@ -54,7 +54,7 @@ public class PointAnnotationManager: AnnotationManager {
 
     internal init(id: String,
                   style: Style,
-                  view: UIView,
+                  singleTapGestureRecognizer: UIGestureRecognizer,
                   mapFeatureQueryable: MapFeatureQueryable,
                   shouldPersist: Bool,
                   layerPosition: LayerPosition?,
@@ -63,7 +63,7 @@ public class PointAnnotationManager: AnnotationManager {
         self.style = style
         self.sourceId = id + "-source"
         self.layerId = id + "-layer"
-        self.view = view
+        self.singleTapGestureRecognizer = singleTapGestureRecognizer
         self.mapFeatureQueryable = mapFeatureQueryable
         self.shouldPersist = shouldPersist
 
@@ -464,36 +464,23 @@ public class PointAnnotationManager: AnnotationManager {
         }
     }
 
-    // MARK: - Selection Handling -
+    // MARK: - Tap Handling -
 
     /// Set this delegate in order to be called back if a tap occurs on an annotation being managed by this manager.
     public weak var delegate: AnnotationInteractionDelegate? {
         didSet {
-            if delegate != nil {
-                setupTapRecognizer()
-            } else {
-                guard let view = view, let recognizer = tapGestureRecognizer else { return }
-                view.removeGestureRecognizer(recognizer)
-                tapGestureRecognizer = nil
+            if delegate != nil && oldValue == nil {
+                singleTapGestureRecognizer?.addTarget(self, action: #selector(handleTap(_:)))
+            } else if delegate == nil && oldValue != nil {
+                singleTapGestureRecognizer?.removeTarget(self, action: #selector(handleTap(_:)))
             }
         }
-    }
-
-    /// The `UITapGestureRecognizer` that's listening to touch events on the map for the annotations present in this manager
-    public var tapGestureRecognizer: UITapGestureRecognizer?
-
-    internal func setupTapRecognizer() {
-        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
-        tapRecognizer.numberOfTapsRequired = 1
-        tapRecognizer.numberOfTouchesRequired = 1
-        view?.addGestureRecognizer(tapRecognizer)
-        tapGestureRecognizer = tapRecognizer
     }
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {
         let options = RenderedQueryOptions(layerIds: [layerId], filter: nil)
         mapFeatureQueryable.queryRenderedFeatures(
-            at: tap.location(in: view),
+            at: tap.location(in: tap.view),
             options: options) { [weak self] (result) in
 
             guard let self = self else { return }

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -32,9 +32,6 @@ public class PointAnnotationManager: AnnotationManager {
     /// Dependency Required to query for rendered features on tap
     private let mapFeatureQueryable: MapFeatureQueryable
 
-    /// Dependency required to add gesture recognizer to the MapView
-    private weak var singleTapGestureRecognizer: UIGestureRecognizer?
-
     /// Storage for common layer properties
     private var layerProperties: [String: Any] = [:] {
         didSet {
@@ -63,9 +60,11 @@ public class PointAnnotationManager: AnnotationManager {
         self.style = style
         self.sourceId = id + "-source"
         self.layerId = id + "-layer"
-        self.singleTapGestureRecognizer = singleTapGestureRecognizer
         self.mapFeatureQueryable = mapFeatureQueryable
         self.shouldPersist = shouldPersist
+
+        // Add target-action for tap handling
+        singleTapGestureRecognizer.addTarget(self, action: #selector(handleTap(_:)))
 
         do {
             try makeSourceAndLayer(layerPosition: layerPosition)
@@ -467,17 +466,12 @@ public class PointAnnotationManager: AnnotationManager {
     // MARK: - Tap Handling -
 
     /// Set this delegate in order to be called back if a tap occurs on an annotation being managed by this manager.
-    public weak var delegate: AnnotationInteractionDelegate? {
-        didSet {
-            if delegate != nil && oldValue == nil {
-                singleTapGestureRecognizer?.addTarget(self, action: #selector(handleTap(_:)))
-            } else if delegate == nil && oldValue != nil {
-                singleTapGestureRecognizer?.removeTarget(self, action: #selector(handleTap(_:)))
-            }
-        }
-    }
+    public weak var delegate: AnnotationInteractionDelegate?
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {
+
+        guard let delegate = delegate else { return }
+
         let options = RenderedQueryOptions(layerIds: [layerId], filter: nil)
         mapFeatureQueryable.queryRenderedFeatures(
             at: tap.location(in: tap.view),
@@ -506,7 +500,7 @@ public class PointAnnotationManager: AnnotationManager {
 
                 // If `tappedAnnotations` is not empty, call delegate
                 if !tappedAnnotations.isEmpty {
-                    self.delegate?.annotationManager(
+                    delegate.annotationManager(
                         self,
                         didDetectTappedAnnotations: tappedAnnotations)
                 }

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -470,7 +470,7 @@ public class PointAnnotationManager: AnnotationManager {
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {
 
-        guard let delegate = delegate else { return }
+        guard delegate != nil else { return }
 
         let options = RenderedQueryOptions(layerIds: [layerId], filter: nil)
         mapFeatureQueryable.queryRenderedFeatures(

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -466,6 +466,7 @@ public class PointAnnotationManager: AnnotationManager {
     // MARK: - Tap Handling -
 
     /// Set this delegate in order to be called back if a tap occurs on an annotation being managed by this manager.
+    /// - NOTE: This annotation manager listens to tap events via the `GestureManager.singleTapGestureRecognizer`.
     public weak var delegate: AnnotationInteractionDelegate?
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -232,7 +232,7 @@ public class PolygonAnnotationManager: AnnotationManager {
 
                 // If `tappedAnnotations` is not empty, call delegate
                 if !tappedAnnotations.isEmpty {
-                    delegate.annotationManager(
+                    self.delegate?.annotationManager(
                         self,
                         didDetectTappedAnnotations: tappedAnnotations)
                 }

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -33,7 +33,7 @@ public class PolygonAnnotationManager: AnnotationManager {
     private let mapFeatureQueryable: MapFeatureQueryable
 
     /// Dependency required to add gesture recognizer to the MapView
-    private weak var view: UIView?
+    private weak var singleTapGestureRecognizer: UIGestureRecognizer?
 
     /// Storage for common layer properties
     private var layerProperties: [String: Any] = [:] {
@@ -54,7 +54,7 @@ public class PolygonAnnotationManager: AnnotationManager {
 
     internal init(id: String,
                   style: Style,
-                  view: UIView,
+                  singleTapGestureRecognizer: UIGestureRecognizer,
                   mapFeatureQueryable: MapFeatureQueryable,
                   shouldPersist: Bool,
                   layerPosition: LayerPosition?,
@@ -63,7 +63,7 @@ public class PolygonAnnotationManager: AnnotationManager {
         self.style = style
         self.sourceId = id + "-source"
         self.layerId = id + "-layer"
-        self.view = view
+        self.singleTapGestureRecognizer = singleTapGestureRecognizer
         self.mapFeatureQueryable = mapFeatureQueryable
         self.shouldPersist = shouldPersist
 
@@ -196,36 +196,23 @@ public class PolygonAnnotationManager: AnnotationManager {
         }
     }
 
-    // MARK: - Selection Handling -
+    // MARK: - Tap Handling -
 
     /// Set this delegate in order to be called back if a tap occurs on an annotation being managed by this manager.
     public weak var delegate: AnnotationInteractionDelegate? {
         didSet {
-            if delegate != nil {
-                setupTapRecognizer()
-            } else {
-                guard let view = view, let recognizer = tapGestureRecognizer else { return }
-                view.removeGestureRecognizer(recognizer)
-                tapGestureRecognizer = nil
+            if delegate != nil && oldValue == nil {
+                singleTapGestureRecognizer?.addTarget(self, action: #selector(handleTap(_:)))
+            } else if delegate == nil && oldValue != nil {
+                singleTapGestureRecognizer?.removeTarget(self, action: #selector(handleTap(_:)))
             }
         }
-    }
-
-    /// The `UITapGestureRecognizer` that's listening to touch events on the map for the annotations present in this manager
-    public var tapGestureRecognizer: UITapGestureRecognizer?
-
-    internal func setupTapRecognizer() {
-        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
-        tapRecognizer.numberOfTapsRequired = 1
-        tapRecognizer.numberOfTouchesRequired = 1
-        view?.addGestureRecognizer(tapRecognizer)
-        tapGestureRecognizer = tapRecognizer
     }
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {
         let options = RenderedQueryOptions(layerIds: [layerId], filter: nil)
         mapFeatureQueryable.queryRenderedFeatures(
-            at: tap.location(in: view),
+            at: tap.location(in: tap.view),
             options: options) { [weak self] (result) in
 
             guard let self = self else { return }

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -32,9 +32,6 @@ public class PolygonAnnotationManager: AnnotationManager {
     /// Dependency Required to query for rendered features on tap
     private let mapFeatureQueryable: MapFeatureQueryable
 
-    /// Dependency required to add gesture recognizer to the MapView
-    private weak var singleTapGestureRecognizer: UIGestureRecognizer?
-
     /// Storage for common layer properties
     private var layerProperties: [String: Any] = [:] {
         didSet {
@@ -63,9 +60,11 @@ public class PolygonAnnotationManager: AnnotationManager {
         self.style = style
         self.sourceId = id + "-source"
         self.layerId = id + "-layer"
-        self.singleTapGestureRecognizer = singleTapGestureRecognizer
         self.mapFeatureQueryable = mapFeatureQueryable
         self.shouldPersist = shouldPersist
+
+        // Add target-action for tap handling
+        singleTapGestureRecognizer.addTarget(self, action: #selector(handleTap(_:)))
 
         do {
             try makeSourceAndLayer(layerPosition: layerPosition)
@@ -199,17 +198,12 @@ public class PolygonAnnotationManager: AnnotationManager {
     // MARK: - Tap Handling -
 
     /// Set this delegate in order to be called back if a tap occurs on an annotation being managed by this manager.
-    public weak var delegate: AnnotationInteractionDelegate? {
-        didSet {
-            if delegate != nil && oldValue == nil {
-                singleTapGestureRecognizer?.addTarget(self, action: #selector(handleTap(_:)))
-            } else if delegate == nil && oldValue != nil {
-                singleTapGestureRecognizer?.removeTarget(self, action: #selector(handleTap(_:)))
-            }
-        }
-    }
+    public weak var delegate: AnnotationInteractionDelegate?
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {
+
+        guard let delegate = delegate else { return }
+
         let options = RenderedQueryOptions(layerIds: [layerId], filter: nil)
         mapFeatureQueryable.queryRenderedFeatures(
             at: tap.location(in: tap.view),
@@ -238,7 +232,7 @@ public class PolygonAnnotationManager: AnnotationManager {
 
                 // If `tappedAnnotations` is not empty, call delegate
                 if !tappedAnnotations.isEmpty {
-                    self.delegate?.annotationManager(
+                    delegate.annotationManager(
                         self,
                         didDetectTappedAnnotations: tappedAnnotations)
                 }

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -202,7 +202,7 @@ public class PolygonAnnotationManager: AnnotationManager {
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {
 
-        guard let delegate = delegate else { return }
+        guard delegate != nil else { return }
 
         let options = RenderedQueryOptions(layerIds: [layerId], filter: nil)
         mapFeatureQueryable.queryRenderedFeatures(

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -198,6 +198,7 @@ public class PolygonAnnotationManager: AnnotationManager {
     // MARK: - Tap Handling -
 
     /// Set this delegate in order to be called back if a tap occurs on an annotation being managed by this manager.
+    /// - NOTE: This annotation manager listens to tap events via the `GestureManager.singleTapGestureRecognizer`.
     public weak var delegate: AnnotationInteractionDelegate?
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -262,7 +262,7 @@ public class PolylineAnnotationManager: AnnotationManager {
 
                 // If `tappedAnnotations` is not empty, call delegate
                 if !tappedAnnotations.isEmpty {
-                    delegate.annotationManager(
+                    self.delegate?.annotationManager(
                         self,
                         didDetectTappedAnnotations: tappedAnnotations)
                 }

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -33,7 +33,7 @@ public class PolylineAnnotationManager: AnnotationManager {
     private let mapFeatureQueryable: MapFeatureQueryable
 
     /// Dependency required to add gesture recognizer to the MapView
-    private weak var view: UIView?
+    private weak var singleTapGestureRecognizer: UIGestureRecognizer?
 
     /// Storage for common layer properties
     private var layerProperties: [String: Any] = [:] {
@@ -54,7 +54,7 @@ public class PolylineAnnotationManager: AnnotationManager {
 
     internal init(id: String,
                   style: Style,
-                  view: UIView,
+                  singleTapGestureRecognizer: UIGestureRecognizer,
                   mapFeatureQueryable: MapFeatureQueryable,
                   shouldPersist: Bool,
                   layerPosition: LayerPosition?,
@@ -63,7 +63,7 @@ public class PolylineAnnotationManager: AnnotationManager {
         self.style = style
         self.sourceId = id + "-source"
         self.layerId = id + "-layer"
-        self.view = view
+        self.singleTapGestureRecognizer = singleTapGestureRecognizer
         self.mapFeatureQueryable = mapFeatureQueryable
         self.shouldPersist = shouldPersist
 
@@ -226,36 +226,23 @@ public class PolylineAnnotationManager: AnnotationManager {
         }
     }
 
-    // MARK: - Selection Handling -
+    // MARK: - Tap Handling -
 
     /// Set this delegate in order to be called back if a tap occurs on an annotation being managed by this manager.
     public weak var delegate: AnnotationInteractionDelegate? {
         didSet {
-            if delegate != nil {
-                setupTapRecognizer()
-            } else {
-                guard let view = view, let recognizer = tapGestureRecognizer else { return }
-                view.removeGestureRecognizer(recognizer)
-                tapGestureRecognizer = nil
+            if delegate != nil && oldValue == nil {
+                singleTapGestureRecognizer?.addTarget(self, action: #selector(handleTap(_:)))
+            } else if delegate == nil && oldValue != nil {
+                singleTapGestureRecognizer?.removeTarget(self, action: #selector(handleTap(_:)))
             }
         }
-    }
-
-    /// The `UITapGestureRecognizer` that's listening to touch events on the map for the annotations present in this manager
-    public var tapGestureRecognizer: UITapGestureRecognizer?
-
-    internal func setupTapRecognizer() {
-        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
-        tapRecognizer.numberOfTapsRequired = 1
-        tapRecognizer.numberOfTouchesRequired = 1
-        view?.addGestureRecognizer(tapRecognizer)
-        tapGestureRecognizer = tapRecognizer
     }
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {
         let options = RenderedQueryOptions(layerIds: [layerId], filter: nil)
         mapFeatureQueryable.queryRenderedFeatures(
-            at: tap.location(in: view),
+            at: tap.location(in: tap.view),
             options: options) { [weak self] (result) in
 
             guard let self = self else { return }

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -232,7 +232,7 @@ public class PolylineAnnotationManager: AnnotationManager {
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {
 
-        guard let delegate = delegate else { return }
+        guard delegate != nil else { return }
 
         let options = RenderedQueryOptions(layerIds: [layerId], filter: nil)
         mapFeatureQueryable.queryRenderedFeatures(

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -228,6 +228,7 @@ public class PolylineAnnotationManager: AnnotationManager {
     // MARK: - Tap Handling -
 
     /// Set this delegate in order to be called back if a tap occurs on an annotation being managed by this manager.
+    /// - NOTE: This annotation manager listens to tap events via the `GestureManager.singleTapGestureRecognizer`.
     public weak var delegate: AnnotationInteractionDelegate?
 
     @objc internal func handleTap(_ tap: UITapGestureRecognizer) {

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -234,7 +234,11 @@ open class MapView: UIView {
         location = LocationManager(style: mapboxMap.style)
 
         // Initialize/Configure annotations orchestrator
-        annotations = AnnotationOrchestrator(view: self, mapFeatureQueryable: mapboxMap, style: mapboxMap.style, displayLinkCoordinator: self)
+        annotations = AnnotationOrchestrator(
+            singleTapGestureRecognizer: gestures.singleTapGestureRecognizer,
+            mapFeatureQueryable: mapboxMap,
+            style: mapboxMap.style,
+            displayLinkCoordinator: self)
     }
 
     private func checkForMetalSupport() {

--- a/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
+++ b/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
@@ -61,6 +61,17 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
             mapboxMap: mapboxMap,
             cameraAnimationsManager: cameraAnimationsManager)
     }
+    
+    func makeSingleTapGestureHandler(view: UIView,
+                                     mapboxMap: MapboxMapProtocol,
+                                     cameraAnimationsManager: CameraAnimationsManagerProtocol) -> GestureHandler {
+        let gestureRecognizer = UITapGestureRecognizer()
+        view.addGestureRecognizer(gestureRecognizer)
+        return SingleTapGestureHandler(
+            gestureRecognizer: gestureRecognizer,
+            mapboxMap: mapboxMap,
+            cameraAnimationsManager: cameraAnimationsManager)
+    }
 
     func makeDoubleTouchToZoomOutGestureHandler(view: UIView,
                                                 mapboxMap: MapboxMapProtocol,
@@ -109,6 +120,10 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
                 mapboxMap: mapboxMap,
                 cameraAnimationsManager: cameraAnimationsManager),
             quickZoomGestureHandler: makeQuickZoomGestureHandler(
+                view: view,
+                mapboxMap: mapboxMap,
+                cameraAnimationsManager: cameraAnimationsManager),
+            singleTapGestureHandler: makeSingleTapGestureHandler(
                 view: view,
                 mapboxMap: mapboxMap,
                 cameraAnimationsManager: cameraAnimationsManager))

--- a/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
+++ b/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
@@ -61,7 +61,7 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
             mapboxMap: mapboxMap,
             cameraAnimationsManager: cameraAnimationsManager)
     }
-    
+
     func makeSingleTapGestureHandler(view: UIView,
                                      mapboxMap: MapboxMapProtocol,
                                      cameraAnimationsManager: CameraAnimationsManagerProtocol) -> GestureHandler {

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/SingleTapGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/SingleTapGestureHandler.swift
@@ -2,7 +2,7 @@ import UIKit
 
 /// `SingleTapGestureHandler` manages a gesture recognizer looking for single tap touch events
 internal final class SingleTapGestureHandler: GestureHandler {
-    
+
     internal init(gestureRecognizer: UITapGestureRecognizer,
                   mapboxMap: MapboxMapProtocol,
                   cameraAnimationsManager: CameraAnimationsManagerProtocol) {
@@ -14,7 +14,7 @@ internal final class SingleTapGestureHandler: GestureHandler {
             cameraAnimationsManager: cameraAnimationsManager)
         gestureRecognizer.addTarget(self, action: #selector(handleGesture(_:)))
     }
-    
+
     @objc private func handleGesture(_ gestureRecognizer: UITapGestureRecognizer) {
         switch gestureRecognizer.state {
         case .recognized:

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/SingleTapGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/SingleTapGestureHandler.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+/// `SingleTapGestureHandler` manages a gesture recognizer looking for single tap touch events
+internal final class SingleTapGestureHandler: GestureHandler {
+    
+    internal init(gestureRecognizer: UITapGestureRecognizer,
+                  mapboxMap: MapboxMapProtocol,
+                  cameraAnimationsManager: CameraAnimationsManagerProtocol) {
+        gestureRecognizer.numberOfTapsRequired = 1
+        gestureRecognizer.numberOfTouchesRequired = 1
+        super.init(
+            gestureRecognizer: gestureRecognizer,
+            mapboxMap: mapboxMap,
+            cameraAnimationsManager: cameraAnimationsManager)
+        gestureRecognizer.addTarget(self, action: #selector(handleGesture(_:)))
+    }
+    
+    @objc private func handleGesture(_ gestureRecognizer: UITapGestureRecognizer) {
+        switch gestureRecognizer.state {
+        case .recognized:
+            cameraAnimationsManager.cancelAnimations()
+            delegate?.gestureBegan(for: .singleTap)
+        default:
+            break
+        }
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -70,6 +70,11 @@ public final class GestureManager: GestureHandlerDelegate {
     public var quickZoomGestureRecognizer: UIGestureRecognizer {
         return quickZoomGestureHandler.gestureRecognizer
     }
+    
+    /// The gesture recognizer for the single tap gesture
+    public var singleTapGestureRecognizer: UIGestureRecognizer {
+        return singleTapGestureHandler.gestureRecognizer
+    }
 
     /// Set this delegate to be called back if a gesture begins
     public weak var delegate: GestureManagerDelegate?
@@ -80,19 +85,22 @@ public final class GestureManager: GestureHandlerDelegate {
     private let doubleTapToZoomInGestureHandler: GestureHandler
     private let doubleTouchToZoomOutGestureHandler: GestureHandler
     private let quickZoomGestureHandler: GestureHandler
+    private let singleTapGestureHandler: GestureHandler
 
     internal init(panGestureHandler: PanGestureHandlerProtocol,
                   pinchGestureHandler: GestureHandler,
                   pitchGestureHandler: GestureHandler,
                   doubleTapToZoomInGestureHandler: GestureHandler,
                   doubleTouchToZoomOutGestureHandler: GestureHandler,
-                  quickZoomGestureHandler: GestureHandler) {
+                  quickZoomGestureHandler: GestureHandler,
+                  singleTapGestureHandler: GestureHandler) {
         self.panGestureHandler = panGestureHandler
         self.pinchGestureHandler = pinchGestureHandler
         self.pitchGestureHandler = pitchGestureHandler
         self.doubleTapToZoomInGestureHandler = doubleTapToZoomInGestureHandler
         self.doubleTouchToZoomOutGestureHandler = doubleTouchToZoomOutGestureHandler
         self.quickZoomGestureHandler = quickZoomGestureHandler
+        self.singleTapGestureHandler = singleTapGestureHandler
 
         panGestureHandler.delegate = self
         pinchGestureHandler.delegate = self
@@ -100,6 +108,7 @@ public final class GestureManager: GestureHandlerDelegate {
         doubleTapToZoomInGestureHandler.delegate = self
         doubleTouchToZoomOutGestureHandler.delegate = self
         quickZoomGestureHandler.delegate = self
+        singleTapGestureHandler.delegate = self
 
         pinchGestureHandler.gestureRecognizer.require(toFail: panGestureHandler.gestureRecognizer)
         pitchGestureHandler.gestureRecognizer.require(toFail: panGestureHandler.gestureRecognizer)

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -70,7 +70,7 @@ public final class GestureManager: GestureHandlerDelegate {
     public var quickZoomGestureRecognizer: UIGestureRecognizer {
         return quickZoomGestureHandler.gestureRecognizer
     }
-    
+
     /// The gesture recognizer for the single tap gesture
     public var singleTapGestureRecognizer: UIGestureRecognizer {
         return singleTapGestureHandler.gestureRecognizer

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -72,6 +72,9 @@ public final class GestureManager: GestureHandlerDelegate {
     }
 
     /// The gesture recognizer for the single tap gesture
+    /// - NOTE: The single tap gesture recognizer is primarily used to route tap events to the
+    ///         `*AnnotationManager`s. You can add a target-action pair to this gesture recognizer
+    ///         to be notified when a single tap occurs on the map.
     public var singleTapGestureRecognizer: UIGestureRecognizer {
         return singleTapGestureHandler.gestureRecognizer
     }

--- a/Sources/MapboxMaps/Gestures/GestureType.swift
+++ b/Sources/MapboxMaps/Gestures/GestureType.swift
@@ -16,4 +16,7 @@ public enum GestureType: Hashable, CaseIterable {
 
     /// The quick zoom gesture
     case quickZoom
+    
+    /// The single tap gesture
+    case singleTap
 }

--- a/Sources/MapboxMaps/Gestures/GestureType.swift
+++ b/Sources/MapboxMaps/Gestures/GestureType.swift
@@ -16,7 +16,7 @@ public enum GestureType: Hashable, CaseIterable {
 
     /// The quick zoom gesture
     case quickZoom
-    
+
     /// The single tap gesture
     case singleTap
 }

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
@@ -42,7 +42,8 @@ final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
             pitchGestureHandler: makeGestureHandler(),
             doubleTapToZoomInGestureHandler: makeGestureHandler(),
             doubleTouchToZoomOutGestureHandler: makeGestureHandler(),
-            quickZoomGestureHandler: makeGestureHandler())
+            quickZoomGestureHandler: makeGestureHandler(),
+            singleTapGestureHandler: makeGestureHandler())
     }
 
     func makeGestureHandler() -> GestureHandler {

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/SingleTapGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/SingleTapGestureHandlerTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import MapboxMaps
+
+final class SingleTapGestureHandlerTests: XCTestCase {
+
+    var gestureRecognizer: MockTapGestureRecognizer!
+    var cameraAnimationsManager: MockCameraAnimationsManager!
+    var mapboxMap: MockMapboxMap!
+    var gestureHandler: SingleTapGestureHandler!
+    // swiftlint:disable:next weak_delegate
+    var delegate: MockGestureHandlerDelegate!
+
+    override func setUp() {
+        super.setUp()
+        gestureRecognizer = MockTapGestureRecognizer()
+        cameraAnimationsManager = MockCameraAnimationsManager()
+        mapboxMap = MockMapboxMap()
+        gestureHandler = SingleTapGestureHandler(
+            gestureRecognizer: gestureRecognizer,
+            mapboxMap: mapboxMap,
+            cameraAnimationsManager: cameraAnimationsManager)
+        delegate = MockGestureHandlerDelegate()
+        gestureHandler.delegate = delegate
+    }
+
+    override func tearDown() {
+        delegate = nil
+        gestureHandler = nil
+        mapboxMap = nil
+        cameraAnimationsManager = nil
+        gestureRecognizer = nil
+        super.tearDown()
+    }
+
+    func testInitialization() {
+        XCTAssertTrue(gestureRecognizer === gestureHandler.gestureRecognizer)
+        XCTAssertEqual(gestureRecognizer.numberOfTapsRequired, 1)
+        XCTAssertEqual(gestureRecognizer.numberOfTouchesRequired, 1)
+    }
+
+    func testHandler() {
+        gestureRecognizer.getStateStub.defaultReturnValue = .recognized
+        gestureRecognizer.sendActions()
+
+        XCTAssertEqual(delegate.gestureBeganStub.parameters, [.singleTap])
+        XCTAssertEqual(cameraAnimationsManager.cancelAnimationsStub.invocations.count, 1)
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -11,6 +11,7 @@ final class GestureManagerTests: XCTestCase {
     var doubleTapToZoomInGestureHandler: GestureHandler!
     var doubleTouchToZoomOutGestureHandler: GestureHandler!
     var quickZoomGestureHandler: GestureHandler!
+    var singleTapGestureHandler: GestureHandler!
     var gestureManager: GestureManager!
     // swiftlint:disable:next weak_delegate
     var delegate: MockGestureManagerDelegate!
@@ -28,13 +29,15 @@ final class GestureManagerTests: XCTestCase {
         doubleTapToZoomInGestureHandler = makeGestureHandler()
         doubleTouchToZoomOutGestureHandler = makeGestureHandler()
         quickZoomGestureHandler = makeGestureHandler()
+        singleTapGestureHandler = makeGestureHandler()
         gestureManager = GestureManager(
             panGestureHandler: panGestureHandler,
             pinchGestureHandler: pinchGestureHandler,
             pitchGestureHandler: pitchGestureHandler,
             doubleTapToZoomInGestureHandler: doubleTapToZoomInGestureHandler,
             doubleTouchToZoomOutGestureHandler: doubleTouchToZoomOutGestureHandler,
-            quickZoomGestureHandler: quickZoomGestureHandler)
+            quickZoomGestureHandler: quickZoomGestureHandler,
+            singleTapGestureHandler: singleTapGestureHandler)
         delegate =  MockGestureManagerDelegate()
         gestureManager.delegate = delegate
     }
@@ -47,6 +50,7 @@ final class GestureManagerTests: XCTestCase {
         doubleTapToZoomInGestureHandler = nil
         pitchGestureHandler = nil
         pinchGestureHandler = nil
+        singleTapGestureHandler = nil
         panGestureHandler = nil
         cameraAnimationsManager = nil
         mapboxMap = nil
@@ -70,6 +74,10 @@ final class GestureManagerTests: XCTestCase {
 
     func testPitchGestureRecognizer() {
         XCTAssertTrue(gestureManager.pitchGestureRecognizer === pitchGestureHandler.gestureRecognizer)
+    }
+
+    func testSingleTapGestureRecognizer() {
+        XCTAssertTrue(gestureManager.singleTapGestureRecognizer === singleTapGestureHandler.gestureRecognizer)
     }
 
     func testDoubleTapToZoomInGestureRecognizer() {

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -113,6 +113,10 @@ final class GestureManagerTests: XCTestCase {
     func testDoubleTouchToZoomOutGestureHandlerDelegate() {
         XCTAssertTrue(doubleTouchToZoomOutGestureHandler.delegate === gestureManager)
     }
+    
+    func testSingleTapGestureHandlerDelegate() {
+        XCTAssertTrue(singleTapGestureHandler.delegate === gestureManager)
+    }
 
     func testQuickZoomGestureHandlerDelegate() {
         XCTAssertTrue(quickZoomGestureHandler.delegate === gestureManager)

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -113,7 +113,7 @@ final class GestureManagerTests: XCTestCase {
     func testDoubleTouchToZoomOutGestureHandlerDelegate() {
         XCTAssertTrue(doubleTouchToZoomOutGestureHandler.delegate === gestureManager)
     }
-    
+
     func testSingleTapGestureHandlerDelegate() {
         XCTAssertTrue(singleTapGestureHandler.delegate === gestureManager)
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR redesigns the way single tap gestures work in the MapView and each *AnnotationManager. The changes are motivated by a desire to make the `GestureManager` the home of all gesture related functionality. Accordingly, the GestureManager now owns a `SingleTapGestureHandler` (and  exposes its associated gesture recognizer). 

The `singleTapGestureRecognizer` is injected into the `AnnotationsOrchestrator` and then into any constructed `*AnnotationManager`s. 

From a user's perspective, setting the `AnnotationInteractionDelegate` on an annotation manger results in a target-action being added to the singleTapGestureRecognizer.

