### PR TITLE
Remove mapFeatureQueryable from AnnotationManager initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Send location update when puck is nil and other location-related improvements. ([#765](https://github.com/mapbox/mapbox-maps-ios/pull/765))
 * Update to MapboxCoreMaps 10.2.0-beta.1 and MapboxCommon 21.0.0-rc.1. ([#836](https://github.com/mapbox/mapbox-maps-ios/pull/836))
 * Updates pan and pinch gesture handling to work iteratively rather than based on initial state. ([#837](https://github.com/mapbox/mapbox-maps-ios/pull/837))
+* `AnnotationOrchestrator`, rather than the annotation managers, now manages the single-tap gesture recognizer for annotations. ([#840](https://github.com/mapbox/mapbox-maps-ios/pull/840))
 
 ## 10.1.0 - November 4, 2021
 

--- a/Sources/MapboxMaps/Annotations/AnnotationOrchestrator.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationOrchestrator.swift
@@ -91,7 +91,6 @@ public class AnnotationOrchestrator {
         let annotationManager = PointAnnotationManager(
             id: id,
             style: style,
-            mapFeatureQueryable: mapFeatureQueryable,
             layerPosition: layerPosition,
             displayLinkCoordinator: displayLinkCoordinator)
         annotationManagersByIdInternal[id] = annotationManager
@@ -115,7 +114,6 @@ public class AnnotationOrchestrator {
         let annotationManager = PolygonAnnotationManager(
             id: id,
             style: style,
-            mapFeatureQueryable: mapFeatureQueryable,
             layerPosition: layerPosition,
             displayLinkCoordinator: displayLinkCoordinator)
         annotationManagersByIdInternal[id] = annotationManager
@@ -139,7 +137,6 @@ public class AnnotationOrchestrator {
         let annotationManager = PolylineAnnotationManager(
             id: id,
             style: style,
-            mapFeatureQueryable: mapFeatureQueryable,
             layerPosition: layerPosition,
             displayLinkCoordinator: displayLinkCoordinator)
         annotationManagersByIdInternal[id] = annotationManager
@@ -163,7 +160,6 @@ public class AnnotationOrchestrator {
         let annotationManager = CircleAnnotationManager(
             id: id,
             style: style,
-            mapFeatureQueryable: mapFeatureQueryable,
             layerPosition: layerPosition,
             displayLinkCoordinator: displayLinkCoordinator)
         annotationManagersByIdInternal[id] = annotationManager

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -35,9 +35,6 @@ public class CircleAnnotationManager: AnnotationManagerInternal {
     /// Dependency required to add sources/layers to the map
     private let style: Style
 
-    /// Dependency Required to query for rendered features on tap
-    private let mapFeatureQueryable: MapFeatureQueryable
-
     /// Storage for common layer properties
     private var layerProperties: [String: Any] = [:] {
         didSet {
@@ -58,14 +55,12 @@ public class CircleAnnotationManager: AnnotationManagerInternal {
 
     internal init(id: String,
                   style: Style,
-                  mapFeatureQueryable: MapFeatureQueryable,
                   layerPosition: LayerPosition?,
                   displayLinkCoordinator: DisplayLinkCoordinator) {
         self.id = id
         self.sourceId = id
         self.layerId = id
         self.style = style
-        self.mapFeatureQueryable = mapFeatureQueryable
         self.displayLinkCoordinator = displayLinkCoordinator
 
         do {

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -35,9 +35,6 @@ public class PointAnnotationManager: AnnotationManagerInternal {
     /// Dependency required to add sources/layers to the map
     private let style: Style
 
-    /// Dependency Required to query for rendered features on tap
-    private let mapFeatureQueryable: MapFeatureQueryable
-
     /// Storage for common layer properties
     private var layerProperties: [String: Any] = [:] {
         didSet {
@@ -58,14 +55,12 @@ public class PointAnnotationManager: AnnotationManagerInternal {
 
     internal init(id: String,
                   style: Style,
-                  mapFeatureQueryable: MapFeatureQueryable,
                   layerPosition: LayerPosition?,
                   displayLinkCoordinator: DisplayLinkCoordinator) {
         self.id = id
         self.sourceId = id
         self.layerId = id
         self.style = style
-        self.mapFeatureQueryable = mapFeatureQueryable
         self.displayLinkCoordinator = displayLinkCoordinator
 
         do {

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -35,9 +35,6 @@ public class PolygonAnnotationManager: AnnotationManagerInternal {
     /// Dependency required to add sources/layers to the map
     private let style: Style
 
-    /// Dependency Required to query for rendered features on tap
-    private let mapFeatureQueryable: MapFeatureQueryable
-
     /// Storage for common layer properties
     private var layerProperties: [String: Any] = [:] {
         didSet {
@@ -58,14 +55,12 @@ public class PolygonAnnotationManager: AnnotationManagerInternal {
 
     internal init(id: String,
                   style: Style,
-                  mapFeatureQueryable: MapFeatureQueryable,
                   layerPosition: LayerPosition?,
                   displayLinkCoordinator: DisplayLinkCoordinator) {
         self.id = id
         self.sourceId = id
         self.layerId = id
         self.style = style
-        self.mapFeatureQueryable = mapFeatureQueryable
         self.displayLinkCoordinator = displayLinkCoordinator
 
         do {

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -35,9 +35,6 @@ public class PolylineAnnotationManager: AnnotationManagerInternal {
     /// Dependency required to add sources/layers to the map
     private let style: Style
 
-    /// Dependency Required to query for rendered features on tap
-    private let mapFeatureQueryable: MapFeatureQueryable
-
     /// Storage for common layer properties
     private var layerProperties: [String: Any] = [:] {
         didSet {
@@ -58,14 +55,12 @@ public class PolylineAnnotationManager: AnnotationManagerInternal {
 
     internal init(id: String,
                   style: Style,
-                  mapFeatureQueryable: MapFeatureQueryable,
                   layerPosition: LayerPosition?,
                   displayLinkCoordinator: DisplayLinkCoordinator) {
         self.id = id
         self.sourceId = id
         self.layerId = id
         self.style = style
-        self.mapFeatureQueryable = mapFeatureQueryable
         self.displayLinkCoordinator = displayLinkCoordinator
 
         do {


### PR DESCRIPTION

<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

This PR removes the unused `*AnnotationManager.mapFeatureQueryable` properties and updates the changelog for https://github.com/mapbox/mapbox-maps-ios/pull/840.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
