### PR TITLE
Add GestureOptions.pinchPanEnabled and GestureOptions.pinchZoomEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Remove experimental GestureOptions.pinchBehavior property. ([#1125](https://github.com/mapbox/mapbox-maps-ios/pull/1125))
 * Update to MapboxCoreMaps 10.4.0-beta.1 and MapboxCommon 21.2.0-beta.1. ([#1126](https://github.com/mapbox/mapbox-maps-ios/pull/1126))
 * Exposed APIs to allow positioning of other views relative to the logoView, compassView, scaleBarView and attributionButton. ([#1130](https://github.com/mapbox/mapbox-maps-ios/pull/1130))
+* Add `GestureOptions.pinchPanEnabled` and `.pinchZoomEnabled`. ([#1092](https://github.com/mapbox/mapbox-maps-ios/pull/1092))
 
 ## 10.3.0 - February 10, 2022
 

--- a/Sources/MapboxMaps/Foundation/Extensions/FloatingPoint.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/FloatingPoint.swift
@@ -1,6 +1,15 @@
 extension FloatingPoint {
     internal func wrapped(to range: Range<Self>) -> Self {
         let d = range.upperBound - range.lowerBound
-        return fmod((fmod((self - range.lowerBound), d) + d), d) + range.lowerBound
+        return fmod(fmod(self - range.lowerBound, d) + d, d) + range.lowerBound
+    }
+
+    internal func toDegrees() -> Self {
+        return self * 180 / .pi
+    }
+
+    /// Calculates the rotation between two angles in radians. Result is wrapped to [0, 2pi)
+    internal func wrappedAngle(to: Self) -> Self {
+        return (to - self).wrapped(to: 0..<(2 * .pi))
     }
 }

--- a/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
+++ b/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
@@ -61,7 +61,9 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
         view.addGestureRecognizer(gestureRecognizer)
         return PinchGestureHandler(
             gestureRecognizer: gestureRecognizer,
-            mapboxMap: mapboxMap)
+            mapboxMap: mapboxMap,
+            pinchBehaviorProvider: PinchBehaviorProvider(
+                mapboxMap: mapboxMap))
     }
 
     func makePitchGestureHandler(view: UIView,

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/EmptyPinchBehavior.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/EmptyPinchBehavior.swift
@@ -1,0 +1,6 @@
+internal final class EmptyPinchBehavior: PinchBehavior {
+    func update(pinchMidpoint: CGPoint,
+                pinchScale: CGFloat,
+                pinchAngle: CGFloat) {
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/PanPinchBehavior.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/PanPinchBehavior.swift
@@ -1,0 +1,27 @@
+internal final class PanPinchBehavior: PinchBehavior {
+    private let initialCameraState: CameraState
+    private let initialPinchMidpoint: CGPoint
+    private let mapboxMap: MapboxMapProtocol
+
+    internal init(initialCameraState: CameraState,
+                  initialPinchMidpoint: CGPoint,
+                  mapboxMap: MapboxMapProtocol) {
+        self.initialCameraState = initialCameraState
+        self.initialPinchMidpoint = initialPinchMidpoint
+        self.mapboxMap = mapboxMap
+    }
+
+    internal func update(pinchMidpoint: CGPoint,
+                         pinchScale: CGFloat,
+                         pinchAngle: CGFloat) {
+        mapboxMap.setCamera(to: CameraOptions(
+            center: initialCameraState.center))
+
+        mapboxMap.dragStart(for: initialPinchMidpoint)
+        let dragOptions = mapboxMap.dragCameraOptions(
+            from: initialPinchMidpoint,
+            to: pinchMidpoint)
+        mapboxMap.setCamera(to: dragOptions)
+        mapboxMap.dragEnd()
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/PanRotatePinchBehavior.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/PanRotatePinchBehavior.swift
@@ -1,0 +1,41 @@
+internal final class PanRotatePinchBehavior: PinchBehavior {
+    private let initialCameraState: CameraState
+    private let initialPinchMidpoint: CGPoint
+    private let initialPinchAngle: CGFloat
+    private let mapboxMap: MapboxMapProtocol
+
+    internal init(initialCameraState: CameraState,
+                  initialPinchMidpoint: CGPoint,
+                  initialPinchAngle: CGFloat,
+                  mapboxMap: MapboxMapProtocol) {
+        self.initialCameraState = initialCameraState
+        self.initialPinchMidpoint = initialPinchMidpoint
+        self.initialPinchAngle = initialPinchAngle
+        self.mapboxMap = mapboxMap
+    }
+
+    internal func update(pinchMidpoint: CGPoint,
+                         pinchScale: CGFloat,
+                         pinchAngle: CGFloat) {
+        mapboxMap.setCamera(
+            to: CameraOptions(
+                center: initialCameraState.center,
+                bearing: initialCameraState.bearing))
+
+        mapboxMap.dragStart(for: initialPinchMidpoint)
+        let dragOptions = mapboxMap.dragCameraOptions(
+            from: initialPinchMidpoint,
+            to: pinchMidpoint)
+        mapboxMap.setCamera(to: dragOptions)
+        mapboxMap.dragEnd()
+
+        // flip the sign since the UIKit coordinate system is flipped
+        // relative to the coordinate system used for bearing.
+        let bearingIncrement = -initialPinchAngle
+            .wrappedAngle(to: pinchAngle)
+            .toDegrees()
+        mapboxMap.setCamera(to: CameraOptions(
+            anchor: pinchMidpoint,
+            bearing: initialCameraState.bearing + CLLocationDirection(bearingIncrement)))
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/PanZoomPinchBehavior.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/PanZoomPinchBehavior.swift
@@ -1,0 +1,34 @@
+internal final class PanZoomPinchBehavior: PinchBehavior {
+    private let initialCameraState: CameraState
+    private let initialPinchMidpoint: CGPoint
+    private let mapboxMap: MapboxMapProtocol
+
+    internal init(initialCameraState: CameraState,
+                  initialPinchMidpoint: CGPoint,
+                  mapboxMap: MapboxMapProtocol) {
+        self.initialCameraState = initialCameraState
+        self.initialPinchMidpoint = initialPinchMidpoint
+        self.mapboxMap = mapboxMap
+    }
+
+    internal func update(pinchMidpoint: CGPoint,
+                         pinchScale: CGFloat,
+                         pinchAngle: CGFloat) {
+        mapboxMap.setCamera(
+            to: CameraOptions(
+                center: initialCameraState.center,
+                zoom: initialCameraState.zoom))
+
+        mapboxMap.dragStart(for: initialPinchMidpoint)
+        let dragOptions = mapboxMap.dragCameraOptions(
+            from: initialPinchMidpoint,
+            to: pinchMidpoint)
+        mapboxMap.setCamera(to: dragOptions)
+        mapboxMap.dragEnd()
+
+        let zoomIncrement = log2(pinchScale)
+        mapboxMap.setCamera(to: CameraOptions(
+            anchor: pinchMidpoint,
+            zoom: initialCameraState.zoom + zoomIncrement))
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/PanZoomRotatePinchBehavior.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/PanZoomRotatePinchBehavior.swift
@@ -1,0 +1,45 @@
+internal final class PanZoomRotatePinchBehavior: PinchBehavior {
+    private let initialCameraState: CameraState
+    private let initialPinchMidpoint: CGPoint
+    private let initialPinchAngle: CGFloat
+    private let mapboxMap: MapboxMapProtocol
+
+    internal init(initialCameraState: CameraState,
+                  initialPinchMidpoint: CGPoint,
+                  initialPinchAngle: CGFloat,
+                  mapboxMap: MapboxMapProtocol) {
+        self.initialCameraState = initialCameraState
+        self.initialPinchMidpoint = initialPinchMidpoint
+        self.initialPinchAngle = initialPinchAngle
+        self.mapboxMap = mapboxMap
+    }
+
+    internal func update(pinchMidpoint: CGPoint,
+                         pinchScale: CGFloat,
+                         pinchAngle: CGFloat) {
+        mapboxMap.setCamera(
+            to: CameraOptions(
+                center: initialCameraState.center,
+                zoom: initialCameraState.zoom,
+                bearing: initialCameraState.bearing))
+
+        mapboxMap.dragStart(for: initialPinchMidpoint)
+        let dragOptions = mapboxMap.dragCameraOptions(
+            from: initialPinchMidpoint,
+            to: pinchMidpoint)
+        mapboxMap.setCamera(to: dragOptions)
+        mapboxMap.dragEnd()
+
+        let zoomIncrement = log2(pinchScale)
+        // flip the sign since the UIKit coordinate system is flipped
+        // relative to the coordinate system used for bearing.
+        let bearingIncrement = -initialPinchAngle
+            .wrappedAngle(to: pinchAngle)
+            .toDegrees()
+        mapboxMap.setCamera(
+            to: CameraOptions(
+                anchor: pinchMidpoint,
+                zoom: initialCameraState.zoom + zoomIncrement,
+                bearing: initialCameraState.bearing + CLLocationDirection(bearingIncrement)))
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/PinchBehavior.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/PinchBehavior.swift
@@ -1,0 +1,5 @@
+internal protocol PinchBehavior: AnyObject {
+    func update(pinchMidpoint: CGPoint,
+                pinchScale: CGFloat,
+                pinchAngle: CGFloat)
+}

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/PinchBehaviorProvider.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/PinchBehaviorProvider.swift
@@ -1,0 +1,72 @@
+import CoreLocation
+
+internal protocol PinchBehaviorProviderProtocol: AnyObject {
+    // swiftlint:disable:next function_parameter_count
+    func makePinchBehavior(panEnabled: Bool,
+                           zoomEnabled: Bool,
+                           rotateEnabled: Bool,
+                           initialCameraState: CameraState,
+                           initialPinchMidpoint: CGPoint,
+                           initialPinchAngle: CGFloat) -> PinchBehavior
+}
+
+internal final class PinchBehaviorProvider: PinchBehaviorProviderProtocol {
+
+    private let mapboxMap: MapboxMapProtocol
+
+    init(mapboxMap: MapboxMapProtocol) {
+        self.mapboxMap = mapboxMap
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    internal func makePinchBehavior(panEnabled: Bool,
+                                    zoomEnabled: Bool,
+                                    rotateEnabled: Bool,
+                                    initialCameraState: CameraState,
+                                    initialPinchMidpoint: CGPoint,
+                                    initialPinchAngle: CGFloat) -> PinchBehavior {
+        switch (panEnabled, zoomEnabled, rotateEnabled) {
+        case (true, true, true):
+            return PanZoomRotatePinchBehavior(
+                initialCameraState: initialCameraState,
+                initialPinchMidpoint: initialPinchMidpoint,
+                initialPinchAngle: initialPinchAngle,
+                mapboxMap: mapboxMap)
+        case (true, true, false):
+            return PanZoomPinchBehavior(
+                initialCameraState: initialCameraState,
+                initialPinchMidpoint: initialPinchMidpoint,
+                mapboxMap: mapboxMap)
+        case (true, false, true):
+            return PanRotatePinchBehavior(
+                initialCameraState: initialCameraState,
+                initialPinchMidpoint: initialPinchMidpoint,
+                initialPinchAngle: initialPinchAngle,
+                mapboxMap: mapboxMap)
+        case (true, false, false):
+            return PanPinchBehavior(
+                initialCameraState: initialCameraState,
+                initialPinchMidpoint: initialPinchMidpoint,
+                mapboxMap: mapboxMap)
+        case (false, true, true):
+            return ZoomRotatePinchBehavior(
+                initialCameraState: initialCameraState,
+                initialPinchMidpoint: initialPinchMidpoint,
+                initialPinchAngle: initialPinchAngle,
+                mapboxMap: mapboxMap)
+        case (false, true, false):
+            return ZoomPinchBehavior(
+                initialCameraState: initialCameraState,
+                initialPinchMidpoint: initialPinchMidpoint,
+                mapboxMap: mapboxMap)
+        case (false, false, true):
+            return RotatePinchBehavior(
+                initialCameraState: initialCameraState,
+                initialPinchMidpoint: initialPinchMidpoint,
+                initialPinchAngle: initialPinchAngle,
+                mapboxMap: mapboxMap)
+        case (false, false, false):
+            return EmptyPinchBehavior()
+        }
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/RotatePinchBehavior.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/RotatePinchBehavior.swift
@@ -1,0 +1,29 @@
+internal final class RotatePinchBehavior: PinchBehavior {
+    private let initialCameraState: CameraState
+    private let initialPinchMidpoint: CGPoint
+    private let initialPinchAngle: CGFloat
+    private let mapboxMap: MapboxMapProtocol
+
+    internal init(initialCameraState: CameraState,
+                  initialPinchMidpoint: CGPoint,
+                  initialPinchAngle: CGFloat,
+                  mapboxMap: MapboxMapProtocol) {
+        self.initialCameraState = initialCameraState
+        self.initialPinchMidpoint = initialPinchMidpoint
+        self.initialPinchAngle = initialPinchAngle
+        self.mapboxMap = mapboxMap
+    }
+
+    internal func update(pinchMidpoint: CGPoint,
+                         pinchScale: CGFloat,
+                         pinchAngle: CGFloat) {
+        // flip the sign since the UIKit coordinate system is flipped
+        // relative to the coordinate system used for bearing.
+        let bearingIncrement = -initialPinchAngle
+            .wrappedAngle(to: pinchAngle)
+            .toDegrees()
+        mapboxMap.setCamera(to: CameraOptions(
+            anchor: initialPinchMidpoint,
+            bearing: initialCameraState.bearing + CLLocationDirection(bearingIncrement)))
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/ZoomPinchBehavior.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/ZoomPinchBehavior.swift
@@ -1,0 +1,22 @@
+internal final class ZoomPinchBehavior: PinchBehavior {
+    private let initialCameraState: CameraState
+    private let initialPinchMidpoint: CGPoint
+    private let mapboxMap: MapboxMapProtocol
+
+    internal init(initialCameraState: CameraState,
+                  initialPinchMidpoint: CGPoint,
+                  mapboxMap: MapboxMapProtocol) {
+        self.initialCameraState = initialCameraState
+        self.initialPinchMidpoint = initialPinchMidpoint
+        self.mapboxMap = mapboxMap
+    }
+
+    internal func update(pinchMidpoint: CGPoint,
+                         pinchScale: CGFloat,
+                         pinchAngle: CGFloat) {
+        let zoomIncrement = log2(pinchScale)
+        mapboxMap.setCamera(to: CameraOptions(
+            anchor: initialPinchMidpoint,
+            zoom: initialCameraState.zoom + zoomIncrement))
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/ZoomRotatePinchBehavior.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PinchBehaviors/ZoomRotatePinchBehavior.swift
@@ -1,0 +1,32 @@
+internal final class ZoomRotatePinchBehavior: PinchBehavior {
+    private let initialCameraState: CameraState
+    private let initialPinchMidpoint: CGPoint
+    private let initialPinchAngle: CGFloat
+    private let mapboxMap: MapboxMapProtocol
+
+    internal init(initialCameraState: CameraState,
+                  initialPinchMidpoint: CGPoint,
+                  initialPinchAngle: CGFloat,
+                  mapboxMap: MapboxMapProtocol) {
+        self.initialCameraState = initialCameraState
+        self.initialPinchMidpoint = initialPinchMidpoint
+        self.initialPinchAngle = initialPinchAngle
+        self.mapboxMap = mapboxMap
+    }
+
+    internal func update(pinchMidpoint: CGPoint,
+                         pinchScale: CGFloat,
+                         pinchAngle: CGFloat) {
+        let zoomIncrement = log2(pinchScale)
+
+        // flip the sign since the UIKit coordinate system is flipped
+        // relative to the coordinate system used for bearing.
+        let bearingIncrement = -initialPinchAngle
+            .wrappedAngle(to: pinchAngle)
+            .toDegrees()
+        mapboxMap.setCamera(to: CameraOptions(
+            anchor: initialPinchMidpoint,
+            zoom: initialCameraState.zoom + zoomIncrement,
+            bearing: initialCameraState.bearing + CLLocationDirection(bearingIncrement)))
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -21,6 +21,8 @@ public final class GestureManager: GestureHandlerDelegate {
             panGestureRecognizer.isEnabled = newValue.panEnabled
             pinchGestureRecognizer.isEnabled = newValue.pinchEnabled
             pinchGestureHandler.rotateEnabled = newValue.pinchRotateEnabled
+            pinchGestureHandler.zoomEnabled = newValue.pinchZoomEnabled
+            pinchGestureHandler.panEnabled = newValue.pinchPanEnabled
             pitchGestureRecognizer.isEnabled = newValue.pitchEnabled
             doubleTapToZoomInGestureRecognizer.isEnabled = newValue.doubleTapToZoomInEnabled
             doubleTouchToZoomOutGestureRecognizer.isEnabled = newValue.doubleTouchToZoomOutEnabled
@@ -33,6 +35,8 @@ public final class GestureManager: GestureHandlerDelegate {
             gestureOptions.panEnabled = panGestureRecognizer.isEnabled
             gestureOptions.pinchEnabled = pinchGestureRecognizer.isEnabled
             gestureOptions.pinchRotateEnabled = pinchGestureHandler.rotateEnabled
+            gestureOptions.pinchZoomEnabled = pinchGestureHandler.zoomEnabled
+            gestureOptions.pinchPanEnabled = pinchGestureHandler.panEnabled
             gestureOptions.pitchEnabled = pitchGestureRecognizer.isEnabled
             gestureOptions.doubleTapToZoomInEnabled = doubleTapToZoomInGestureRecognizer.isEnabled
             gestureOptions.doubleTouchToZoomOutEnabled = doubleTouchToZoomOutGestureRecognizer.isEnabled

--- a/Sources/MapboxMaps/Gestures/GestureOptions.swift
+++ b/Sources/MapboxMaps/Gestures/GestureOptions.swift
@@ -28,6 +28,14 @@ public struct GestureOptions: Equatable {
     /// Defaults to `true`.
     public var pinchRotateEnabled: Bool = true
 
+    /// Whether zoom is enabled for the pinch gesture.
+    /// Defaults to `true`.
+    public var pinchZoomEnabled: Bool = true
+
+    /// Whether pan is enabled for the pinch gesture.
+    /// Defaults to `true`.
+    public var pinchPanEnabled: Bool = true
+
     /// Whether the pitch gesture is enabled. Defaults to `true`.
     public var pitchEnabled: Bool = true
 

--- a/Tests/MapboxMapsTests/Foundation/Extensions/FloatingPointTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Extensions/FloatingPointTests.swift
@@ -55,4 +55,54 @@ final class FloatingPointTests: XCTestCase {
         XCTAssertEqual(6.wrapped(to: -2..<2), -2)
         XCTAssertEqual(7.wrapped(to: -2..<2), -1)
     }
+
+    func testToDegrees() {
+        XCTAssertEqual(0.toDegrees(), 0)
+        XCTAssertEqual((Double.pi / 4).toDegrees(), 45, accuracy: 1e-8)
+        XCTAssertEqual((Double.pi / 2).toDegrees(), 90, accuracy: 1e-8)
+        XCTAssertEqual((3 * Double.pi / 4).toDegrees(), 135, accuracy: 1e-8)
+        XCTAssertEqual(Double.pi.toDegrees(), 180, accuracy: 1e-8)
+        XCTAssertEqual((2 * Double.pi).toDegrees(), 360, accuracy: 1e-8)
+        XCTAssertEqual((-2 * Double.pi).toDegrees(), -360, accuracy: 1e-8)
+        XCTAssertEqual((4 * Double.pi).toDegrees(), 720, accuracy: 1e-8)
+    }
+
+    func testWrappedAngleWithoutChange() {
+        let anyAngle = CGFloat.random(in: 0..<2 * .pi)
+        XCTAssertEqual(anyAngle.wrappedAngle(to: anyAngle), 0)
+    }
+
+    func testWrappedAngleLargeNegativeRotation() {
+        // just greater than -2 pi; result should wrap to being just greater than 0
+        let rotation = 0.wrappedAngle(to: -(2 * .pi) + 1e-8)
+
+        // value should be just greater than 0
+        XCTAssertGreaterThan(rotation, 0)
+        XCTAssertEqual(rotation, 0, accuracy: 1e-6)
+    }
+
+    func testWrappedAngleSmallNegativeRotation() {
+        let rotation = 0.wrappedAngle(to: -1e-8)
+
+        // value should be just less than 2pi
+        XCTAssertLessThan(rotation, 2 * .pi)
+        XCTAssertEqual(rotation, 2 * .pi, accuracy: 1e-6)
+    }
+
+    func testWrappedAngleLargePositiveRotation() {
+        // just less than 2 pi
+        let rotation = 0.wrappedAngle(to: (2 * .pi) - 1e-8)
+
+        // value should be just less than 2pi
+        XCTAssertLessThan(rotation, 2 * .pi)
+        XCTAssertEqual(rotation, 2 * .pi, accuracy: 1e-6)
+    }
+
+    func testWrappedAngleSmallPositiveRotation() {
+        let rotation = 0.wrappedAngle(to: 1e-8)
+
+        // value should be just greater than 0
+        XCTAssertGreaterThan(rotation, 0)
+        XCTAssertEqual(rotation, 0, accuracy: 1e-6)
+    }
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockPinchGestureHandler.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockPinchGestureHandler.swift
@@ -2,4 +2,8 @@
 
 final class MockPinchGestureHandler: GestureHandler, PinchGestureHandlerProtocol {
     var rotateEnabled: Bool = true
+
+    var zoomEnabled: Bool = true
+
+    var panEnabled: Bool = true
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockPinchGestureRecognizer.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockPinchGestureRecognizer.swift
@@ -13,13 +13,13 @@ final class MockPinchGestureRecognizer: UIPinchGestureRecognizer {
     }
 
     let getScaleStub = Stub<Void, CGFloat>(defaultReturnValue: 1)
+    let setScaleStub = Stub<CGFloat, Void>()
     override var scale: CGFloat {
         get {
             getScaleStub.call()
         }
-        // swiftlint:disable:next unused_setter_value
         set {
-            fatalError("unimplemented")
+            setScaleStub.call(with: newValue)
         }
     }
 

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/BasePinchChangedBehaviorTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/BasePinchChangedBehaviorTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import MapboxMaps
+
+class BasePinchChangedBehaviorTests: XCTestCase {
+    var initialCameraState: CameraState!
+    var initialPinchMidpoint: CGPoint!
+    var initialPinchAngle: CGFloat!
+    var mapboxMap: MockMapboxMap!
+    var behavior: PinchBehavior!
+
+    override func setUp() {
+        super.setUp()
+        initialCameraState = .random()
+        initialPinchMidpoint = .random()
+        initialPinchAngle = .random(in: 0..<360)
+        mapboxMap = MockMapboxMap()
+    }
+
+    override func tearDown() {
+        behavior = nil
+        mapboxMap = nil
+        initialPinchAngle = nil
+        initialPinchMidpoint = nil
+        initialCameraState = nil
+        super.tearDown()
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/EmptyPinchChangedBehaviorTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/EmptyPinchChangedBehaviorTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import MapboxMaps
+
+final class EmptyPinchChangedBehaviorTests: BasePinchChangedBehaviorTests {
+    override func setUp() {
+        super.setUp()
+        behavior = EmptyPinchBehavior()
+    }
+
+    func testUpdate() {
+        behavior.update(
+            pinchMidpoint: .random(),
+            pinchScale: .random(in: 0..<2),
+            pinchAngle: .random(in: 0..<2 * .pi))
+
+        XCTAssertTrue(mapboxMap.setCameraStub.invocations.isEmpty)
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/Mocks/MockPinchBehavior.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/Mocks/MockPinchBehavior.swift
@@ -1,0 +1,16 @@
+@testable import MapboxMaps
+
+final class MockPinchBehavior: PinchBehavior {
+    struct UpdateParams: Equatable {
+        var pinchMidpoint: CGPoint
+        var pinchScale: CGFloat
+        var pinchAngle: CGFloat
+    }
+    let updateStub = Stub<UpdateParams, Void>()
+    func update(pinchMidpoint: CGPoint, pinchScale: CGFloat, pinchAngle: CGFloat) {
+        updateStub.call(with: .init(
+            pinchMidpoint: pinchMidpoint,
+            pinchScale: pinchScale,
+            pinchAngle: pinchAngle))
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/Mocks/MockPinchBehaviorProvider.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/Mocks/MockPinchBehaviorProvider.swift
@@ -1,0 +1,28 @@
+@testable import MapboxMaps
+
+final class MockPinchBehaviorProvider: PinchBehaviorProviderProtocol {
+    struct MakePinchBehaviorParams: Equatable {
+        var panEnabled: Bool
+        var zoomEnabled: Bool
+        var rotateEnabled: Bool
+        var initialCameraState: CameraState
+        var initialPinchMidpoint: CGPoint
+        var initialPinchAngle: CGFloat
+    }
+    let makePinchBehaviorStub = Stub<MakePinchBehaviorParams, PinchBehavior>(defaultReturnValue: MockPinchBehavior())
+    // swiftlint:disable:next function_parameter_count
+    func makePinchBehavior(panEnabled: Bool,
+                           zoomEnabled: Bool,
+                           rotateEnabled: Bool,
+                           initialCameraState: CameraState,
+                           initialPinchMidpoint: CGPoint,
+                           initialPinchAngle: CGFloat) -> PinchBehavior {
+        makePinchBehaviorStub.call(with: .init(
+            panEnabled: panEnabled,
+            zoomEnabled: zoomEnabled,
+            rotateEnabled: rotateEnabled,
+            initialCameraState: initialCameraState,
+            initialPinchMidpoint: initialPinchMidpoint,
+            initialPinchAngle: initialPinchAngle))
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/PanPinchChangedBehaviorTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/PanPinchChangedBehaviorTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import MapboxMaps
+
+final class PanPinchChangedBehaviorTests: BasePinchChangedBehaviorTests {
+    override func setUp() {
+        super.setUp()
+        behavior = PanPinchBehavior(
+            initialCameraState: initialCameraState,
+            initialPinchMidpoint: initialPinchMidpoint,
+            mapboxMap: mapboxMap)
+    }
+
+    func testUpdate() {
+        let pinchMidpoint = CGPoint.random()
+        let dragCameraOptions = CameraOptions.random()
+        mapboxMap.dragCameraOptionsStub.defaultReturnValue = dragCameraOptions
+
+        behavior.update(
+            pinchMidpoint: pinchMidpoint,
+            pinchScale: .random(in: 0..<2),
+            pinchAngle: .random(in: 0..<2 * .pi))
+
+        // verify camera gets set twice
+        guard mapboxMap.setCameraStub.invocations.count == 2 else {
+            XCTFail("Did not receive the expected number of setCamera invocations.")
+            return
+        }
+
+        // verify that the first set camera invocation resets the center
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.invocations[0].parameters,
+            CameraOptions(center: initialCameraState.center))
+
+        // verify that dragStart is called once with initial midpoint
+        XCTAssertEqual(
+            mapboxMap.dragStartStub.invocations.map(\.parameters),
+            [initialPinchMidpoint])
+
+        // verify that dragCameraOptions is invoked once with expected parameters
+        XCTAssertEqual(
+            mapboxMap.dragCameraOptionsStub.invocations.map(\.parameters),
+            [.init(from: initialPinchMidpoint, to: pinchMidpoint)])
+
+        // verify that setCamera is invoked a second time with the return value
+        // from dragCameraOptions
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.invocations[1].parameters,
+            dragCameraOptions)
+
+        // verify drag end is invoked once
+        XCTAssertEqual(mapboxMap.dragEndStub.invocations.count, 1)
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/PanRotatePinchChangedBehaviorTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/PanRotatePinchChangedBehaviorTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import MapboxMaps
+
+final class PanRotatePinchChangedBehaviorTests: BasePinchChangedBehaviorTests {
+    override func setUp() {
+        super.setUp()
+        behavior = PanRotatePinchBehavior(
+            initialCameraState: initialCameraState,
+            initialPinchMidpoint: initialPinchMidpoint,
+            initialPinchAngle: initialPinchAngle,
+            mapboxMap: mapboxMap)
+    }
+
+    func testUpdate() throws {
+        let pinchMidpoint = CGPoint.random()
+        let dragCameraOptions = CameraOptions.random()
+        mapboxMap.dragCameraOptionsStub.defaultReturnValue = dragCameraOptions
+
+        behavior.update(
+            pinchMidpoint: pinchMidpoint,
+            pinchScale: .random(in: 0..<2),
+            pinchAngle: initialPinchAngle + (.pi/4))
+
+        // verify that setCamera is invoked 3 times
+        guard mapboxMap.setCameraStub.invocations.count == 3 else {
+            XCTFail("Did not receive the expected number of setCamera invocations.")
+            return
+        }
+
+        // verify that the first setCamera invocation resets center and bearing
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.invocations[0].parameters,
+            CameraOptions(
+                center: initialCameraState.center,
+                bearing: initialCameraState.bearing))
+
+        // verify that dragStart is invoked once with the initial pinch midpoint
+        XCTAssertEqual(
+            mapboxMap.dragStartStub.invocations.map(\.parameters),
+            [initialPinchMidpoint])
+
+        // verify that dragCameraOptions is invoked once with the expected
+        // parameters
+        XCTAssertEqual(
+            mapboxMap.dragCameraOptionsStub.invocations.map(\.parameters),
+            [.init(from: initialPinchMidpoint, to: pinchMidpoint)])
+
+        // verify that setCamera is invoked a second time with the return value
+        // from dragCameraOptions
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.invocations[1].parameters,
+            dragCameraOptions)
+
+        // verify that dragEnd is invoked once
+        XCTAssertEqual(mapboxMap.dragEndStub.invocations.count, 1)
+
+        // verify that setCamera is invoked a third time with the expected
+        // anchor and bearing
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.invocations[2].parameters.anchor,
+            pinchMidpoint)
+        let bearing = try XCTUnwrap(mapboxMap.setCameraStub.invocations[2].parameters.bearing)
+        XCTAssertEqual(bearing, initialCameraState.bearing - 45, accuracy: 1e-10)
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/PanZoomPinchChangedBehaviorTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/PanZoomPinchChangedBehaviorTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import MapboxMaps
+
+final class PanZoomPinchChangedBehaviorTests: BasePinchChangedBehaviorTests {
+    override func setUp() {
+        super.setUp()
+        behavior = PanZoomPinchBehavior(
+            initialCameraState: initialCameraState,
+            initialPinchMidpoint: initialPinchMidpoint,
+            mapboxMap: mapboxMap)
+    }
+
+    func testUpdate() throws {
+        let pinchMidpoint = CGPoint.random()
+        let pinchScale = CGFloat.random(in: 0.1..<10)
+        let dragCameraOptions = CameraOptions.random()
+        mapboxMap.dragCameraOptionsStub.defaultReturnValue = dragCameraOptions
+
+        behavior.update(
+            pinchMidpoint: pinchMidpoint,
+            pinchScale: pinchScale,
+            pinchAngle: .random(in: 0..<2 * .pi))
+
+        // verify that setCamera is invoked 3 times
+        guard mapboxMap.setCameraStub.invocations.count == 3 else {
+            XCTFail("Did not receive the expected number of setCamera invocations.")
+            return
+        }
+
+        // verify that the first setCamera invocation resets center and zoom
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.invocations[0].parameters,
+            CameraOptions(
+                center: initialCameraState.center,
+                zoom: initialCameraState.zoom))
+
+        // verify that dragStart is invoked once with the initial pinch midpoint
+        XCTAssertEqual(
+            mapboxMap.dragStartStub.invocations.map(\.parameters),
+            [initialPinchMidpoint])
+
+        // verify that dragCameraOptions is invoked once with the expected
+        // parameters
+        XCTAssertEqual(
+            mapboxMap.dragCameraOptionsStub.invocations.map(\.parameters),
+            [.init(from: initialPinchMidpoint, to: pinchMidpoint)])
+
+        // verify that setCamera is invoked a second time with the return value
+        // from dragCameraOptions
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.invocations[1].parameters,
+            dragCameraOptions)
+
+        // verify that dragEnd is invoked once
+        XCTAssertEqual(mapboxMap.dragEndStub.invocations.count, 1)
+
+        // verify that setCamera is invoked a third time with the expected
+        // anchor and zoom
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.invocations[2].parameters.anchor,
+            pinchMidpoint)
+        let zoom = try XCTUnwrap(mapboxMap.setCameraStub.invocations[2].parameters.zoom)
+        XCTAssertEqual(zoom, initialCameraState.zoom + log2(pinchScale))
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/PanZoomRotatePinchChangedBehaviorTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/PanZoomRotatePinchChangedBehaviorTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import MapboxMaps
+
+final class PanZoomRotatePinchChangedBehaviorTests: BasePinchChangedBehaviorTests {
+    override func setUp() {
+        super.setUp()
+        behavior = PanZoomRotatePinchBehavior(
+            initialCameraState: initialCameraState,
+            initialPinchMidpoint: initialPinchMidpoint,
+            initialPinchAngle: initialPinchAngle,
+            mapboxMap: mapboxMap)
+    }
+
+    func testUpdate() throws {
+        let pinchScale = CGFloat.random(in: 0.1..<10)
+        let pinchMidpoint = CGPoint.random()
+        let dragCameraOptions = CameraOptions.random()
+        mapboxMap.dragCameraOptionsStub.defaultReturnValue = dragCameraOptions
+
+        behavior.update(
+            pinchMidpoint: pinchMidpoint,
+            pinchScale: pinchScale,
+            pinchAngle: initialPinchAngle + (.pi/4))
+
+        // verify that setCamera is invoked 3 times
+        guard mapboxMap.setCameraStub.invocations.count == 3 else {
+            XCTFail("Did not receive the expected number of setCamera invocations.")
+            return
+        }
+
+        // verify that the first setCamera invocation resets center and zoom
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.invocations[0].parameters,
+            CameraOptions(
+                center: initialCameraState.center,
+                zoom: initialCameraState.zoom,
+                bearing: initialCameraState.bearing))
+
+        // verify that dragStart is invoked once with the initial pinch midpoint
+        XCTAssertEqual(
+            mapboxMap.dragStartStub.invocations.map(\.parameters),
+            [initialPinchMidpoint])
+
+        // verify that dragCameraOptions is invoked once with the expected
+        // parameters
+        XCTAssertEqual(
+            mapboxMap.dragCameraOptionsStub.invocations.map(\.parameters),
+            [.init(from: initialPinchMidpoint, to: pinchMidpoint)])
+
+        // verify that setCamera is invoked a second time with the return value
+        // from dragCameraOptions
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.invocations[1].parameters,
+            dragCameraOptions)
+
+        // verify that dragEnd is invoked once
+        XCTAssertEqual(mapboxMap.dragEndStub.invocations.count, 1)
+
+        // verify that setCamera is invoked a third time with the expected
+        // anchor and zoom
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.invocations[2].parameters.anchor,
+            pinchMidpoint)
+        let zoom = try XCTUnwrap(mapboxMap.setCameraStub.invocations[2].parameters.zoom)
+        XCTAssertEqual(zoom, initialCameraState.zoom + log2(pinchScale))
+        let bearing = try XCTUnwrap(mapboxMap.setCameraStub.invocations[2].parameters.bearing)
+        XCTAssertEqual(bearing, initialCameraState.bearing - 45, accuracy: 1e-10)
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/PinchBehaviorProviderTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/PinchBehaviorProviderTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import MapboxMaps
+
+final class PinchBehaviorProviderTests: XCTestCase {
+    func testPinchChangedBehaviorType() {
+        let provider = PinchBehaviorProvider(mapboxMap: MockMapboxMap())
+
+        XCTAssertTrue(
+            provider.makePinchBehavior(
+                panEnabled: true,
+                zoomEnabled: true,
+                rotateEnabled: true,
+                initialCameraState: .random(),
+                initialPinchMidpoint: .random(),
+                initialPinchAngle: .random(in: 0..<2 * .pi))
+            is PanZoomRotatePinchBehavior)
+        XCTAssertTrue(
+            provider.makePinchBehavior(
+                panEnabled: true,
+                zoomEnabled: true,
+                rotateEnabled: false,
+                initialCameraState: .random(),
+                initialPinchMidpoint: .random(),
+                initialPinchAngle: .random(in: 0..<2 * .pi))
+            is PanZoomPinchBehavior)
+        XCTAssertTrue(
+            provider.makePinchBehavior(
+                panEnabled: true,
+                zoomEnabled: false,
+                rotateEnabled: true,
+                initialCameraState: .random(),
+                initialPinchMidpoint: .random(),
+                initialPinchAngle: .random(in: 0..<2 * .pi))
+            is PanRotatePinchBehavior)
+        XCTAssertTrue(
+            provider.makePinchBehavior(
+                panEnabled: true,
+                zoomEnabled: false,
+                rotateEnabled: false,
+                initialCameraState: .random(),
+                initialPinchMidpoint: .random(),
+                initialPinchAngle: .random(in: 0..<2 * .pi))
+            is PanPinchBehavior)
+        XCTAssertTrue(
+            provider.makePinchBehavior(
+                panEnabled: false,
+                zoomEnabled: true,
+                rotateEnabled: true,
+                initialCameraState: .random(),
+                initialPinchMidpoint: .random(),
+                initialPinchAngle: .random(in: 0..<2 * .pi))
+            is ZoomRotatePinchBehavior)
+        XCTAssertTrue(
+            provider.makePinchBehavior(
+                panEnabled: false,
+                zoomEnabled: true,
+                rotateEnabled: false,
+                initialCameraState: .random(),
+                initialPinchMidpoint: .random(),
+                initialPinchAngle: .random(in: 0..<2 * .pi))
+            is ZoomPinchBehavior)
+        XCTAssertTrue(
+            provider.makePinchBehavior(
+                panEnabled: false,
+                zoomEnabled: false,
+                rotateEnabled: true,
+                initialCameraState: .random(),
+                initialPinchMidpoint: .random(),
+                initialPinchAngle: .random(in: 0..<2 * .pi))
+            is RotatePinchBehavior)
+        XCTAssertTrue(
+            provider.makePinchBehavior(
+                panEnabled: false,
+                zoomEnabled: false,
+                rotateEnabled: false,
+                initialCameraState: .random(),
+                initialPinchMidpoint: .random(),
+                initialPinchAngle: .random(in: 0..<2 * .pi))
+            is EmptyPinchBehavior)
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/RotatePinchChangedBehaviorTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/RotatePinchChangedBehaviorTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import MapboxMaps
+
+final class RotatePinchChangedBehaviorTests: BasePinchChangedBehaviorTests {
+    override func setUp() {
+        super.setUp()
+        behavior = RotatePinchBehavior(
+            initialCameraState: initialCameraState,
+            initialPinchMidpoint: initialPinchMidpoint,
+            initialPinchAngle: initialPinchAngle,
+            mapboxMap: mapboxMap)
+    }
+
+    func testUpdate() throws {
+        behavior.update(
+            pinchMidpoint: .random(),
+            pinchScale: .random(in: 0..<2),
+            pinchAngle: initialPinchAngle + (.pi/4))
+
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 1)
+        let invocation = try XCTUnwrap(mapboxMap.setCameraStub.invocations.first)
+        XCTAssertEqual(invocation.parameters.anchor, initialPinchMidpoint)
+        let bearing = try XCTUnwrap(invocation.parameters.bearing)
+        XCTAssertEqual(bearing, initialCameraState.bearing - 45, accuracy: 1e-10)
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/ZoomPinchChangedBehaviorTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/ZoomPinchChangedBehaviorTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import MapboxMaps
+
+final class ZoomPinchChangedBehaviorTests: BasePinchChangedBehaviorTests {
+    override func setUp() {
+        super.setUp()
+        behavior = ZoomPinchBehavior(
+            initialCameraState: initialCameraState,
+            initialPinchMidpoint: initialPinchMidpoint,
+            mapboxMap: mapboxMap)
+    }
+
+    func testUpdate() {
+        let pinchScale = CGFloat.random(in: 0.1..<10)
+
+        behavior.update(
+            pinchMidpoint: .random(),
+            pinchScale: pinchScale,
+            pinchAngle: .random(in: 0..<2 * .pi))
+
+        XCTAssertEqual(
+            mapboxMap.setCameraStub.invocations.map(\.parameters),
+            [CameraOptions(
+                anchor: initialPinchMidpoint,
+                zoom: initialCameraState.zoom + log2(pinchScale))])
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/ZoomRotatePinchChangedBehaviorTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PinchBehaviors/ZoomRotatePinchChangedBehaviorTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import MapboxMaps
+
+final class ZoomRotatePinchChangedBehaviorTests: BasePinchChangedBehaviorTests {
+    override func setUp() {
+        super.setUp()
+        behavior = ZoomRotatePinchBehavior(
+            initialCameraState: initialCameraState,
+            initialPinchMidpoint: initialPinchMidpoint,
+            initialPinchAngle: initialPinchAngle,
+            mapboxMap: mapboxMap)
+    }
+
+    func testUpdate() throws {
+        let pinchScale = CGFloat.random(in: 0.1..<10)
+
+        behavior.update(
+            pinchMidpoint: .random(),
+            pinchScale: pinchScale,
+            pinchAngle: initialPinchAngle + (.pi/4))
+
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 1)
+
+        let invocation = try XCTUnwrap(mapboxMap.setCameraStub.invocations.first)
+        XCTAssertEqual(invocation.parameters.anchor, initialPinchMidpoint)
+        XCTAssertEqual(invocation.parameters.zoom, initialCameraState.zoom + log2(pinchScale))
+        let bearing = try XCTUnwrap(invocation.parameters.bearing)
+        XCTAssertEqual(bearing, initialCameraState.bearing - 45, accuracy: 1e-10)
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -393,25 +393,77 @@ final class GestureManagerTests: XCTestCase {
     }
 
     func testOptionsPinchRotateEnabled() {
-        XCTAssertEqual(gestureManager.options.pinchRotateEnabled, true)
-        XCTAssertEqual(pinchGestureHandler.rotateEnabled, true)
+        XCTAssertTrue(gestureManager.options.pinchRotateEnabled)
+        XCTAssertTrue(pinchGestureHandler.rotateEnabled)
 
         gestureManager.options.pinchRotateEnabled = false
 
-        XCTAssertEqual(gestureManager.options.pinchRotateEnabled, false)
-        XCTAssertEqual(pinchGestureHandler.rotateEnabled, false)
+        XCTAssertFalse(gestureManager.options.pinchRotateEnabled)
+        XCTAssertFalse(pinchGestureHandler.rotateEnabled)
 
         gestureManager.options.pinchRotateEnabled = true
 
-        XCTAssertEqual(gestureManager.options.pinchRotateEnabled, true)
-        XCTAssertEqual(pinchGestureHandler.rotateEnabled, true)
+        XCTAssertTrue(gestureManager.options.pinchRotateEnabled)
+        XCTAssertTrue(pinchGestureHandler.rotateEnabled)
 
         pinchGestureHandler.rotateEnabled = false
 
-        XCTAssertEqual(gestureManager.options.pinchRotateEnabled, pinchGestureHandler.rotateEnabled)
+        XCTAssertFalse(gestureManager.options.pinchRotateEnabled)
+        XCTAssertFalse(pinchGestureHandler.rotateEnabled)
 
         pinchGestureHandler.rotateEnabled = true
 
-        XCTAssertEqual(gestureManager.options.pinchRotateEnabled, pinchGestureHandler.rotateEnabled)
+        XCTAssertTrue(gestureManager.options.pinchRotateEnabled)
+        XCTAssertTrue(pinchGestureHandler.rotateEnabled)
+    }
+
+    func testOptionsPinchZoomEnabled() {
+        XCTAssertTrue(gestureManager.options.pinchZoomEnabled)
+        XCTAssertTrue(pinchGestureHandler.zoomEnabled)
+
+        gestureManager.options.pinchZoomEnabled = false
+
+        XCTAssertFalse(gestureManager.options.pinchZoomEnabled)
+        XCTAssertFalse(pinchGestureHandler.zoomEnabled)
+
+        gestureManager.options.pinchZoomEnabled = true
+
+        XCTAssertTrue(gestureManager.options.pinchZoomEnabled)
+        XCTAssertTrue(pinchGestureHandler.zoomEnabled)
+
+        pinchGestureHandler.zoomEnabled = false
+
+        XCTAssertFalse(gestureManager.options.pinchZoomEnabled)
+        XCTAssertFalse(pinchGestureHandler.zoomEnabled)
+
+        pinchGestureHandler.zoomEnabled = true
+
+        XCTAssertTrue(gestureManager.options.pinchZoomEnabled)
+        XCTAssertTrue(pinchGestureHandler.zoomEnabled)
+    }
+
+    func testOptionsPinchPanEnabled() {
+        XCTAssertTrue(gestureManager.options.pinchPanEnabled)
+        XCTAssertTrue(pinchGestureHandler.panEnabled)
+
+        gestureManager.options.pinchPanEnabled = false
+
+        XCTAssertFalse(gestureManager.options.pinchPanEnabled)
+        XCTAssertFalse(pinchGestureHandler.panEnabled)
+
+        gestureManager.options.pinchPanEnabled = true
+
+        XCTAssertTrue(gestureManager.options.pinchPanEnabled)
+        XCTAssertTrue(pinchGestureHandler.panEnabled)
+
+        pinchGestureHandler.panEnabled = false
+
+        XCTAssertFalse(gestureManager.options.pinchPanEnabled)
+        XCTAssertFalse(pinchGestureHandler.panEnabled)
+
+        pinchGestureHandler.panEnabled = true
+
+        XCTAssertTrue(gestureManager.options.pinchPanEnabled)
+        XCTAssertTrue(pinchGestureHandler.panEnabled)
     }
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureOptionsTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureOptionsTests.swift
@@ -8,6 +8,8 @@ final class GestureOptionsTests: XCTestCase {
         XCTAssertTrue(options.panEnabled)
         XCTAssertTrue(options.pinchEnabled)
         XCTAssertTrue(options.pinchRotateEnabled)
+        XCTAssertTrue(options.pinchZoomEnabled)
+        XCTAssertTrue(options.pinchPanEnabled)
         XCTAssertTrue(options.pitchEnabled)
         XCTAssertTrue(options.doubleTapToZoomInEnabled)
         XCTAssertTrue(options.doubleTouchToZoomOutEnabled)


### PR DESCRIPTION
Allows developers to isolate pan and zoom with pinch gesture.

Includes significant refactoring to `PanGestureHandler`. Now each combination of `pinchPanEnabled`, `pinchRotateEnabled`, and `pinchZoomEnabled` is backed by a separate `PinchBehavior` implementation. While it does introduce a larger number of classes, each new class is simple and easy to test, and the main `PinchGestureHandler` implementation is greatly simplified as well.

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
