### PR TITLE
Update MapboxCoreMaps and MapboxCommon

### DIFF
--- a/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "dccd79aee4c21298d1beb81cc0e86eccbe911ae0",
-          "version": "2.0.0"
+          "revision": "132aaf7f90fb3e334acd685ae7040a2b70b80d26",
+          "version": "2.1.0"
         }
       }
     ]

--- a/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "8d107b2dae7822f75e1bedfebe3be9d14a1d81df",
-          "version": "20.1.0"
+          "revision": "0cb49b20841410d0da2bf41c0884ebc7235f5485",
+          "version": "21.0.0-rc.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "ebb10128747d417c23755486eeb976fbe89f103c",
-          "version": "10.1.0"
+          "revision": "9ec005ccbe185880c93cd4ed0bf6175cccb731f7",
+          "version": "10.2.0-beta.1"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 * Fixed an issue where camera animations triggered with `startAnimation(afterDelay:)` could appear jerky after a pan gesture. ([#789](https://github.com/mapbox/mapbox-maps-ios/pull/789))
 * Send location update when puck is nil and other location-related improvements. ([#765](https://github.com/mapbox/mapbox-maps-ios/pull/765))
-* Update to MapboxCoreMaps 10.2.0-beta.1 and MapboxCommon 21.0.0-rc.1. ([#]())
+* Update to MapboxCoreMaps 10.2.0-beta.1 and MapboxCommon 21.0.0-rc.1. ([#836](https://github.com/mapbox/mapbox-maps-ios/pull/836))
 
 ## 10.1.0 - November 4, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 * Fixed an issue where camera animations triggered with `startAnimation(afterDelay:)` could appear jerky after a pan gesture. ([#789](https://github.com/mapbox/mapbox-maps-ios/pull/789))
 * Send location update when puck is nil and other location-related improvements. ([#765](https://github.com/mapbox/mapbox-maps-ios/pull/765))
+* Update to MapboxCoreMaps 10.2.0-beta.1 and MapboxCommon 21.0.0-rc.1. ([#]())
 
 ## 10.1.0 - November 4, 2021
 

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -21,8 +21,8 @@ Pod::Spec.new do |m|
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
   m.resources = ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json']
 
-  m.dependency 'MapboxCoreMaps', '10.1.0'
-  m.dependency 'MapboxCommon', '20.1.0'
+  m.dependency 'MapboxCoreMaps', '10.2.0-beta.1'
+  m.dependency 'MapboxCommon', '21.0.0-rc.1'
   m.dependency 'MapboxMobileEvents', '1.0.6'
   m.dependency 'Turf', '~> 2.0'
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "8d107b2dae7822f75e1bedfebe3be9d14a1d81df",
-          "version": "20.1.0"
+          "revision": "0cb49b20841410d0da2bf41c0884ebc7235f5485",
+          "version": "21.0.0-rc.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "ebb10128747d417c23755486eeb976fbe89f103c",
-          "version": "10.1.0"
+          "revision": "9ec005ccbe185880c93cd4ed0bf6175cccb731f7",
+          "version": "10.2.0-beta.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "dccd79aee4c21298d1beb81cc0e86eccbe911ae0",
-          "version": "2.0.0"
+          "revision": "132aaf7f90fb3e334acd685ae7040a2b70b80d26",
+          "version": "2.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
             targets: ["MapboxMaps"]),
     ],
     dependencies: [
-        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.1.0")),
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("20.1.0")),
+        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.2.0-beta.1")),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("21.0.0-rc.1")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", .exact("1.0.6")),
         .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.0.0"),
         .package(name: "CocoaImageHashing", url: "https://github.com/ameingast/cocoaimagehashing", .exact("1.9.0"))

--- a/scripts/release/packager/versions.json
+++ b/scripts/release/packager/versions.json
@@ -1,6 +1,6 @@
 {
-	"MapboxCoreMaps": "10.1.0",
-	"MapboxCommon": "20.1.0",
+	"MapboxCoreMaps": "10.2.0-beta.1",
+	"MapboxCommon": "21.0.0-rc.1",
 	"Turf": "v2.0.0",
 	"MapboxMobileEvents": "v1.0.6"
 }

--- a/scripts/release/packager/versions.json
+++ b/scripts/release/packager/versions.json
@@ -1,6 +1,6 @@
 {
 	"MapboxCoreMaps": "10.2.0-beta.1",
 	"MapboxCommon": "21.0.0-rc.1",
-	"Turf": "v2.0.0",
+	"Turf": "v2.1.0",
 	"MapboxMobileEvents": "v1.0.6"
 }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Document any changes to public APIs.

### Summary of changes

#### Features ✨ and improvements 🏁

* Add heatmap layer support to globe view
* Add circle layer support to globe
* Improve performance for querying large number of features
* Cache layer layout key inside layer, so that it is not re-evaluated at every parse of the every tile
* Model layer now supports loading of external gltf files
* Add cancelable Query Rendered Features API to the Map interface
* Core renderer prints its version on initialization
* Introduce experimental Map.setMemoryBudget method for setting memory budget for a Map and runtime "resource-budget" property for data sources
* Improve performance by avoiding re-layout of invisible fading tiles
* Reduce memory consumption of a model layer by avoiding duplicate texture uploads
* Introduce ViewAnnotation API and corresponding support in gl-native
* Update mapbox-common to v21.0.0-rc.1

#### Bug fixes 🐞

* Release all unused resources when `Map.reduceMemoryUse` is invoked
* Fix crash for the case when an empty fill extrusion bucket is tried to be rendered
* Fix transparency issues with value < 0.5 for models rendered by the model layer 
* Fix regression where setting the same geojson source URL did not refresh the data
* Fix symbol layers with variable anchor placement not being placed correctly on globe view
* Fix crash in symbol reprojection code caused by division by zero
* Fix issue with bounds constraining behavior when terrain is enabled
