### PR TITLE
Update to MapboxCoreMaps 10.3.0

### DIFF
--- a/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "8a63edd2e83fd75ef67bd9450400ecd6d8592d70",
-          "version": "21.1.0-rc.1"
+          "revision": "d0adb996dfad19ed1edc611ee640e6c7506951a0",
+          "version": "21.1.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "cdd47bd2954bda58d87c7becd28e4bd663200907",
-          "version": "10.3.0-rc.1"
+          "revision": "e836e21f4f94e79dfde100b971c5573c6000bb8d",
+          "version": "10.3.0"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+* Updated to MapboxCoreMaps 10.3.0 and MapboxCommon 21.1.0. ([#1078](https://github.com/mapbox/mapbox-maps-ios/pull/1078))
+
 ## 10.3.0-rc.1 – January 26, 2022
 
 * Exposed API to invalidate `OfflineRegion`. ([#1026](https://github.com/mapbox/mapbox-maps-ios/pull/1026))

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -21,8 +21,8 @@ Pod::Spec.new do |m|
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
   m.resources = ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json']
 
-  m.dependency 'MapboxCoreMaps', '10.3.0-rc.1'
-  m.dependency 'MapboxCommon', '21.1.0-rc.1'
+  m.dependency 'MapboxCoreMaps', '10.3.0'
+  m.dependency 'MapboxCommon', '21.1.0'
   m.dependency 'MapboxMobileEvents', '1.0.7'
   m.dependency 'Turf', '~> 2.0'
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "8a63edd2e83fd75ef67bd9450400ecd6d8592d70",
-          "version": "21.1.0-rc.1"
+          "revision": "d0adb996dfad19ed1edc611ee640e6c7506951a0",
+          "version": "21.1.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "cdd47bd2954bda58d87c7becd28e4bd663200907",
-          "version": "10.3.0-rc.1"
+          "revision": "e836e21f4f94e79dfde100b971c5573c6000bb8d",
+          "version": "10.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
             targets: ["MapboxMaps"]),
     ],
     dependencies: [
-        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.3.0-rc.1")),
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("21.1.0-rc.1")),
+        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.3.0")),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("21.1.0")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", .exact("1.0.7")),
         .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.0.0"),
         .package(name: "CocoaImageHashing", url: "https://github.com/ameingast/cocoaimagehashing", .exact("1.9.0"))

--- a/scripts/release/packager/versions.json
+++ b/scripts/release/packager/versions.json
@@ -1,6 +1,6 @@
 {
-	"MapboxCoreMaps": "10.3.0-rc.1",
-	"MapboxCommon": "21.1.0-rc.1",
+	"MapboxCoreMaps": "10.3.0",
+	"MapboxCommon": "21.1.0",
 	"Turf": "v2.1.0",
 	"MapboxMobileEvents": "v1.0.7"
 }


### PR DESCRIPTION
## Features ✨ and improvements 🏁
* Update mapbox-common to v21.1.0
* Improve performance for symbol layout rendering in continuous mode
* Introduce metadata setter API for the legacy offline region
* Optimize zooming on terrain and globe
* Thin out repeated line labels at overscaled tiles in order to avoid excessive memory usage
* Tile cache refrains from eviction of the tiles that are parents for the most recently added tile
* Remove experimental designation from persistent layer APIs
* Avoid re-creation of the available sprites set
* The tile cache clears tiles graphics data before performing the tiles eviction, when budget is set in megabytes
* Delete geometry tiles layout result on worker thread
* When memory budget in megabytes is set, engine will try to use ETC1 compression for raster layer to decrease GPU memory consumption
* Implements depth sorting per mesh and better transparency for models
* Implement Metal MSAA support
* Remove extra deallocations from render tree destructor
* Minor optimization related to globe mesh construction
* Fill extrusion layer support for globe view
* Limit the delayed network request maximum time in the scheduler task queue, and thus avoid excessive memory usage
* Line gradient is pre-calculated on worker thread during bucket creation. Line gradient gets updated only if the line-gradient layer property value is modified
* Increase priority of a renderer thread for Android platform


## Bug fixes 🐞
* Include geometry data buffer size when calculating total size of a tile
* Fix crash at application exit on iOS platform
* Fix screen coordinate queries when using zero pitch and high zoom values
* [Android] View Annotation API: move internal Java files to corresponding package
* vector-tile updated to v1.0.4, fixing an end of buffer exception
* Reduces drag sensitivity around and above horizon
* Erase corrupt tiles from TileStore
* Add perspective correction for non-rectangular images
* Fix rendering artifacts when compressed and un-compresed raster tiles are rendered
* Fix globe rendering artifact on darwin platform when MSAA is enabled
* Fix a crash when using a custom layer on Metal with MSAA disabled
* Fixed terrain occluding 3D location indicator
* Avoid creating new symbol instances if the feature is outside of tile boundaries to avoid incorrect symbol cross tile indexing. In the meanwhile, disable draping for this layer otherwise symbol will only be shown on the tile that has the symbol instance created.
* Fix location indicator layer rendering when SwiftShader is used
* Fix fill extrusion disappearance after render tiles are returned from the tile cache when the source memory budget is set in megabytes