### PR TITLE
Delay adding puck images until adding layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Removed experimental designation from persistent layer APIs. ([#849](https://github.com/mapbox/mapbox-maps-ios/pull/849))
 * Removed `AnnotationView` wrapper views from `ViewAnnotationManager` API. ([#846](https://github.com/mapbox/mapbox-maps-ios/pull/846))
 * Reduce geometry wrapping using GeometryConvertible. ([#861](https://github.com/mapbox/mapbox-maps-ios/pull/861))
+* Fixed an issue that could prevent the location puck from appearing. ([#862](https://github.com/mapbox/mapbox-maps-ios/pull/862)) 
 
 ## 10.2.0-beta.1 - November 19, 2021
 

--- a/Sources/MapboxMaps/Location/Puck/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck2D.swift
@@ -9,7 +9,6 @@ internal final class Puck2D: NSObject, Puck {
             }
             if isActive {
                 locationProducer.add(self)
-                addImages()
                 updateLayer()
             } else {
                 locationProducer.remove(self)
@@ -153,6 +152,12 @@ internal final class Puck2D: NSObject, Puck {
         if style.layerExists(withId: Self.layerID) {
             try! style.setLayerProperties(for: Self.layerID, properties: allLayerProperties)
         } else {
+            // add the images at the same time as adding the layer. doing it earlier results
+            // in the images getting removed if the style reloads in between when the images
+            // were added and when the persistent layer is added. The presence of a persistent
+            // layer causes MapboxCoreMaps to skip clearing images when the style reloads.
+            // https://github.com/mapbox/mapbox-maps-ios/issues/860
+            addImages()
             try! style.addPersistentLayer(with: allLayerProperties, layerPosition: nil)
         }
     }

--- a/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
@@ -123,10 +123,21 @@ final class Puck2DTests: XCTestCase {
         XCTAssertTrue(style.addImageStub.parameters[2].image === configuration.shadowImage, line: line)
     }
 
-    func testActivatingPuckAddsImagesIfLatestLocationIsNil() {
+    func testActivatingPuckDoesNotAddImagesIfLatestLocationIsNil() {
         locationProducer.latestLocation = nil
 
         puck2D.isActive = true
+
+        XCTAssertEqual(style.addImageStub.invocations.count, 0)
+
+        // When the location becomes non-nil, then the images get added
+        let location = Location(
+            location: CLLocation(),
+            heading: nil,
+            accuracyAuthorization: .fullAccuracy)
+        locationProducer.latestLocation = location
+
+        puck2D.locationUpdate(newLocation: location)
 
         verifyAddImages()
     }
@@ -148,6 +159,10 @@ final class Puck2DTests: XCTestCase {
             bearingImage: nil,
             shadowImage: nil)
         recreatePuck()
+        locationProducer.latestLocation = Location(
+            location: CLLocation(),
+            heading: nil,
+            accuracyAuthorization: .fullAccuracy)
 
         puck2D.isActive = true
 


### PR DESCRIPTION
Fixes #860

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Update the changelog

### Summary of changes

Fixes an issue that caused the location puck to fail to render if it was configured prior to the style loading and the first location update didn't happen until after the style loaded.

Previously, the style images were added to the style as soon as the puck was activated. However, in the situation described above, the persistent puck layer would not be added until after the style loaded. MapboxCoreMaps clears style images during reload if there are no persistent layers. That meant that the puck images were missing when the puck layer was finally added.

This fix updates the logic to delay adding the images to the style until it's time to add the persistent layer.