### PR TITLE
Turf v2.0.0

### DIFF
--- a/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "007896bb945432d4683e114fcf2f089edff4ceeb",
-          "version": "2.0.0-rc.2"
+          "revision": "dccd79aee4c21298d1beb81cc0e86eccbe911ae0",
+          "version": "2.0.0"
         }
       }
     ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Mapbox welcomes participation and contributions from everyone.
 * `TileRegionLoadOptions` init now takes a `Geometry` instead of a `MapboxCommon.Geometry`. ([#711](https://github.com/mapbox/mapbox-maps-ios/pull/711))
 * `CameraAnimationsManager.options` has been removed. Use `MapboxMap.cameraBounds` and `MapboxMap.setCameraBounds(with:)` instead. ([#712](https://github.com/mapbox/mapbox-maps-ios/pull/712))
 * `MapboxMap.setCameraBounds(for:)` has been renamed to `.setCameraBounds(with:)` ([#712](https://github.com/mapbox/mapbox-maps-ios/pull/712))
-* Requires [Turf v2.0.0-rc.2](https://github.com/mapbox/turf-swift/releases/tag/v2.0.0-rc.2). ([#715](https://github.com/mapbox/mapbox-maps-ios/pull/715))
+* Requires [Turf v2._x_](https://github.com/mapbox/turf-swift/releases/tag/v2.0.0). ([#741](https://github.com/mapbox/mapbox-maps-ios/pull/741))
 * Renames `Style.updateGeoJSONSource<T: GeoJSONObject>(withId:geoJSON:)` to `Style.updateGeoJSONSource(withId:geoJSON:)`. Instead of passing in the expected GeoJSON object type, you perform pattern matching on the return value using `case let`. ([#715](https://github.com/mapbox/mapbox-maps-ios/pull/715))
 * `MapboxCoreMaps.Settings` is now deprecated. ([#732](https://github.com/mapbox/mapbox-maps-ios/pull/732))
 * Setting `data` property on a GeoJSON source via `Style.setSourceProperty(for:property:value:)` or `Style.updateGeoJSONSource(withId:geoJSON:)` is now asynchronous and never returns an error. Errors will be reported asynchronously via a `MapEvents.EventKind.mapLoadingError` event instead. ([#732](https://github.com/mapbox/mapbox-maps-ios/pull/732))

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -24,6 +24,6 @@ Pod::Spec.new do |m|
   m.dependency 'MapboxCoreMaps', '10.0.0'
   m.dependency 'MapboxCommon', '20.0.0'
   m.dependency 'MapboxMobileEvents', '1.0.5'
-  m.dependency 'Turf', '2.0.0-rc.2'
+  m.dependency 'Turf', '~> 2.0'
 
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "007896bb945432d4683e114fcf2f089edff4ceeb",
-          "version": "2.0.0-rc.2"
+          "revision": "dccd79aee4c21298d1beb81cc0e86eccbe911ae0",
+          "version": "2.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.0.0")),
         .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("20.0.0")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", .exact("1.0.5")),
-        .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", .exact("2.0.0-rc.2")),
+        .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.0.0"),
         .package(name: "CocoaImageHashing", url: "https://github.com/ameingast/cocoaimagehashing", .exact("1.9.0"))
     ],
     targets: [

--- a/scripts/release/packager/versions.json
+++ b/scripts/release/packager/versions.json
@@ -1,6 +1,6 @@
 {
 	"MapboxCoreMaps": "10.0.0",
 	"MapboxCommon": "20.0.0",
-	"Turf": "v2.0.0-rc.2",
+	"Turf": "v2.0.0",
 	"MapboxMobileEvents": "v1.0.5"
 }


### PR DESCRIPTION
Updated SPM and CocoaPods manifests for MapboxMaps to require Turf v2._x_. [Turf v2.0.0](https://github.com/mapbox/turf-swift/releases/tag/v2.0.0) comes with a number of backwards-incompatible changes compared to either v1._x_ or v2.0.0-rc.1 related to GeoJSON types, as seen in #715. However, there have been no backwards-incompatible changes since v2.0.0-rc.2, so this PR is solely about updating the dependency files.

/cc @mapbox/maps-ios