### PR TITLE
Exclude swiftlint config from packaged artifact

### DIFF
--- a/scripts/release/packager/project.yml
+++ b/scripts/release/packager/project.yml
@@ -35,6 +35,7 @@ targets:
         excludes:
           - "**/*.plist"
           - "**/*.h"
+          - "**/.swiftlint.yml"
       - path: "Sources/MapboxMaps/Info.plist"
       - path: "Sources/MapboxMaps/MapboxMaps.h"
     dependencies:


### PR DESCRIPTION
Our packaging script was accidentally including our swiftlint config as a bundled resource.