### PR TITLE
Use gesture location as anchor for double tap and touch gestures

### DIFF
--- a/Sources/MapboxMaps/Gestures/GestureHandlers/DoubleTapToZoomInGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/DoubleTapToZoomInGestureHandler.swift
@@ -22,10 +22,12 @@ internal final class DoubleTapToZoomInGestureHandler: GestureHandler {
     @objc private func handleGesture(_ gestureRecognizer: UITapGestureRecognizer) {
         switch gestureRecognizer.state {
         case .recognized:
+            guard let view = gestureRecognizer.view else { return }
             delegate?.gestureBegan(for: .doubleTapToZoomIn)
             delegate?.gestureEnded(for: .doubleTapToZoomIn, willAnimate: true)
+            let tapLocation = gestureRecognizer.location(in: view)
             cameraAnimationsManager.ease(
-                to: CameraOptions(zoom: mapboxMap.cameraState.zoom + 1),
+                to: CameraOptions(anchor: tapLocation, zoom: mapboxMap.cameraState.zoom + 1),
                 duration: 0.3,
                 curve: .easeOut) { _ in
                     self.delegate?.animationEnded(for: .doubleTapToZoomIn)

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/DoubleTouchToZoomOutGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/DoubleTouchToZoomOutGestureHandler.swift
@@ -23,10 +23,13 @@ internal final class DoubleTouchToZoomOutGestureHandler: GestureHandler {
     @objc private func handleGesture(_ gestureRecognizer: UITapGestureRecognizer) {
         switch gestureRecognizer.state {
         case .recognized:
+            guard let view = gestureRecognizer.view else { return }
             delegate?.gestureBegan(for: .doubleTouchToZoomOut)
             delegate?.gestureEnded(for: .doubleTouchToZoomOut, willAnimate: true)
+
+            let tapLocation = gestureRecognizer.location(in: view)
             cameraAnimationsManager.ease(
-                to: CameraOptions(zoom: mapboxMap.cameraState.zoom - 1),
+                to: CameraOptions(anchor: tapLocation, zoom: mapboxMap.cameraState.zoom - 1),
                 duration: 0.3,
                 curve: .easeOut) { _ in
                     self.delegate?.animationEnded(for: .doubleTouchToZoomOut)

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/DoubleTapToZoomInGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/DoubleTapToZoomInGestureHandlerTests.swift
@@ -44,9 +44,11 @@ final class DoubleTapToZoomInGestureHandlerTests: XCTestCase {
 
         gestureRecognizer.sendActions()
 
+        let view = try XCTUnwrap(gestureRecognizer.view)
+        let tapLocation = gestureRecognizer.location(in: view)
         XCTAssertEqual(delegate.gestureBeganStub.parameters, [.doubleTapToZoomIn])
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.count, 1)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.camera, CameraOptions(zoom: mapboxMap.cameraState.zoom + 1))
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.camera, CameraOptions(anchor: tapLocation,zoom: mapboxMap.cameraState.zoom + 1))
         XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.duration, 0.3)
         XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.curve, .easeOut)
         XCTAssertEqual(delegate.gestureEndedStub.parameters.first?.gestureType, .doubleTapToZoomIn)

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/DoubleTapToZoomInGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/DoubleTapToZoomInGestureHandlerTests.swift
@@ -9,10 +9,13 @@ final class DoubleTapToZoomInGestureHandlerTests: XCTestCase {
     var gestureHandler: DoubleTapToZoomInGestureHandler!
     // swiftlint:disable:next weak_delegate
     var delegate: MockGestureHandlerDelegate!
+    var view: UIView!
 
     override func setUp() {
         super.setUp()
+        view = UIView()
         gestureRecognizer = MockTapGestureRecognizer()
+        view.addGestureRecognizer(gestureRecognizer)
         cameraAnimationsManager = MockCameraAnimationsManager()
         mapboxMap = MockMapboxMap()
         gestureHandler = DoubleTapToZoomInGestureHandler(
@@ -29,6 +32,7 @@ final class DoubleTapToZoomInGestureHandlerTests: XCTestCase {
         mapboxMap = nil
         cameraAnimationsManager = nil
         gestureRecognizer = nil
+        view = nil
         super.tearDown()
     }
 

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/DoubleTouchToZoomOutGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/DoubleTouchToZoomOutGestureHandlerTests.swift
@@ -9,10 +9,13 @@ final class DoubleTouchToZoomOutGestureHandlerTests: XCTestCase {
     var gestureHandler: DoubleTouchToZoomOutGestureHandler!
     // swiftlint:disable:next weak_delegate
     var delegate: MockGestureHandlerDelegate!
+    var view: UIView!
 
     override func setUp() {
         super.setUp()
+        view = UIView()
         gestureRecognizer = MockTapGestureRecognizer()
+        view.addGestureRecognizer(gestureRecognizer)
         cameraAnimationsManager = MockCameraAnimationsManager()
         mapboxMap = MockMapboxMap()
         gestureHandler = DoubleTouchToZoomOutGestureHandler(
@@ -29,6 +32,7 @@ final class DoubleTouchToZoomOutGestureHandlerTests: XCTestCase {
         mapboxMap = nil
         cameraAnimationsManager = nil
         gestureRecognizer = nil
+        view = nil
         super.tearDown()
     }
 
@@ -44,9 +48,12 @@ final class DoubleTouchToZoomOutGestureHandlerTests: XCTestCase {
 
         gestureRecognizer.sendActions()
 
+        let view = try XCTUnwrap(gestureRecognizer.view)
+        let tapLocation = gestureRecognizer.location(in: view)
+
         XCTAssertEqual(delegate.gestureBeganStub.parameters, [.doubleTouchToZoomOut])
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.count, 1)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.camera, CameraOptions(zoom: mapboxMap.cameraState.zoom - 1))
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.camera, CameraOptions(anchor: tapLocation, zoom: mapboxMap.cameraState.zoom - 1))
         XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.duration, 0.3)
         XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.curve, .easeOut)
         XCTAssertEqual(delegate.gestureEndedStub.parameters.first?.gestureType, .doubleTouchToZoomOut)

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockTapGestureRecognizer.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockTapGestureRecognizer.swift
@@ -1,6 +1,9 @@
 import UIKit
 
 final class MockTapGestureRecognizer: UITapGestureRecognizer {
+    override var view: UIView? {
+        return UIView(frame: CGRect(x: 0, y: 0, width: 40, height: 40))
+    }
     let getStateStub = Stub<Void, UIGestureRecognizer.State>(defaultReturnValue: .possible)
     override var state: UIGestureRecognizer.State {
         get {

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockTapGestureRecognizer.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockTapGestureRecognizer.swift
@@ -1,9 +1,6 @@
 import UIKit
 
 final class MockTapGestureRecognizer: UITapGestureRecognizer {
-    override var view: UIView? {
-        return UIView(frame: CGRect(x: 0, y: 0, width: 40, height: 40))
-    }
     let getStateStub = Stub<Void, UIGestureRecognizer.State>(defaultReturnValue: .possible)
     override var state: UIGestureRecognizer.State {
         get {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes
This PR updates the double tap and touch gestures to use the location of the tap as the anchor for subsequent camera changes. The center coordinate was previously used.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
