### PR TITLE
Deprecated function queryFeatureExtension

### DIFF
--- a/Sources/MapboxMaps/Foundation/MapFeatureQueryable.swift
+++ b/Sources/MapboxMaps/Foundation/MapFeatureQueryable.swift
@@ -25,17 +25,17 @@ internal protocol MapFeatureQueryable: AnyObject {
                                args: [String: Any]?,
                                completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void)
 
-    func getGeoJsonClusterLeaves(for sourceId: String,
+    func getGeoJsonClusterLeaves(forSourceId sourceId: String,
                                  feature: Feature,
                                  limit: UInt64,
                                  offset: UInt64,
                                  completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void)
 
-    func getGeoJsonClusterChildren(for sourceId: String,
+    func getGeoJsonClusterChildren(forSourceId sourceId: String,
                                    feature: Feature,
                                    completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void)
 
-    func getGeoJsonClusterExpansionZoom(for sourceId: String,
+    func getGeoJsonClusterExpansionZoom(forSourceId sourceId: String,
                                         feature: Feature,
                                         completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void)
 }

--- a/Sources/MapboxMaps/Foundation/MapFeatureQueryable.swift
+++ b/Sources/MapboxMaps/Foundation/MapFeatureQueryable.swift
@@ -24,4 +24,18 @@ internal protocol MapFeatureQueryable: AnyObject {
                                extensionField: String,
                                args: [String: Any]?,
                                completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void)
+
+    func getGeoJsonClusterLeaves(for sourceId: String,
+                                 feature: Feature,
+                                 limit: UInt64,
+                                 offset: UInt64,
+                                 completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void)
+
+    func getGeoJsonClusterChildren(for sourceId: String,
+                                   feature: Feature,
+                                   completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void)
+
+    func getGeoJsonClusterExpansionZoom(for sourceId: String,
+                                        feature: Feature,
+                                        completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void)
 }

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -730,8 +730,8 @@ extension MapboxMap: MapFeatureQueryable {
                                      extensionField: "leaves",
                                      args: ["limit": limit, "offset": offset],
                                      callback: coreAPIClosureAdapter(for: completion,
-                                                                        type: FeatureExtensionValue.self,
-                                                                        concreteErrorType: MapError.self))
+                                                                     type: FeatureExtensionValue.self,
+                                                                     concreteErrorType: MapError.self))
     }
 
     /// Returns the children (original points or clusters) of a cluster (on the next zoom level)
@@ -752,8 +752,8 @@ extension MapboxMap: MapFeatureQueryable {
                                      extensionField: "children",
                                      args: nil,
                                      callback: coreAPIClosureAdapter(for: completion,
-                                                                        type: FeatureExtensionValue.self,
-                                                                        concreteErrorType: MapError.self))
+                                                                     type: FeatureExtensionValue.self,
+                                                                     concreteErrorType: MapError.self))
     }
 
     /// Returns the zoom on which the cluster expands into several children (useful for "click to zoom" feature)
@@ -774,8 +774,8 @@ extension MapboxMap: MapFeatureQueryable {
                                      extensionField: "expansion-zoom",
                                      args: nil,
                                      callback: coreAPIClosureAdapter(for: completion,
-                                                                        type: FeatureExtensionValue.self,
-                                                                        concreteErrorType: MapError.self))
+                                                                     type: FeatureExtensionValue.self,
+                                                                     concreteErrorType: MapError.self))
     }
 }
 

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -690,6 +690,7 @@ extension MapboxMap: MapFeatureQueryable {
     ///   - completion: The result could be a feature extension value containing
     ///         either a value (expansion-zoom) or a feature collection (children
     ///         or leaves). An error is passed if the operation was not successful.
+    /// Deprecated. Use getGeoJsonClusterLeaves/getGeoJsonClusterChildren/getGeoJsonClusterExpansionZoom to instead.
     public func queryFeatureExtension(for sourceId: String,
                                       feature: Feature,
                                       extension: String,
@@ -705,6 +706,76 @@ extension MapboxMap: MapFeatureQueryable {
                                      callback: coreAPIClosureAdapter(for: completion,
                                                                      type: FeatureExtensionValue.self,
                                                                      concreteErrorType: MapError.self))
+    }
+
+    /// Returns all the leaves (original points) of a cluster (given its cluster_id) from a GeoJSON source, with pagination support: limit is the number of leaves
+    /// to return (set to Infinity for all points), and offset is the amount of points to skip (for pagination).
+    ///
+    /// - Parameters:
+    ///   - sourceId: The identifier of the source to query.
+    ///   - feature: Feature to look for in the query.
+    ///   - limit: the number of points to return from the query, default to 10
+    ///   - offset: the amount of points to skip, default to 0
+    ///   - completion: The result could be a feature extension value containing
+    ///         either a value (expansion-zoom) or a feature collection (children
+    ///         or leaves). An error is passed if the operation was not successful.
+    public func getGeoJsonClusterLeaves(for sourceId: String,
+                                        feature: Feature,
+                                        limit: UInt64 = 10,
+                                        offset: UInt64 = 0,
+                                        completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void) {
+        __map.queryFeatureExtensions(forSourceIdentifier: sourceId,
+                                     feature: MapboxCommon.Feature(feature),
+                                     extension: "supercluster",
+                                     extensionField: "leaves",
+                                     args: ["limit": limit, "offset": offset],
+                                     callback: coreAPIClosureAdapter(for: completion,
+                                                                        type: FeatureExtensionValue.self,
+                                                                        concreteErrorType: MapError.self))
+    }
+
+    /// Returns the children (original points or clusters) of a cluster (on the next zoom level)
+    /// given its id (cluster_id value from feature properties) from a GeoJSON source.
+    ///
+    /// - Parameters:
+    ///   - sourceId: The identifier of the source to query.
+    ///   - feature: Feature to look for in the query.
+    ///   - completion: The result could be a feature extension value containing
+    ///         either a value (expansion-zoom) or a feature collection (children
+    ///         or leaves). An error is passed if the operation was not successful.
+    public func getGeoJsonClusterChildren(for sourceId: String,
+                                          feature: Feature,
+                                          completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void) {
+        __map.queryFeatureExtensions(forSourceIdentifier: sourceId,
+                                     feature: MapboxCommon.Feature(feature),
+                                     extension: "supercluster",
+                                     extensionField: "children",
+                                     args: nil,
+                                     callback: coreAPIClosureAdapter(for: completion,
+                                                                        type: FeatureExtensionValue.self,
+                                                                        concreteErrorType: MapError.self))
+    }
+
+    /// Returns the zoom on which the cluster expands into several children (useful for "click to zoom" feature)
+    /// given the cluster's cluster_id (cluster_id value from feature properties) from a GeoJSON source.
+    ///
+    /// - Parameters:
+    ///   - sourceId: The identifier of the source to query.
+    ///   - feature: Feature to look for in the query.
+    ///   - completion: The result could be a feature extension value containing
+    ///         either a value (expansion-zoom) or a feature collection (children
+    ///         or leaves). An error is passed if the operation was not successful.
+    public func getGeoJsonClusterExpansionZoom(for sourceId: String,
+                                               feature: Feature,
+                                               completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void) {
+        __map.queryFeatureExtensions(forSourceIdentifier: sourceId,
+                                     feature: MapboxCommon.Feature(feature),
+                                     extension: "supercluster",
+                                     extensionField: "expansion-zoom",
+                                     args: nil,
+                                     callback: coreAPIClosureAdapter(for: completion,
+                                                                        type: FeatureExtensionValue.self,
+                                                                        concreteErrorType: MapError.self))
     }
 }
 

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -719,7 +719,7 @@ extension MapboxMap: MapFeatureQueryable {
     ///   - completion: The result could be a feature extension value containing
     ///         either a value (expansion-zoom) or a feature collection (children
     ///         or leaves). An error is passed if the operation was not successful.
-    public func getGeoJsonClusterLeaves(for sourceId: String,
+    public func getGeoJsonClusterLeaves(forSourceId sourceId: String,
                                         feature: Feature,
                                         limit: UInt64 = 10,
                                         offset: UInt64 = 0,
@@ -743,7 +743,7 @@ extension MapboxMap: MapFeatureQueryable {
     ///   - completion: The result could be a feature extension value containing
     ///         either a value (expansion-zoom) or a feature collection (children
     ///         or leaves). An error is passed if the operation was not successful.
-    public func getGeoJsonClusterChildren(for sourceId: String,
+    public func getGeoJsonClusterChildren(forSourceId sourceId: String,
                                           feature: Feature,
                                           completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void) {
         __map.queryFeatureExtensions(forSourceIdentifier: sourceId,
@@ -765,7 +765,7 @@ extension MapboxMap: MapFeatureQueryable {
     ///   - completion: The result could be a feature extension value containing
     ///         either a value (expansion-zoom) or a feature collection (children
     ///         or leaves). An error is passed if the operation was not successful.
-    public func getGeoJsonClusterExpansionZoom(for sourceId: String,
+    public func getGeoJsonClusterExpansionZoom(forSourceId sourceId: String,
                                                feature: Feature,
                                                completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void) {
         __map.queryFeatureExtensions(forSourceIdentifier: sourceId,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: #988 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Deprecated function queryFeatureExtension, use getGeoJsonClusterLeaves/getGeoJsonClusterChildren/getGeoJsonClusterExpansionZoom to instead.</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes
This PR deprecated queryFeatureExtension and introduces getGeoJsonClusterLeaves/getGeoJsonClusterChildren/getGeoJsonClusterExpansionZoom which are more covinience to users.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
