### PR TITLE
Set location for 2D puck when accuracy is reduced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
     ([#902])(https://github.com/mapbox/mapbox-maps-ios/pull/902)
 * Added `Style.removeTerrain()` to allow removing terrain. ([#918](https://github.com/mapbox/mapbox-maps-ios/pull/918))
 * `Snapshotter` initialization now triggers a turnstyle event. ([#908](https://github.com/mapbox/mapbox-maps-ios/pull/908))
+* Fixed a bug where 2D puck location was never set when location accuracy authorization was reduced. ([#989](https://github.com/mapbox/mapbox-maps-ios/pull/989))
 
 ## 10.2.0 - December 15, 2021
 * Update to MapboxCoreMaps 10.2.0 and MapboxCommon 21.0.1. ([#952](https://github.com/mapbox/mapbox-maps-ios/pull/952))

--- a/Sources/MapboxMaps/Location/Puck/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck2D.swift
@@ -80,6 +80,11 @@ internal final class Puck2D: NSObject, Puck {
             return
         }
         var layer = LocationIndicatorLayer(id: Self.layerID)
+        layer.location = .constant([
+            location.coordinate.latitude,
+            location.coordinate.longitude,
+            location.location.altitude
+        ])
         switch location.accuracyAuthorization {
         case .fullAccuracy:
             layer.topImage = .constant(.name(Self.topImageId))
@@ -87,11 +92,6 @@ internal final class Puck2D: NSObject, Puck {
             if configuration.shadowImage != nil {
                 layer.shadowImage = .constant(.name(Self.shadowImageId))
             }
-            layer.location = .constant([
-                location.coordinate.latitude,
-                location.coordinate.longitude,
-                location.location.altitude
-            ])
             layer.locationTransition = StyleTransition(duration: 0.5, delay: 0)
             layer.topImageSize = configuration.resolvedScale
             layer.bearingImageSize = configuration.resolvedScale

--- a/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
@@ -316,6 +316,11 @@ final class Puck2DTests: XCTestCase {
         puck2D.isActive = true
 
         var expectedLayer = LocationIndicatorLayer(id: "puck")
+        expectedLayer.location = .constant([
+            location.coordinate.latitude,
+            location.coordinate.longitude,
+            location.altitude
+        ])
         expectedLayer.accuracyRadius = .expression(Exp(.interpolate) {
             Exp(.linear)
             Exp(.zoom)
@@ -354,6 +359,11 @@ final class Puck2DTests: XCTestCase {
         let originalKeys = try originalLayer.jsonObject().keys
 
         var expectedLayer = LocationIndicatorLayer(id: "puck")
+        expectedLayer.location = .constant([
+            location.coordinate.latitude,
+            location.coordinate.longitude,
+            location.altitude
+        ])
         expectedLayer.accuracyRadius = .expression(Exp(.interpolate) {
             Exp(.linear)
             Exp(.zoom)


### PR DESCRIPTION
Fixes #983

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Update the changelog

### Summary of changes

Fixes a bug where 2D puck location was never set when location accuracy authorization was reduced.