### PR TITLE
Update globe docs: heatmap and circle layers are now supported

### DIFF
--- a/Sources/MapboxMaps/Foundation/MapProjection.swift
+++ b/Sources/MapboxMaps/Foundation/MapProjection.swift
@@ -74,10 +74,8 @@
 /// that preserves true proportions between different areas of the map.
 ///
 /// Some layers are not supported when map is in Globe projection:
-///  - circle
 ///  - custom
 ///  - fill extrusion
-///  - heatmap
 ///  - location indicator
 ///
 /// If Globe projection is set it will be switched automatically to Mercator projection


### PR DESCRIPTION
This PR updates the documentation of the globe projection mode: The circle and heatmap layers are now supported with the latest core update. (See: https://github.com/mapbox/mapbox-maps-ios/pull/836)