### PR TITLE
Expose triggerRepaint API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 * Exposed `triggerRepaint()` to allow manual map repainting.
     ([#964])(https://github.com/mapbox/mapbox-maps-ios/pull/964)
+* Exposed `TransitionOptions` to allow control over symbol fade duration.
+    ([#902])(https://github.com/mapbox/mapbox-maps-ios/pull/902)
 * Added `Style.removeTerrain()` to allow removing terrain. ([#918](https://github.com/mapbox/mapbox-maps-ios/pull/918))
 * `Snapshotter` initialization now triggers a turnstyle event. ([#908](https://github.com/mapbox/mapbox-maps-ios/pull/908))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+* Exposed `triggerRepaint()` to allow manual map repainting.
+    ([#964])(https://github.com/mapbox/mapbox-maps-ios/pull/964)
 * Added `Style.removeTerrain()` to allow removing terrain. ([#918](https://github.com/mapbox/mapbox-maps-ios/pull/918))
 * `Snapshotter` initialization now triggers a turnstyle event. ([#908](https://github.com/mapbox/mapbox-maps-ios/pull/908))
 

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -59,6 +59,11 @@ public final class MapboxMap: MapboxMapProtocol {
 
     // MARK: - Style loading
 
+    /// Triggers a repaint of the map.
+    public func triggerRepaint() {
+        __map.triggerRepaint()
+    }
+
     private func observeStyleLoad(_ completion: @escaping (Result<Style, Error>) -> Void) {
         onNext(eventTypes: [.styleLoaded, .mapLoadingError]) { event in
             switch event.type {


### PR DESCRIPTION
Exposes the `triggerRepaint` API to allow manual map repainting. Please note that calling this method is typically unnecessary but may be needed if using a custom layer that needs to be redrawn independently of other map changes.