### PR TITLE
Make persistent layer APIs non-experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Update to MapboxCoreMaps 10.2.0-beta.1 and MapboxCommon 21.0.0-rc.1. ([#836](https://github.com/mapbox/mapbox-maps-ios/pull/836))
 * Updates pan and pinch gesture handling to work iteratively rather than based on initial state. ([#837](https://github.com/mapbox/mapbox-maps-ios/pull/837))
 * `AnnotationOrchestrator`, rather than the annotation managers, now manages the single-tap gesture recognizer for annotations. ([#840](https://github.com/mapbox/mapbox-maps-ios/pull/840))
+* Removed experimental designation from persistent layer APIs. ([#](https://github.com/mapbox/mapbox-maps-ios/pull/))
 
 ## 10.1.0 - November 4, 2021
 

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -60,7 +60,7 @@ public final class Style: StyleProtocol {
     ///   - layerPosition: Position at which to add the map.
     ///
     /// - Throws: StyleError or type conversion errors
-    @_spi(Experimental) public func addPersistentLayer(_ layer: Layer, layerPosition: LayerPosition? = nil) throws {
+    public func addPersistentLayer(_ layer: Layer, layerPosition: LayerPosition? = nil) throws {
         // Attempt to encode the provided layer into JSON and apply it to the map
         let layerJSON = try layer.jsonObject()
         try addPersistentLayer(with: layerJSON, layerPosition: layerPosition)
@@ -363,7 +363,7 @@ public final class Style: StyleProtocol {
     ///
     /// - Throws:
     ///     An error describing why the operation was unsuccessful
-    @_spi(Experimental) public func addPersistentLayer(with properties: [String: Any], layerPosition: LayerPosition?) throws {
+    public func addPersistentLayer(with properties: [String: Any], layerPosition: LayerPosition?) throws {
         return try handleExpected {
             return styleManager.addPersistentStyleLayer(forProperties: properties, layerPosition: layerPosition?.corePosition)
         }
@@ -371,7 +371,7 @@ public final class Style: StyleProtocol {
 
     /// Returns `true` if the id passed in is associated to a persistent layer
     /// - Parameter id: The layer identifier to test
-    @_spi(Experimental) public func isPersistentLayer(id: String) throws -> Bool {
+    public func isPersistentLayer(id: String) throws -> Bool {
         return try handleExpected {
             return styleManager.isStyleLayerPersistent(forLayerId: id)
         }
@@ -391,7 +391,7 @@ public final class Style: StyleProtocol {
     ///
     /// - Throws:
     ///     An error describing why the operation was unsuccessful.
-    @_spi(Experimental) public func addPersistentCustomLayer(withId id: String, layerHost: CustomLayerHost, layerPosition: LayerPosition?) throws {
+    public func addPersistentCustomLayer(withId id: String, layerHost: CustomLayerHost, layerPosition: LayerPosition?) throws {
         return try handleExpected {
             return styleManager.addPersistentStyleCustomLayer(forLayerId: id, layerHost: layerHost, layerPosition: layerPosition?.corePosition)
         }

--- a/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationIntegrationTests.swift
@@ -1,6 +1,6 @@
 // This file is generated
 import XCTest
-@_spi(Experimental) @testable import MapboxMaps
+@testable import MapboxMaps
 
 final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationIntegrationTests.swift
@@ -1,6 +1,6 @@
 // This file is generated
 import XCTest
-@_spi(Experimental) @testable import MapboxMaps
+@testable import MapboxMaps
 
 final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationIntegrationTests.swift
@@ -1,6 +1,6 @@
 // This file is generated
 import XCTest
-@_spi(Experimental) @testable import MapboxMaps
+@testable import MapboxMaps
 
 final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationIntegrationTests.swift
@@ -1,6 +1,6 @@
 // This file is generated
 import XCTest
-@_spi(Experimental) @testable import MapboxMaps
+@testable import MapboxMaps
 
 final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LocationIndicatorLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/LocationIndicatorLayerIntegrationTests.swift
@@ -1,6 +1,6 @@
 // This file is generated
 import XCTest
-@_spi(Experimental) @testable import MapboxMaps
+@testable import MapboxMaps
 
 final class LocationIndicatorLayerIntegrationTests: MapViewIntegrationTestCase {
 

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable @_spi(Experimental) import MapboxMaps
+@testable import MapboxMaps
 
 internal class StyleIntegrationTests: MapViewIntegrationTestCase {
 


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Update the changelog

### Summary of changes

Removes the `@_spi(Experimental)` designation from the persistent layer APIs.