### PR TITLE
Add first view annotation before map load in view annotation samples

### DIFF
--- a/Apps/Examples/Examples/All Examples/ViewAnnotationBasicExample.swift
+++ b/Apps/Examples/Examples/All Examples/ViewAnnotationBasicExample.swift
@@ -18,9 +18,10 @@ final class ViewAnnotationBasicExample: UIViewController, ExampleProtocol {
         mapView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(onMapClick)))
         view.addSubview(mapView)
 
+        addViewAnnotation(at: mapView.mapboxMap.coordinate(for: mapView.center))
+
         mapView.mapboxMap.onNext(.mapLoaded) { [weak self] _ in
             guard let self = self else { return }
-            self.addViewAnnotation(at: self.mapView.mapboxMap.coordinate(for: self.mapView.center))
             self.finish()
         }
     }

--- a/Apps/Examples/Examples/All Examples/ViewAnnotationMarkerExample.swift
+++ b/Apps/Examples/Examples/All Examples/ViewAnnotationMarkerExample.swift
@@ -46,9 +46,10 @@ final class ViewAnnotationMarkerExample: UIViewController, ExampleProtocol {
         mapView.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(onMapLongClick)))
         view.addSubview(mapView)
 
+        addMarkerAndAnnotation(at: mapView.mapboxMap.coordinate(for: mapView.center))
+
         mapView.mapboxMap.onNext(.mapLoaded) { [weak self] _ in
             guard let self = self else { return }
-            self.addMarkerAndAnnotation(at: self.mapView.mapboxMap.coordinate(for: self.mapView.center))
             self.finish()
         }
 


### PR DESCRIPTION
Small changes in the view annotation samples to demonstrate that annotations can be added before the map load.

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
