### PR TITLE
Check whether the userInfo for annotations is nil

### DIFF
--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
@@ -25,7 +25,9 @@ public struct CircleAnnotation: Annotation {
         feature.identifier = .string(id)
         var properties = JSONObject()
         properties["layerProperties"] = JSONValue(rawValue: layerProperties)
-        properties["userInfo"] = userInfo.flatMap(JSONValue.init(rawValue:))
+        if let userInfoValue = userInfo.flatMap(JSONValue.init(rawValue:)) {
+            properties["userInfo"] = userInfoValue
+        }
         feature.properties = properties
         return feature
     }

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
@@ -25,7 +25,9 @@ public struct PointAnnotation: Annotation {
         feature.identifier = .string(id)
         var properties = JSONObject()
         properties["layerProperties"] = JSONValue(rawValue: layerProperties)
-        properties["userInfo"] = userInfo.flatMap(JSONValue.init(rawValue:))
+        if let userInfoValue = userInfo.flatMap(JSONValue.init(rawValue:)) {
+            properties["userInfo"] = userInfoValue
+        }
         feature.properties = properties
         return feature
     }

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
@@ -25,7 +25,9 @@ public struct PolygonAnnotation: Annotation {
         feature.identifier = .string(id)
         var properties = JSONObject()
         properties["layerProperties"] = JSONValue(rawValue: layerProperties)
-        properties["userInfo"] = userInfo.flatMap(JSONValue.init(rawValue:))
+        if let userInfoValue = userInfo.flatMap(JSONValue.init(rawValue:)) {
+            properties["userInfo"] = userInfoValue
+        }
         feature.properties = properties
         return feature
     }

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
@@ -25,7 +25,9 @@ public struct PolylineAnnotation: Annotation {
         feature.identifier = .string(id)
         var properties = JSONObject()
         properties["layerProperties"] = JSONValue(rawValue: layerProperties)
-        properties["userInfo"] = userInfo.flatMap(JSONValue.init(rawValue:))
+        if let userInfoValue = userInfo.flatMap(JSONValue.init(rawValue:)) {
+            properties["userInfo"] = userInfoValue
+        }
         feature.properties = properties
         return feature
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.

### Summary of changes

This PR addresses a crash when adding annotations that do not have a value for `userInfo`. The `userInfo` dictionary was being initialized with a `nil` value, which then led to a crash in `[MGMStyleManager setStyleSourcePropertiesForSourceId:]`.
 
### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
