### PR TITLE
Improve panning behavior on pitched maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Reduce geometry wrapping using GeometryConvertible. ([#861](https://github.com/mapbox/mapbox-maps-ios/pull/861))
 * Fixed an issue that could prevent the location puck from appearing. ([#862](https://github.com/mapbox/mapbox-maps-ios/pull/862))
 * Add support for exponentials to `StyleColor`. ([#873](https://github.com/mapbox/mapbox-maps-ios/pull/873))
+* Improve panning behavior on pitched maps. ([#888](https://github.com/mapbox/mapbox-maps-ios/pull/888))
 
 ## 10.2.0-beta.1 - November 19, 2021
 

--- a/Sources/MapboxMaps/Camera/CameraAnimationsManager.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimationsManager.swift
@@ -11,7 +11,7 @@ internal protocol CameraAnimationsManagerProtocol: AnyObject {
     func decelerate(location: CGPoint,
                     velocity: CGPoint,
                     decelerationFactor: CGFloat,
-                    locationChangeHandler: @escaping (_ location: CGPoint) -> Void,
+                    locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void,
                     completion: @escaping () -> Void)
 
     func cancelAnimations()
@@ -288,15 +288,15 @@ public class CameraAnimationsManager: CameraAnimationsManagerProtocol {
 
     /// This function will handle the natural decelration of a gesture when there is a velocity provided. A use case for this is the pan gesture.
     /// - Parameters:
-    ///   - location: Current location of center coordinate
-    ///   - velocity: The speed at which the map should move over time
-    ///   - decelerationFactor: A multiplication factor that determines the speed at which the velocity should slow down.
-    ///   - locationChangeHandler: Change handler to be passed through to the animator
-    ///   - completion: Completion to be called after animation has finished
+    ///   - location: The initial location. This location will be simulated based on velocity and decelerationFactor.
+    ///   - velocity: The initial velocity.
+    ///   - decelerationFactor: A factor by which the velocity is multiplied once per millisecond. Typically slightly less than 1 so that the velocity slowly decreases over time.
+    ///   - locationChangeHandler: A block that is called at each frame which provides the updated from and to location.
+    ///   - completion: A completion block that is called when the animation finishes.
     internal func decelerate(location: CGPoint,
                              velocity: CGPoint,
                              decelerationFactor: CGFloat,
-                             locationChangeHandler: @escaping (_ location: CGPoint) -> Void,
+                             locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void,
                              completion: @escaping () -> Void) {
 
         // Stop the `internalAnimator` before beginning a deceleration

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -553,7 +553,7 @@ public final class MapboxMap: MapboxMapProtocol {
         let reprojectErrorMargin = min(10, topMargin / 2)
         var p = point
         p.y -= topMargin
-        let coordinate = coordinate(for: p)
+        let coordinate = self.coordinate(for: p)
         let roundtripPoint = self.point(for: coordinate)
         return roundtripPoint.y >= p.y + reprojectErrorMargin
     }

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -25,6 +25,7 @@ internal protocol MapboxMapProtocol: AnyObject {
     func updateViewAnnotation(withId id: String, options: ViewAnnotationOptions) throws
     func removeViewAnnotation(withId id: String) throws
     func options(forViewAnnotationWithId id: String) throws -> ViewAnnotationOptions
+    func pointIsAboveHorizon(_ point: CGPoint) -> Bool
 }
 
 public final class MapboxMap: MapboxMapProtocol {
@@ -541,6 +542,19 @@ public final class MapboxMap: MapboxMapProtocol {
     /// the user has ended a drag gesture initiated by `dragStart`.
     public func dragEnd() {
         __map.dragEnd()
+    }
+
+    internal func pointIsAboveHorizon(_ point: CGPoint) -> Bool {
+        guard case .mercator = try? mapProjection() else {
+            return false
+        }
+        let topMargin = 0.04 * size.height
+        let reprojectErrorMargin = min(10, topMargin / 2)
+        var p = point
+        p.y -= topMargin
+        let coordinate = coordinate(for: p)
+        let roundtripPoint = self.point(for: coordinate)
+        return roundtripPoint.y >= p.y + reprojectErrorMargin
     }
 
     // MARK: - Gesture and Animation Flags

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -28,6 +28,7 @@ internal protocol MapboxMapProtocol: AnyObject {
     func pointIsAboveHorizon(_ point: CGPoint) -> Bool
 }
 
+// swiftlint:disable:next type_body_length
 public final class MapboxMap: MapboxMapProtocol {
     /// The underlying renderer object responsible for rendering the map
     private let __map: Map

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PanGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PanGestureHandler.swift
@@ -84,9 +84,7 @@ internal final class PanGestureHandler: GestureHandler, PanGestureHandlerProtoco
                 return
             }
             lastChangedDate = dateProvider.now
-            let clampedTouchLocation = clampTouchLocation(
-                touchLocation,
-                previousTouchLocation: previousTouchLocation)
+            let clampedTouchLocation = touchLocation.clamped(to: previousTouchLocation, panMode: panMode)
             pan(from: previousTouchLocation, to: clampedTouchLocation)
             self.previousTouchLocation = clampedTouchLocation
         case .ended:
@@ -111,7 +109,7 @@ internal final class PanGestureHandler: GestureHandler, PanGestureHandlerProtoco
                 y: max(touchLocation.y, 3 * height / 4))
             cameraAnimationsManager.decelerate(
                 location: initialDecelerationLocation,
-                velocity: clampTouchLocation(velocity, previousTouchLocation: .zero),
+                velocity: velocity.clamped(to: .zero, panMode: panMode),
                 decelerationFactor: decelerationFactor,
                 locationChangeHandler: pan(from:to:),
                 completion: endAnimation)
@@ -145,21 +143,23 @@ internal final class PanGestureHandler: GestureHandler, PanGestureHandlerProtoco
         delegate?.animationEnded(for: .pan)
     }
 
-    private func clampTouchLocation(_ touchLocation: CGPoint, previousTouchLocation: CGPoint) -> CGPoint {
-        switch panMode {
-        case .horizontal:
-            return CGPoint(x: touchLocation.x, y: previousTouchLocation.y)
-        case .vertical:
-            return CGPoint(x: previousTouchLocation.x, y: touchLocation.y)
-        case .horizontalAndVertical:
-            return touchLocation
-        }
-    }
-
     private func pan(from fromPoint: CGPoint, to toPoint: CGPoint) {
         mapboxMap.setCamera(
             to: mapboxMap.dragCameraOptions(
                 from: fromPoint,
                 to: toPoint))
+    }
+}
+
+private extension CGPoint {
+    func clamped(to point: CGPoint, panMode: PanMode) -> CGPoint {
+        switch panMode {
+        case .horizontal:
+            return CGPoint(x: x, y: point.y)
+        case .vertical:
+            return CGPoint(x: point.x, y: y)
+        case .horizontalAndVertical:
+            return self
+        }
     }
 }

--- a/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimationsManager.swift
+++ b/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimationsManager.swift
@@ -33,14 +33,14 @@ final class MockCameraAnimationsManager: CameraAnimationsManagerProtocol {
         var location: CGPoint
         var velocity: CGPoint
         var decelerationFactor: CGFloat
-        var locationChangeHandler: (_ location: CGPoint) -> Void
+        var locationChangeHandler: (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void
         var completion: () -> Void
     }
     let decelerateStub = Stub<DecelerateParameters, Void>()
     func decelerate(location: CGPoint,
                     velocity: CGPoint,
                     decelerationFactor: CGFloat,
-                    locationChangeHandler: @escaping (_ location: CGPoint) -> Void,
+                    locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void,
                     completion: @escaping () -> Void) {
 
         return decelerateStub.call(

--- a/Tests/MapboxMapsTests/Camera/Mocks/MockLocationChangeHandler.swift
+++ b/Tests/MapboxMapsTests/Camera/Mocks/MockLocationChangeHandler.swift
@@ -1,0 +1,14 @@
+@testable import MapboxMaps
+
+struct LocationChangeHandlerParams: Equatable {
+    var fromLocation: CGPoint
+    var toLocation: CGPoint
+}
+
+typealias MockLocationChangeHandler = Stub<LocationChangeHandlerParams, Void>
+
+extension MockLocationChangeHandler {
+    func call(withFromLocation fromLocation: CGPoint, toLocation: CGPoint) {
+        call(with: .init(fromLocation: fromLocation, toLocation: toLocation))
+    }
+}

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMapboxMap.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMapboxMap.swift
@@ -1,5 +1,6 @@
-@testable import MapboxMaps
+@testable @_spi(Experimental) import MapboxMaps
 @_implementationOnly import MapboxCoreMaps_Private
+import CoreLocation
 
 final class MockMapboxMap: MapboxMapProtocol {
 
@@ -117,5 +118,10 @@ final class MockMapboxMap: MapboxMapProtocol {
     let optionsForViewAnnotationWithIdStub = Stub<String, MapboxMaps.ViewAnnotationOptions>(defaultReturnValue: ViewAnnotationOptions())
     func options(forViewAnnotationWithId id: String) throws -> MapboxMaps.ViewAnnotationOptions {
         return optionsForViewAnnotationWithIdStub.call(with: id)
+    }
+
+    let pointIsAboveHorizonStub = Stub<CGPoint, Bool>(defaultReturnValue: .random())
+    func pointIsAboveHorizon(_ point: CGPoint) -> Bool {
+        pointIsAboveHorizonStub.call(with: point)
     }
 }

--- a/Tests/MapboxMapsTests/Helpers/Stub.swift
+++ b/Tests/MapboxMapsTests/Helpers/Stub.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 final class Stub<ParametersType, ReturnType> {
 
     struct Invocation {


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Update the changelog

### Summary of changes

Improves panning behavior on pitched maps:

* Panning does not begin until a touch is below the horizon
* Pan deceleration is disabled if the final touch location is above the horizon
* Pan deceleration is simulated as a series of small pan gestures in the bottom portion of the map to avoid allowing the simulated touches to go near the more sensitive horizon area.