### PR TITLE
Test integrations for SPM/CocoaPods/Direct Download

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -685,11 +685,7 @@ jobs:
       - image: cimg/base:stable
     steps:
       - parse-release-version-if-available
-      - run:
-          name: Configure .netrc
-          command: |
-            echo "machine api.mapbox.com login mapbox password $SDK_REGISTRY_TOKEN" >> ~/.netrc
-            chmod 0600 ~/.netrc
+      - inject-netrc-credentials
       - run:
           name: Wait binaries public access
           command: |
@@ -710,12 +706,16 @@ commands:
       - run:
           name: Allow cloning from github.com via HTTPS
           command: git config --global --unset url."ssh://git@github.com".insteadOf
+      - inject-netrc-credentials
+      - inject-mapbox-public-token
+
+  inject-netrc-credentials:
+    steps:
       - run:
           name: Configure .netrc
           command: |
             echo "machine api.mapbox.com login mapbox password $SDK_REGISTRY_TOKEN" >> ~/.netrc
             chmod 0600 ~/.netrc
-      - inject-mapbox-public-token
 
   inject-mapbox-public-token:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,16 +139,31 @@ workflows:
               only: main
       - check-api-compatibility
       - create-xcframework
+      - validate-integrations-for-branch
 
   release:
     jobs:
       - release:
           name: "Release"
-          filters:
+          filters: &release-tags-filter
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
             branches:
               ignore: /.*/
+      - binaries-accessible?:
+          type: approval
+          filters:
+            <<: *release-tags-filter
+      - wait-for-binaries:
+          filters:
+            <<: *release-tags-filter
+          requires:
+            - binaries-accessible?
+      - validate-integrations:
+          filters:
+            <<: *release-tags-filter
+          requires:
+            - wait-for-binaries
 
 # ==============================================================================
 
@@ -203,10 +218,15 @@ jobs:
     steps:
       - checkout
       - run: brew install swiftlint
-      - run: swiftlint lint --strict
+      - run: swiftlint lint --strict --reporter junit | tee result.xml
+      - store_artifacts:
+          path: result.xml
+      - store_test_results:
+          path: result.xml
 
   depsvalidator:
     <<: *base-job
+    resource_class: macos.x86.medium.gen2
     steps:
       - checkout
       - run:
@@ -218,6 +238,7 @@ jobs:
 
   build-sdk:
     <<: *base-job
+    resource_class: macos.x86.medium.gen2
     steps:
       - checkout
       - configure-environment
@@ -312,6 +333,7 @@ jobs:
 
   unit-test-sdk:
     <<: *base-job
+    resource_class: macos.x86.medium.gen2
     steps:
       - checkout
       - add-mapbox-submodules-key
@@ -493,6 +515,7 @@ jobs:
 
   create-xcframework:
     <<: *base-job
+    resource_class: macos.x86.medium.gen2
     steps:
       - checkout
       - add-mapbox-submodules-key
@@ -538,6 +561,7 @@ jobs:
     <<: *base-job
     macos:
       xcode: 13.0.0
+    resource_class: macos.x86.medium.gen2
     steps:
       - checkout
       - add-mapbox-submodules-key
@@ -545,6 +569,42 @@ jobs:
       - configure-environment
       - install-dependencies
       - check-breaking-api
+
+  validate-integrations-for-branch:
+    description: <
+      This job is designed to be called on daily bases.
+      It is validating dependency managers integration per branch version rule.
+      However, this job would run exclusively for open PRs to the release branches (aka "release/v.*"")
+    macos:
+      xcode: 13.2.1
+    resource_class: macos.x86.medium.gen2
+    steps:
+      - checkout
+      - configure-environment
+      - run: brew install xcodegen
+      - run:
+          name: Validate SPM and CocoaPods integrations for current branch
+          command: scripts/validate-integrations/validate-integrations.sh -b $CIRCLE_BRANCH
+
+  validate-integrations:
+    description: <
+      This job is designed to be called after SDK Registry PR merge.
+      It requires binaries to be publicly available and downloadable.
+      SPM, Cocoapods and DirectDownload tests would be called.
+    macos:
+      xcode: 13.2.1
+    resource_class: macos.x86.medium.gen2
+    steps:
+      - checkout
+      - parse-release-version-if-available
+      - install-mbx-ci
+      - configure-environment
+      - run:
+          name: Install dependencies
+          command: brew install gh xcodegen
+      - run:
+          name: Test direct download integrations
+          command: scripts/validate-integrations/validate-integrations.sh -v "$VERSION"
 
   # This job:
   # - builds XCFrameworks
@@ -555,10 +615,7 @@ jobs:
   release:
     <<: *base-job
     steps:
-      - run:
-          name: Parse SDK version from release tag
-          command: |
-            echo "export VERSION=${CIRCLE_TAG#v}" >> $BASH_ENV
+      - parse-release-version-if-available
       - slack/notify:
           message: '<$CIRCLE_BUILD_URL|Release tag for \`v$VERSION\` started.>'
           include_visit_job_action: true
@@ -604,12 +661,41 @@ jobs:
       - run:
           name: Publish CocoaPods Podspec
           command: pod trunk push
+      - run:
+          name: Inject new Podspec version to CDN cache
+          description: |
+            Force adding new version to the cache to avoid long running clone operation
+            The following command would take the latest CocoaPods version from cache.
+
+            Alternative is to replace CDN with Specs repository and checkout it for the latest changes. It usually takes 3+ minutes on CircleCI
+          command: |
+            source scripts/utilities/cocoapods.sh
+            pod_inject_cdn_version MapboxMaps "$VERSION"
+      - run:
+          name: Test SPM and CocoaPods integrations per version rule
+          command: scripts/validate-integrations/validate-integrations.sh -d -v "$VERSION"
       - slack/status:
           fail_only: false
           include_visit_job_action: true
           failure_message: ':tests-fail-red-cross: <$CIRCLE_BUILD_URL|Release tag for \`v$VERSION\` failed.>'
           success_message: ':green_circle: <$CIRCLE_BUILD_URL|Release tag for \`v$VERSION\` succeeded!> :tada:'
 
+  wait-for-binaries:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - parse-release-version-if-available
+      - run:
+          name: Configure .netrc
+          command: |
+            echo "machine api.mapbox.com login mapbox password $SDK_REGISTRY_TOKEN" >> ~/.netrc
+            chmod 0600 ~/.netrc
+      - run:
+          name: Wait binaries public access
+          command: |
+            echo $VERSION
+            timeout 1800 bash -c 'while [[ "$(curl -n -s -o /dev/null -w ''%{http_code}'' https://api.mapbox.com/downloads/v2/mobile-maps-ios/releases/ios/$VERSION/MapboxMaps.zip)" != "200" ]]; do sleep 5; done' || false
+          no_output_timeout: 30m
 # ==============================================================================
 # Reusable commands
 commands:
@@ -626,7 +712,9 @@ commands:
           command: git config --global --unset url."ssh://git@github.com".insteadOf
       - run:
           name: Configure .netrc
-          command: echo "machine api.mapbox.com login mapbox password $SDK_REGISTRY_TOKEN" >> ~/.netrc
+          command: |
+            echo "machine api.mapbox.com login mapbox password $SDK_REGISTRY_TOKEN" >> ~/.netrc
+            chmod 0600 ~/.netrc
       - inject-mapbox-public-token
 
   inject-mapbox-public-token:
@@ -819,3 +907,12 @@ commands:
           name: Locate derived data directory
           command: |
             echo "export DERIVED_DATA_PATH=\"$(find ~/Library/Developer/Xcode/DerivedData -name "<< parameters.base_name >>*" -depth 1)\"" >> $BASH_ENV
+
+  parse-release-version-if-available:
+    steps:
+      - run:
+          name: Parse SDK version from release tag
+          command: |
+            if [[ -n "$CIRCLE_TAG" ]]; then
+              echo "export VERSION=${CIRCLE_TAG#v}" >> $BASH_ENV
+            fi

--- a/scripts/utilities/cocoapods.sh
+++ b/scripts/utilities/cocoapods.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+pod_inject_cdn_version() {
+    local library_name=$1
+    local version=$2
+    
+    pod search "$library_name" --no-pager > /dev/null
+    LIBRARY_NAME_HASH=$(md5 -qs "$library_name")
+    CDN_HASH_PATH="$HOME/.cocoapods/repos/trunk/all_pods_versions_${LIBRARY_NAME_HASH:0:1}_${LIBRARY_NAME_HASH:1:1}_${LIBRARY_NAME_HASH:2:1}.txt"
+    cat "$CDN_HASH_PATH"
+    sed -i '' -E "s/($library_name.*)/\1\/${version}/g" "$CDN_HASH_PATH"
+    cat "$CDN_HASH_PATH"
+}

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -3,4 +3,5 @@
 __UTILS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "$__UTILS_SCRIPT_DIR/utilities/helpers.sh"
 source "$__UTILS_SCRIPT_DIR/utilities/git.sh"
+source "$__UTILS_SCRIPT_DIR/utilities/cocoapods.sh"
 

--- a/scripts/validate-integrations/MapLoadingUITest.swift
+++ b/scripts/validate-integrations/MapLoadingUITest.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+class MapLoadingUITest: XCTestCase {
+    func testExample() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let existancePredicate = NSPredicate(format: "exists == 1")
+        let query = app.alerts.firstMatch
+        expectation(for: existancePredicate, evaluatedWith: query, handler: nil)
+
+        waitForExpectations(timeout: 10, handler: nil)
+
+        let loadedPredicate = NSPredicate(format: "label CONTAINS[c] %@", "Loaded")
+        let loadedAlert = app.alerts.containing(loadedPredicate)
+
+        XCTAssertEqual(loadedAlert.count, 1)
+
+        let failedPredicate = NSPredicate(format: "label CONTAINS[c] %@", "Failed")
+        let failedAlert = app.alerts.containing(failedPredicate)
+
+        XCTAssertEqual(failedAlert.count, 0)
+    }
+
+}

--- a/scripts/validate-integrations/Podfile
+++ b/scripts/validate-integrations/Podfile
@@ -1,0 +1,10 @@
+# Uncomment the next line to define a global platform for your project
+platform :ios, '11.0'
+
+target 'CocoaPodsIntegration' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  pod 'MapboxMaps', 'VERSION_HERE'
+
+end

--- a/scripts/validate-integrations/ViewController.swift
+++ b/scripts/validate-integrations/ViewController.swift
@@ -1,0 +1,44 @@
+import Foundation
+import UIKit
+import MapboxMaps
+
+class ViewController: UIViewController {
+    let mapView = MapView(frame: .zero)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.addSubview(mapView)
+        mapView.mapboxMap.onNext(.mapLoaded) { _ in
+            self.showAlert(text: "Loaded")
+        }
+
+        mapView.mapboxMap.onNext(.mapLoadingError) { _ in
+            self.showAlert(text: "Failed")
+        }
+    }
+
+    func showAlert(text: String) {
+        let alert = UIAlertController(title: text, message: nil, preferredStyle: .alert)
+        alert.addAction(UIAlertAction())
+        alert.accessibilityLabel = "custom-alert"
+
+        show(alert, sender: self)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        mapView.frame = view.bounds
+    }
+}
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    lazy var window: UIWindow? = UIWindow(frame: UIScreen.main.bounds)
+
+    func applicationDidFinishLaunching(_ application: UIApplication) {
+        window?.rootViewController = ViewController()
+        window?.makeKeyAndVisible()
+    }
+}

--- a/scripts/validate-integrations/project.yml
+++ b/scripts/validate-integrations/project.yml
@@ -1,0 +1,63 @@
+name: ValidateLatestMaps
+options:
+  bundleIdPrefix: com.mapbox
+settings:
+  DEVELOPMENT_TEAM: GJZR2MEM28
+packages:
+  MapboxMaps:
+    url: https://github.com/mapbox/mapbox-maps-ios.git
+    ${MAPS_VERSION_RULE}: ${MAPS_VERSION}
+targets:
+  SwiftPackageManagerIntegration:
+    templates:
+      - Application
+    dependencies:
+      - package: MapboxMaps
+  SwiftPackageManagerIntegrationUITest:
+    templates:
+      - UITest
+    dependencies:
+      - target: SwiftPackageManagerIntegration
+  CocoaPodsIntegration:
+    templates:
+      - Application
+  CocoaPodsIntegrationUITest:
+    templates:
+      - UITest
+    dependencies:
+      - target: CocoaPodsIntegration
+  DirectDynamicDownload:
+    templates:
+      - Application
+    dependencies:
+      - framework: ${DYNAMIC_ARTIFACTS_PATH}/MapboxMaps.xcframework
+      - framework: ${DYNAMIC_ARTIFACTS_PATH}/MapboxCoreMaps.xcframework
+      - framework: ${DYNAMIC_ARTIFACTS_PATH}/MapboxCommon.xcframework
+      - framework: ${DYNAMIC_ARTIFACTS_PATH}/MapboxMobileEvents.xcframework
+      - framework: ${DYNAMIC_ARTIFACTS_PATH}/Turf.xcframework
+  DirectDynamicDownloadUITest:
+    templates:
+      - UITest
+    dependencies:
+      - target: DirectDynamicDownload
+targetTemplates:
+  Application:
+    sources: [ViewController.swift]
+    platform: iOS
+    deploymentTarget:
+      iOS: 11.0
+    type: application
+    info:
+      path: Info.plist
+      properties:
+        MBXAccessToken: ${MBX_TOKEN}
+        UILaunchStoryboardName: LaunchScreen
+    scheme:
+      testTargets:
+        - ${target_name}UITest
+  UITest:
+    type: bundle.ui-testing
+    platform: iOS
+    sources: MapLoadingUITest.swift
+    info:
+      path: Info-tests.plist

--- a/scripts/validate-integrations/validate-integrations.sh
+++ b/scripts/validate-integrations/validate-integrations.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+UTILS_PATH="$SCRIPT_DIR/../utils.sh"
+TMP_ROOT=$(mktemp -d)
+
+# shellcheck source=../utils.sh
+source "$UTILS_PATH"
+
+VERSION_RULE=0
+BRANCH_RULE=0
+ENABLE_DIRECT_DOWNLOADS_VALIDATION=1
+EXCLUSIVE_DIRECT_DOWNLOADS_VALIDATION=0
+
+main() {
+    PROJECTS_TO_TEST=("SwiftPackageManagerIntegration" "CocoaPodsIntegration")
+    if [[ $VERSION_RULE == 1 && $ENABLE_DIRECT_DOWNLOADS_VALIDATION == 1 ]]; then
+        step "Download MapboxMaps binaries"
+
+        if [[ $EXCLUSIVE_DIRECT_DOWNLOADS_VALIDATION == 1 ]]; then
+            PROJECTS_TO_TEST=("DirectDynamicDownload")
+        else
+            PROJECTS_TO_TEST+=("DirectDynamicDownload")
+        fi
+        DYNAMIC_ARTIFACTS_DOWNLOAD_PATH="$TMP_ROOT/Dynamic/"
+        curl -n "https://api.mapbox.com/downloads/v2/mobile-maps-ios/releases/ios/$MAPS_VERSION/MapboxMaps.zip" -o "$TMP_ROOT/MapboxMaps.zip"
+        unzip -q "$TMP_ROOT/MapboxMaps.zip" -d "$DYNAMIC_ARTIFACTS_DOWNLOAD_PATH"
+
+        export DYNAMIC_ARTIFACTS_PATH="$DYNAMIC_ARTIFACTS_DOWNLOAD_PATH/artifacts"
+    fi
+
+    step "Generate Xcode project with Xcodegen"
+    pushd "$SCRIPT_DIR" > /dev/null || exit 1
+    MBX_TOKEN="$(cat ~/.mapbox)" xcodegen
+
+    if [[ $BRANCH_RULE == 1 ]]; then
+        # Escape '/' and '\' to make Bash and Sed happy
+        sed -i '' -E "s/(pod 'MapboxMaps',).*/\1 :git => 'https:\/\/github.com\/mapbox\/mapbox-maps-ios.git', :branch => '${MAPS_VERSION//\//\\/}'/" Podfile
+    elif [[ $VERSION_RULE == 1 ]]; then
+        sed -i '' -E "s/(pod 'MapboxMaps',).*/\1 '= $MAPS_VERSION'/" Podfile
+    fi
+
+    pod install
+
+    info "Start simulator"
+    xcrun simctl boot "iPhone 13"
+
+    info "Building logs available at $TMP_ROOT"
+    WORKSPACE_PATH="$SCRIPT_DIR/ValidateLatestMaps.xcworkspace"
+
+    results_path="$SCRIPT_DIR/results"
+    [[ -d "$results_path" ]] && rm -rf "$results_path"
+
+    for scheme in "${PROJECTS_TO_TEST[@]}"
+    do
+        step "Building $scheme scheme"
+        xcodebuild clean build -workspace "$WORKSPACE_PATH" -scheme "$scheme" -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED='NO' &> "$TMP_ROOT/${scheme}_xcode.log"
+        info "Finished $scheme building"
+    done
+
+    git clean -fdx "$SCRIPT_DIR" --quiet
+    git checkout HEAD -- Podfile
+
+    exit 0
+}
+
+print_usage () {
+    cat <<HELP_USAGE
+Usage:
+        $0 -b branch_name
+        $0 -v version_name [-d]
+
+    -v  Force MapboxMaps tag version to be used for SPM build
+    -d  Disable downloads validation. Suitable for running validation before binaries would be available
+    -o  Enable exclusive validation for direct downloads. It makes sense to run after the first run with -d option
+    -b  MapboxMaps branch name to be used
+HELP_USAGE
+}
+
+while getopts 'b:v:do' flag; do
+case "${flag}" in
+    v)  VERSION_RULE=1
+        export MAPS_VERSION="$OPTARG"
+        export MAPS_VERSION_RULE="version"
+        ;;
+    b)
+        BRANCH_RULE=1
+        export MAPS_VERSION="$OPTARG"
+        export MAPS_VERSION_RULE="branch"
+        ;;
+    d)
+        ENABLE_DIRECT_DOWNLOADS_VALIDATION=0
+        ;;
+    o)
+        EXCLUSIVE_DIRECT_DOWNLOADS_VALIDATION=1
+        ;;
+    *) print_usage
+    exit 1 ;;
+esac
+done
+
+if [ $OPTIND -eq 1 ]; then
+    print_usage
+else
+    main
+fi
+
+exit 1


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
## Summary of changes

This PR introduces a script to test SDK integration as well as continuous integration support for daily and release workflows. 
Script validates Swift Package Manager integration through branch and the explicit version, CocoaPods (branch and version), and direct usage of Dynamic XCFrameworks. 
The integration test is implemented as a UITest. Custom sample code shows alerts for successfull and failed map loading events, and UITest check the existance of concrete alerts.
For some reason, CircleCI wasn't able to pass UI tests so I switched back to the simple building testings. The rest of infrastructure is ready for enabling testing – you only have to add `test` after the `build` action in `xcodebuild` command.

### Other small changes:
- Report `swiftlint` issues as JUnit. That would enable CircleCI to render issues on the workflow list screen
    <img width="400" alt="Untitled" src="https://user-images.githubusercontent.com/735178/148075013-03971f86-cd3a-43d7-bb12-a887c4e85507.png">
- Bump several jobs to the new `macos.x86.medium.gen2` resource class to improve building times as well as cost/minute aspect. I have tested medium/macos.x86.medium.gen2/large instances and found the best credit/time ratio. 
- Extract release version parsing (based on CIRCLE_TAG) to the `parse-release-version-if-available` command.
- There is new `scripts/utilities/cocoapods.sh` script that provides helper function `pod_inject_cdn_version` to inject newer version to the CocoaPods CDN cache. It also would get the latest cache for particular SDK.
- [Experimental] Release flow now includes approval job that should be manually confirmed as soon as SDK Registry would make new binaries publicly available. As an aditional layer of defence, the new `release-worktrail-validation` job would try to download binaries during 30 minutes timeframe. That job also uses the cheapest instance of docker image.
- Restrict ~/.netrc permissions to `0600` – that was required by CocoaPods.
- New `release-tags-filter` YAML anchor to make release-only job filters.

### Additional notes
I want to leave some notes about the original implementation of CI integration. My initial intend was to run checks exclusively for PRs into the `release/v*` branches. However, CircleCI doesn't expose environment variable of base PR branch. I was able to track it down with the power of GitHub API:

```shell
CIRCLE_PR_TARGET_BRANCH=$(GITHUB_TOKEN=$(mbx-ci github reader token) gh pr view $CIRCLE_PR_NUMBER --json baseRefName -q ".baseRefName")
```



## Pull request checklist:
 - [x] Briefly describe the changes in this PR.



PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: https://github.com/mapbox/mapbox-maps-ios-internal/issues/370