### PR TITLE
Fix to only localize the primary localization and not the fall-throug…

### DIFF
--- a/Sources/MapboxMaps/Style/Style+Localization.swift
+++ b/Sources/MapboxMaps/Style/Style+Localization.swift
@@ -113,7 +113,7 @@ extension String {
                                               range: range,
                                               withTemplate: replacement)
     }
-    
+
     /// Updates string once using the first occurrence of a regex
     /// - Parameters:
     ///   - replacement: New string to replace the matched pattern
@@ -121,9 +121,8 @@ extension String {
     internal mutating func updateOnceExpression(replacement: String, regex: NSRegularExpression) {
         var range = NSRange(location: 0, length: self.count)
         range = regex.rangeOfFirstMatch(in: self, options: [], range: range)
-        if (range.lowerBound == NSNotFound) {
+        if (range.lowerBound == NSNotFound)
             return
-        }
         self = regex.stringByReplacingMatches(in: self,
                                               options: [],
                                               range: range,

--- a/Sources/MapboxMaps/Style/Style+Localization.swift
+++ b/Sources/MapboxMaps/Style/Style+Localization.swift
@@ -119,7 +119,8 @@ extension String {
     ///   - replacement: New string to replace the matched pattern
     ///   - regex: The regex pattern that will be matched for replacement
     internal mutating func updateOnceExpression(replacement: String, regex: NSRegularExpression) {
-        var range = regex.rangeOfFirstMatch(in: self, options: [], range: range)
+        var range = NSRange(location: 0, length: NSString(string: self).length)
+        range = regex.rangeOfFirstMatch(in: self, options: [], range: range)
         if range.lowerBound == NSNotFound {
             return
         }

--- a/Sources/MapboxMaps/Style/Style+Localization.swift
+++ b/Sources/MapboxMaps/Style/Style+Localization.swift
@@ -85,7 +85,7 @@ extension Style {
 
         if var stringExpression = String(data: try JSONEncoder().encode(symbolLayer.textField), encoding: .utf8),
            stringExpression != "null" {
-            stringExpression.updateExpression(replacement: replacement, regex: expressionCoalesce)
+            stringExpression.updateOnceExpression(replacement: replacement, regex: expressionCoalesce)
             stringExpression.updateExpression(replacement: replacement, regex: expressionAbbr)
 
             // Turn the new json string back into an Expression
@@ -108,6 +108,22 @@ extension String {
     internal mutating func updateExpression(replacement: String, regex: NSRegularExpression) {
         let range = NSRange(location: 0, length: self.count)
 
+        self = regex.stringByReplacingMatches(in: self,
+                                              options: [],
+                                              range: range,
+                                              withTemplate: replacement)
+    }
+    
+    /// Updates string once using the first occurrence of a regex
+    /// - Parameters:
+    ///   - replacement: New string to replace the matched pattern
+    ///   - regex: The regex pattern that will be matched for replacement
+    internal mutating func updateOnceExpression(replacement: String, regex: NSRegularExpression) {
+        var range = NSRange(location: 0, length: self.count)
+        range = regex.rangeOfFirstMatch(in: self, options: [], range: range)
+        if (range.lowerBound == NSNotFound) {
+            return
+        }
         self = regex.stringByReplacingMatches(in: self,
                                               options: [],
                                               range: range,

--- a/Sources/MapboxMaps/Style/Style+Localization.swift
+++ b/Sources/MapboxMaps/Style/Style+Localization.swift
@@ -119,10 +119,10 @@ extension String {
     ///   - replacement: New string to replace the matched pattern
     ///   - regex: The regex pattern that will be matched for replacement
     internal mutating func updateOnceExpression(replacement: String, regex: NSRegularExpression) {
-        var range = NSRange(location: 0, length: self.count)
-        range = regex.rangeOfFirstMatch(in: self, options: [], range: range)
-        if (range.lowerBound == NSNotFound)
+        var range = regex.rangeOfFirstMatch(in: self, options: [], range: range)
+        if range.lowerBound == NSNotFound {
             return
+        }
         self = regex.stringByReplacingMatches(in: self,
                                               options: [],
                                               range: range,

--- a/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
@@ -33,12 +33,12 @@ final class StyleLocalizationTests: MapViewIntegrationTestCase {
 
         XCTAssertThrowsError(try style.localizeLabels(into: Locale(identifier: "tlh")))
     }
-    
+
     func testOnlyLocalizesFirstLocalization() throws {
         var source = GeoJSONSource()
         source.data = .feature(Feature(geometry: Point(CLLocationCoordinate2D(latitude: 0, longitude: 0))))
         try style.addSource(source, id: "a")
-        
+
         var symbolLayer = SymbolLayer(id: "a")
         symbolLayer.source = "a"
         symbolLayer.textField = .expression(
@@ -57,13 +57,13 @@ final class StyleLocalizationTests: MapViewIntegrationTestCase {
                 FormatOptions()
             }
         )
-        
+
         try style.addLayer(symbolLayer)
-        
+
         try style.localizeLabels(into: Locale(identifier: "de"))
-        
+
         let updatedLayer = try style.layer(withId: "a", type: SymbolLayer.self)
-        
+
         XCTAssertEqual(updatedLayer.textField, .expression(
             Exp(.format) {
                 Exp(.coalesce) {


### PR DESCRIPTION
…h localizations

<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: https://github.com/mapbox/mapbox-maps-ios/issues/855

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 ~~- [ ] Include before/after visuals or gifs if this PR includes visual changes.~~
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 ~~- [ ] Document any changes to public APIs.~~
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

Reduces the programatically set localization to the primary localization, instead of overriding all fallbacks with the primary.
Eg. layer defines: name_en, name_de, name - localizeLabales("ko") no longer results in: name_ko, name_ko, name - but in name_ko, name_de, name.

This should help until we can have: https://github.com/mapbox/mapbox-maps-ios/issues/653
to hopefully also programatically set all fallback languages.

No tests added, since existing cover the previously expected behavior.

### User impact (optional)

a customer with be able ship their v10 migration
