### PR TITLE
Implement iterative pan gesture handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Fixed an issue where camera animations triggered with `startAnimation(afterDelay:)` could appear jerky after a pan gesture. ([#789](https://github.com/mapbox/mapbox-maps-ios/pull/789))
 * Send location update when puck is nil and other location-related improvements. ([#765](https://github.com/mapbox/mapbox-maps-ios/pull/765))
 * Update to MapboxCoreMaps 10.2.0-beta.1 and MapboxCommon 21.0.0-rc.1. ([#836](https://github.com/mapbox/mapbox-maps-ios/pull/836))
+* Updates pan and pinch gesture handling to work iteratively rather than based on initial state. ([#837](https://github.com/mapbox/mapbox-maps-ios/pull/837))
 
 ## 10.1.0 - November 4, 2021
 

--- a/Sources/MapboxMaps/Foundation/Camera/CameraAnimationsManager.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/CameraAnimationsManager.swift
@@ -11,7 +11,7 @@ internal protocol CameraAnimationsManagerProtocol: AnyObject {
     func decelerate(location: CGPoint,
                     velocity: CGPoint,
                     decelerationFactor: CGFloat,
-                    locationChangeHandler: @escaping (CGPoint) -> Void,
+                    locationChangeHandler: @escaping (_ location: CGPoint) -> Void,
                     completion: @escaping () -> Void)
 
     func cancelAnimations()
@@ -296,7 +296,7 @@ public class CameraAnimationsManager: CameraAnimationsManagerProtocol {
     internal func decelerate(location: CGPoint,
                              velocity: CGPoint,
                              decelerationFactor: CGFloat,
-                             locationChangeHandler: @escaping (CGPoint) -> Void,
+                             locationChangeHandler: @escaping (_ location: CGPoint) -> Void,
                              completion: @escaping () -> Void) {
 
         // Stop the `internalAnimator` before beginning a deceleration

--- a/Sources/MapboxMaps/Foundation/Camera/GestureDecelerationCameraAnimator.swift
+++ b/Sources/MapboxMaps/Foundation/Camera/GestureDecelerationCameraAnimator.swift
@@ -5,7 +5,7 @@ internal final class GestureDecelerationCameraAnimator: NSObject, CameraAnimator
     private var location: CGPoint
     private var velocity: CGPoint
     private let decelerationFactor: CGFloat
-    private let locationChangeHandler: (CGPoint) -> Void
+    private let locationChangeHandler: (_ location: CGPoint) -> Void
     private var previousDate: Date?
     private let dateProvider: DateProvider
     private weak var delegate: CameraAnimatorDelegate?
@@ -14,7 +14,7 @@ internal final class GestureDecelerationCameraAnimator: NSObject, CameraAnimator
     internal init(location: CGPoint,
                   velocity: CGPoint,
                   decelerationFactor: CGFloat,
-                  locationChangeHandler: @escaping (CGPoint) -> Void,
+                  locationChangeHandler: @escaping (_ location: CGPoint) -> Void,
                   dateProvider: DateProvider,
                   delegate: CameraAnimatorDelegate) {
         self.location = location

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PanGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PanGestureHandler.swift
@@ -76,7 +76,7 @@ internal final class PanGestureHandler: GestureHandler, PanGestureHandlerProtoco
             guard let lastChangedDate = lastChangedDate,
                   dateProvider.now.timeIntervalSince(lastChangedDate) < decelerationTimeout else {
                       previousTouchLocation = nil
-                      lastChangedDate = nil
+                      self.lastChangedDate = nil
                       mapboxMap.dragEnd()
                       delegate?.gestureEnded(for: .pan, willAnimate: false)
                       return

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PanGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PanGestureHandler.swift
@@ -17,10 +17,7 @@ internal final class PanGestureHandler: GestureHandler, PanGestureHandlerProtoco
     internal var panMode: PanMode = .horizontalAndVertical
 
     /// The touch location in the gesture's view when the gesture began
-    private var initialTouchLocation: CGPoint?
-
-    /// The camera state when the gesture began
-    private var initialCameraState: CameraState?
+    private var previousTouchLocation: CGPoint?
 
     /// The date when the most recent gesture changed event was handled
     private var lastChangedDate: Date?
@@ -54,19 +51,21 @@ internal final class PanGestureHandler: GestureHandler, PanGestureHandlerProtoco
 
         switch gestureRecognizer.state {
         case .began:
-            initialTouchLocation = touchLocation
-            initialCameraState = mapboxMap.cameraState
+            previousTouchLocation = touchLocation
+            mapboxMap.dragStart(for: touchLocation)
             delegate?.gestureBegan(for: .pan)
         case .changed:
-            guard let initialTouchLocation = initialTouchLocation,
-                  let initialCameraState = initialCameraState else {
+            guard let previousTouchLocation = previousTouchLocation else {
                 return
             }
             lastChangedDate = dateProvider.now
+            let clampedTouchLocation = clampTouchLocation(
+                touchLocation,
+                previousTouchLocation: previousTouchLocation)
             handleChange(
-                withTouchLocation: touchLocation,
-                initialTouchLocation: initialTouchLocation,
-                initialCameraState: initialCameraState)
+                withTouchLocation: clampedTouchLocation,
+                previousTouchLocation: previousTouchLocation)
+            self.previousTouchLocation = clampedTouchLocation
         case .ended:
             // Only decelerate if the gesture ended quickly. Otherwise,
             // you get a deceleration in situations where you drag, then
@@ -74,67 +73,61 @@ internal final class PanGestureHandler: GestureHandler, PanGestureHandlerProtoco
             // it without further dragging. This specific time interval
             // is just the result of manual tuning.
             let decelerationTimeout: TimeInterval = 1.0 / 30.0
-            let maxPitchForDeceleration: CGFloat = 60
-            guard let initialTouchLocation = initialTouchLocation,
-                  let initialCameraState = initialCameraState,
-                  let lastChangedDate = lastChangedDate,
-                  dateProvider.now.timeIntervalSince(lastChangedDate) < decelerationTimeout,
-                  mapboxMap.cameraState.pitch <= maxPitchForDeceleration else {
-                delegate?.gestureEnded(for: .pan, willAnimate: false)
-                return
-            }
+            guard let lastChangedDate = lastChangedDate,
+                  dateProvider.now.timeIntervalSince(lastChangedDate) < decelerationTimeout else {
+                      previousTouchLocation = nil
+                      lastChangedDate = nil
+                      mapboxMap.dragEnd()
+                      delegate?.gestureEnded(for: .pan, willAnimate: false)
+                      return
+                  }
+            var previousDecelerationLocation = touchLocation
             cameraAnimationsManager.decelerate(
                 location: touchLocation,
                 velocity: gestureRecognizer.velocity(in: view),
-                // Decelerate more quickly when pitched. This is a workaround for an issue
-                // in the drag API that we hope to fix in MapboxCoreMaps in a future release.
-                decelerationFactor: decelerationFactor * (1 - mapboxMap.cameraState.pitch / 5000),
+                decelerationFactor: decelerationFactor,
                 locationChangeHandler: { (touchLocation) in
-                    // here we capture the initial state so that we can clear
-                    // it immediately after starting the animation
+                    let clampedTouchLocation = self.clampTouchLocation(
+                        touchLocation,
+                        previousTouchLocation: previousDecelerationLocation)
                     self.handleChange(
-                        withTouchLocation: touchLocation,
-                        initialTouchLocation: initialTouchLocation,
-                        initialCameraState: initialCameraState)
+                        withTouchLocation: clampedTouchLocation,
+                        previousTouchLocation: previousDecelerationLocation)
+                    previousDecelerationLocation = clampedTouchLocation
                 },
-                completion: {
+                completion: { [mapboxMap] in
+                    mapboxMap.dragEnd()
                     self.delegate?.animationEnded(for: .pan)
                 })
-            self.initialTouchLocation = nil
-            self.initialCameraState = nil
+            self.previousTouchLocation = nil
             self.lastChangedDate = nil
             delegate?.gestureEnded(for: .pan, willAnimate: true)
         case .cancelled:
             // no deceleration
-            initialTouchLocation = nil
-            initialCameraState = nil
+            previousTouchLocation = nil
             lastChangedDate = nil
+            mapboxMap.dragEnd()
             delegate?.gestureEnded(for: .pan, willAnimate: false)
         default:
             break
         }
     }
 
-    private func handleChange(withTouchLocation touchLocation: CGPoint, initialTouchLocation: CGPoint, initialCameraState: CameraState) {
-        // Reset the camera to its state when the gesture began
-        mapboxMap.setCamera(to: CameraOptions(cameraState: initialCameraState))
-
-        let clampedTouchLocation: CGPoint
+    private func clampTouchLocation(_ touchLocation: CGPoint, previousTouchLocation: CGPoint) -> CGPoint {
         switch panMode {
         case .horizontal:
-            clampedTouchLocation = CGPoint(x: touchLocation.x, y: initialTouchLocation.y)
+            return CGPoint(x: touchLocation.x, y: previousTouchLocation.y)
         case .vertical:
-            clampedTouchLocation = CGPoint(x: initialTouchLocation.x, y: touchLocation.y)
+            return CGPoint(x: previousTouchLocation.x, y: touchLocation.y)
         case .horizontalAndVertical:
-            clampedTouchLocation = touchLocation
+            return touchLocation
         }
+    }
 
-        // Execute the drag relative to the initial touch location
-        mapboxMap.dragStart(for: initialTouchLocation)
-        let dragCameraOptions = mapboxMap.dragCameraOptions(
-            from: initialTouchLocation,
-            to: clampedTouchLocation)
-        mapboxMap.setCamera(to: dragCameraOptions)
-        mapboxMap.dragEnd()
+    private func handleChange(withTouchLocation touchLocation: CGPoint, previousTouchLocation: CGPoint) {
+        mapboxMap.setCamera(
+            to: mapboxMap.dragCameraOptions(
+                from: previousTouchLocation,
+                to: touchLocation))
     }
 }

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchGestureHandler.swift
@@ -39,6 +39,7 @@ internal final class PinchGestureHandler: GestureHandler, PinchGestureHandlerPro
         gestureRecognizer.addTarget(self, action: #selector(handleGesture(_:)))
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     @objc private func handleGesture(_ gestureRecognizer: UIPinchGestureRecognizer) {
         guard let view = gestureRecognizer.view else {
             return

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchGestureHandler.swift
@@ -11,13 +11,10 @@ internal final class PinchGestureHandler: GestureHandler, PinchGestureHandlerPro
     internal var rotateEnabled: Bool = true
 
     /// The midpoint of the touches in the gesture's view when the gesture began
-    private var initialPinchMidpoint: CGPoint?
+    private var previousPinchMidpoint: CGPoint?
 
     /// The angle from touch location 0 to touch location 1 when the gesture began or unpaused
     private var initialPinchAngle: CGFloat?
-
-    /// The camera center when the gesture began or unpaused
-    private var initialCenter: CLLocationCoordinate2D?
 
     /// The camera zoom when the gesture began
     private var initialZoom: CGFloat?
@@ -29,6 +26,10 @@ internal final class PinchGestureHandler: GestureHandler, PinchGestureHandlerPro
     private var initialRotateEnabled: Bool?
 
     private let mapboxMap: MapboxMapProtocol
+
+    private var isDragging = false
+
+    private var gestureBegan = false
 
     /// Initialize the handler which creates the panGestureRecognizer and adds to the view
     internal init(gestureRecognizer: UIPinchGestureRecognizer,
@@ -46,60 +47,54 @@ internal final class PinchGestureHandler: GestureHandler, PinchGestureHandlerPro
 
         switch gestureRecognizer.state {
         case .began:
-            initialPinchMidpoint = pinchMidpoint
-            initialPinchAngle = pinchAngle(with: gestureRecognizer)
-            initialCenter = mapboxMap.cameraState.center
+            guard gestureRecognizer.numberOfTouches == 2 else {
+                return
+            }
+            startDragging(with: pinchMidpoint)
+            previousPinchMidpoint = pinchMidpoint
+            initialPinchAngle = pinchAngleForGestureBegan(with: gestureRecognizer)
             initialZoom = mapboxMap.cameraState.zoom
             initialBearing = mapboxMap.cameraState.bearing
             initialRotateEnabled = rotateEnabled
+            gestureBegan = true
             delegate?.gestureBegan(for: .pinch)
         case .changed:
             // UIPinchGestureRecognizer sends a .changed event when the number
             // of touches decreases from 2 to 1. If this happens, we pause our
             // gesture handling.
-            //
-            // if a second touch goes down again before the gesture ends, we
-            // resume and re-capture the initial state (except for zoom since
-            // UIPinchGestureRecognizer provides continuity of scale values)
             guard gestureRecognizer.numberOfTouches == 2 else {
-                initialPinchMidpoint = nil
+                previousPinchMidpoint = nil
                 initialPinchAngle = nil
-                initialCenter = nil
                 initialBearing = nil
+                stopDraggingIfNeeded()
                 return
             }
             guard let initialZoom = initialZoom,
                   let initialRotateEnabled = initialRotateEnabled else {
                 return
             }
-            // Using explicit self to help older versions of Xcode (pre-12.5) figure
-            // out the scope of these variables. https://bugs.swift.org/browse/SR-8669
-            let pinchAngle = self.pinchAngle(with: gestureRecognizer)
-            guard let initialPinchMidpoint = initialPinchMidpoint,
+
+            // if a second touch goes down again before the gesture ends, we
+            // resume and re-capture the initial state (except for zoom since
+            // UIPinchGestureRecognizer provides continuity of scale values)
+            let pinchAngle = pinchAngleForGestureChanged(with: gestureRecognizer)
+            guard let previousPinchMidpoint = previousPinchMidpoint,
                   let initialPinchAngle = initialPinchAngle,
-                  let initialCenter = initialCenter,
                   let initialBearing = initialBearing else {
-                self.initialPinchMidpoint = pinchMidpoint
-                self.initialPinchAngle = pinchAngle
-                self.initialCenter = mapboxMap.cameraState.center
-                self.initialBearing = mapboxMap.cameraState.bearing
+                      startDragging(with: pinchMidpoint)
+                      self.previousPinchMidpoint = pinchMidpoint
+                      self.initialPinchAngle = pinchAngle
+                      self.initialBearing = mapboxMap.cameraState.bearing
                 return
             }
 
             let zoomIncrement = log2(gestureRecognizer.scale)
-            var cameraOptions = CameraOptions()
-            cameraOptions.center = initialCenter
-            cameraOptions.zoom = initialZoom
-            cameraOptions.bearing = initialRotateEnabled ? initialBearing : nil
 
-            mapboxMap.setCamera(to: cameraOptions)
+            mapboxMap.setCamera(to: mapboxMap.dragCameraOptions(
+                from: previousPinchMidpoint,
+                to: pinchMidpoint))
+            self.previousPinchMidpoint = pinchMidpoint
 
-            mapboxMap.dragStart(for: initialPinchMidpoint)
-            let dragOptions = mapboxMap.dragCameraOptions(
-                from: initialPinchMidpoint,
-                to: pinchMidpoint)
-            mapboxMap.setCamera(to: dragOptions)
-            mapboxMap.dragEnd()
             // the two angles will always be in the range [0, 2pi)
             // so the resulting rotation will be in the range (-2pi, 2pi)
             var rotation = pinchAngle - initialPinchAngle
@@ -119,15 +114,31 @@ internal final class PinchGestureHandler: GestureHandler, PinchGestureHandlerPro
                     zoom: initialZoom + zoomIncrement,
                     bearing: initialRotateEnabled ? (initialBearing + rotationInDegrees) : nil))
         case .ended, .cancelled:
-            initialPinchMidpoint = nil
+            previousPinchMidpoint = nil
             initialPinchAngle = nil
-            initialCenter = nil
             initialZoom = nil
             initialBearing = nil
             initialRotateEnabled = nil
-            delegate?.gestureEnded(for: .pinch, willAnimate: false)
+            stopDraggingIfNeeded()
+            if gestureBegan {
+                delegate?.gestureEnded(for: .pinch, willAnimate: false)
+            }
+            gestureBegan = false
         default:
             break
+        }
+    }
+
+    private func startDragging(with point: CGPoint) {
+        precondition(!isDragging)
+        isDragging = true
+        mapboxMap.dragStart(for: point)
+    }
+
+    private func stopDraggingIfNeeded() {
+        if isDragging {
+            isDragging = false
+            mapboxMap.dragEnd()
         }
     }
 
@@ -138,6 +149,18 @@ internal final class PinchGestureHandler: GestureHandler, PinchGestureHandlerPro
             angle += 2 * .pi
         }
         return angle
+    }
+
+    // this method is added to help diagnose a crash in pinchAngle. if the crash continues to happen,
+    // we'll be able to tell which invocation of pinchAngle is responsible.
+    private func pinchAngleForGestureBegan(with gestureRecognizer: UIPinchGestureRecognizer) -> CGFloat {
+        return pinchAngle(with: gestureRecognizer)
+    }
+
+    // this method is added to help diagnose a crash in pinchAngle. if the crash continues to happen,
+    // we'll be able to tell which invocation of pinchAngle is responsible.
+    private func pinchAngleForGestureChanged(with gestureRecognizer: UIPinchGestureRecognizer) -> CGFloat {
+        return pinchAngle(with: gestureRecognizer)
     }
 
     private func pinchAngle(with gestureRecognizer: UIPinchGestureRecognizer) -> CGFloat {

--- a/Tests/MapboxMapsTests/Foundation/Camera/Mocks/MockCameraAnimationsManager.swift
+++ b/Tests/MapboxMapsTests/Foundation/Camera/Mocks/MockCameraAnimationsManager.swift
@@ -33,14 +33,14 @@ final class MockCameraAnimationsManager: CameraAnimationsManagerProtocol {
         var location: CGPoint
         var velocity: CGPoint
         var decelerationFactor: CGFloat
-        var locationChangeHandler: (CGPoint) -> Void
+        var locationChangeHandler: (_ location: CGPoint) -> Void
         var completion: () -> Void
     }
     let decelerateStub = Stub<DecelerateParameters, Void>()
     func decelerate(location: CGPoint,
                     velocity: CGPoint,
                     decelerationFactor: CGFloat,
-                    locationChangeHandler: @escaping (CGPoint) -> Void,
+                    locationChangeHandler: @escaping (_ location: CGPoint) -> Void,
                     completion: @escaping () -> Void) {
 
         return decelerateStub.call(

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockGestureHandlerDelegate.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockGestureHandlerDelegate.swift
@@ -6,7 +6,7 @@ final class MockGestureHandlerDelegate: GestureHandlerDelegate {
         gestureBeganStub.call(with: gestureType)
     }
 
-    struct GestureEndedParams {
+    struct GestureEndedParams: Equatable {
         var gestureType: GestureType
         var willAnimate: Bool
     }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchGestureHandlerTests.swift
@@ -40,15 +40,19 @@ final class PinchGestureHandlerTests: XCTestCase {
 
         gestureRecognizer.sendActions()
 
+        XCTAssertEqual(mapboxMap.dragStartStub.invocations.count, 1)
         XCTAssertEqual(delegate.gestureBeganStub.parameters, [.pinch])
     }
 
     func testPinchChanged() throws {
         pinchGestureHandler.rotateEnabled = true
 
+        // Set up and send the gesture began event
         let initialCameraState = CameraState.random()
-        let initialPinchMidpoint = CGPoint(x: 0.0, y: 0.0)
-        let changedPinchMidpoint = CGPoint(x: 1.0, y: 1.0)
+        let pinchMidpoints = [
+            CGPoint(x: 0.0, y: 0.0),
+            CGPoint(x: 1.0, y: 1.0),
+            CGPoint(x: 10.0, y: 10.0)]
         mapboxMap.cameraState = initialCameraState
         mapboxMap.dragCameraOptionsStub.defaultReturnValue = CameraOptions(
             center: .random(),
@@ -56,7 +60,7 @@ final class PinchGestureHandlerTests: XCTestCase {
 
         // set up internal state by calling handlePinch in the .began state
         gestureRecognizer.getStateStub.defaultReturnValue = .began
-        gestureRecognizer.locationStub.defaultReturnValue = initialPinchMidpoint
+        gestureRecognizer.locationStub.defaultReturnValue = pinchMidpoints[0]
         // these touches are consistent with the initial pinch midpoint
         // and yield an angle of 45° for the initial state
         gestureRecognizer.locationOfTouchStub.returnValueQueue = [
@@ -64,8 +68,10 @@ final class PinchGestureHandlerTests: XCTestCase {
             CGPoint(x: 1, y: 1)]
         gestureRecognizer.getNumberOfTouchesStub.defaultReturnValue = 2
         gestureRecognizer.sendActions()
+
+        // Set up and send the gesture changed event
         gestureRecognizer.getStateStub.defaultReturnValue = .changed
-        gestureRecognizer.locationStub.defaultReturnValue = changedPinchMidpoint
+        gestureRecognizer.locationStub.defaultReturnValue = pinchMidpoints[1]
         // the new touch angle is 90° - that's 45° increase from the initial.
         // this should come through as -45° change in bearing since the
         // coordinate systems are flipped.
@@ -73,43 +79,36 @@ final class PinchGestureHandlerTests: XCTestCase {
             CGPoint(x: 1, y: 0),
             CGPoint(x: 1, y: 2)]
         gestureRecognizer.getScaleStub.defaultReturnValue = 2.0
-
         gestureRecognizer.sendActions()
 
-        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 3)
-        guard mapboxMap.setCameraStub.invocations.count == 3 else {
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 2)
+        guard mapboxMap.setCameraStub.invocations.count == 2 else {
             return
         }
-        XCTAssertEqual(mapboxMap.dragStartStub.invocations.count, 1)
         XCTAssertEqual(mapboxMap.dragCameraOptionsStub.invocations.count, 1)
-        XCTAssertEqual(mapboxMap.dragEndStub.invocations.count, 1)
-
-        XCTAssertEqual(
-            mapboxMap.setCameraStub.parameters[0],
-            CameraOptions(
-                center: initialCameraState.center,
-                zoom: initialCameraState.zoom,
-                bearing: initialCameraState.bearing))
-
-        XCTAssertEqual(
-            mapboxMap.dragStartStub.parameters.first,
-            initialPinchMidpoint)
-
         XCTAssertEqual(
             mapboxMap.dragCameraOptionsStub.parameters.first,
-            .init(from: initialPinchMidpoint, to: changedPinchMidpoint))
-
+            .init(from: pinchMidpoints[0], to: pinchMidpoints[1]))
         XCTAssertEqual(
-            mapboxMap.setCameraStub.parameters[1],
+            mapboxMap.setCameraStub.parameters[0],
             mapboxMap.dragCameraOptionsStub.returnedValues.first)
-
         let returnedScale = try XCTUnwrap(gestureRecognizer.getScaleStub.returnedValues.last)
         XCTAssertEqual(
-            mapboxMap.setCameraStub.parameters[2],
+            mapboxMap.setCameraStub.parameters[1],
             CameraOptions(
-                anchor: changedPinchMidpoint,
+                anchor: pinchMidpoints[1],
                 zoom: initialCameraState.zoom + log2(returnedScale),
                 bearing: initialCameraState.bearing - 45))
+
+        // Set up and send a second gesture changed event to make sure we use drag API incrementally
+        gestureRecognizer.locationStub.defaultReturnValue = pinchMidpoints[2]
+        mapboxMap.dragCameraOptionsStub.reset()
+        gestureRecognizer.sendActions()
+
+        XCTAssertEqual(mapboxMap.dragCameraOptionsStub.invocations.count, 1)
+        XCTAssertEqual(
+            mapboxMap.dragCameraOptionsStub.parameters.first,
+            .init(from: pinchMidpoints[1], to: pinchMidpoints[2]))
     }
 
     func testPinchChangedWithRotateEnabledFalse() {
@@ -135,12 +134,11 @@ final class PinchGestureHandlerTests: XCTestCase {
         gestureRecognizer.getStateStub.defaultReturnValue = .changed
         gestureRecognizer.sendActions()
 
-        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 3)
-        guard mapboxMap.setCameraStub.invocations.count == 3 else {
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 2)
+        guard mapboxMap.setCameraStub.invocations.count == 2 else {
             return
         }
-        XCTAssertNil(mapboxMap.setCameraStub.parameters[0].bearing)
-        XCTAssertNil(mapboxMap.setCameraStub.parameters[2].bearing)
+        XCTAssertNil(mapboxMap.setCameraStub.parameters[1].bearing)
     }
 
     func testSettingRotateEnabledToTrueDuringGestureHasNoImpactOnCurrentGesture() {
@@ -160,12 +158,11 @@ final class PinchGestureHandlerTests: XCTestCase {
         gestureRecognizer.getStateStub.defaultReturnValue = .changed
         gestureRecognizer.sendActions()
 
-        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 3)
-        guard mapboxMap.setCameraStub.invocations.count == 3 else {
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 2)
+        guard mapboxMap.setCameraStub.invocations.count == 2 else {
             return
         }
-        XCTAssertNil(mapboxMap.setCameraStub.parameters[0].bearing)
-        XCTAssertNil(mapboxMap.setCameraStub.parameters[2].bearing)
+        XCTAssertNil(mapboxMap.setCameraStub.parameters[1].bearing)
     }
 
     func testSettingRotateEnabledToFalseDuringGestureHasNoImpactOnCurrentGesture() throws {
@@ -196,49 +193,117 @@ final class PinchGestureHandlerTests: XCTestCase {
         gestureRecognizer.getStateStub.defaultReturnValue = .changed
         gestureRecognizer.sendActions()
 
-        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 3)
-        guard mapboxMap.setCameraStub.invocations.count == 3 else {
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 2)
+        guard mapboxMap.setCameraStub.invocations.count == 2 else {
             return
         }
-        XCTAssertEqual(mapboxMap.setCameraStub.parameters[0].bearing, initialCameraState.bearing)
-        XCTAssertEqual(mapboxMap.setCameraStub.parameters[2].bearing, initialCameraState.bearing - 45)
+        XCTAssertEqual(mapboxMap.setCameraStub.parameters[1].bearing, initialCameraState.bearing - 45)
     }
 
     func testPinchChangedWhenNumberOfTouchesDecreasesToOneThenGoesBackToTwo() {
         gestureRecognizer.getStateStub.returnValueQueue = [
             .began, .changed, .changed, .changed, .changed]
         gestureRecognizer.getNumberOfTouchesStub.returnValueQueue = [
-            2, 1, 2, 2] // this is only called on .changed
+            2, 2, 1, 2, 2]
         let initialCameraState = CameraState.random()
         mapboxMap.cameraState = initialCameraState
         gestureRecognizer.sendActions() // began (2 touches)
         gestureRecognizer.sendActions() // changed (2 touches)
+
+        // Gesture pauses when number of touches decreases to 1
+        mapboxMap.dragEndStub.reset()
+
         gestureRecognizer.sendActions() // changed (1 touch)
+
+        XCTAssertEqual(mapboxMap.dragEndStub.invocations.count, 1)
+
+        // Gesture re-captures initial state when number of touches increases back to 2
         let resumedCameraState = CameraState.random()
         mapboxMap.cameraState = resumedCameraState
+        // 45 degree touch angle
+        gestureRecognizer.locationOfTouchStub.returnValueQueue = [
+            CGPoint(x: -1, y: -1),
+            CGPoint(x: 1, y: 1)]
+        let resumedPinchMidpoint = CGPoint.random()
+        gestureRecognizer.locationStub.defaultReturnValue = resumedPinchMidpoint
+        mapboxMap.dragStartStub.reset()
+
         gestureRecognizer.sendActions() // changed (2 touches)
+
+        XCTAssertEqual(mapboxMap.dragStartStub.parameters, [resumedPinchMidpoint])
+
+        // On second changed event after resume, we can start updating the camera again
+        // 90 degree touch angle
+        gestureRecognizer.locationOfTouchStub.returnValueQueue = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 0, y: 1)]
+        let updatedPinchMidpoint = CGPoint.random()
+        gestureRecognizer.locationStub.defaultReturnValue = updatedPinchMidpoint
+        gestureRecognizer.getScaleStub.defaultReturnValue = 8
         mapboxMap.setCameraStub.reset()
+        mapboxMap.dragCameraOptionsStub.reset()
 
         gestureRecognizer.sendActions() // changed (2 touches)
 
-        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 3)
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 2)
+        XCTAssertEqual(mapboxMap.dragCameraOptionsStub.parameters,
+                       [.init(from: resumedPinchMidpoint, to: updatedPinchMidpoint)])
         XCTAssertEqual(
-            mapboxMap.setCameraStub.parameters.first,
+            mapboxMap.setCameraStub.parameters.last,
             CameraOptions(
-                center: resumedCameraState.center,
-                zoom: initialCameraState.zoom,
-                bearing: resumedCameraState.bearing))
+                anchor: updatedPinchMidpoint,
+                zoom: initialCameraState.zoom + 3,
+                bearing: resumedCameraState.bearing - 45))
     }
 
     func testPinchEnded() throws {
+        gestureRecognizer.getStateStub.defaultReturnValue = .began
+        gestureRecognizer.sendActions()
+        gestureRecognizer.getStateStub.defaultReturnValue = .ended
+        mapboxMap.dragEndStub.reset()
+
+        gestureRecognizer.sendActions()
+
+        XCTAssertEqual(mapboxMap.dragEndStub.invocations.count, 1)
+        XCTAssertEqual(delegate.gestureEndedStub.invocations.count, 1)
+        XCTAssertEqual(delegate.gestureEndedStub.parameters.first?.gestureType, .pinch)
+        XCTAssertEqual(delegate.gestureEndedStub.parameters.first?.willAnimate, false)
+    }
+
+    // This should not be a scenario that actually happens; however, we've received
+    // some crash reports that suggest that this might actually be happening in some
+    // situations, so we're adding some defensive mechanisms to make sure it does
+    // not result in a crash
+    func testGestureBeganWithOnlyOneTouch() {
+        gestureRecognizer.getNumberOfTouchesStub.defaultReturnValue = 1
+        gestureRecognizer.getStateStub.defaultReturnValue = .began
+
+        gestureRecognizer.sendActions()
+
+        XCTAssertTrue(gestureRecognizer.locationOfTouchStub.invocations.isEmpty)
+        XCTAssertTrue(mapboxMap.dragStartStub.invocations.isEmpty)
+        XCTAssertTrue(delegate.gestureBeganStub.invocations.isEmpty)
+
+        // if the gesture didn't have 2 touches when it began, we don't support
+        // resuming the gesture. we could conceivably change this if we confirm
+        // that pinch gestures are indeed beginning with only 1 touch.
+        gestureRecognizer.getNumberOfTouchesStub.defaultReturnValue = 2
+        gestureRecognizer.getStateStub.defaultReturnValue = .changed
+
+        gestureRecognizer.sendActions()
+
+        XCTAssertTrue(gestureRecognizer.locationOfTouchStub.invocations.isEmpty)
+        XCTAssertTrue(mapboxMap.dragStartStub.invocations.isEmpty)
+        XCTAssertTrue(delegate.gestureBeganStub.invocations.isEmpty)
+        XCTAssertTrue(mapboxMap.setCameraStub.invocations.isEmpty)
+        XCTAssertTrue(mapboxMap.dragCameraOptionsStub.invocations.isEmpty)
+
+        // when such a gesture ends, we should just ignore it
         gestureRecognizer.getStateStub.defaultReturnValue = .ended
 
         gestureRecognizer.sendActions()
 
-        XCTAssertEqual(delegate.gestureEndedStub.invocations.count, 1)
-        XCTAssertEqual(delegate.gestureEndedStub.parameters.first?.gestureType, .pinch)
-
-        let willAnimate = try XCTUnwrap(delegate.gestureEndedStub.parameters.first?.willAnimate)
-        XCTAssertFalse(willAnimate)
+        XCTAssertTrue(mapboxMap.dragEndStub.invocations.isEmpty)
+        XCTAssertTrue(delegate.gestureEndedStub.invocations.isEmpty)
     }
 }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

Previously, each frame of a gesture update was calculated as a function of the state when the gesture started + the total gesture change. However, the Drag API was designed to calculated updates incrementally, so we're switching the implementation.

This change anticipates in-progress Drag API improvements, but also provides some immediate benefits by avoiding camera change notifications when resetting the camera to the initial state during pan and pinch gestures:

Fixes #775

Note that each frame of a pinch gesture will still result in 2 camera updates since the bearing and zoom changes have to be set with an anchor and the center changes must not be set with anchor. However, these updates should be logically progressing toward the new camera state rather than jumping back to the initial state at each frame.

Additionally, we've added some defensive logic to try to help avoid and diagnose some crashes we were seeing with PinchGestureHandler:

Fixes #833