### PR TITLE
Access @_spi protected functions from pre-compiled packages

### DIFF
--- a/Configurations/base.xcconfig
+++ b/Configurations/base.xcconfig
@@ -61,6 +61,7 @@ SWIFT_ACTIVE_COMPILATION_CONDITIONS[config=Release] = RELEASE
 
 SWIFT_OPTIMIZATION_LEVEL[config=Debug] = -Onone
 SWIFT_OPTIMIZATION_LEVEL[config=Release] = -O
+SWIFT_EMIT_PRIVATE_MODULE_INTERFACE = YES
 
 // -----------------------------------------------------------------------------
 // Clang


### PR DESCRIPTION
Generate private module interface in order to access `@spi_` protected functions from pre-compiled packages.

`@_spi(Experimental) import MapBox` fails to import protected functions if the package is not local to the project. [Certain examples](https://github.com/mapbox/mapbox-maps-ios/blob/main/Apps/Examples/Examples/All%20Examples/GlobeViewExample.swift) dependent on protected functions are unusable if the package is pre-compiled. 

Resolves warning on import:
```
'@_spi' import of 'MapboxMaps' will not include any SPI symbols; 'MapboxMaps' was built from the public interface at [redacted]/Build/Products/Debug-iphoneos/MapboxMaps.framework/Modules/MapboxMaps.swiftmodule/arm64-apple-ios.swiftinterface
```
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Generate private module interface in order to access protected @spi_(Experimental) functions from pre-compiled packages.</changelog>`.
 - [x] Document any changes to public APIs.
 - [x] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

Adds the `SWIFT_EMIT_PRIVATE_MODULE_INTERFACE` flag to the base config, which includes `@_spi` protected methods in the MapboxMaps swiftinterface.

Proactively included the `-verify-emitted-module-interface` Swift compiler flag, assuming this project would be affected by [these](https://bugs.swift.org/browse/SR-14195) [two](https://bugs.swift.org/browse/SR-898) Swift compiler bugs.

### Testing

Because the repo tests and example app import the local package, the only way to test this is by including it in an entirely separate project, which I have done by including this source branch as an SPM dependency. Fails on upstream, succeeds on head repo.

### User impact

See above. Should BOLO for bugs like #704.