### PR TITLE
Update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,32 +5,20 @@ Please fill out the sections below to complete your submission.
 
 We appreciate your contributions!
 -->
-PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
-
-Fixes: < Link to related issues that will be fixed by this pull request, if they exist >
-
-## Pull request checklist:
- - [ ] Briefly describe the changes in this PR.
- - [ ] Include before/after visuals or gifs if this PR includes visual changes.
- - [ ] Write tests for all new functionality. If tests were not written, please explain why.
- - [ ] Add example if relevant.
- - [ ] Document any changes to public APIs.
- - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
- - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-ios` changelog: `<changelog></changelog>`.
- - [ ] Update the migration guide, API Docs, Markdown files - Readme, Developing, etc
-
-### Summary of changes
 
 <!--
-What changes does this pull request introduce?
+Describe the changes in this PR here.
 
 • If this is a new feature, include a short summary on how to use it.
 • If this is a bug fix, explain how your contribution resolves the problem.
-• Include a screenshot or gif if applicable
+• Include before/after visuals or gifs if this PR includes visual changes.
+• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
 -->
 
-### User impact (optional)
-
-<!--
-If this PR introduces user-facing changes, please note them here.
--->
+## Pull request checklist:
+ - [ ] Write tests for all new functionality. If tests were not written, please explain why.
+ - [ ] Add documentation comments for any added or updated public APIs.
+ - [ ] Describe the changes in this PR, especially public API changes.
+ - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
+ - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
+ - [ ] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).


### PR DESCRIPTION
Trying to streamline PR creation…

* CLA info moved into PR checklist.
* Separated documentation comment checklist item from guides/markdown files since it's more commonly needed.
* Removed checklist item about visuals since it's covered in the comment under Description of changes.
* Removed the suggestion that the PR description should be brief. Brevity hasn't been a problem. If anything, I'd like a bit more thoroughness when describing changes so that we have a better record for future reference.
* Removed the changelog label and changelog entry mechanism. We're not using it, and we just want folks to be adding changelog entries with each PR right now.
* Noted that guides are only available to employees
* Removed redundant User impact section