### PR TITLE
Remove pitch gesture changed angle requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ Mapbox welcomes participation and contributions from everyone.
 ## main
 
 * Updated to MapboxCoreMaps 10.3.0 and MapboxCommon 21.1.0. ([#1078](https://github.com/mapbox/mapbox-maps-ios/pull/1078))
-* Fix compass button regression introduced in rc.1. ([#1083](https://github.com/mapbox/mapbox-maps-ios/pull/1083))
+* Fixed compass button regression introduced in rc.1. ([#1083](https://github.com/mapbox/mapbox-maps-ios/pull/1083))
+* Removed pitch gesture change angle requirements to avoid map freezing during gesture. ([#1089](https://github.com/mapbox/mapbox-maps-ios/pull/1089))
 
 ## 10.3.0-rc.1 – January 26, 2022
 

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PitchGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PitchGestureHandler.swift
@@ -45,16 +45,10 @@ internal final class PitchGestureHandler: GestureHandler, UIGestureRecognizerDel
             }
 
             let translation = gestureRecognizer.translation(in: view)
-            let translationAngle = angleOfLine(from: .zero, to: translation)
-
-            // If the angle between the touch locations is less than the maximum
-            // AND the translation angle is more than 60 degrees, update the pitch.
-            if touchAngleIsLessThanMaximum(for: gestureRecognizer), abs(translationAngle) > 60 {
-                let verticalGestureTranslation = translation.y
-                let slowDown = CGFloat(2.0)
-                let newPitch = initialPitch - (verticalGestureTranslation / slowDown)
-                mapboxMap.setCamera(to: CameraOptions(pitch: newPitch))
-            }
+            let verticalGestureTranslation = translation.y
+            let slowDown = CGFloat(2.0)
+            let newPitch = initialPitch - (verticalGestureTranslation / slowDown)
+            mapboxMap.setCamera(to: CameraOptions(pitch: newPitch))
         case .ended, .cancelled:
             initialPitch = nil
             delegate?.gestureEnded(for: .pitch, willAnimate: false)

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PitchGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PitchGestureHandlerTests.swift
@@ -87,26 +87,7 @@ final class PitchGestureHandlerTests: XCTestCase {
 
         gestureRecognizer.sendActions()
 
-        XCTAssertEqual(gestureRecognizer.locationOfTouchStub.invocations.count, 2)
-        guard gestureRecognizer.locationOfTouchStub.invocations.count == 2 else {
-            return
-        }
-        XCTAssertEqual(gestureRecognizer.locationOfTouchStub.parameters[0].touchIndex, 0)
-        XCTAssertEqual(gestureRecognizer.locationOfTouchStub.parameters[1].touchIndex, 1)
         XCTAssertEqual(mapboxMap.setCameraStub.parameters, [CameraOptions(pitch: mapboxMap.cameraState.pitch - 12.5)])
-    }
-
-    func testPitchWillNotTrigger() {
-        gestureRecognizer.getStateStub.defaultReturnValue = .began
-        gestureRecognizer.sendActions() // Start gesture to set it to .began
-        gestureRecognizer.getStateStub.defaultReturnValue = .changed
-        gestureRecognizer.locationOfTouchStub.returnValueQueue = [CGPoint(x: 0, y: 0), CGPoint(x: 100, y: .random(in: 100...200))]
-        gestureRecognizer.translationStub.defaultReturnValue = CGPoint(x: 0, y: 25)
-
-        gestureRecognizer.sendActions()
-
-        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 0,
-                       "pitch gesture isn't triggered if touch points equals or exceeds 45°")
     }
 
     func testPitchEnded() throws {


### PR DESCRIPTION
* Once the pitch gesture begins to recognize, there's no value in
  continuing to restrict the angle between the touches or the
  translation angle. Doing so has undesired consequence of making it
  look like the map is freezing and unfreezing when the translation
  or touch angle is crossing their respective thresholds.

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
