### PR TITLE
Fix bug with setting options on LocationManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Added `Style.removeTerrain()` to allow removing terrain. ([#918](https://github.com/mapbox/mapbox-maps-ios/pull/918))
 * `Snapshotter` initialization now triggers a turnstyle event. ([#908](https://github.com/mapbox/mapbox-maps-ios/pull/908))
 * Fixed a bug where 2D puck location was never set when location accuracy authorization was reduced. ([#989](https://github.com/mapbox/mapbox-maps-ios/pull/989))
+* Fixed a bug where setting LocationManager.options would cause the LocationProvider to be reconfigured. ([#992](https://github.com/mapbox/mapbox-maps-ios/pull/992))
 
 ## 10.2.0 - December 15, 2021
 * Update to MapboxCoreMaps 10.2.0 and MapboxCommon 21.0.1. ([#952](https://github.com/mapbox/mapbox-maps-ios/pull/952))

--- a/Sources/MapboxMaps/Location/LocationManager.swift
+++ b/Sources/MapboxMaps/Location/LocationManager.swift
@@ -74,7 +74,15 @@ public final class LocationManager: NSObject {
     }
 
     private func syncOptions() {
-        locationProducer.locationProvider.locationProviderOptions = options
+        // workaround to avoid calling LocationProducer.locationProvider's didSet
+        // when locationProvider is a class. In next major version, we should constrain
+        // LocationProvider to always be a class.
+        if type(of: locationProducer.locationProvider) is AnyClass {
+            var provider = locationProducer.locationProvider
+            provider.locationProviderOptions = options
+        } else {
+            locationProducer.locationProvider.locationProviderOptions = options
+        }
         puckManager.puckType = options.puckType
         puckManager.puckBearingSource = options.puckBearingSource
     }

--- a/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
@@ -71,6 +71,21 @@ final class LocationManagerTests: XCTestCase {
         XCTAssertEqual(puckManager.puckBearingSource, options.puckBearingSource)
     }
 
+    func testOptionsPropagationDoesNotInvokeLocationProviderSetterWhenItIsAClass() {
+        locationManager.options = LocationOptions()
+
+        XCTAssertTrue(locationProducer.didSetLocationProviderStub.invocations.isEmpty)
+    }
+
+    func testOptionsPropagationDoesInvokeLocationProviderSetterWhenItIsAValueType() {
+        locationManager.overrideLocationProvider(with: MockLocationProviderStruct())
+        locationProducer.didSetLocationProviderStub.reset()
+
+        locationManager.options = LocationOptions()
+
+        XCTAssertEqual(locationProducer.didSetLocationProviderStub.invocations.count, 1)
+    }
+
     func testOverrideLocationProvider() {
         let customLocationProvider = MockLocationProvider()
 

--- a/Tests/MapboxMapsTests/Location/Mocks/MockLocationProducer.swift
+++ b/Tests/MapboxMapsTests/Location/Mocks/MockLocationProducer.swift
@@ -9,7 +9,12 @@ final class MockLocationProducer: LocationProducerProtocol {
 
     var consumers = NSHashTable<LocationConsumer>.weakObjects()
 
-    var locationProvider: LocationProvider = MockLocationProvider()
+    let didSetLocationProviderStub = Stub<LocationProvider, Void>()
+    var locationProvider: LocationProvider = MockLocationProvider() {
+        didSet {
+            didSetLocationProviderStub.call(with: locationProvider)
+        }
+    }
 
     let addStub = Stub<LocationConsumer, Void>()
     func add(_ consumer: LocationConsumer) {

--- a/Tests/MapboxMapsTests/Location/Mocks/MockLocationProvider.swift
+++ b/Tests/MapboxMapsTests/Location/Mocks/MockLocationProvider.swift
@@ -58,3 +58,43 @@ final class MockLocationProvider: LocationProvider {
         dismissHeadingCalibrationDisplayStub.call()
     }
 }
+
+struct MockLocationProviderStruct: LocationProvider {
+
+    var locationProviderOptions = LocationOptions()
+
+    var authorizationStatus: CLAuthorizationStatus = .notDetermined
+
+    var accuracyAuthorization: CLAccuracyAuthorization = .fullAccuracy
+
+    var heading: CLHeading?
+
+    var headingOrientation: CLDeviceOrientation = .unknown
+
+    func setDelegate(_ delegate: LocationProviderDelegate) {
+    }
+
+    func requestAlwaysAuthorization() {
+    }
+
+    func requestWhenInUseAuthorization() {
+    }
+
+    func requestTemporaryFullAccuracyAuthorization(withPurposeKey purposeKey: String) {
+    }
+
+    func startUpdatingLocation() {
+    }
+
+    func stopUpdatingLocation() {
+    }
+
+    func startUpdatingHeading() {
+    }
+
+    func stopUpdatingHeading() {
+    }
+
+    func dismissHeadingCalibrationDisplay() {
+    }
+}


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Update the changelog

### Summary of changes

LocationProvider is not constrained to be a class, so when syncOptions() was called, it triggered the setter for the property that stored it rather than merely setting a property on the object itself. This caused the location provider to be stopped and restarted and have its delegate reconfigured each time options were set on LocationManager.

In v11, let's plan to constrain LocationProvider to AnyObject and remove this workaround.