### PR TITLE
Add missing StyleColor support for exponentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Mapbox welcomes participation and contributions from everyone.
 * Removed experimental designation from persistent layer APIs. ([#849](https://github.com/mapbox/mapbox-maps-ios/pull/849))
 * Removed `AnnotationView` wrapper views from `ViewAnnotationManager` API. ([#846](https://github.com/mapbox/mapbox-maps-ios/pull/846))
 * Reduce geometry wrapping using GeometryConvertible. ([#861](https://github.com/mapbox/mapbox-maps-ios/pull/861))
-* Fixed an issue that could prevent the location puck from appearing. ([#862](https://github.com/mapbox/mapbox-maps-ios/pull/862)) 
+* Fixed an issue that could prevent the location puck from appearing. ([#862](https://github.com/mapbox/mapbox-maps-ios/pull/862))
+* Add support for exponentials to `StyleColor`. ([#873](https://github.com/mapbox/mapbox-maps-ios/pull/873))
 
 ## 10.2.0-beta.1 - November 19, 2021
 

--- a/Sources/MapboxMaps/Style/Types/StyleColor.swift
+++ b/Sources/MapboxMaps/Style/Types/StyleColor.swift
@@ -81,8 +81,8 @@ public struct StyleColor: Codable, Equatable {
     /// - Parameter rgbaString: An rgba color string
     internal init?(rgbaString: String) {
         let nsString = NSString(string: rgbaString)
-        let jsonNumberRegex = "(-?(?:0|[1-9][0-9]*)(?:.[0-9]+)?(?:[eE][+-]?[0-9]+)?)"
-        let regex = try! NSRegularExpression(pattern: "^ *rgba\\( *\(jsonNumberRegex) *, *\(jsonNumberRegex) *, *\(jsonNumberRegex) *, *\(jsonNumberRegex) *\\) *$", options: [])
+        let numberRegex = "(-?(?:0|[1-9][0-9]*)(?:.[0-9]+)?(?:[eE][+-]?[0-9]+)?)"
+        let regex = try! NSRegularExpression(pattern: "^ *rgba\\( *\(numberRegex) *, *\(numberRegex) *, *\(numberRegex) *, *\(numberRegex) *\\) *$", options: [])
         let matches = regex.matches(in: rgbaString, options: [], range: NSRange(location: 0, length: nsString.length))
         guard matches.count == 1, let firstMatch = matches.first else {
             return nil

--- a/Sources/MapboxMaps/Style/Types/StyleColor.swift
+++ b/Sources/MapboxMaps/Style/Types/StyleColor.swift
@@ -81,7 +81,8 @@ public struct StyleColor: Codable, Equatable {
     /// - Parameter rgbaString: An rgba color string
     internal init?(rgbaString: String) {
         let nsString = NSString(string: rgbaString)
-        let regex = try! NSRegularExpression(pattern: "^ *rgba\\( *([0-9.]+) *, *([0-9.]+) *, *([0-9.]+) *, *([0-9.]+) *\\) *$", options: [])
+        let jsonNumberRegex = "(-?(?:0|[1-9][0-9]*)(?:.[0-9]+)?(?:[eE][+-]?[0-9]+)?)"
+        let regex = try! NSRegularExpression(pattern: "^ *rgba\\( *\(jsonNumberRegex) *, *\(jsonNumberRegex) *, *\(jsonNumberRegex) *, *\(jsonNumberRegex) *\\) *$", options: [])
         let matches = regex.matches(in: rgbaString, options: [], range: NSRange(location: 0, length: nsString.length))
         guard matches.count == 1, let firstMatch = matches.first else {
             return nil


### PR DESCRIPTION
## Pull request checklist:
 - [x] Updates StyleColor to be able to decode rgba strings that contain numerics with exponents.
 - [x] Update the changelog

### Summary of changes

`StyleColor` previously failed to deserialize rgba strings that included exponentials. This PR updates the regex used to parse the rgba strings to allow exponents.