### PR TITLE
Use Xcode 13.0 for Examples device farm tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ workflows:
           report_failure: true
       - run-app-tests-on-devices:
           name: "Run Examples tests on devices"
-          xcode: "12.5.0"
+          xcode: "13.0.0"
           device-farm-project: $(DEVICE_FARM_PROJECT_EXAMPLES)
           device-pool: $(DEVICE_FARM_EXAMPLES_POOL)
           scheme: "Examples"
@@ -103,7 +103,7 @@ workflows:
               ignore: main
       - run-app-tests-on-devices:
           name: "Run Examples tests on devices"
-          xcode: "12.5.0"
+          xcode: "13.0.0"
           device-farm-project: $(DEVICE_FARM_PROJECT_EXAMPLES)
           device-pool: $(DEVICE_FARM_EXAMPLES_POOL)
           scheme: "Examples"
@@ -126,7 +126,7 @@ workflows:
               only: main
       - run-app-tests-on-devices:
           name: "Run Examples tests on devices (main)"
-          xcode: "12.5.0"
+          xcode: "13.0.0"
           device-farm-project: $(DEVICE_FARM_PROJECT_EXAMPLES)
           device-pool: $(DEVICE_FARM_EXAMPLES_POOL)
           scheme: "Examples"
@@ -292,7 +292,7 @@ jobs:
                   echo "Falling back to `master` branch:"
                   curl --fail -X POST --header "Content-Type: application/json" --data "{\"build_parameters\":{\"CIRCLE_JOB\":\"ios-maps-v10-build\",\"SOURCE_HASH\":\"${CIRCLE_SHA1}\",\"SOURCE_NAME\":\"ios-maps-v10\"}}" https://circleci.com/api/v1.1/project/github/mapbox/mobile-metrics/tree/master?circle-token=${CIRCLECI_METRICS_TOKEN}
                 fi
-              fi  
+              fi
             else
               echo "CIRCLECI_METRICS_TOKEN not provided"
             fi
@@ -405,7 +405,7 @@ jobs:
               APP_NAME=<< parameters.app-name >> \
               CONFIGURATION=Release \
               BUILD_DIR="$DERIVED_DATA_PATH"
-          when: always          
+          when: always
       - run:
           name: Converting and uploading coverage
           command: |
@@ -521,7 +521,7 @@ jobs:
           report_failure: << parameters.report_failure >>
           message: "create-xcframework"
 
-  # This job is responsible for building and uploading the xcframework bundle to S3. 
+  # This job is responsible for building and uploading the xcframework bundle to S3.
   # This job will also create a PR in api-downloads for SDK Registry access.
   ios-build-release:
     <<: *base-job


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'


### Summary of changes
This PR updates the CircleCI config to use Xcode 13 for the Examples device farm tests. This is to address failures parsing the coverage report.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
