### PR TITLE
Update to MapboxCoreMaps v10.1.0 & Common v20.1.0

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/MapboxMaps.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/MapboxMaps.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1310"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "2a69ad31f9226c8378922a595d8aa4281814b027",
-          "version": "20.1.0-rc.2"
+          "revision": "8d107b2dae7822f75e1bedfebe3be9d14a1d81df",
+          "version": "20.1.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "3312d5c28650bd0fea10d96fb1d08fe0b77ab171",
-          "version": "10.1.0-rc"
+          "revision": "ebb10128747d417c23755486eeb976fbe89f103c",
+          "version": "10.1.0"
         }
       },
       {

--- a/Apps/DebugApp/DebugApp.xcodeproj/project.pbxproj
+++ b/Apps/DebugApp/DebugApp.xcodeproj/project.pbxproj
@@ -221,7 +221,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1100;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1310;
 				ORGANIZATIONNAME = "Mapbox Inc";
 				TargetAttributes = {
 					35F08DD72347987700768B9F = {

--- a/Apps/DebugApp/DebugApp.xcodeproj/xcshareddata/xcschemes/DebugApp.xcscheme
+++ b/Apps/DebugApp/DebugApp.xcodeproj/xcshareddata/xcschemes/DebugApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Apps/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Apps/Examples/Examples.xcodeproj/project.pbxproj
@@ -265,7 +265,6 @@
 				077E3B8F2581966300564A3E /* FitCameraToGeometryExample.swift */,
 				0CE3D3C225818786000585A2 /* FlyToExample.swift */,
 				30F095BE270B39AF00F368DC /* GlobeViewExample.swift */,
-				07B071CD2547CF2B007F2865 /* MultipleGeometriesExample.swift */,
 				666E0D4925664EE7000B8AF5 /* LayerPositionExample.swift */,
 				C64ED3C82541CA3A00ADADFB /* LineAnnotationExample.swift */,
 				0C78AC2825BF70E40057F570 /* LineGradientExample.swift */,
@@ -457,7 +456,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1200;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1310;
 				TargetAttributes = {
 					077C4EE9252F7E88007636F1 = {
 						CreatedOnToolsVersion = 12.0;

--- a/Apps/Examples/Examples.xcodeproj/xcshareddata/xcschemes/Examples.xcscheme
+++ b/Apps/Examples/Examples.xcodeproj/xcshareddata/xcschemes/Examples.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Apps/StressTest/StressTest.xcodeproj/xcshareddata/xcschemes/StressTest.xcscheme
+++ b/Apps/StressTest/StressTest.xcodeproj/xcshareddata/xcschemes/StressTest.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+## main
+
+* Update to `MapboxCoreMaps` v10.1.0 and `MapboxCommon` v20.1.0. ([#807](https://github.com/mapbox/mapbox-maps-ios/pull/807))
+
 ## 10.1.0-rc.1 - October 28, 2021
 
 * Fixed an issue with `UIImage` conversion that led to a "mismatched image size" error. ([#790](https://github.com/mapbox/mapbox-maps-ios/pull/790))

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -21,8 +21,8 @@ Pod::Spec.new do |m|
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
   m.resources = ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json']
 
-  m.dependency 'MapboxCoreMaps', '10.1.0-rc'
-  m.dependency 'MapboxCommon', '20.1.0-rc.2'
+  m.dependency 'MapboxCoreMaps', '10.1.0'
+  m.dependency 'MapboxCommon', '20.1.0'
   m.dependency 'MapboxMobileEvents', '1.0.6'
   m.dependency 'Turf', '~> 2.0'
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "2a69ad31f9226c8378922a595d8aa4281814b027",
-          "version": "20.1.0-rc.2"
+          "revision": "8d107b2dae7822f75e1bedfebe3be9d14a1d81df",
+          "version": "20.1.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "3312d5c28650bd0fea10d96fb1d08fe0b77ab171",
-          "version": "10.1.0-rc"
+          "revision": "ebb10128747d417c23755486eeb976fbe89f103c",
+          "version": "10.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
             targets: ["MapboxMaps"]),
     ],
     dependencies: [
-        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.1.0-rc")),
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("20.1.0-rc.2")),
+        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.1.0")),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("20.1.0")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", .exact("1.0.6")),
         .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.0.0"),
         .package(name: "CocoaImageHashing", url: "https://github.com/ameingast/cocoaimagehashing", .exact("1.9.0"))

--- a/scripts/release/packager/versions.json
+++ b/scripts/release/packager/versions.json
@@ -1,6 +1,6 @@
 {
-	"MapboxCoreMaps": "10.1.0-rc",
-	"MapboxCommon": "20.1.0-rc.2",
+	"MapboxCoreMaps": "10.1.0",
+	"MapboxCommon": "20.1.0",
 	"Turf": "v2.0.0",
 	"MapboxMobileEvents": "v1.0.6"
 }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Update the changelog

### Summary of changes

Updates to MapboxCoreMaps v10.1.0 and MapboxCommon v20.1.0.

* Fix rendering artifact when some of the model layer models may have wrong placement when globe view projection is used
* Fix rare heatmap flickering when zooming the map
* Fix an issue where an `Observable` event could be dispatched on a thread, different from the subscription thread
* Fix an issue where `promoteId` parameter for VectorSource was overwritten when source tilejson is loaded
*  Relax numeric property getter in queryFeatureExtensions API, so that `cluster_id` property can be double or signed integer
* Move `MBMTask`, `MBMClient` and `MBMMetalViewProvider` interfaces to internal MapboxCoreMaps module, so that we avoid class name clashes with `Swift.Task`
*  UIImage instances that have padded rows are now handled correctly during conversion to MBMImage
