### PR TITLE
[style] Add tile request delay APIs.

### DIFF
--- a/Apps/Examples/Examples/All Examples/RasterTileSourceExample.swift
+++ b/Apps/Examples/Examples/All Examples/RasterTileSourceExample.swift
@@ -1,8 +1,13 @@
 import MapboxMaps
+import UIKit
 
 @objc(RasterTileSourceExample)
 class RasterTileSourceExample: UIViewController, ExampleProtocol {
     var mapView: MapView!
+    var isTileRequestDelayEnabled = false
+
+    let button = UIButton(type: .system)
+    let sourceId = "raster-source"
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -20,6 +25,21 @@ class RasterTileSourceExample: UIViewController, ExampleProtocol {
         mapView.mapboxMap.onNext(.mapLoaded) { _ in
             self.addRasterSource()
         }
+
+        button.setTitle("Enable tile request delay", for: .normal)
+        button.backgroundColor = .white
+        button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(button)
+        NSLayoutConstraint.activate([button.centerXAnchor.constraint(equalTo: view.centerXAnchor), button.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)])
+        button.addTarget(self, action: #selector(toggleTileRequestDelay), for: .touchUpInside)
+    }
+
+    @objc
+    func toggleTileRequestDelay() {
+        isTileRequestDelayEnabled.toggle()
+        try? mapView.mapboxMap.style.setSourceProperty(for: sourceId, property: "tile-requests-delay", value: isTileRequestDelayEnabled ? 5000 : 0)
+        button.setTitle(isTileRequestDelayEnabled ? "Disable tile request delay" : "Enable tile request delay", for: .normal)
     }
 
     func addRasterSource() {
@@ -39,7 +59,7 @@ class RasterTileSourceExample: UIViewController, ExampleProtocol {
 
         // Specify that the layer should use the source with the ID `raster-source`. This ID will be
         // assigned to the `RasterSource` when it is added to the style.
-        let sourceId = "raster-source"
+
         rasterLayer.source = sourceId
 
         do {

--- a/Sources/MapboxMaps/Style/Generated/Sources/RasterDemSource.swift
+++ b/Sources/MapboxMaps/Style/Generated/Sources/RasterDemSource.swift
@@ -72,6 +72,16 @@ public struct RasterDemSource: Source {
      * When a set of tiles for a current zoom level is being rendered and some of the ideal tiles that cover the screen are not yet loaded, parent tile could be used instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times. This property sets the maximum limit for how much a parent tile can be overscaled. 
     */
     public var maxOverscaleFactorForParentTiles: Double?
+      
+    /** 
+     * For the tiled sources, this property sets the tile requests delay. The given delay comes in action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering of the transient tiles and thus to improve the rendering performance, especially on low-end devices. 
+    */
+    public var tileRequestsDelay: Double?
+      
+    /** 
+     * For the tiled sources, this property sets the tile network requests delay. The given delay comes in action only during an ongoing animation or gestures. It helps to avoid loading the transient tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is superseded with tile-requests-delay property value, if both are provided. 
+    */
+    public var tileNetworkRequestsDelay: Double?
      
     public init() {
       self.type = .rasterDem

--- a/Sources/MapboxMaps/Style/Generated/Sources/RasterSource.swift
+++ b/Sources/MapboxMaps/Style/Generated/Sources/RasterSource.swift
@@ -72,6 +72,16 @@ public struct RasterSource: Source {
      * When a set of tiles for a current zoom level is being rendered and some of the ideal tiles that cover the screen are not yet loaded, parent tile could be used instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times. This property sets the maximum limit for how much a parent tile can be overscaled. 
     */
     public var maxOverscaleFactorForParentTiles: Double?
+      
+    /** 
+     * For the tiled sources, this property sets the tile requests delay. The given delay comes in action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering of the transient tiles and thus to improve the rendering performance, especially on low-end devices. 
+    */
+    public var tileRequestsDelay: Double?
+      
+    /** 
+     * For the tiled sources, this property sets the tile network requests delay. The given delay comes in action only during an ongoing animation or gestures. It helps to avoid loading the transient tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is superseded with tile-requests-delay property value, if both are provided. 
+    */
+    public var tileNetworkRequestsDelay: Double?
      
     public init() {
       self.type = .raster

--- a/Sources/MapboxMaps/Style/Generated/Sources/VectorSource.swift
+++ b/Sources/MapboxMaps/Style/Generated/Sources/VectorSource.swift
@@ -72,6 +72,16 @@ public struct VectorSource: Source {
      * When a set of tiles for a current zoom level is being rendered and some of the ideal tiles that cover the screen are not yet loaded, parent tile could be used instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times. This property sets the maximum limit for how much a parent tile can be overscaled. 
     */
     public var maxOverscaleFactorForParentTiles: Double?
+      
+    /** 
+     * For the tiled sources, this property sets the tile requests delay. The given delay comes in action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering of the transient tiles and thus to improve the rendering performance, especially on low-end devices. 
+    */
+    public var tileRequestsDelay: Double?
+      
+    /** 
+     * For the tiled sources, this property sets the tile network requests delay. The given delay comes in action only during an ongoing animation or gestures. It helps to avoid loading the transient tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is superseded with tile-requests-delay property value, if both are provided. 
+    */
+    public var tileNetworkRequestsDelay: Double?
      
     public init() {
       self.type = .vector

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterDemSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterDemSourceIntegrationTests.swift
@@ -29,6 +29,8 @@ final class RasterDemSourceIntegrationTests: MapViewIntegrationTestCase {
             source.prefetchZoomDelta = Double.testSourceValue()
             source.minimumTileUpdateInterval = Double.testSourceValue()
             source.maxOverscaleFactorForParentTiles = Double.testSourceValue()
+            source.tileRequestsDelay = Double.testSourceValue()
+            source.tileNetworkRequestsDelay = Double.testSourceValue()
 
             // Add the source
             do {

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/RasterSourceIntegrationTests.swift
@@ -29,6 +29,8 @@ final class RasterSourceIntegrationTests: MapViewIntegrationTestCase {
             source.prefetchZoomDelta = Double.testSourceValue()
             source.minimumTileUpdateInterval = Double.testSourceValue()
             source.maxOverscaleFactorForParentTiles = Double.testSourceValue()
+            source.tileRequestsDelay = Double.testSourceValue()
+            source.tileNetworkRequestsDelay = Double.testSourceValue()
 
             // Add the source
             do {

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/VectorSourceIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Sources/VectorSourceIntegrationTests.swift
@@ -29,6 +29,8 @@ final class VectorSourceIntegrationTests: MapViewIntegrationTestCase {
             source.prefetchZoomDelta = Double.testSourceValue()
             source.minimumTileUpdateInterval = Double.testSourceValue()
             source.maxOverscaleFactorForParentTiles = Double.testSourceValue()
+            source.tileRequestsDelay = Double.testSourceValue()
+            source.tileNetworkRequestsDelay = Double.testSourceValue()
 
             // Add the source
             do {

--- a/Tests/MapboxMapsTests/Style/Generated/Sources/RasterDemSourceTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Sources/RasterDemSourceTests.swift
@@ -18,6 +18,8 @@ final class RasterDemSourceTests: XCTestCase {
         source.prefetchZoomDelta = Double.testSourceValue()
         source.minimumTileUpdateInterval = Double.testSourceValue()
         source.maxOverscaleFactorForParentTiles = Double.testSourceValue()
+        source.tileRequestsDelay = Double.testSourceValue()
+        source.tileNetworkRequestsDelay = Double.testSourceValue()
 
         var data: Data?
         do {
@@ -46,6 +48,8 @@ final class RasterDemSourceTests: XCTestCase {
             XCTAssert(decodedSource.prefetchZoomDelta == Double.testSourceValue())
             XCTAssert(decodedSource.minimumTileUpdateInterval == Double.testSourceValue())
             XCTAssert(decodedSource.maxOverscaleFactorForParentTiles == Double.testSourceValue())
+            XCTAssert(decodedSource.tileRequestsDelay == Double.testSourceValue())
+            XCTAssert(decodedSource.tileNetworkRequestsDelay == Double.testSourceValue())
         } catch {
             XCTFail("Failed to decode RasterDemSource.")
         }

--- a/Tests/MapboxMapsTests/Style/Generated/Sources/RasterSourceTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Sources/RasterSourceTests.swift
@@ -18,6 +18,8 @@ final class RasterSourceTests: XCTestCase {
         source.prefetchZoomDelta = Double.testSourceValue()
         source.minimumTileUpdateInterval = Double.testSourceValue()
         source.maxOverscaleFactorForParentTiles = Double.testSourceValue()
+        source.tileRequestsDelay = Double.testSourceValue()
+        source.tileNetworkRequestsDelay = Double.testSourceValue()
 
         var data: Data?
         do {
@@ -46,6 +48,8 @@ final class RasterSourceTests: XCTestCase {
             XCTAssert(decodedSource.prefetchZoomDelta == Double.testSourceValue())
             XCTAssert(decodedSource.minimumTileUpdateInterval == Double.testSourceValue())
             XCTAssert(decodedSource.maxOverscaleFactorForParentTiles == Double.testSourceValue())
+            XCTAssert(decodedSource.tileRequestsDelay == Double.testSourceValue())
+            XCTAssert(decodedSource.tileNetworkRequestsDelay == Double.testSourceValue())
         } catch {
             XCTFail("Failed to decode RasterSource.")
         }

--- a/Tests/MapboxMapsTests/Style/Generated/Sources/VectorSourceTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Sources/VectorSourceTests.swift
@@ -18,6 +18,8 @@ final class VectorSourceTests: XCTestCase {
         source.prefetchZoomDelta = Double.testSourceValue()
         source.minimumTileUpdateInterval = Double.testSourceValue()
         source.maxOverscaleFactorForParentTiles = Double.testSourceValue()
+        source.tileRequestsDelay = Double.testSourceValue()
+        source.tileNetworkRequestsDelay = Double.testSourceValue()
 
         var data: Data?
         do {
@@ -46,6 +48,8 @@ final class VectorSourceTests: XCTestCase {
             XCTAssert(decodedSource.prefetchZoomDelta == Double.testSourceValue())
             XCTAssert(decodedSource.minimumTileUpdateInterval == Double.testSourceValue())
             XCTAssert(decodedSource.maxOverscaleFactorForParentTiles == Double.testSourceValue())
+            XCTAssert(decodedSource.tileRequestsDelay == Double.testSourceValue())
+            XCTAssert(decodedSource.tileNetworkRequestsDelay == Double.testSourceValue())
         } catch {
             XCTFail("Failed to decode VectorSource.")
         }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Introduce `tileRequestDelay` and `tileNetworkRequestsDelay` runtime source properties for vector, raster and raster-dem sources.</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

This PR introduces `tileRequestDelay` and `tileNetworkRequestsDelay` runtime source properties for vector, raster and raster-dem sources:

The "tile-requests-delay" property:
```
    /**
     * For vector, raster and raster-dem sources, this property sets the tile requests delay.
     *
     * The given delay comes in action only during an ongoing animation or gestures.
     * It helps to avoid loading, parsing and rendering of the "transient" tiles and
     * thus to improve the rendering performance, especially on low-end devices.
     *
     * The delay is represented by a Double value in milliseconds.
     */
```
The "tile-network-requests-delay" property:
```
    /**
     * For vector, raster and raster-dem sources, this property sets the tile network requests delay.
     *
     * The given delay comes in action only during an ongoing animation or gestures.
     * It helps to avoid loading the "transient" tiles from the network and
     * thus to avoid redundant network requests.
     *
     * The delay is represented by a Double value in milliseconds.
     * 
     * Note that "tile-network-requests-delay" value is superseded with "tile-requests-delay" 
     * property value, if both are provided.
     */
```

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
