### PR TITLE
Lint characters involved in Trojan Source attacks

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,3 +17,8 @@ disabled_rules:
   - todo
   - trailing_comma
   - type_name
+custom_rules:
+  trojan_source:
+    regex: "[\u202A\u202B\u202D\u202E\u2066\u2067\u2068\u202C\u2069]"
+    severity: error
+    message: "Source should not contain characters that may be used in reordering attacks. See https://trojansource.codes/trojan-source.pdf"


### PR DESCRIPTION
Trojan Source attacks have recently been highlighted. This SwiftLint rule aims to help detect attempts to introduce relevant characters into the project's source code.

Further reading:
- https://trojansource.codes/trojan-source.pdf
- https://forums.swift.org/t/is-swift-vulnerable-to-trojan-source-attacks/53205
- https://krebsonsecurity.com/2021/11/trojan-source-bug-threatens-the-security-of-all-code/
