### PR TITLE
Use default values for wrapped MapProjection types

### DIFF
--- a/Apps/Examples/Examples/All Examples/GlobeViewExample.swift
+++ b/Apps/Examples/Examples/All Examples/GlobeViewExample.swift
@@ -13,7 +13,7 @@ public class GlobeViewExample: UIViewController, ExampleProtocol {
     }
 
     internal var mapView: MapView!
-    internal var currentProjection: MapProjection = .globe(GlobeMapProjection())
+    internal var currentProjection: MapProjection = .globe()
 
     private lazy var infoLabel: UILabel = {
         let label = UILabel(frame: .zero)
@@ -131,7 +131,7 @@ public class GlobeViewExample: UIViewController, ExampleProtocol {
     }
 
     @objc private func projectionSwitched(sender: UIButton) {
-        currentProjection = currentProjection == .globe(GlobeMapProjection()) ? .mercator(MercatorMapProjection()) : .globe(GlobeMapProjection())
+        currentProjection = currentProjection == .globe() ? .mercator() : .globe()
         try! mapView.mapboxMap.setMapProjection(currentProjection)
         updateInfoText()
     }

--- a/Sources/MapboxMaps/Foundation/MapProjection.swift
+++ b/Sources/MapboxMaps/Foundation/MapProjection.swift
@@ -8,10 +8,10 @@
 /// Mapbox map supports Mercator and Globe projections.
 @_spi(Experimental) public enum MapProjection: Codable, Hashable {
     // Wraps `MercatorMapProjection`
-    case mercator(_ projection: MercatorMapProjection)
+    case mercator(_ projection: MercatorMapProjection = MercatorMapProjection())
 
     // Wraps `GlobeMapProjection`
-    case globe(_ projection: GlobeMapProjection)
+    case globe(_ projection: GlobeMapProjection = GlobeMapProjection())
 
     /// Name of the wrapped projection
     public var name: String {

--- a/Tests/MapboxMapsTests/Foundation/MapProjectionTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapProjectionTests.swift
@@ -4,9 +4,9 @@ import XCTest
 final class MapProjectionTests: XCTestCase {
 
     func testNameProperty() {
-        var projection = MapProjection.globe(GlobeMapProjection())
+        var projection = MapProjection.globe()
         XCTAssertEqual(projection.name, "globe")
-        projection = MapProjection.mercator(MercatorMapProjection())
+        projection = MapProjection.mercator()
         XCTAssertEqual(projection.name, "mercator")
     }
 

--- a/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
@@ -206,17 +206,17 @@ final class MapboxMapTests: XCTestCase {
 
     func testSetMapProjection() {
         XCTAssertEqual(mapboxMap.__testingMap.getMapProjection() as? [String: String], ["name": "mercator"])
-        try? mapboxMap.setMapProjection(.globe(GlobeMapProjection()))
+        try? mapboxMap.setMapProjection(.globe())
         XCTAssertEqual(mapboxMap.__testingMap.getMapProjection() as? [String: String], ["name": "globe"])
     }
 
     func testGetMapProjection() {
         mapboxMap.__testingMap.setMapProjectionForProjection(["name": "mercator"])
         var projection = try? mapboxMap.mapProjection()
-        XCTAssertEqual(projection, .mercator(MercatorMapProjection()))
+        XCTAssertEqual(projection, .mercator())
 
         mapboxMap.__testingMap.setMapProjectionForProjection(["name": "globe"])
         projection = try? mapboxMap.mapProjection()
-        XCTAssertEqual(projection, .globe(GlobeMapProjection()))
+        XCTAssertEqual(projection, .globe())
     }
 }


### PR DESCRIPTION
This small PR simplifies the MapProjection usage further by using the default values in the MapProjection enum for the wrapped types.
It also makes it more similar to the Android implementation, where the underlying values are not explicitly initialized at the moment.

cc @macdrevx 