### PR TITLE
Add MapboxMaps.json to podspec

### DIFF
--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |m|
   m.swift_version = '5.3'
 
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
-  m.resources = 'Sources/**/*.{xcassets,strings}'
+  m.resources = ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json']
 
   m.dependency 'MapboxCoreMaps', '10.0.0'
   m.dependency 'MapboxCommon', '20.0.2'


### PR DESCRIPTION
Fixes an issue where MapboxMaps.json was not included when installing v10.0.0 and v10.0.2 via CocoaPods. The corresponding specs have already been updated in CocoaPods trunk, so this will just ensure that we don't repeat this mistake if we need a v10.0.3 patch. The change landed in the main branch prior to any v10.1 releases.