### PR TITLE
Generate private module interface

### DIFF
--- a/scripts/release/packager/project.yml
+++ b/scripts/release/packager/project.yml
@@ -20,6 +20,7 @@ targets:
         CODE_SIGN_STYLE: Automatic
         BUILD_DIR: .build
         SWIFT_TREAT_WARNINGS_AS_ERRORS: "YES"
+        SWIFT_EMIT_PRIVATE_MODULE_INTERFACE: "YES"
       configs:
         Debug:
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: $(inherited) USING_TURF_WITH_LIBRARY_EVOLUTION


### PR DESCRIPTION
Allows accessing `@spi_` APIs when using pre-built XCFrameworks.

Fixes #832 