### PR TITLE
Update MapboxCoreMaps and MapboxCommon

### DIFF
--- a/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "0cb49b20841410d0da2bf41c0884ebc7235f5485",
-          "version": "21.0.0-rc.1"
+          "revision": "ff38feb00183210d0e8807a205f9de2be97a5a38",
+          "version": "21.0.0-rc.2"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "9ec005ccbe185880c93cd4ed0bf6175cccb731f7",
-          "version": "10.2.0-beta.1"
+          "revision": "9fe2c2e9c39c463973be407f3ba4d9a11c95f9c9",
+          "version": "10.2.0-rc.1"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Add support for exponentials to `StyleColor`. ([#873](https://github.com/mapbox/mapbox-maps-ios/pull/873))
 * Improve panning behavior on pitched maps. ([#888](https://github.com/mapbox/mapbox-maps-ios/pull/888))
 * Add pinch gesture tradeoff configuration option. ([#890](https://github.com/mapbox/mapbox-maps-ios/pull/890))
+* Update to MapboxCoreMaps 10.2.0-rc.1 and MapboxCommon 21.0.0-rc.2. ([#891](https://github.com/mapbox/mapbox-maps-ios/pull/891))
 
 ## 10.2.0-beta.1 - November 19, 2021
 

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -21,8 +21,8 @@ Pod::Spec.new do |m|
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
   m.resources = ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json']
 
-  m.dependency 'MapboxCoreMaps', '10.2.0-beta.1'
-  m.dependency 'MapboxCommon', '21.0.0-rc.1'
+  m.dependency 'MapboxCoreMaps', '10.2.0-rc.1'
+  m.dependency 'MapboxCommon', '21.0.0-rc.2'
   m.dependency 'MapboxMobileEvents', '1.0.6'
   m.dependency 'Turf', '~> 2.0'
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "0cb49b20841410d0da2bf41c0884ebc7235f5485",
-          "version": "21.0.0-rc.1"
+          "revision": "ff38feb00183210d0e8807a205f9de2be97a5a38",
+          "version": "21.0.0-rc.2"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "9ec005ccbe185880c93cd4ed0bf6175cccb731f7",
-          "version": "10.2.0-beta.1"
+          "revision": "9fe2c2e9c39c463973be407f3ba4d9a11c95f9c9",
+          "version": "10.2.0-rc.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
             targets: ["MapboxMaps"]),
     ],
     dependencies: [
-        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.2.0-beta.1")),
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("21.0.0-rc.1")),
+        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.2.0-rc.1")),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("21.0.0-rc.2")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", .exact("1.0.6")),
         .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.0.0"),
         .package(name: "CocoaImageHashing", url: "https://github.com/ameingast/cocoaimagehashing", .exact("1.9.0"))

--- a/scripts/release/packager/versions.json
+++ b/scripts/release/packager/versions.json
@@ -1,6 +1,6 @@
 {
-	"MapboxCoreMaps": "10.2.0-beta.1",
-	"MapboxCommon": "21.0.0-rc.1",
+	"MapboxCoreMaps": "10.2.0-rc.1",
+	"MapboxCommon": "21.0.0-rc.2",
 	"Turf": "v2.1.0",
 	"MapboxMobileEvents": "v1.0.6"
 }


### PR DESCRIPTION
* Reverts "Improve performance by avoiding re-layout of invisible fading tiles" because it caused regression on globe view projection zooming in/out.
* Reduces drag sensitivity around and above horizon