### PR TITLE
Fix compass button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## main
 
 * Updated to MapboxCoreMaps 10.3.0 and MapboxCommon 21.1.0. ([#1078](https://github.com/mapbox/mapbox-maps-ios/pull/1078))
+* Fix compass button regression introduced in rc.1. ([#1083](https://github.com/mapbox/mapbox-maps-ios/pull/1083))
 
 ## 10.3.0-rc.1 – January 26, 2022
 

--- a/Sources/MapboxMaps/Gestures/GestureRecognizers/AnyTouchGestureRecognizer.swift
+++ b/Sources/MapboxMaps/Gestures/GestureRecognizers/AnyTouchGestureRecognizer.swift
@@ -40,6 +40,7 @@ internal final class AnyTouchGestureRecognizer: UIGestureRecognizer {
         self.timerProvider = timerProvider
         super.init(target: nil, action: nil)
         self.cancelsTouchesInView = false
+        self.delaysTouchesEnded = false
     }
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {

--- a/Tests/MapboxMapsTests/Gestures/GestureRecognizers/AnyTouchGestureRecognizerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureRecognizers/AnyTouchGestureRecognizerTests.swift
@@ -25,6 +25,8 @@ final class AnyTouchGestureRecognizerTests: XCTestCase {
 
     func testInitialization() {
         XCTAssertFalse(gestureRecognizer.cancelsTouchesInView)
+        XCTAssertFalse(gestureRecognizer.delaysTouchesBegan)
+        XCTAssertFalse(gestureRecognizer.delaysTouchesEnded)
     }
 
     func testCanBePreventedBy() {


### PR DESCRIPTION
* The delay introduced to AnyTouchGestureRecognizer in #1058 prevented
  touch end events from being delivered to the compass view, which
  broke the interaction where you can tap the compass to set the map
  bearing to 0. This has been resolved by setting delaysTouchesEnded to
  false on AnyTouchGestureRecognizer.

Fixes #1082

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
