### PR TITLE
End AnyTouchGestureRecognizer in .changed state

### DIFF
--- a/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
+++ b/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
@@ -93,7 +93,6 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
     }
 
     func makeAnyTouchGestureHandler(view: UIView,
-                                    mapboxMap: MapboxMapProtocol,
                                     cameraAnimationsManager: CameraAnimationsManagerProtocol) -> GestureHandler {
         // 0.15 seconds is a sufficient delay to avoid interrupting animations
         // in between a rapid succession of double tap or double touch gestures.
@@ -140,7 +139,6 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
                 mapboxMap: mapboxMap),
             anyTouchGestureHandler: makeAnyTouchGestureHandler(
                 view: view,
-                mapboxMap: mapboxMap,
                 cameraAnimationsManager: cameraAnimationsManager),
             mapboxMap: mapboxMap)
     }

--- a/Sources/MapboxMaps/Gestures/GestureRecognizers/AnyTouchGestureRecognizer.swift
+++ b/Sources/MapboxMaps/Gestures/GestureRecognizers/AnyTouchGestureRecognizer.swift
@@ -18,8 +18,15 @@ internal final class AnyTouchGestureRecognizer: UIGestureRecognizer {
             } else if !oldValue.isEmpty, touches.isEmpty {
                 timer?.invalidate()
                 timer = nil
-                if state == .began {
+                // handling .changed here because even though
+                // this class never sets state to .changed,
+                // the superclass does so automatically if
+                // the touch input changes after .began
+                switch state {
+                case .began, .changed:
                     state = .ended
+                default:
+                    break
                 }
             }
         }

--- a/Tests/MapboxMapsTests/Gestures/GestureRecognizers/AnyTouchGestureRecognizerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureRecognizers/AnyTouchGestureRecognizerTests.swift
@@ -107,4 +107,28 @@ final class AnyTouchGestureRecognizerTests: XCTestCase {
         XCTAssertEqual(timer.invalidateStub.invocations.count, 1)
         XCTAssertEqual(gestureRecognizer.state, .possible)
     }
+
+    func testTouchHandlingWithChangedTouches() throws {
+        let touch = UITouch()
+        let event = UIEvent()
+
+        // touch 0 begins
+        gestureRecognizer.touchesBegan([touch], with: event)
+
+        // the timer fires
+        let makeTimerInvocation = try XCTUnwrap(timerProvider.makeScheduledTimerStub.invocations.first)
+        makeTimerInvocation.parameters.block(makeTimerInvocation.returnValue)
+
+        // the state changes
+        XCTAssertEqual(gestureRecognizer.state, .began)
+
+        // the state is updated to .changed (UIKit does this automatically,
+        // but for testing purposes, we'll do it manually
+        gestureRecognizer.state = .changed
+
+        // touch 0 ends
+        gestureRecognizer.touchesEnded([touch], with: event)
+
+        XCTAssertEqual(gestureRecognizer.state, .ended)
+    }
 }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'

### Summary of changes

Fixes a regression introduced by #1058 ([link to diff](https://github.com/mapbox/mapbox-maps-ios/pull/1058/files#diff-2419251848f5a902d3779fc3a39b33efe87a7068841e16efc65e70d232494863R21-R23)) that prevented `AnyTouchGestureRecognizer` from ending. This manifested as animations ceasing to work after user interaction.