### PR TITLE
Viewport refinements

### DIFF
--- a/Sources/MapboxMaps/Viewport/States/FollowPuck/FollowPuckViewportStateDataSource.swift
+++ b/Sources/MapboxMaps/Viewport/States/FollowPuck/FollowPuckViewportStateDataSource.swift
@@ -46,7 +46,7 @@ internal final class FollowPuckViewportStateDataSource: NSObject, FollowPuckView
             center: location.location.coordinate,
             padding: options.padding,
             zoom: options.zoom,
-            bearing: options.bearing.evaluate(with: location),
+            bearing: options.bearing?.evaluate(with: location),
             pitch: options.pitch)
     }
 

--- a/Sources/MapboxMaps/Viewport/States/FollowPuck/FollowPuckViewportStateOptions.swift
+++ b/Sources/MapboxMaps/Viewport/States/FollowPuck/FollowPuckViewportStateOptions.swift
@@ -1,30 +1,32 @@
 @_spi(Experimental) public struct FollowPuckViewportStateOptions: Hashable {
-    public var zoom: CGFloat
-    public var pitch: CGFloat
-    public var bearing: FollowPuckViewportStateBearing
-    public var padding: UIEdgeInsets
+    public var padding: UIEdgeInsets?
+    public var zoom: CGFloat?
+    public var bearing: FollowPuckViewportStateBearing?
+    public var pitch: CGFloat?
     public var animationDuration: TimeInterval
 
-    public init(zoom: CGFloat = 15,
-                pitch: CGFloat = 40,
-                bearing: FollowPuckViewportStateBearing = .constant(0),
-                padding: UIEdgeInsets = .zero,
+    public init(padding: UIEdgeInsets? = .zero,
+                zoom: CGFloat? = 16.35,
+                bearing: FollowPuckViewportStateBearing? = .heading,
+                pitch: CGFloat? = 45,
                 animationDuration: TimeInterval = 1) {
-        self.zoom = zoom
-        self.pitch = pitch
-        self.bearing = bearing
         self.padding = padding
+        self.zoom = zoom
+        self.bearing = bearing
+        self.pitch = pitch
         self.animationDuration = animationDuration
     }
 
     public func hash(into hasher: inout Hasher) {
+        if let padding = padding {
+            hasher.combine(padding.top)
+            hasher.combine(padding.left)
+            hasher.combine(padding.bottom)
+            hasher.combine(padding.right)
+        }
         hasher.combine(zoom)
-        hasher.combine(pitch)
         hasher.combine(bearing)
-        hasher.combine(padding.top)
-        hasher.combine(padding.left)
-        hasher.combine(padding.bottom)
-        hasher.combine(padding.right)
+        hasher.combine(pitch)
         hasher.combine(animationDuration)
     }
 }

--- a/Sources/MapboxMaps/Viewport/States/Overview/OverviewViewportState.swift
+++ b/Sources/MapboxMaps/Viewport/States/Overview/OverviewViewportState.swift
@@ -43,7 +43,7 @@ import Turf
         observableCameraOptions.notify(with: mapboxMap.camera(
             for: options.geometry,
             padding: options.padding,
-            bearing: CGFloat(options.bearing),
+            bearing: options.bearing.map(CGFloat.init(_:)),
             pitch: options.pitch))
     }
 

--- a/Sources/MapboxMaps/Viewport/States/Overview/OverviewViewportStateOptions.swift
+++ b/Sources/MapboxMaps/Viewport/States/Overview/OverviewViewportStateOptions.swift
@@ -4,14 +4,14 @@ import CoreLocation
 @_spi(Experimental) public struct OverviewViewportStateOptions: Equatable {
     public var geometry: Geometry
     public var padding: UIEdgeInsets
-    public var bearing: CLLocationDirection
-    public var pitch: CGFloat
+    public var bearing: CLLocationDirection?
+    public var pitch: CGFloat?
     public var animationDuration: TimeInterval
 
     public init(geometry: GeometryConvertible,
                 padding: UIEdgeInsets = .zero,
-                bearing: CLLocationDirection = 0,
-                pitch: CGFloat = 0,
+                bearing: CLLocationDirection? = 0,
+                pitch: CGFloat? = 0,
                 animationDuration: TimeInterval = 1) {
         self.geometry = geometry.geometry
         self.padding = padding

--- a/Sources/MapboxMaps/Viewport/ViewportImpl.swift
+++ b/Sources/MapboxMaps/Viewport/ViewportImpl.swift
@@ -74,7 +74,7 @@ internal final class ViewportImpl: ViewportImplProtocol {
     // MARK: - Changing States
 
     internal func idle() {
-        idle(invokingCancelable: true, reason: .programmatic)
+        idle(invokingCancelable: true, reason: .idleRequested)
     }
 
     private func idle(invokingCancelable: Bool, reason: ViewportStatusChangeReason) {
@@ -159,10 +159,10 @@ internal final class ViewportImpl: ViewportImplProtocol {
                     self.notifyObservers(
                         withFromStatus: fromStatus,
                         toStatus: self.status,
-                        reason: .programmatic)
+                        reason: .transitionSucceeded)
                 } else {
                     // the transition failed for some reason (e.g. its animations were canceled externally)
-                    self.idle(invokingCancelable: false, reason: .programmatic)
+                    self.idle(invokingCancelable: false, reason: .transitionFailed)
                 }
             }
 
@@ -188,7 +188,7 @@ internal final class ViewportImpl: ViewportImplProtocol {
             notifyObservers(
                 withFromStatus: fromStatus,
                 toStatus: status,
-                reason: .programmatic)
+                reason: .transitionStarted)
         }
     }
 

--- a/Sources/MapboxMaps/Viewport/ViewportStatusObserver.swift
+++ b/Sources/MapboxMaps/Viewport/ViewportStatusObserver.swift
@@ -4,16 +4,20 @@
                                  reason: ViewportStatusChangeReason)
 }
 
-@_spi(Experimental) public struct ViewportStatusChangeReason: RawRepresentable, Hashable {
-    public typealias RawValue = String
+@_spi(Experimental) public struct ViewportStatusChangeReason: Hashable {
+    private var rawValue: String
 
-    public var rawValue: String
-
-    public init(rawValue: String) {
+    private init(rawValue: String) {
         self.rawValue = rawValue
     }
 
-    public static let programmatic = ViewportStatusChangeReason(rawValue: "PROGRAMMATIC")
+    public static let idleRequested = ViewportStatusChangeReason(rawValue: "IDLE_REQUESTED")
+
+    public static let transitionStarted = ViewportStatusChangeReason(rawValue: "TRANSITION_STARTED")
+
+    public static let transitionSucceeded = ViewportStatusChangeReason(rawValue: "TRANSITION_SUCCEEDED")
+
+    public static let transitionFailed = ViewportStatusChangeReason(rawValue: "TRANSITION_FAILED")
 
     public static let userInteraction = ViewportStatusChangeReason(rawValue: "USER_INTERACTION")
 }

--- a/Tests/MapboxMapsTests/Viewport/States/FollowPuck/FollowPuckViewportStateDataSoruceTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/States/FollowPuck/FollowPuckViewportStateDataSoruceTests.swift
@@ -40,7 +40,7 @@ final class FollowPuckViewportStateDataSourceTests: XCTestCase {
             center: location.location.coordinate,
             padding: options.padding,
             zoom: options.zoom,
-            bearing: options.bearing.evaluate(with: location),
+            bearing: options.bearing?.evaluate(with: location),
             pitch: options.pitch)
     }
 

--- a/Tests/MapboxMapsTests/Viewport/States/FollowPuck/FollowPuckViewportStateOptionsTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/States/FollowPuck/FollowPuckViewportStateOptionsTests.swift
@@ -5,31 +5,31 @@ final class FollowPuckViewportStateOptionsTests: XCTestCase {
     func testInitializerDefaultParameters() {
         let options = FollowPuckViewportStateOptions()
 
-        XCTAssertEqual(options.zoom, 15)
-        XCTAssertEqual(options.pitch, 40)
-        XCTAssertEqual(options.bearing, .constant(0))
         XCTAssertEqual(options.padding, .zero)
+        XCTAssertEqual(options.zoom, 16.35)
+        XCTAssertEqual(options.bearing, .heading)
+        XCTAssertEqual(options.pitch, 45)
         XCTAssertEqual(options.animationDuration, 1)
     }
 
     func testInitializer() {
-        let zoom = CGFloat.random(in: 0...20)
-        let pitch = CGFloat.random(in: 0...80)
-        let bearing = FollowPuckViewportStateBearing.random()
         let padding = UIEdgeInsets.random()
+        let zoom = CGFloat.random(in: 0...20)
+        let bearing = FollowPuckViewportStateBearing.random()
+        let pitch = CGFloat.random(in: 0...80)
         let animationDuration = TimeInterval.random(in: 0...10)
 
         let options = FollowPuckViewportStateOptions(
-            zoom: zoom,
-            pitch: pitch,
-            bearing: bearing,
             padding: padding,
+            zoom: zoom,
+            bearing: bearing,
+            pitch: pitch,
             animationDuration: animationDuration)
 
-        XCTAssertEqual(options.zoom, zoom)
-        XCTAssertEqual(options.pitch, pitch)
-        XCTAssertEqual(options.bearing, bearing)
         XCTAssertEqual(options.padding, padding)
+        XCTAssertEqual(options.zoom, zoom)
+        XCTAssertEqual(options.bearing, bearing)
+        XCTAssertEqual(options.pitch, pitch)
         XCTAssertEqual(options.animationDuration, animationDuration)
     }
 
@@ -45,37 +45,72 @@ final class FollowPuckViewportStateOptionsTests: XCTestCase {
     }
 
     func testEquatableAndHashable() {
-        var options1 = FollowPuckViewportStateOptions.random()
-        options1.bearing = .constant(0)
+        let options1 = FollowPuckViewportStateOptions(
+            padding: .random(),
+            zoom: .random(in: 0...20),
+            bearing: .constant(0),
+            pitch: .random(in: 0...80),
+            animationDuration: .random(in: -2...2))
         var options2 = options1
         verifyEqual(options1, options1)
 
         options2 = options1
-        options2.zoom += .random(in: 1...10)
+        options2.padding?.top += .random(in: 1...10)
         verifyNotEqual(options1, options2)
 
         options2 = options1
-        options2.pitch += .random(in: 1...10)
+        options2.padding?.left += .random(in: 1...10)
         verifyNotEqual(options1, options2)
 
         options2 = options1
-        options2.bearing = .constant(.random(in: 0...10))
+        options2.padding?.bottom += .random(in: 1...10)
         verifyNotEqual(options1, options2)
 
         options2 = options1
-        options2.padding.top += .random(in: 1...10)
+        options2.padding?.right += .random(in: 1...10)
         verifyNotEqual(options1, options2)
 
         options2 = options1
-        options2.padding.left += .random(in: 1...10)
+        options2.zoom? += .random(in: 1...10)
         verifyNotEqual(options1, options2)
 
         options2 = options1
-        options2.padding.bottom += .random(in: 1...10)
+        options2.bearing = .constant(.random(in: 1...10))
         verifyNotEqual(options1, options2)
 
         options2 = options1
-        options2.padding.right += .random(in: 1...10)
+        options2.pitch? += .random(in: 1...10)
+        verifyNotEqual(options1, options2)
+
+        options2 = options1
+        options2.animationDuration += .random(in: 1...10)
+        verifyNotEqual(options1, options2)
+    }
+
+    func testEquatableAndHashableWithNils() {
+        let options1 = FollowPuckViewportStateOptions(
+            padding: nil,
+            zoom: nil,
+            bearing: nil,
+            pitch: nil,
+            animationDuration: .random(in: -2...2))
+        var options2 = options1
+        verifyEqual(options1, options1)
+
+        options2 = options1
+        options2.padding = .random()
+        verifyNotEqual(options1, options2)
+
+        options2 = options1
+        options2.zoom = .random(in: 1...10)
+        verifyNotEqual(options1, options2)
+
+        options2 = options1
+        options2.bearing = .constant(.random(in: 1...10))
+        verifyNotEqual(options1, options2)
+
+        options2 = options1
+        options2.pitch = .random(in: 1...10)
         verifyNotEqual(options1, options2)
 
         options2 = options1

--- a/Tests/MapboxMapsTests/Viewport/States/FollowPuck/Random/FollowPuckViewportStateOptions+Random.swift
+++ b/Tests/MapboxMapsTests/Viewport/States/FollowPuck/Random/FollowPuckViewportStateOptions+Random.swift
@@ -3,10 +3,10 @@
 extension FollowPuckViewportStateOptions {
     static func random() -> Self {
         return FollowPuckViewportStateOptions(
-            zoom: .random(in: 0...20),
-            pitch: .random(in: 0...80),
-            bearing: .random(),
-            padding: .random(),
+            padding: .random(.random()),
+            zoom: .random(.random(in: 0...20)),
+            bearing: .random(.random()),
+            pitch: .random(.random(in: 0...80)),
             animationDuration: .random(in: -2...2))
     }
 }

--- a/Tests/MapboxMapsTests/Viewport/States/Overview/OverviewViewportStateOptionsTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/States/Overview/OverviewViewportStateOptionsTests.swift
@@ -23,8 +23,8 @@ final class OverviewViewportStateOptionsTests: XCTestCase {
             LineString([.random(), .random()])
         ].randomElement()!
         let padding = UIEdgeInsets.random()
-        let bearing = CLLocationDirection.random(in: 0..<360)
-        let pitch = CGFloat.random(in: 0...80)
+        let bearing = CLLocationDirection?.random(.random(in: 0..<360))
+        let pitch = CGFloat?.random(.random(in: 0...80))
         let animationDuration = TimeInterval.random(in: 0..<10)
 
         let options = OverviewViewportStateOptions(

--- a/Tests/MapboxMapsTests/Viewport/States/Overview/OverviewViewportStateTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/States/Overview/OverviewViewportStateTests.swift
@@ -43,7 +43,7 @@ final class OverviewViewportStateTest: XCTestCase {
         let cameraForInvocation = try XCTUnwrap(mapboxMap.cameraForGeometryStub.invocations.first)
         XCTAssertEqual(cameraForInvocation.parameters.geometry, options.geometry)
         XCTAssertEqual(cameraForInvocation.parameters.padding, options.padding)
-        XCTAssertEqual(cameraForInvocation.parameters.bearing, CGFloat(options.bearing))
+        XCTAssertEqual(cameraForInvocation.parameters.bearing, options.bearing.map(CGFloat.init(_:)))
         XCTAssertEqual(cameraForInvocation.parameters.pitch, options.pitch)
 
         XCTAssertEqual(observableCameraOptions.notifyStub.invocations.map(\.parameters), [cameraForInvocation.returnValue])

--- a/Tests/MapboxMapsTests/Viewport/States/Overview/Random/OverviewViewportStateOptions+Random.swift
+++ b/Tests/MapboxMapsTests/Viewport/States/Overview/Random/OverviewViewportStateOptions+Random.swift
@@ -5,8 +5,8 @@ extension OverviewViewportStateOptions {
         return OverviewViewportStateOptions(
             geometry: Point(.random()),
             padding: .random(),
-            bearing: .random(in: 0..<360),
-            pitch: .random(in: 0...80),
+            bearing: .random(.random(in: 0..<360)),
+            pitch: .random(.random(in: 0...80)),
             animationDuration: .random(in: 0..<10))
     }
 }

--- a/Tests/MapboxMapsTests/Viewport/ViewportImplTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/ViewportImplTests.swift
@@ -116,7 +116,7 @@ final class ViewportImplTests: XCTestCase {
         XCTAssertEqual(viewportImpl.status, transitionStatus)
         XCTAssertEqual(
             statusObserver.viewportStatusDidChangeStub.invocations.map(\.parameters),
-            [.init(fromStatus: fromState.map(ViewportStatus.state) ?? .idle, toStatus: viewportImpl.status, reason: .programmatic)])
+            [.init(fromStatus: fromState.map(ViewportStatus.state) ?? .idle, toStatus: viewportImpl.status, reason: .transitionStarted)])
         statusObserver.viewportStatusDidChangeStub.reset()
         XCTAssertEqual(expectedTransition.runStub.invocations.count, 1)
         let runInvocation = try XCTUnwrap(expectedTransition.runStub.invocations.first)
@@ -134,7 +134,7 @@ final class ViewportImplTests: XCTestCase {
         XCTAssertEqual(viewportImpl.status, .state(toState))
         XCTAssertEqual(
             statusObserver.viewportStatusDidChangeStub.invocations.map(\.parameters),
-            [.init(fromStatus: transitionStatus, toStatus: .state(toState), reason: .programmatic)])
+            [.init(fromStatus: transitionStatus, toStatus: .state(toState), reason: .transitionSucceeded)])
     }
 
     func testTransitionToStateFromNilUsingDefaultTransition() throws {
@@ -218,10 +218,10 @@ final class ViewportImplTests: XCTestCase {
             statusObserver.viewportStatusDidChangeStub.invocations.map(\.parameters),
             [.init(fromStatus: .idle,
                    toStatus: .transition(defaultTransition, toState: stateA),
-                   reason: .programmatic),
+                   reason: .transitionStarted),
              .init(fromStatus: .transition(defaultTransition, toState: stateA),
                    toStatus: .transition(defaultTransition, toState: stateB),
-                   reason: .programmatic)])
+                   reason: .transitionStarted)])
 
         // idle to ensure that the correct final cancelable was stored
         idleAndNotify()
@@ -249,18 +249,18 @@ final class ViewportImplTests: XCTestCase {
             statusObserver.viewportStatusDidChangeStub.invocations.map(\.parameters),
             [.init(fromStatus: .idle,
                    toStatus: .transition(defaultTransition, toState: stateA),
-                   reason: .programmatic),
+                   reason: .transitionStarted),
              .init(fromStatus: .transition(defaultTransition, toState: stateA),
                    toStatus: .transition(defaultTransition, toState: stateB),
-                   reason: .programmatic)])
+                   reason: .transitionStarted)])
         XCTAssertEqual(
             observer2.viewportStatusDidChangeStub.invocations.map(\.parameters),
             [.init(fromStatus: .idle,
                    toStatus: .transition(defaultTransition, toState: stateA),
-                   reason: .programmatic),
+                   reason: .transitionStarted),
              .init(fromStatus: .transition(defaultTransition, toState: stateA),
                    toStatus: .transition(defaultTransition, toState: stateB),
-                   reason: .programmatic)])
+                   reason: .transitionStarted)])
     }
 
     func testIdleFromNonNilState() throws {
@@ -273,7 +273,7 @@ final class ViewportImplTests: XCTestCase {
         XCTAssertEqual(viewportImpl.status, .idle)
         XCTAssertEqual(
             statusObserver.viewportStatusDidChangeStub.invocations.map(\.parameters),
-            [.init(fromStatus: .state(fromState), toStatus: .idle, reason: .programmatic)])
+            [.init(fromStatus: .state(fromState), toStatus: .idle, reason: .idleRequested)])
     }
 
     func testIdleFromNilState() {
@@ -352,10 +352,10 @@ final class ViewportImplTests: XCTestCase {
             statusObserver.viewportStatusDidChangeStub.invocations.map(\.parameters),
             [.init(fromStatus: .idle,
                    toStatus: .transition(defaultTransition, toState: stateA),
-                   reason: .programmatic),
+                   reason: .transitionStarted),
              .init(fromStatus: .transition(defaultTransition, toState: stateA),
                    toStatus: .transition(defaultTransition, toState: stateB),
-                   reason: .programmatic)])
+                   reason: .transitionStarted)])
 
         // idle to ensure that the correct final cancelable was stored
         viewportImpl.idle()
@@ -382,10 +382,10 @@ final class ViewportImplTests: XCTestCase {
             statusObserver.viewportStatusDidChangeStub.invocations.map(\.parameters),
             [.init(fromStatus: .idle,
                    toStatus: .transition(defaultTransition, toState: stateA),
-                   reason: .programmatic),
+                   reason: .transitionStarted),
              .init(fromStatus: .transition(defaultTransition, toState: stateA),
                    toStatus: .idle,
-                   reason: .programmatic)])
+                   reason: .idleRequested)])
     }
 
     func testIgnoresViewportTransitionRunCompletionBlockInvocationIfCanceledBySecondTransition() throws {
@@ -419,10 +419,10 @@ final class ViewportImplTests: XCTestCase {
             statusObserver.viewportStatusDidChangeStub.invocations.map(\.parameters),
             [.init(fromStatus: .idle,
                    toStatus: .transition(defaultTransition, toState: stateA),
-                   reason: .programmatic),
+                   reason: .transitionStarted),
              .init(fromStatus: .transition(defaultTransition, toState: stateA),
                    toStatus: .transition(defaultTransition, toState: stateB),
-                   reason: .programmatic)])
+                   reason: .transitionStarted)])
 
         // idle to ensure that the correct final cancelable was stored
         viewportImpl.idle()
@@ -459,10 +459,10 @@ final class ViewportImplTests: XCTestCase {
             statusObserver.viewportStatusDidChangeStub.invocations.map(\.parameters),
             [.init(fromStatus: .idle,
                    toStatus: .transition(defaultTransition, toState: state),
-                   reason: .programmatic),
+                   reason: .transitionStarted),
              .init(fromStatus: .transition(defaultTransition, toState: state),
                    toStatus: .idle,
-                   reason: .programmatic)])
+                   reason: .idleRequested)])
     }
 
     func testViewportTransitionRunFailureResultsInIdleStatus() throws {
@@ -485,10 +485,10 @@ final class ViewportImplTests: XCTestCase {
             statusObserver.viewportStatusDidChangeStub.invocations.map(\.parameters),
             [.init(fromStatus: .idle,
                    toStatus: .transition(defaultTransition, toState: state),
-                   reason: .programmatic),
+                   reason: .transitionStarted),
              .init(fromStatus: .transition(defaultTransition, toState: state),
                    toStatus: .idle,
-                   reason: .programmatic)])
+                   reason: .transitionFailed)])
     }
 
     func testDefaultTransitionInitialization() {


### PR DESCRIPTION
## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes

* Replaced `ViewportStatusChangeReason.programmatic` with `.idleRequested`, `.transitionStarted`, `.transitionSucceeded`, and `.transitionFailed` to provide extra visibility into what caused the status change
* Reordered the fields of `FollowPuckViewportStateOptions` for consistency with `CameraOptions`
* Updated the default values for `FollowPuckViewportStateOptions` to match Android
* Made `FollowPuckViewportStateOptions.padding`, `.zoom`, `.bearing`, `.pitch`, `OverviewViewportStateOptions.bearing`, and `.pitch` optional to enable easier gestures customization. Specifying `nil` will cause the state to avoid updating that aspect of the camera leaving it open for control by gestures.