### PR TITLE
Fix crash in Examples

### DIFF
--- a/Apps/Examples/Examples/All Examples/OfflineRegionManagerExample.swift
+++ b/Apps/Examples/Examples/All Examples/OfflineRegionManagerExample.swift
@@ -46,7 +46,7 @@ public class OfflineRegionManagerExample: UIViewController, ExampleProtocol {
     internal func setupExample() {
         let uriString = mapView.mapboxMap.style.uri!.rawValue
         let offlineRegionDef = OfflineRegionGeometryDefinition(styleURL: uriString,
-                                                               geometry: MapboxCommon.Geometry(point: coord as NSValue),
+                                                               geometry: MapboxCommon.Geometry(point: CGPoint(x: coord.latitude, y: coord.longitude) as NSValue),
                                                                minZoom: zoom - 2,
                                                                maxZoom: zoom + 2,
                                                                pixelRatio: Float(UIScreen.main.scale),


### PR DESCRIPTION
#714 used `as NSValue` to convert a `CLLocationCoordinate2D`. Despite compiling, this fails at runtime if MapKit is not linked (which is the case in the Examples app).

This fixes the crash by boxing as a `CGPoint` instead. This is consistent with how the conversion is done in the SDK.