### PR TITLE
Update stylegen to only return assigned layerId and sourceId values

### DIFF
--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -65,8 +65,8 @@ public class CircleAnnotationManager: AnnotationManagerInternal {
                   layerPosition: LayerPosition?,
                   displayLinkCoordinator: DisplayLinkCoordinator) {
         self.id = id
-        self.sourceId = id + "-source"
-        self.layerId = id + "-layer"
+        self.sourceId = id
+        self.layerId = id
         self.style = style
         self.gestureRecognizer = gestureRecognizer
         self.mapFeatureQueryable = mapFeatureQueryable

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -65,8 +65,8 @@ public class PointAnnotationManager: AnnotationManagerInternal {
                   layerPosition: LayerPosition?,
                   displayLinkCoordinator: DisplayLinkCoordinator) {
         self.id = id
-        self.sourceId = id + "-source"
-        self.layerId = id + "-layer"
+        self.sourceId = id
+        self.layerId = id
         self.style = style
         self.gestureRecognizer = gestureRecognizer
         self.mapFeatureQueryable = mapFeatureQueryable

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -65,8 +65,8 @@ public class PolygonAnnotationManager: AnnotationManagerInternal {
                   layerPosition: LayerPosition?,
                   displayLinkCoordinator: DisplayLinkCoordinator) {
         self.id = id
-        self.sourceId = id + "-source"
-        self.layerId = id + "-layer"
+        self.sourceId = id
+        self.layerId = id
         self.style = style
         self.gestureRecognizer = gestureRecognizer
         self.mapFeatureQueryable = mapFeatureQueryable

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -65,8 +65,8 @@ public class PolylineAnnotationManager: AnnotationManagerInternal {
                   layerPosition: LayerPosition?,
                   displayLinkCoordinator: DisplayLinkCoordinator) {
         self.id = id
-        self.sourceId = id + "-source"
-        self.layerId = id + "-layer"
+        self.sourceId = id
+        self.layerId = id
         self.style = style
         self.gestureRecognizer = gestureRecognizer
         self.mapFeatureQueryable = mapFeatureQueryable


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-maps-ios/issues/763:
- removes "-layer" and "-source" suffix from layerId and sourceId respectively