### PR TITLE
Update to MapboxCoreMaps 10.3.1

### DIFF
--- a/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "e836e21f4f94e79dfde100b971c5573c6000bb8d",
-          "version": "10.3.0"
+          "revision": "039915474ad635d42f543f93268ba56e301d5286",
+          "version": "10.3.1"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
-* Updated to MapboxCoreMaps 10.3.0 and MapboxCommon 21.1.0. ([#1078](https://github.com/mapbox/mapbox-maps-ios/pull/1078))
+* Updated to MapboxCoreMaps 10.3.1 and MapboxCommon 21.1.0. ([#1091](https://github.com/mapbox/mapbox-maps-ios/pull/1091))
 * Fixed compass button regression introduced in rc.1. ([#1083](https://github.com/mapbox/mapbox-maps-ios/pull/1083))
 * Removed pitch gesture change angle requirements to avoid map freezing during gesture. ([#1089](https://github.com/mapbox/mapbox-maps-ios/pull/1089))
 

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |m|
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
   m.resources = ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json']
 
-  m.dependency 'MapboxCoreMaps', '10.3.0'
+  m.dependency 'MapboxCoreMaps', '10.3.1'
   m.dependency 'MapboxCommon', '21.1.0'
   m.dependency 'MapboxMobileEvents', '1.0.7'
   m.dependency 'Turf', '~> 2.0'

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "e836e21f4f94e79dfde100b971c5573c6000bb8d",
-          "version": "10.3.0"
+          "revision": "039915474ad635d42f543f93268ba56e301d5286",
+          "version": "10.3.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["MapboxMaps"]),
     ],
     dependencies: [
-        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.3.0")),
+        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.3.1")),
         .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("21.1.0")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", .exact("1.0.7")),
         .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.0.0"),

--- a/scripts/release/packager/versions.json
+++ b/scripts/release/packager/versions.json
@@ -1,5 +1,5 @@
 {
-	"MapboxCoreMaps": "10.3.0",
+	"MapboxCoreMaps": "10.3.1",
 	"MapboxCommon": "21.1.0",
 	"Turf": "v2.1.0",
 	"MapboxMobileEvents": "v1.0.7"


### PR DESCRIPTION
## Bug fixes 🐞
* Avoid possible crash at program exit caused by dummy tracer accessed after destruction
* Fix crash for the case when a map event is handled by an Observer of a destructed map

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
