### PR TITLE
Add pinch gesture tradeoff configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Fixed an issue that could prevent the location puck from appearing. ([#862](https://github.com/mapbox/mapbox-maps-ios/pull/862))
 * Add support for exponentials to `StyleColor`. ([#873](https://github.com/mapbox/mapbox-maps-ios/pull/873))
 * Improve panning behavior on pitched maps. ([#888](https://github.com/mapbox/mapbox-maps-ios/pull/888))
+* Add pinch gesture tradeoff configuration option. ([#890](https://github.com/mapbox/mapbox-maps-ios/pull/890))
 
 ## 10.2.0-beta.1 - November 19, 2021
 

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchGestureHandler.swift
@@ -2,6 +2,7 @@ import UIKit
 
 internal protocol PinchGestureHandlerProtocol: GestureHandler {
     var rotateEnabled: Bool { get set }
+    var behavior: PinchGestureBehavior { get set }
 }
 
 internal protocol PinchGestureHandlerImpl: AnyObject {

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchGestureHandlerImpl1.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchGestureHandlerImpl1.swift
@@ -1,0 +1,167 @@
+import UIKit
+
+/// `PinchGestureHandler` updates the map camera in response to a 2-touch
+/// gesture that may consist of translation, scaling, and rotation
+internal final class PinchGestureHandlerImpl1: PinchGestureHandlerImpl {
+    /// Whether pinch gesture can rotate map or not
+    internal var rotateEnabled: Bool = true
+
+    /// The midpoint of the touches in the gesture's view when the gesture began
+    private var initialPinchMidpoint: CGPoint?
+
+    /// The angle from touch location 0 to touch location 1 when the gesture began or unpaused
+    private var initialPinchAngle: CGFloat?
+
+    /// The camera center when the gesture began or unpaused
+    private var initialCenter: CLLocationCoordinate2D?
+
+    /// The camera zoom when the gesture began
+    private var initialZoom: CGFloat?
+
+    /// The camera bearing when the gesture began or unpaused
+    private var initialBearing: CLLocationDirection?
+
+    /// The rotateEnabled setting when the gesture began
+    private var initialRotateEnabled: Bool?
+
+    private var gestureBegan = false
+
+    private let mapboxMap: MapboxMapProtocol
+
+    internal weak var delegate: GestureHandlerDelegate?
+
+    /// Initialize the handler which creates the panGestureRecognizer and adds to the view
+    internal init(mapboxMap: MapboxMapProtocol) {
+        self.mapboxMap = mapboxMap
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    internal func handleGesture(_ gestureRecognizer: UIPinchGestureRecognizer, state: UIGestureRecognizer.State) {
+        guard let view = gestureRecognizer.view else {
+            return
+        }
+        let pinchMidpoint = gestureRecognizer.location(in: view)
+
+        switch state {
+        case .began:
+            guard gestureRecognizer.numberOfTouches == 2 else {
+                return
+            }
+            initialPinchMidpoint = pinchMidpoint
+            initialPinchAngle = pinchAngleForGestureBegan(with: gestureRecognizer)
+            initialCenter = mapboxMap.cameraState.center
+            initialZoom = mapboxMap.cameraState.zoom
+            initialBearing = mapboxMap.cameraState.bearing
+            initialRotateEnabled = rotateEnabled
+            gestureBegan = true
+            delegate?.gestureBegan(for: .pinch)
+        case .changed:
+            // UIPinchGestureRecognizer sends a .changed event when the number
+            // of touches decreases from 2 to 1. If this happens, we pause our
+            // gesture handling.
+            //
+            // if a second touch goes down again before the gesture ends, we
+            // resume and re-capture the initial state (except for zoom since
+            // UIPinchGestureRecognizer provides continuity of scale values)
+            guard gestureRecognizer.numberOfTouches == 2 else {
+                initialPinchMidpoint = nil
+                initialPinchAngle = nil
+                initialCenter = nil
+                initialBearing = nil
+                return
+            }
+            guard let initialZoom = initialZoom,
+                  let initialRotateEnabled = initialRotateEnabled else {
+                return
+            }
+            // Using explicit self to help older versions of Xcode (pre-12.5) figure
+            // out the scope of these variables. https://bugs.swift.org/browse/SR-8669
+            let pinchAngle = self.pinchAngleForGestureChanged(with: gestureRecognizer)
+            guard let initialPinchMidpoint = initialPinchMidpoint,
+                  let initialPinchAngle = initialPinchAngle,
+                  let initialCenter = initialCenter,
+                  let initialBearing = initialBearing else {
+                self.initialPinchMidpoint = pinchMidpoint
+                self.initialPinchAngle = pinchAngle
+                self.initialCenter = mapboxMap.cameraState.center
+                self.initialBearing = mapboxMap.cameraState.bearing
+                return
+            }
+
+            let zoomIncrement = log2(gestureRecognizer.scale)
+            var cameraOptions = CameraOptions()
+            cameraOptions.center = initialCenter
+            cameraOptions.zoom = initialZoom
+            cameraOptions.bearing = initialRotateEnabled ? initialBearing : nil
+
+            mapboxMap.setCamera(to: cameraOptions)
+
+            mapboxMap.dragStart(for: initialPinchMidpoint)
+            let dragOptions = mapboxMap.dragCameraOptions(
+                from: initialPinchMidpoint,
+                to: pinchMidpoint)
+            mapboxMap.setCamera(to: dragOptions)
+            mapboxMap.dragEnd()
+            // the two angles will always be in the range [0, 2pi)
+            // so the resulting rotation will be in the range (-2pi, 2pi)
+            var rotation = pinchAngle - initialPinchAngle
+            // if the rotation is negative, add 2pi so that the final
+            // result is in the range [0, 2pi)
+            if rotation < 0 {
+                rotation += 2 * .pi
+            }
+            // convert from radians to degrees and flip the sign since
+            // the iOS coordinate system is flipped relative to the
+            // coordinate system used for bearing in the map.
+            let rotationInDegrees = Double(rotation * 180.0 / .pi * -1)
+
+            mapboxMap.setCamera(
+                to: CameraOptions(
+                    anchor: pinchMidpoint,
+                    zoom: initialZoom + zoomIncrement,
+                    bearing: initialRotateEnabled ? (initialBearing + rotationInDegrees) : nil))
+        case .ended, .cancelled:
+            initialPinchMidpoint = nil
+            initialPinchAngle = nil
+            initialCenter = nil
+            initialZoom = nil
+            initialBearing = nil
+            initialRotateEnabled = nil
+            if gestureBegan {
+                delegate?.gestureEnded(for: .pinch, willAnimate: false)
+            }
+            gestureBegan = false
+        default:
+            break
+        }
+    }
+
+    /// Returns the angle in radians in the range [0, 2pi)
+    private func angleOfLine(from point0: CGPoint, to point1: CGPoint) -> CGFloat {
+        var angle = atan2(point1.y - point0.y, point1.x - point0.x)
+        if angle < 0 {
+            angle += 2 * .pi
+        }
+        return angle
+    }
+
+    // this method is added to help diagnose a crash in pinchAngle. if the crash continues to happen,
+    // we'll be able to tell which invocation of pinchAngle is responsible.
+    private func pinchAngleForGestureBegan(with gestureRecognizer: UIPinchGestureRecognizer) -> CGFloat {
+        return pinchAngle(with: gestureRecognizer)
+    }
+
+    // this method is added to help diagnose a crash in pinchAngle. if the crash continues to happen,
+    // we'll be able to tell which invocation of pinchAngle is responsible.
+    private func pinchAngleForGestureChanged(with gestureRecognizer: UIPinchGestureRecognizer) -> CGFloat {
+        return pinchAngle(with: gestureRecognizer)
+    }
+
+    private func pinchAngle(with gestureRecognizer: UIPinchGestureRecognizer) -> CGFloat {
+        // we guard for this at the call site
+        let view = gestureRecognizer.view!
+        let pinchPoint0 = gestureRecognizer.location(ofTouch: 0, in: view)
+        let pinchPoint1 = gestureRecognizer.location(ofTouch: 1, in: view)
+        return angleOfLine(from: pinchPoint0, to: pinchPoint1)
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchGestureHandlerImpl2.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchGestureHandlerImpl2.swift
@@ -1,0 +1,169 @@
+import UIKit
+
+/// `PinchGestureHandler` updates the map camera in response to a 2-touch
+/// gesture that may consist of translation, scaling, and rotation
+internal final class PinchGestureHandlerImpl2: PinchGestureHandlerImpl {
+    /// Whether pinch gesture can rotate map or not
+    internal var rotateEnabled: Bool = true
+
+    /// The midpoint of the touches in the gesture's view when the gesture began
+    private var previousPinchMidpoint: CGPoint?
+
+    /// The angle from touch location 0 to touch location 1 when the gesture began or unpaused
+    private var initialPinchAngle: CGFloat?
+
+    /// The camera zoom when the gesture began
+    private var initialZoom: CGFloat?
+
+    /// The camera bearing when the gesture began or unpaused
+    private var initialBearing: CLLocationDirection?
+
+    /// The rotateEnabled setting when the gesture began
+    private var initialRotateEnabled: Bool?
+
+    private let mapboxMap: MapboxMapProtocol
+
+    private var isDragging = false
+
+    private var gestureBegan = false
+
+    internal weak var delegate: GestureHandlerDelegate?
+
+    /// Initialize the handler which creates the panGestureRecognizer and adds to the view
+    internal init(mapboxMap: MapboxMapProtocol) {
+        self.mapboxMap = mapboxMap
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    internal func handleGesture(_ gestureRecognizer: UIPinchGestureRecognizer, state: UIGestureRecognizer.State) {
+        guard let view = gestureRecognizer.view else {
+            return
+        }
+        let pinchMidpoint = gestureRecognizer.location(in: view)
+
+        switch state {
+        case .began:
+            guard gestureRecognizer.numberOfTouches == 2 else {
+                return
+            }
+            startDragging(with: pinchMidpoint)
+            previousPinchMidpoint = pinchMidpoint
+            initialPinchAngle = pinchAngleForGestureBegan(with: gestureRecognizer)
+            initialZoom = mapboxMap.cameraState.zoom
+            initialBearing = mapboxMap.cameraState.bearing
+            initialRotateEnabled = rotateEnabled
+            gestureBegan = true
+            delegate?.gestureBegan(for: .pinch)
+        case .changed:
+            // UIPinchGestureRecognizer sends a .changed event when the number
+            // of touches decreases from 2 to 1. If this happens, we pause our
+            // gesture handling.
+            guard gestureRecognizer.numberOfTouches == 2 else {
+                previousPinchMidpoint = nil
+                initialPinchAngle = nil
+                initialBearing = nil
+                stopDraggingIfNeeded()
+                return
+            }
+            guard let initialZoom = initialZoom,
+                  let initialRotateEnabled = initialRotateEnabled else {
+                return
+            }
+
+            // if a second touch goes down again before the gesture ends, we
+            // resume and re-capture the initial state (except for zoom since
+            // UIPinchGestureRecognizer provides continuity of scale values)
+            let pinchAngle = pinchAngleForGestureChanged(with: gestureRecognizer)
+            guard let previousPinchMidpoint = previousPinchMidpoint,
+                  let initialPinchAngle = initialPinchAngle,
+                  let initialBearing = initialBearing else {
+                      startDragging(with: pinchMidpoint)
+                      self.previousPinchMidpoint = pinchMidpoint
+                      self.initialPinchAngle = pinchAngle
+                      self.initialBearing = mapboxMap.cameraState.bearing
+                return
+            }
+
+            let zoomIncrement = log2(gestureRecognizer.scale)
+
+            mapboxMap.setCamera(to: mapboxMap.dragCameraOptions(
+                from: previousPinchMidpoint,
+                to: pinchMidpoint))
+            self.previousPinchMidpoint = pinchMidpoint
+
+            // the two angles will always be in the range [0, 2pi)
+            // so the resulting rotation will be in the range (-2pi, 2pi)
+            var rotation = pinchAngle - initialPinchAngle
+            // if the rotation is negative, add 2pi so that the final
+            // result is in the range [0, 2pi)
+            if rotation < 0 {
+                rotation += 2 * .pi
+            }
+            // convert from radians to degrees and flip the sign since
+            // the iOS coordinate system is flipped relative to the
+            // coordinate system used for bearing in the map.
+            let rotationInDegrees = Double(rotation * 180.0 / .pi * -1)
+
+            mapboxMap.setCamera(
+                to: CameraOptions(
+                    anchor: pinchMidpoint,
+                    zoom: initialZoom + zoomIncrement,
+                    bearing: initialRotateEnabled ? (initialBearing + rotationInDegrees) : nil))
+        case .ended, .cancelled:
+            previousPinchMidpoint = nil
+            initialPinchAngle = nil
+            initialZoom = nil
+            initialBearing = nil
+            initialRotateEnabled = nil
+            stopDraggingIfNeeded()
+            if gestureBegan {
+                delegate?.gestureEnded(for: .pinch, willAnimate: false)
+            }
+            gestureBegan = false
+        default:
+            break
+        }
+    }
+
+    private func startDragging(with point: CGPoint) {
+        precondition(!isDragging)
+        isDragging = true
+        mapboxMap.dragStart(for: point)
+    }
+
+    private func stopDraggingIfNeeded() {
+        if isDragging {
+            isDragging = false
+            mapboxMap.dragEnd()
+        }
+    }
+
+    /// Returns the angle in radians in the range [0, 2pi)
+    private func angleOfLine(from point0: CGPoint, to point1: CGPoint) -> CGFloat {
+        var angle = atan2(point1.y - point0.y, point1.x - point0.x)
+        if angle < 0 {
+            angle += 2 * .pi
+        }
+        return angle
+    }
+
+    // this method is added to help diagnose a crash in pinchAngle. if the crash continues to happen,
+    // we'll be able to tell which invocation of pinchAngle is responsible.
+    private func pinchAngleForGestureBegan(with gestureRecognizer: UIPinchGestureRecognizer) -> CGFloat {
+        return pinchAngle(with: gestureRecognizer)
+    }
+
+    // this method is added to help diagnose a crash in pinchAngle. if the crash continues to happen,
+    // we'll be able to tell which invocation of pinchAngle is responsible.
+    private func pinchAngleForGestureChanged(with gestureRecognizer: UIPinchGestureRecognizer) -> CGFloat {
+        return pinchAngle(with: gestureRecognizer)
+    }
+
+    private func pinchAngle(with gestureRecognizer: UIPinchGestureRecognizer) -> CGFloat {
+        // we guard for this at the call site
+        let view = gestureRecognizer.view!
+        let pinchPoint0 = gestureRecognizer.location(ofTouch: 0, in: view)
+        let pinchPoint1 = gestureRecognizer.location(ofTouch: 1, in: view)
+        return angleOfLine(from: pinchPoint0, to: pinchPoint1)
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -21,6 +21,7 @@ public final class GestureManager: GestureHandlerDelegate {
             panGestureRecognizer.isEnabled = newValue.panEnabled
             pinchGestureRecognizer.isEnabled = newValue.pinchEnabled
             pinchGestureHandler.rotateEnabled = newValue.pinchRotateEnabled
+            pinchGestureHandler.behavior = newValue.pinchBehavior
             pitchGestureRecognizer.isEnabled = newValue.pitchEnabled
             doubleTapToZoomInGestureRecognizer.isEnabled = newValue.doubleTapToZoomInEnabled
             doubleTouchToZoomOutGestureRecognizer.isEnabled = newValue.doubleTouchToZoomOutEnabled
@@ -33,6 +34,7 @@ public final class GestureManager: GestureHandlerDelegate {
             gestureOptions.panEnabled = panGestureRecognizer.isEnabled
             gestureOptions.pinchEnabled = pinchGestureRecognizer.isEnabled
             gestureOptions.pinchRotateEnabled = pinchGestureHandler.rotateEnabled
+            gestureOptions.pinchBehavior = pinchGestureHandler.behavior
             gestureOptions.pitchEnabled = pitchGestureRecognizer.isEnabled
             gestureOptions.doubleTapToZoomInEnabled = doubleTapToZoomInGestureRecognizer.isEnabled
             gestureOptions.doubleTouchToZoomOutEnabled = doubleTouchToZoomOutGestureRecognizer.isEnabled

--- a/Sources/MapboxMaps/Gestures/GestureOptions.swift
+++ b/Sources/MapboxMaps/Gestures/GestureOptions.swift
@@ -14,6 +14,23 @@ public enum PanMode: String, Equatable, CaseIterable {
     case horizontalAndVertical
 }
 
+/// Represents the available pinch gesture implementations. Each implementation has
+/// some shortcomings, and we hope to eliminate the need to make this trade-off in a
+/// future release.
+@_spi(Experimental) public enum PinchGestureBehavior {
+
+    /// This case represents the pinch gesture behavior that was in place in v10.1. It
+    /// resets the camera to the initial state at each frame, resulting in the issue reported
+    /// in https://github.com/mapbox/mapbox-maps-ios/issues/775
+    case tracksTouchLocationsWhenPanningAfterZoomChange
+
+    /// This case represents a new pinch gesture behavior that solves
+    /// https://github.com/mapbox/mapbox-maps-ios/issues/775 but
+    /// introduces an issue where panning while zooming doesn't work as expected:
+    /// https://github.com/mapbox/mapbox-maps-ios/issues/864
+    case doesNotResetCameraAtEachFrame
+}
+
 /// Configuration options for the built-in gestures
 public struct GestureOptions: Equatable {
 
@@ -27,6 +44,10 @@ public struct GestureOptions: Equatable {
     /// Whether rotation is enabled for the pinch gesture.
     /// Defaults to `true`.
     public var pinchRotateEnabled: Bool = true
+
+    /// Can be used to make the desired trade-off between two available pinch gesture implementations. See ``PinchGestureBehavior`` for details.
+    /// This API is marked as experimental in anticipation of future pinch gesture improvements that remove or update the nature of this trade-off.
+    @_spi(Experimental) public var pinchBehavior: PinchGestureBehavior = .tracksTouchLocationsWhenPanningAfterZoomChange
 
     /// Whether the pitch gesture is enabled. Defaults to `true`.
     public var pitchEnabled: Bool = true

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockPinchGestureHandler.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockPinchGestureHandler.swift
@@ -1,5 +1,7 @@
-@testable import MapboxMaps
+@_spi(Experimental) @testable import MapboxMaps
 
 final class MockPinchGestureHandler: GestureHandler, PinchGestureHandlerProtocol {
     var rotateEnabled: Bool = true
+
+    var behavior: PinchGestureBehavior = .tracksTouchLocationsWhenPanningAfterZoomChange
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchGestureHandlerImpl2Tests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchGestureHandlerImpl2Tests.swift
@@ -1,0 +1,310 @@
+import XCTest
+@_spi(Experimental) @testable import MapboxMaps
+
+final class PinchGestureHandlerImpl2Tests: XCTestCase {
+    var view: UIView!
+    var gestureRecognizer: MockPinchGestureRecognizer!
+    var mapboxMap: MockMapboxMap!
+    var pinchGestureHandler: PinchGestureHandler!
+    // swiftlint:disable:next weak_delegate
+    var delegate: MockGestureHandlerDelegate!
+
+    override func setUp() {
+        super.setUp()
+        view = UIView()
+        gestureRecognizer = MockPinchGestureRecognizer()
+        view.addGestureRecognizer(gestureRecognizer)
+        mapboxMap = MockMapboxMap()
+        pinchGestureHandler = PinchGestureHandler(
+            gestureRecognizer: gestureRecognizer,
+            mapboxMap: mapboxMap)
+        delegate = MockGestureHandlerDelegate()
+        pinchGestureHandler.delegate = delegate
+        pinchGestureHandler.behavior = .doesNotResetCameraAtEachFrame
+    }
+
+    override func tearDown() {
+        pinchGestureHandler = nil
+        delegate = nil
+        mapboxMap = nil
+        gestureRecognizer = nil
+        view = nil
+        super.tearDown()
+    }
+
+    func testInitialization() {
+        XCTAssertTrue(gestureRecognizer === pinchGestureHandler.gestureRecognizer)
+    }
+
+    func testPinchBegan() {
+        gestureRecognizer.getStateStub.defaultReturnValue = .began
+
+        gestureRecognizer.sendActions()
+
+        XCTAssertEqual(mapboxMap.dragStartStub.invocations.count, 1)
+        XCTAssertEqual(delegate.gestureBeganStub.parameters, [.pinch])
+    }
+
+    func testPinchChanged() throws {
+        pinchGestureHandler.rotateEnabled = true
+
+        // Set up and send the gesture began event
+        let initialCameraState = CameraState.random()
+        let pinchMidpoints = [
+            CGPoint(x: 0.0, y: 0.0),
+            CGPoint(x: 1.0, y: 1.0),
+            CGPoint(x: 10.0, y: 10.0)]
+        mapboxMap.cameraState = initialCameraState
+        mapboxMap.dragCameraOptionsStub.defaultReturnValue = CameraOptions(
+            center: .random(),
+            zoom: .random(in: 0...20))
+
+        // set up internal state by calling handlePinch in the .began state
+        gestureRecognizer.getStateStub.defaultReturnValue = .began
+        gestureRecognizer.locationStub.defaultReturnValue = pinchMidpoints[0]
+        // these touches are consistent with the initial pinch midpoint
+        // and yield an angle of 45° for the initial state
+        gestureRecognizer.locationOfTouchStub.returnValueQueue = [
+            CGPoint(x: -1, y: -1),
+            CGPoint(x: 1, y: 1)]
+        gestureRecognizer.getNumberOfTouchesStub.defaultReturnValue = 2
+        gestureRecognizer.sendActions()
+
+        // Set up and send the gesture changed event
+        gestureRecognizer.getStateStub.defaultReturnValue = .changed
+        gestureRecognizer.locationStub.defaultReturnValue = pinchMidpoints[1]
+        // the new touch angle is 90° - that's 45° increase from the initial.
+        // this should come through as -45° change in bearing since the
+        // coordinate systems are flipped.
+        gestureRecognizer.locationOfTouchStub.returnValueQueue = [
+            CGPoint(x: 1, y: 0),
+            CGPoint(x: 1, y: 2)]
+        gestureRecognizer.getScaleStub.defaultReturnValue = 2.0
+        gestureRecognizer.sendActions()
+
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 2)
+        guard mapboxMap.setCameraStub.invocations.count == 2 else {
+            return
+        }
+        XCTAssertEqual(mapboxMap.dragCameraOptionsStub.invocations.count, 1)
+        XCTAssertEqual(
+            mapboxMap.dragCameraOptionsStub.parameters.first,
+            .init(from: pinchMidpoints[0], to: pinchMidpoints[1]))
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.parameters[0],
+            mapboxMap.dragCameraOptionsStub.returnedValues.first)
+        let returnedScale = try XCTUnwrap(gestureRecognizer.getScaleStub.returnedValues.last)
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.parameters[1],
+            CameraOptions(
+                anchor: pinchMidpoints[1],
+                zoom: initialCameraState.zoom + log2(returnedScale),
+                bearing: initialCameraState.bearing - 45))
+
+        // Set up and send a second gesture changed event to make sure we use drag API incrementally
+        gestureRecognizer.locationStub.defaultReturnValue = pinchMidpoints[2]
+        mapboxMap.dragCameraOptionsStub.reset()
+        gestureRecognizer.sendActions()
+
+        XCTAssertEqual(mapboxMap.dragCameraOptionsStub.invocations.count, 1)
+        XCTAssertEqual(
+            mapboxMap.dragCameraOptionsStub.parameters.first,
+            .init(from: pinchMidpoints[1], to: pinchMidpoints[2]))
+    }
+
+    func testPinchChangedWithRotateEnabledFalse() {
+        pinchGestureHandler.rotateEnabled = false
+
+        mapboxMap.cameraState = .random()
+
+        // these touches are consistent with the initial pinch midpoint
+        // and yield an angle of 45° for the initial state
+        gestureRecognizer.getNumberOfTouchesStub.defaultReturnValue = 2
+        gestureRecognizer.locationOfTouchStub.returnValueQueue = [
+            CGPoint(x: -1, y: -1),
+            CGPoint(x: 1, y: 1)]
+        gestureRecognizer.getStateStub.defaultReturnValue = .began
+        gestureRecognizer.sendActions()
+
+        // the new touch angle is 90° - that's 45° increase from the initial.
+        // this should come through as -45° change in bearing since the
+        // coordinate systems are flipped.
+        gestureRecognizer.locationOfTouchStub.returnValueQueue = [
+            CGPoint(x: 1, y: 0),
+            CGPoint(x: 1, y: 2)]
+        gestureRecognizer.getStateStub.defaultReturnValue = .changed
+        gestureRecognizer.sendActions()
+
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 2)
+        guard mapboxMap.setCameraStub.invocations.count == 2 else {
+            return
+        }
+        XCTAssertNil(mapboxMap.setCameraStub.parameters[1].bearing)
+    }
+
+    func testSettingRotateEnabledToTrueDuringGestureHasNoImpactOnCurrentGesture() {
+        pinchGestureHandler.rotateEnabled = false
+
+        mapboxMap.cameraState = .random()
+
+        // set up internal state by calling handlePinch in the .began state
+        gestureRecognizer.getNumberOfTouchesStub.defaultReturnValue = 2
+        gestureRecognizer.getStateStub.defaultReturnValue = .began
+        gestureRecognizer.sendActions()
+
+        // set rotateEnabled to true after the gesture has started.
+        // the gesture should continue based on rotateEnabled = false
+        // since that was the value when the gesture started
+        pinchGestureHandler.rotateEnabled = true
+        gestureRecognizer.getStateStub.defaultReturnValue = .changed
+        gestureRecognizer.sendActions()
+
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 2)
+        guard mapboxMap.setCameraStub.invocations.count == 2 else {
+            return
+        }
+        XCTAssertNil(mapboxMap.setCameraStub.parameters[1].bearing)
+    }
+
+    func testSettingRotateEnabledToFalseDuringGestureHasNoImpactOnCurrentGesture() throws {
+        pinchGestureHandler.rotateEnabled = true
+
+        let initialCameraState = CameraState.random()
+        mapboxMap.cameraState = initialCameraState
+
+        // these touches are consistent with the initial pinch midpoint
+        // and yield an angle of 45° for the initial state
+        gestureRecognizer.getNumberOfTouchesStub.defaultReturnValue = 2
+        gestureRecognizer.locationOfTouchStub.returnValueQueue = [
+            CGPoint(x: -1, y: -1),
+            CGPoint(x: 1, y: 1)]
+        gestureRecognizer.getStateStub.defaultReturnValue = .began
+        gestureRecognizer.sendActions()
+
+        // set rotateEnabled to false after the gesture has started.
+        // the gesture should continue based on rotateEnabled = true
+        // since that was the value when the gesture started
+        pinchGestureHandler.rotateEnabled = false
+        // the new touch angle is 90° - that's 45° increase from the initial.
+        // this should come through as -45° change in bearing since the
+        // coordinate systems are flipped.
+        gestureRecognizer.locationOfTouchStub.returnValueQueue = [
+            CGPoint(x: 1, y: 0),
+            CGPoint(x: 1, y: 2)]
+        gestureRecognizer.getStateStub.defaultReturnValue = .changed
+        gestureRecognizer.sendActions()
+
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 2)
+        guard mapboxMap.setCameraStub.invocations.count == 2 else {
+            return
+        }
+        XCTAssertEqual(mapboxMap.setCameraStub.parameters[1].bearing, initialCameraState.bearing - 45)
+    }
+
+    func testPinchChangedWhenNumberOfTouchesDecreasesToOneThenGoesBackToTwo() {
+        gestureRecognizer.getStateStub.returnValueQueue = [
+            .began, .changed, .changed, .changed, .changed]
+        gestureRecognizer.getNumberOfTouchesStub.returnValueQueue = [
+            2, 2, 1, 2, 2]
+        let initialCameraState = CameraState.random()
+        mapboxMap.cameraState = initialCameraState
+        gestureRecognizer.sendActions() // began (2 touches)
+        gestureRecognizer.sendActions() // changed (2 touches)
+
+        // Gesture pauses when number of touches decreases to 1
+        mapboxMap.dragEndStub.reset()
+
+        gestureRecognizer.sendActions() // changed (1 touch)
+
+        XCTAssertEqual(mapboxMap.dragEndStub.invocations.count, 1)
+
+        // Gesture re-captures initial state when number of touches increases back to 2
+        let resumedCameraState = CameraState.random()
+        mapboxMap.cameraState = resumedCameraState
+        // 45 degree touch angle
+        gestureRecognizer.locationOfTouchStub.returnValueQueue = [
+            CGPoint(x: -1, y: -1),
+            CGPoint(x: 1, y: 1)]
+        let resumedPinchMidpoint = CGPoint.random()
+        gestureRecognizer.locationStub.defaultReturnValue = resumedPinchMidpoint
+        mapboxMap.dragStartStub.reset()
+
+        gestureRecognizer.sendActions() // changed (2 touches)
+
+        XCTAssertEqual(mapboxMap.dragStartStub.parameters, [resumedPinchMidpoint])
+
+        // On second changed event after resume, we can start updating the camera again
+        // 90 degree touch angle
+        gestureRecognizer.locationOfTouchStub.returnValueQueue = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 0, y: 1)]
+        let updatedPinchMidpoint = CGPoint.random()
+        gestureRecognizer.locationStub.defaultReturnValue = updatedPinchMidpoint
+        gestureRecognizer.getScaleStub.defaultReturnValue = 8
+        mapboxMap.setCameraStub.reset()
+        mapboxMap.dragCameraOptionsStub.reset()
+
+        gestureRecognizer.sendActions() // changed (2 touches)
+
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 2)
+        XCTAssertEqual(mapboxMap.dragCameraOptionsStub.parameters,
+                       [.init(from: resumedPinchMidpoint, to: updatedPinchMidpoint)])
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.parameters.last,
+            CameraOptions(
+                anchor: updatedPinchMidpoint,
+                zoom: initialCameraState.zoom + 3,
+                bearing: resumedCameraState.bearing - 45))
+    }
+
+    func testPinchEnded() throws {
+        gestureRecognizer.getStateStub.defaultReturnValue = .began
+        gestureRecognizer.sendActions()
+        gestureRecognizer.getStateStub.defaultReturnValue = .ended
+        mapboxMap.dragEndStub.reset()
+
+        gestureRecognizer.sendActions()
+
+        XCTAssertEqual(mapboxMap.dragEndStub.invocations.count, 1)
+        XCTAssertEqual(delegate.gestureEndedStub.invocations.count, 1)
+        XCTAssertEqual(delegate.gestureEndedStub.parameters.first?.gestureType, .pinch)
+        XCTAssertEqual(delegate.gestureEndedStub.parameters.first?.willAnimate, false)
+    }
+
+    // This should not be a scenario that actually happens; however, we've received
+    // some crash reports that suggest that this might actually be happening in some
+    // situations, so we're adding some defensive mechanisms to make sure it does
+    // not result in a crash
+    func testGestureBeganWithOnlyOneTouch() {
+        gestureRecognizer.getNumberOfTouchesStub.defaultReturnValue = 1
+        gestureRecognizer.getStateStub.defaultReturnValue = .began
+
+        gestureRecognizer.sendActions()
+
+        XCTAssertTrue(gestureRecognizer.locationOfTouchStub.invocations.isEmpty)
+        XCTAssertTrue(mapboxMap.dragStartStub.invocations.isEmpty)
+        XCTAssertTrue(delegate.gestureBeganStub.invocations.isEmpty)
+
+        // if the gesture didn't have 2 touches when it began, we don't support
+        // resuming the gesture. we could conceivably change this if we confirm
+        // that pinch gestures are indeed beginning with only 1 touch.
+        gestureRecognizer.getNumberOfTouchesStub.defaultReturnValue = 2
+        gestureRecognizer.getStateStub.defaultReturnValue = .changed
+
+        gestureRecognizer.sendActions()
+
+        XCTAssertTrue(gestureRecognizer.locationOfTouchStub.invocations.isEmpty)
+        XCTAssertTrue(mapboxMap.dragStartStub.invocations.isEmpty)
+        XCTAssertTrue(delegate.gestureBeganStub.invocations.isEmpty)
+        XCTAssertTrue(mapboxMap.setCameraStub.invocations.isEmpty)
+        XCTAssertTrue(mapboxMap.dragCameraOptionsStub.invocations.isEmpty)
+
+        // when such a gesture ends, we should just ignore it
+        gestureRecognizer.getStateStub.defaultReturnValue = .ended
+
+        gestureRecognizer.sendActions()
+
+        XCTAssertTrue(mapboxMap.dragEndStub.invocations.isEmpty)
+        XCTAssertTrue(delegate.gestureEndedStub.invocations.isEmpty)
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import MapboxMaps
+@_spi(Experimental) @testable import MapboxMaps
 
 final class GestureManagerTests: XCTestCase {
 
@@ -401,5 +401,28 @@ final class GestureManagerTests: XCTestCase {
         pinchGestureHandler.rotateEnabled = true
 
         XCTAssertEqual(gestureManager.options.pinchRotateEnabled, pinchGestureHandler.rotateEnabled)
+    }
+
+    func testPinchBehavior() {
+        XCTAssertEqual(gestureManager.options.pinchBehavior, .tracksTouchLocationsWhenPanningAfterZoomChange)
+        XCTAssertEqual(pinchGestureHandler.behavior, .tracksTouchLocationsWhenPanningAfterZoomChange)
+
+        gestureManager.options.pinchBehavior = .doesNotResetCameraAtEachFrame
+
+        XCTAssertEqual(gestureManager.options.pinchBehavior, .doesNotResetCameraAtEachFrame)
+        XCTAssertEqual(pinchGestureHandler.behavior, .doesNotResetCameraAtEachFrame)
+
+        gestureManager.options.pinchBehavior = .tracksTouchLocationsWhenPanningAfterZoomChange
+
+        XCTAssertEqual(gestureManager.options.pinchBehavior, .tracksTouchLocationsWhenPanningAfterZoomChange)
+        XCTAssertEqual(pinchGestureHandler.behavior, .tracksTouchLocationsWhenPanningAfterZoomChange)
+
+        pinchGestureHandler.behavior = .doesNotResetCameraAtEachFrame
+
+        XCTAssertEqual(gestureManager.options.pinchBehavior, pinchGestureHandler.behavior)
+
+        pinchGestureHandler.behavior = .tracksTouchLocationsWhenPanningAfterZoomChange
+
+        XCTAssertEqual(gestureManager.options.pinchBehavior, pinchGestureHandler.behavior)
     }
 }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Document any changes to public APIs.
 - [x] Update the changelog

### Summary of changes

In #837, we fixed #775, but the solution introduced a new issue, #864. At the moment, we don't have a way to solve both issues simultaneously, so this PR introduces a configuration option to allow developers to make the tradeoff between the two issues that is best for their use case.

The new configuration option is marked as experimental because we hope to eliminate the need for developers to make this tradeoff in a future release. Note that experimental APIs may be modified or removed without a major version bump.

The default configuration is set to match the v10.1 behavior.

To use the new option, annotate your import statement with `@_spi(Experimental)` and then set `mapView.gestures.options.pinchBehavior = .doesNotResetCameraAtEachFrame`.

This option may be changed dynamically at any time and the change will take effect when the next pinch gesture begins.