### PR TITLE
Use UIScreen.mainScreen.nativeScale as default pixel ratio in MapOptions

### DIFF
--- a/Sources/MapboxMaps/Foundation/Extensions/Core/MapOptions.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/MapOptions.swift
@@ -11,7 +11,7 @@ extension MapboxCoreMaps.MapOptions {
     ///   - orientation: The view orientation; default is `.upwards`.
     ///   - crossSourceCollisions: Whether cross-source symbol collision detection should be enabled; default is `true`
     ///   - size: Size of the map, if nil (the default), a minimal default size will be used.
-    ///   - pixelRatio: Pixel scale of the map view; default is thee main screen's scale.
+    ///   - pixelRatio: Pixel scale of the map view; default is the main screen's native scale.
     ///   - glyphsRasterizationOptions: A `GlyphsRasterizationOptions` object.
     public convenience init(constrainMode: ConstrainMode = .heightOnly,
                             viewportMode: ViewportMode = .default,

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/MapOptions.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/MapOptions.swift
@@ -19,7 +19,7 @@ extension MapboxCoreMaps.MapOptions {
                             crossSourceCollisions: Bool = true,
                             optimizeForTerrain: Bool = true,
                             size: CGSize? = nil,
-                            pixelRatio: CGFloat = UIScreen.main.scale,
+                            pixelRatio: CGFloat = UIScreen.main.nativeScale,
                             glyphsRasterizationOptions: GlyphsRasterizationOptions = GlyphsRasterizationOptions(fontFamilies: [])) {
 
         let mbmSize: Size?


### PR DESCRIPTION
Fixes: https://github.com/mapbox/mapbox-maps-ios/issues/895

Before:
![IMG_8837](https://user-images.githubusercontent.com/2576246/145038776-8342ed1a-d5f5-4429-8be3-1007405116d2.PNG)

After:
![IMG_8838](https://user-images.githubusercontent.com/2576246/145038765-fa0465c1-ef56-4406-bbb5-2d8c21bee133.PNG)

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
~~- [ ] Write tests for all new functionality. If tests were not written, please explain why.~~
~~- [ ] Add example if relevant.~~
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Set default pixel ratio to use UIScreen.main.nativeScale</changelog>`.
~~- [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc~~

### Summary of changes

See: https://github.com/mapbox/mapbox-maps-ios/issues/895#issuecomment-987930619
