### PR TITLE
Fix telemetry opt-out through attribution dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ Mapbox welcomes participation and contributions from everyone.
 * Adds `TileStore.subscribe(_:)` which can be used to observe a `TileStore`'s activity. The API design deviates from Android's add/remove observer API so that the developer-provided `TileStoreObserver` can be wrapped into a `MapboxCommon_Private.TileStoreObserver` without needing to use global state or something like Objective-C associated objects to look up which wrapper goes with with developer-provided observer when calling `__removeObserver`. ([#737](https://github.com/mapbox/mapbox-maps-ios/pull/737))
 * Adds `TileStoreObserver` protocol. ([#737](https://github.com/mapbox/mapbox-maps-ios/pull/737))
 
+### Bug fixes 🐞
+* Fix telemetry opt-out through attribution dialog. (https://github.com/mapbox/mapbox-maps-ios/pull/743)
+
 ## 10.0.0-rc.9 - Sept 22, 2021
 
 ### Breaking changes ⚠️

--- a/Sources/MapboxMaps/Ornaments/MapboxInfoButtonOrnament.swift
+++ b/Sources/MapboxMaps/Ornaments/MapboxInfoButtonOrnament.swift
@@ -18,7 +18,7 @@ internal class InfoButtonOrnament: UIView {
     }
 
     internal var isMetricsEnabled: Bool {
-        return UserDefaults.standard.bool(forKey: Ornaments.metricsEnabledKey)
+        return UserDefaults.mme_configuration().mme_isCollectionEnabled
     }
 
     internal weak var delegate: InfoButtonOrnamentDelegate?

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -16,7 +16,6 @@ public enum OrnamentVisibility: String, Equatable {
 
 internal struct Ornaments {
     static let localizableTableName = "OrnamentsLocalizable"
-    static let metricsEnabledKey = "MGLMapboxMetricsEnabled"
     static let telemetryURL = "https://www.mapbox.com/telemetry/"
 }
 

--- a/Sources/MapboxMaps/Style/AttributionDialogManager.swift
+++ b/Sources/MapboxMaps/Style/AttributionDialogManager.swift
@@ -23,10 +23,9 @@ internal class AttributionDialogManager {
 
     internal var isMetricsEnabled: Bool {
         get {
-            UserDefaults.standard.bool(forKey: Ornaments.metricsEnabledKey)
+            UserDefaults.mme_configuration().mme_isCollectionEnabled
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: Ornaments.metricsEnabledKey)
             UserDefaults.mme_configuration().mme_isCollectionEnabled = newValue
             MMEEventsManager.shared().pauseOrResumeMetricsCollectionIfRequired()
         }

--- a/Sources/MapboxMaps/Style/AttributionDialogManager.swift
+++ b/Sources/MapboxMaps/Style/AttributionDialogManager.swift
@@ -1,3 +1,5 @@
+import MapboxMobileEvents
+
 internal protocol AttributionDataSource: AnyObject {
     func attributions() -> [Attribution]
 }
@@ -25,6 +27,8 @@ internal class AttributionDialogManager {
         }
         set {
             UserDefaults.standard.set(newValue, forKey: Ornaments.metricsEnabledKey)
+            UserDefaults.mme_configuration().mme_isCollectionEnabled = newValue
+            MMEEventsManager.shared().pauseOrResumeMetricsCollectionIfRequired()
         }
     }
 

--- a/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/InfoButton/MapboxInfoButtonOrnamentTests.swift
@@ -11,6 +11,7 @@ class InfoButtonOrnamentTests: XCTestCase {
         super.setUp()
         parentViewController = MockParentViewController()
         attributionDialogManager = AttributionDialogManager(dataSource: self, delegate: self)
+        UserDefaults.mme_configuration().set(true, forKey: "MMECollectionEnabledInSimulator")
     }
 
     func testInfoButtonTapped() throws {
@@ -36,7 +37,7 @@ class InfoButtonOrnamentTests: XCTestCase {
         infoButton.delegate = attributionDialogManager
 
         parentViewController.view.addSubview(infoButton)
-        UserDefaults.standard.set(true, forKey: Ornaments.metricsEnabledKey)
+        UserDefaults.mme_configuration().mme_isCollectionEnabled = true
         infoButton.infoTapped()
 
         var infoAlert = try XCTUnwrap(parentViewController.currentAlert, "The info alert controller could not be found.")
@@ -70,7 +71,7 @@ class InfoButtonOrnamentTests: XCTestCase {
     }
 
     func testTelemetryOptIn() throws {
-        UserDefaults.standard.set(false, forKey: Ornaments.metricsEnabledKey)
+        UserDefaults.mme_configuration().mme_isCollectionEnabled = false
         let infoButton = InfoButtonOrnament()
         infoButton.delegate = attributionDialogManager
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

1) The bugfix disables telemetry collection when user select "Stop Participating" option in Attribution dialog.
2) Remove `Ornaments.metricsEnabledKey` and use original MME SDK's property instead.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
