### PR TITLE
Add support for accuracy ring color

### DIFF
--- a/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
@@ -58,6 +58,9 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
         // Update puck config
         var configuration = Puck2DConfiguration(topImage: UIImage(named: "star"))
         configuration.showsAccuracyRing = showsAccuracyRing
+        configuration.accuracyRingColor = UIColor.skyBlue
+        configuration.accuracyRingBorderColor = UIColor.lightGray
+
         mapView.location.options.puckType = .puck2D(configuration)
 
         // Update button title

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Refined Viewport API. ([#1040](https://github.com/mapbox/mapbox-maps-ios/pull/1040), [#1050](https://github.com/mapbox/mapbox-maps-ios/pull/1050), [#1058](https://github.com/mapbox/mapbox-maps-ios/pull/1058))
 * Add extension function to show or hide bearing image. ([#980](https://github.com/mapbox/mapbox-maps-ios/pull/980))
 * Updated to MapboxCoreMaps 10.3.0-rc.1 and MapboxCommon 21.1.0-rc.1. ([#1051](https://github.com/mapbox/mapbox-maps-ios/pull/1051))
+* Add APIs to enable customizing 2D puck accuracy ring color. ([#1057](https://github.com/mapbox/mapbox-maps-ios/pull/1057))
 
 ## 10.3.0-beta.1 - January 12, 2022
 

--- a/Sources/MapboxMaps/Location/Puck/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck2D.swift
@@ -102,8 +102,8 @@ internal final class Puck2D: NSObject, Puck {
             layer.bearingTransition = StyleTransition(duration: 0, delay: 0)
             if configuration.showsAccuracyRing {
                 layer.accuracyRadius = .constant(location.horizontalAccuracy)
-                layer.accuracyRadiusColor = .constant(StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
-                layer.accuracyRadiusBorderColor = .constant(StyleColor(.lightGray))
+                layer.accuracyRadiusColor = .constant(StyleColor(configuration.accuracyRingColor))
+                layer.accuracyRadiusBorderColor = .constant(StyleColor(configuration.accuracyRingBorderColor))
             }
             switch puckBearingSource {
             case .heading:
@@ -124,8 +124,8 @@ internal final class Puck2D: NSObject, Puck {
                 8
                 5000
             })
-            layer.accuracyRadiusColor = .constant(StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
-            layer.accuracyRadiusBorderColor = .constant(StyleColor(.lightGray))
+            layer.accuracyRadiusColor = .constant(StyleColor(configuration.accuracyRingColor))
+            layer.accuracyRadiusBorderColor = .constant(StyleColor(configuration.accuracyRingBorderColor))
         }
 
         // LocationIndicatorLayer is a struct, and by default, most of its properties are nil. When it gets

--- a/Sources/MapboxMaps/Location/Puck/PuckType.swift
+++ b/Sources/MapboxMaps/Location/Puck/PuckType.swift
@@ -26,6 +26,12 @@ public struct Puck2DConfiguration: Equatable {
     /// Flag determining if the horizontal accuracy ring should be shown arround the `Puck`. default value is false
     public var showsAccuracyRing: Bool
 
+    /// The color of the accuracy ring.
+    public var accuracyRingColor: UIColor
+
+    /// The color of the accuracy ring border.
+    public var accuracyRingBorderColor: UIColor
+
     /// Initialize a `Puck2D` object with a top image, bearing image, shadow image, scale, and accuracy ring visibility.
     /// - Parameters:
     ///   - topImage: The image to use as the top layer for the location indicator.
@@ -37,12 +43,41 @@ public struct Puck2DConfiguration: Equatable {
                 bearingImage: UIImage? = nil,
                 shadowImage: UIImage? = nil,
                 scale: Value<Double>? = nil,
-                showsAccuracyRing: Bool = false) {
+                showsAccuracyRing: Bool = false
+    ) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage
         self.scale = scale
         self.showsAccuracyRing = showsAccuracyRing
+        self.accuracyRingColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)
+        self.accuracyRingBorderColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)
+    }
+
+    /// Initialize a `Puck2D` object with a top image, bearing image, shadow image, scale, and accuracy ring visibility.
+    /// - Parameters:
+    ///   - topImage: The image to use as the top layer for the location indicator.
+    ///   - bearingImage: The image used as the middle of the location indicator.
+    ///   - shadowImage: The image that acts as a background of the location indicator.
+    ///   - scale: The size of the images, as a scale factor applied to the size of the specified image..
+    ///   - showsAccuracyRing: Indicates whether the location accurary ring should be shown.
+    ///   - accuracyRingColor:The color of the accuracy ring.
+    ///   - accuracyRingBorderColor: The color of the accuracy ring border.
+    public init(topImage: UIImage? = nil,
+                bearingImage: UIImage? = nil,
+                shadowImage: UIImage? = nil,
+                scale: Value<Double>? = nil,
+                showsAccuracyRing: Bool = false,
+                accuracyRingColor: UIColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3),
+                accuracyRingBorderColor: UIColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)
+    ) {
+        self.topImage = topImage
+        self.bearingImage = bearingImage
+        self.shadowImage = shadowImage
+        self.scale = scale
+        self.showsAccuracyRing = showsAccuracyRing
+        self.accuracyRingColor = accuracyRingColor
+        self.accuracyRingBorderColor = accuracyRingBorderColor
     }
 }
 

--- a/Sources/MapboxMaps/Location/Puck/PuckType.swift
+++ b/Sources/MapboxMaps/Location/Puck/PuckType.swift
@@ -43,8 +43,7 @@ public struct Puck2DConfiguration: Equatable {
                 bearingImage: UIImage? = nil,
                 shadowImage: UIImage? = nil,
                 scale: Value<Double>? = nil,
-                showsAccuracyRing: Bool = false
-    ) {
+                showsAccuracyRing: Bool = false) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage
@@ -69,8 +68,7 @@ public struct Puck2DConfiguration: Equatable {
                 scale: Value<Double>? = nil,
                 showsAccuracyRing: Bool = false,
                 accuracyRingColor: UIColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3),
-                accuracyRingBorderColor: UIColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)
-    ) {
+                accuracyRingBorderColor: UIColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage

--- a/Tests/MapboxMapsTests/Helpers/Random/UIColor+Random.swift
+++ b/Tests/MapboxMapsTests/Helpers/Random/UIColor+Random.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+extension UIColor {
+    static func random() -> UIColor {
+        return UIColor(
+            red: .random(in: 0...1),
+            green: .random(in: 0...1),
+            blue: .random(in: 0...1),
+            alpha: .random(in: 0...1))
+    }
+}

--- a/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
@@ -279,7 +279,7 @@ final class Puck2DTests: XCTestCase {
         var expectedLayer = makeExpectedLayer()
         expectedLayer.accuracyRadius = .constant(location.horizontalAccuracy)
         expectedLayer.accuracyRadiusColor = .constant(StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
-        expectedLayer.accuracyRadiusBorderColor = .constant(StyleColor(.lightGray))
+        expectedLayer.accuracyRadiusBorderColor = .constant(StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
         let expectedProperties = try expectedLayer.jsonObject()
         let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.parameters.first?.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
@@ -348,7 +348,7 @@ final class Puck2DTests: XCTestCase {
             5000
         })
         expectedLayer.accuracyRadiusColor = .constant(StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
-        expectedLayer.accuracyRadiusBorderColor = .constant(StyleColor(.lightGray))
+        expectedLayer.accuracyRadiusBorderColor = .constant(StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
         let expectedProperties = try expectedLayer.jsonObject()
         let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.parameters.first?.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
@@ -391,7 +391,7 @@ final class Puck2DTests: XCTestCase {
             5000
         })
         expectedLayer.accuracyRadiusColor = .constant(StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
-        expectedLayer.accuracyRadiusBorderColor = .constant(StyleColor(.lightGray))
+        expectedLayer.accuracyRadiusBorderColor = .constant(StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)))
         var expectedProperties = try expectedLayer.jsonObject()
         for key in originalKeys where expectedProperties[key] == nil {
             expectedProperties[key] = Style.layerPropertyDefaultValue(for: .locationIndicator, property: key)

--- a/Tests/MapboxMapsTests/Location/Puck/PuckTypeTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/PuckTypeTests.swift
@@ -62,4 +62,92 @@ internal class PuckTypeTests: XCTestCase {
 
         XCTAssertNotEqual(puck1, puck2)
     }
+
+    func testPuck2DConfigurationInitializerWithDefaultValues() {
+        let config = Puck2DConfiguration()
+
+        XCTAssertNil(config.topImage)
+        XCTAssertNil(config.bearingImage)
+        XCTAssertNil(config.shadowImage)
+        XCTAssertNil(config.scale)
+        XCTAssertFalse(config.showsAccuracyRing)
+        XCTAssertEqual(config.accuracyRingColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
+        XCTAssertEqual(config.accuracyRingBorderColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
+    }
+
+    func testPuck2DConfigurationInitializerWithNonDefaultValues() {
+        let topImage: UIImage? = .random(UIImage())
+        let bearingImage: UIImage? = .random(UIImage())
+        let shadowImage: UIImage? = .random(UIImage())
+        let scale: Value<Double>? = .random(.constant(.random(in: 0...10)))
+        let showsAccuracyRing: Bool = .random()
+
+        let config = Puck2DConfiguration(
+            topImage: topImage,
+            bearingImage: bearingImage,
+            shadowImage: shadowImage,
+            scale: scale,
+            showsAccuracyRing: showsAccuracyRing)
+
+        XCTAssertTrue(config.topImage === topImage)
+        XCTAssertTrue(config.bearingImage === bearingImage)
+        XCTAssertTrue(config.shadowImage === shadowImage)
+        XCTAssertEqual(config.scale, scale)
+        XCTAssertEqual(config.showsAccuracyRing, showsAccuracyRing)
+        XCTAssertEqual(config.accuracyRingColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
+        XCTAssertEqual(config.accuracyRingBorderColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
+    }
+
+    func testPuck2DConfigurationExtendedInitializerWithDefaultValues() {
+        // need to specify on of the extended params for swift to pick
+        // this overload
+        let config = Puck2DConfiguration(
+            accuracyRingColor: .black)
+
+        XCTAssertNil(config.topImage)
+        XCTAssertNil(config.bearingImage)
+        XCTAssertNil(config.shadowImage)
+        XCTAssertNil(config.scale)
+        XCTAssertFalse(config.showsAccuracyRing)
+        XCTAssertEqual(config.accuracyRingColor, .black)
+        XCTAssertEqual(config.accuracyRingBorderColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
+
+        let config2 = Puck2DConfiguration(
+            accuracyRingBorderColor: .black)
+
+        XCTAssertNil(config2.topImage)
+        XCTAssertNil(config2.bearingImage)
+        XCTAssertNil(config2.shadowImage)
+        XCTAssertNil(config2.scale)
+        XCTAssertFalse(config2.showsAccuracyRing)
+        XCTAssertEqual(config2.accuracyRingColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
+        XCTAssertEqual(config2.accuracyRingBorderColor, .black)
+    }
+
+    func testPuck2DConfigurationExtendedInitializerWithNonDefaultValues() {
+        let topImage: UIImage? = .random(UIImage())
+        let bearingImage: UIImage? = .random(UIImage())
+        let shadowImage: UIImage? = .random(UIImage())
+        let scale: Value<Double>? = .random(.constant(.random(in: 0...10)))
+        let showsAccuracyRing: Bool = .random()
+        let accuracyRingColor: UIColor = .random()
+        let accuracyRingBorderColor: UIColor = .random()
+
+        let config = Puck2DConfiguration(
+            topImage: topImage,
+            bearingImage: bearingImage,
+            shadowImage: shadowImage,
+            scale: scale,
+            showsAccuracyRing: showsAccuracyRing,
+            accuracyRingColor: accuracyRingColor,
+            accuracyRingBorderColor: accuracyRingBorderColor)
+
+        XCTAssertTrue(config.topImage === topImage)
+        XCTAssertTrue(config.bearingImage === bearingImage)
+        XCTAssertTrue(config.shadowImage === shadowImage)
+        XCTAssertEqual(config.scale, scale)
+        XCTAssertEqual(config.showsAccuracyRing, showsAccuracyRing)
+        XCTAssertEqual(config.accuracyRingColor, accuracyRingColor)
+        XCTAssertEqual(config.accuracyRingBorderColor, accuracyRingBorderColor)
+    }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog>Add the support for accuracy ring color and accuracy ring border color</changelog>`.
 - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc

### Summary of changes
This PR add the support for accuracy ring color and accuracy ring border color
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->
