### PR TITLE
GeoJSON objects as expression arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Mapbox welcomes participation and contributions from everyone.
 * The double tap, quick zoom, and double touch gestures now use the gesture's location in the view to anchor camera changes. Previously, they used the camera's center coordinate. ([#722](https://github.com/mapbox/mapbox-maps-ios/pull/722))
 * `MapboxCommon.HTTPServiceFactor.reset()` has been added to release the HTTP service implementation. ([#732](https://github.com/mapbox/mapbox-maps-ios/pull/732))
 * `AnnotationOrchestrator.annotationManagersById` has been added. This dictionary contains all annotation managers that have not been removed. ([#725](https://github.com/mapbox/mapbox-maps-ios/pull/725))
+* Adds the `ExpressionArgument.geoJSONObject(_:)` case, which allows you to include a `Turf.GeoJSONObject` instance in an expression with the `Expression.Operator.distance` or `Expression.Operator.within` operator. ([#730](https://github.com/mapbox/mapbox-maps-ios/pull/730))
 
 ## 10.0.0-rc.9 - Sept 22, 2021
 

--- a/Sources/MapboxMaps/Style/Types/Expression.swift
+++ b/Sources/MapboxMaps/Style/Types/Expression.swift
@@ -137,6 +137,7 @@ public struct Expression: Codable, CustomStringConvertible, Equatable {
         case numberArray([Double])
         case stringArray([String])
         case option(Option)
+        case geoJSONObject(GeoJSONObject)
         case null
         case expression(Expression)
 
@@ -154,33 +155,12 @@ public struct Expression: Codable, CustomStringConvertible, Equatable {
                 return "\(exp)"
             case .option(let option):
                 return "\(option)"
+            case .geoJSONObject(let object):
+                return "\(object)"
             case .numberArray(let array):
                 return "\(array)"
             case .stringArray(let stringArray):
                 return "\(stringArray)"
-            }
-        }
-
-        public static func == (lhs: Expression.Argument, rhs: Expression.Argument) -> Bool {
-            switch (lhs, rhs) {
-            case (.number(let lhsNumber), .number(let rhsNumber)):
-                return lhsNumber == rhsNumber
-            case (.string(let lhsString), .string(let rhsString)):
-                return lhsString == rhsString
-            case (.boolean(let lhsBool), .boolean(let rhsBool)):
-                return lhsBool == rhsBool
-            case (.option(let lhsOption), .option(let rhsOption)):
-                return lhsOption == rhsOption
-            case (.null, .null):
-                return true
-            case (.expression(let lhsExpression), .expression(let rhsExpression)):
-                return lhsExpression == rhsExpression
-            case (.numberArray(let lhsArray), .numberArray(let rhsArray)):
-                return lhsArray == rhsArray
-            case (.stringArray(let lhsArray), .stringArray(let rhsArray)):
-                return lhsArray == rhsArray
-            default:
-                return false
             }
         }
 
@@ -198,6 +178,8 @@ public struct Expression: Codable, CustomStringConvertible, Equatable {
                 try container.encode(boolean)
             case .option(let option):
                 try container.encode(option)
+            case .geoJSONObject(let object):
+                try container.encode(object)
             case .null:
                 try container.encodeNil()
             case .numberArray(let array):
@@ -217,6 +199,8 @@ public struct Expression: Codable, CustomStringConvertible, Equatable {
                 self = .number(validNumber)
             } else if let validBoolean = try? container.decode(Bool.self) {
                 self = .boolean(validBoolean)
+            } else if let object = try? container.decode(GeoJSONObject.self) {
+                self = .geoJSONObject(object)
             } else if let validExpression = try? container.decode(Expression.self) {
                 self = .expression(validExpression)
             } else if let validOption = try? container.decode(Option.self) {

--- a/Sources/MapboxMaps/Style/Types/ExpressionArgumentBuilder.swift
+++ b/Sources/MapboxMaps/Style/Types/ExpressionArgumentBuilder.swift
@@ -90,3 +90,9 @@ extension UIColor: ExpressionArgumentConvertible {
         return [.string(StyleColor(self).rgbaString)]
     }
 }
+
+extension GeoJSONObject: ExpressionArgumentConvertible {
+    public var expressionArguments: [Expression.Argument] {
+        return [.geoJSONObject(self)]
+    }
+}


### PR DESCRIPTION
Added a case to ExpressionArgument that takes a `GeoJSONObject` from Turf.

For example, to filter a symbol layer to only show symbols in Colorado:

```swift
let coloradoCorners: [CLLocationCoordinate2D] = [
    .init(latitude: 37, longitude: -109-2/60-48/60/60),
    .init(latitude: 37, longitude: -102-2/60-48/60/60),
    .init(latitude: 41, longitude: -102-2/60-48/60/60),
    .init(latitude: 41, longitude: -109-2/60-48/60/60),
    .init(latitude: 37, longitude: -109-2/60-48/60/60),
]
var colorado = Geometry.polygon(Polygon([coloradoCorners]))

symbolLayer.filter = Exp(.within) {
    GeoJSONObject.geometry(colorado)
}
```

This might be a backwards-compatible change, since `Expression.Argument` isn’t open to arbitrary `ExpressionArgumentConvertible`-conforming types. However, making this change after v2.0.0 would break backwards compatibility, because application code might switch on the cases of `Expression.Argument`.

Fixes #530.

/cc @jmkiley @macdrevx