### PR TITLE
Animate once when FollowPuckViewportState starts

### DIFF
--- a/Sources/MapboxMaps/Camera/CameraAnimationsManager.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimationsManager.swift
@@ -3,10 +3,10 @@ import UIKit
 
 internal protocol CameraAnimationsManagerProtocol: AnyObject {
     @discardableResult
-    func ease(to camera: CameraOptions,
-              duration: TimeInterval,
-              curve: UIView.AnimationCurve,
-              completion: AnimationCompletion?) -> Cancelable?
+    func internalEase(to camera: CameraOptions,
+                      duration: TimeInterval,
+                      curve: UIView.AnimationCurve,
+                      completion: AnimationCompletion?) -> Cancelable
 
     func decelerate(location: CGPoint,
                     velocity: CGPoint,
@@ -137,6 +137,17 @@ public class CameraAnimationsManager: CameraAnimationsManagerProtocol {
                      duration: TimeInterval,
                      curve: UIView.AnimationCurve = .easeOut,
                      completion: AnimationCompletion? = nil) -> Cancelable? {
+        return internalEase(to: camera, duration: duration, curve: curve, completion: completion)
+    }
+
+    /// Ease to implementation that returns non-optional cancelable. The public API should have
+    /// been like this, but we have to wait until the next major version to change it. This internal API
+    /// allows us to avoid force-unwrapping for internal use.
+    @discardableResult
+    internal func internalEase(to camera: CameraOptions,
+                               duration: TimeInterval,
+                               curve: UIView.AnimationCurve,
+                               completion: AnimationCompletion?) -> Cancelable {
 
         internalAnimator?.stopAnimation()
 
@@ -164,7 +175,7 @@ public class CameraAnimationsManager: CameraAnimationsManagerProtocol {
         animator.startAnimation()
         internalAnimator = animator
 
-        return internalAnimator
+        return animator
     }
 
     // MARK: Animator Functions

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/DoubleTapToZoomInGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/DoubleTapToZoomInGestureHandler.swift
@@ -27,7 +27,7 @@ internal final class DoubleTapToZoomInGestureHandler: GestureHandler {
             delegate?.gestureEnded(for: .doubleTapToZoomIn, willAnimate: true)
 
             let tapLocation = gestureRecognizer.location(in: view)
-            cameraAnimationsManager.ease(
+            cameraAnimationsManager.internalEase(
                 to: CameraOptions(anchor: tapLocation, zoom: mapboxMap.cameraState.zoom + 1),
                 duration: 0.3,
                 curve: .easeOut) { _ in

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/DoubleTouchToZoomOutGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/DoubleTouchToZoomOutGestureHandler.swift
@@ -28,7 +28,7 @@ internal final class DoubleTouchToZoomOutGestureHandler: GestureHandler {
             delegate?.gestureEnded(for: .doubleTouchToZoomOut, willAnimate: true)
 
             let tapLocation = gestureRecognizer.location(in: view)
-            cameraAnimationsManager.ease(
+            cameraAnimationsManager.internalEase(
                 to: CameraOptions(anchor: tapLocation, zoom: mapboxMap.cameraState.zoom - 1),
                 duration: 0.3,
                 curve: .easeOut) { _ in

--- a/Sources/MapboxMaps/Location/InterpolatedLocationProducer.swift
+++ b/Sources/MapboxMaps/Location/InterpolatedLocationProducer.swift
@@ -59,17 +59,21 @@ extension InterpolatedLocationProducer: LocationConsumer {
     internal func locationUpdate(newLocation: Location) {
         let currentDate = dateProvider.now
 
+        // as a first iteration, assume a 1s location update interval and use a
+        // slightly longer interpolation duration to avoid pauses between updates
+        let duration: TimeInterval = 1.1
+
         if let location = interpolatedLocation(with: currentDate) {
             // calculate new start location via interpolation to current date
             startLocation = location
             startDate = currentDate
             endLocation = InterpolatedLocation(location: newLocation)
-            endDate = currentDate + 1
+            endDate = currentDate + duration
         } else {
             // first location: initialize state, no interpolation will happen
             // until the next location update
             startLocation = InterpolatedLocation(location: newLocation)
-            startDate = currentDate - 1
+            startDate = currentDate - duration
             endLocation = startLocation
             endDate = currentDate
         }

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -62,7 +62,7 @@ public class OrnamentsManager: NSObject {
         compassView.translatesAutoresizingMaskIntoConstraints = false
         compassView.tapAction = {
             cameraAnimationsManager.cancelAnimations()
-            cameraAnimationsManager.ease(
+            cameraAnimationsManager.internalEase(
                 to: CameraOptions(bearing: 0),
                 duration: 0.3,
                 curve: .easeOut,

--- a/Sources/MapboxMaps/Viewport/States/FollowPuck/FollowPuckViewportState.swift
+++ b/Sources/MapboxMaps/Viewport/States/FollowPuck/FollowPuckViewportState.swift
@@ -56,12 +56,12 @@ extension FollowPuckViewportState: ViewportState {
                 mapboxMap.setCamera(to: cameraOptions)
             } else if !animationStarted {
                 animationStarted = true
-                compositeCancelable.add(cameraAnimationsManager.ease(
+                compositeCancelable.add(cameraAnimationsManager.internalEase(
                     to: cameraOptions,
                     duration: options.animationDuration,
                     curve: .linear) { _ in
                         animationComplete = true
-                    }!)
+                    })
             }
             return true
         })

--- a/Sources/MapboxMaps/Viewport/States/Overview/OverviewViewportState.swift
+++ b/Sources/MapboxMaps/Viewport/States/Overview/OverviewViewportState.swift
@@ -49,7 +49,7 @@ import Turf
 
     private func animate(to cameraOptions: CameraOptions) {
         cameraAnimationCancelable?.cancel()
-        cameraAnimationCancelable = cameraAnimationsManager.ease(
+        cameraAnimationCancelable = cameraAnimationsManager.internalEase(
             to: cameraOptions,
             duration: max(0, options.animationDuration),
             curve: .linear,

--- a/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimationsManager.swift
+++ b/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimationsManager.swift
@@ -3,19 +3,19 @@ import Foundation
 
 final class MockCameraAnimationsManager: CameraAnimationsManagerProtocol {
 
-    struct EaseToCameraParameters {
+    struct EaseToParameters {
         var camera: CameraOptions
         var duration: TimeInterval
         var curve: UIView.AnimationCurve
         var completion: AnimationCompletion?
     }
-    let easeToStub = Stub<EaseToCameraParameters, Cancelable?>(defaultReturnValue: MockCancelable())
-    func ease(to camera: CameraOptions,
-              duration: TimeInterval,
-              curve: UIView.AnimationCurve,
-              completion: AnimationCompletion?) -> Cancelable? {
+    let easeToStub = Stub<EaseToParameters, Cancelable>(defaultReturnValue: MockCancelable())
+    func internalEase(to camera: CameraOptions,
+                      duration: TimeInterval,
+                      curve: UIView.AnimationCurve,
+                      completion: AnimationCompletion?) -> Cancelable {
         return easeToStub.call(
-            with: EaseToCameraParameters(
+            with: EaseToParameters(
                 camera: camera,
                 duration: duration,
                 curve: curve,

--- a/Tests/MapboxMapsTests/Helpers/Random/UIViewAnimatingPosition+Random.swift
+++ b/Tests/MapboxMapsTests/Helpers/Random/UIViewAnimatingPosition+Random.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+extension UIViewAnimatingPosition {
+    static func random() -> Self {
+        [.start, .current, .end].randomElement()!
+    }
+}

--- a/Tests/MapboxMapsTests/Location/InterpolatedLocationProducerTests.swift
+++ b/Tests/MapboxMapsTests/Location/InterpolatedLocationProducerTests.swift
@@ -114,10 +114,10 @@ final class InterpolatedLocationProducerTests: XCTestCase {
         }
 
         try verifyParticipate(withTimeInterval: 1, expectedPercent: 0)
-        try verifyParticipate(withTimeInterval: 1.5, expectedPercent: 0.5)
-        try verifyParticipate(withTimeInterval: 1.9, expectedPercent: 0.9)
+        try verifyParticipate(withTimeInterval: 1.55, expectedPercent: 0.5)
+        try verifyParticipate(withTimeInterval: 1.99, expectedPercent: 0.9)
 
-        dateProvider.nowStub.defaultReturnValue = Date(timeIntervalSinceReferenceDate: 2)
+        dateProvider.nowStub.defaultReturnValue = Date(timeIntervalSinceReferenceDate: 2.1)
         interpolatedLocationProducer.participate()
         XCTAssertEqual(locationInterpolator.interpolateStub.invocations.count, 0)
         XCTAssertEqual(observableInterpolatedLocation.notifyStub.invocations.map(\.parameters), [interpolatedLocation1])
@@ -142,7 +142,7 @@ final class InterpolatedLocationProducerTests: XCTestCase {
         interpolatedLocationProducer.locationUpdate(newLocation: location1)
 
         // third location delivered while still interpolating from first to second
-        dateProvider.nowStub.defaultReturnValue = Date(timeIntervalSinceReferenceDate: 1.5)
+        dateProvider.nowStub.defaultReturnValue = Date(timeIntervalSinceReferenceDate: 1.55)
         locationInterpolator.interpolateStub.defaultReturnValue = .random()
         interpolatedLocationProducer.locationUpdate(newLocation: location2)
 
@@ -170,11 +170,11 @@ final class InterpolatedLocationProducerTests: XCTestCase {
             locationInterpolator.interpolateStub.reset()
         }
 
-        try verifyParticipate(withTimeInterval: 1.5, expectedPercent: 0)
-        try verifyParticipate(withTimeInterval: 2, expectedPercent: 0.5)
-        try verifyParticipate(withTimeInterval: 2.4, expectedPercent: 0.9)
+        try verifyParticipate(withTimeInterval: 1.55, expectedPercent: 0)
+        try verifyParticipate(withTimeInterval: 2.1, expectedPercent: 0.5)
+        try verifyParticipate(withTimeInterval: 2.54, expectedPercent: 0.9)
 
-        dateProvider.nowStub.defaultReturnValue = Date(timeIntervalSinceReferenceDate: 2.5)
+        dateProvider.nowStub.defaultReturnValue = Date(timeIntervalSinceReferenceDate: 2.66)
         interpolatedLocationProducer.participate()
         XCTAssertEqual(locationInterpolator.interpolateStub.invocations.count, 0)
         XCTAssertEqual(observableInterpolatedLocation.notifyStub.invocations.map(\.parameters), [interpolatedLocation2])


### PR DESCRIPTION
* Changes the default animation duration to 0.3 to minimize visibility of remaining jump.
* Mimics Android implementation
* Use constant for interpolation duration in InterpolatedLocationProducer

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
