### PR TITLE
Add Viewport Examples

### DIFF
--- a/Apps/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Apps/Examples/Examples.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		B5327E9D260124C00095B6BD /* MapboxMaps in Frameworks */ = {isa = PBXBuildFile; productRef = B5327E9C260124C00095B6BD /* MapboxMaps */; };
 		B5327EBF260277930095B6BD /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5327EBE260277930095B6BD /* Example.swift */; };
 		B5327EC3260277AC0095B6BD /* ExampleProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5327EC2260277AC0095B6BD /* ExampleProtocol.swift */; };
+		B57E1BAE27B5B6B900E8E3BA /* ViewportExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57E1BAD27B5B6B900E8E3BA /* ViewportExample.swift */; };
 		C608C107267BC5B1003C86C3 /* LocalizationExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C608C106267BC5B1003C86C3 /* LocalizationExample.swift */; };
 		CA03F10F26268DF700673961 /* OfflineManagerExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03F10E26268DF700673961 /* OfflineManagerExample.swift */; };
 		CA4F1F7225E815CF00822D2A /* SwiftUIExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A2E03C25CB64E20082BC31 /* SwiftUIExample.swift */; };
@@ -185,6 +186,7 @@
 		A4AC5DEB2542CB2200995E4C /* CustomStyleURLExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomStyleURLExample.swift; sourceTree = "<group>"; };
 		B5327EBE260277930095B6BD /* Example.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Example.swift; sourceTree = "<group>"; };
 		B5327EC2260277AC0095B6BD /* ExampleProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleProtocol.swift; sourceTree = "<group>"; };
+		B57E1BAD27B5B6B900E8E3BA /* ViewportExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewportExample.swift; sourceTree = "<group>"; };
 		C608C106267BC5B1003C86C3 /* LocalizationExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationExample.swift; sourceTree = "<group>"; };
 		C64ED3842540A2BE00ADADFB /* CameraAnimationExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraAnimationExample.swift; sourceTree = "<group>"; };
 		C64ED3C42540DD6E00ADADFB /* CustomPointAnnotationExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPointAnnotationExample.swift; sourceTree = "<group>"; };
@@ -267,6 +269,7 @@
 				C64ED3C42540DD6E00ADADFB /* CustomPointAnnotationExample.swift */,
 				A4AC5DEB2542CB2200995E4C /* CustomStyleURLExample.swift */,
 				C69F01EC2543646A001AB49B /* DataDrivenSymbolsExample.swift */,
+				73E27C2527AF024C0067F277 /* DataJoinExample.swift */,
 				17B48066268A4E9300CF0D5E /* DistanceExpressionExample.swift */,
 				077E3B2B2581810600564A3E /* ExternalVectorSourceExample.swift */,
 				07B0715F254789D6007F2865 /* FeaturesAtPointExample.swift */,
@@ -278,7 +281,6 @@
 				C64ED3C82541CA3A00ADADFB /* LineAnnotationExample.swift */,
 				0C78AC2825BF70E40057F570 /* LineGradientExample.swift */,
 				17B40D2326A85500000887EF /* LiveDataExample.swift */,
-				73E27C2527AF024C0067F277 /* DataJoinExample.swift */,
 				C608C106267BC5B1003C86C3 /* LocalizationExample.swift */,
 				07B071CD2547CF2B007F2865 /* MultipleGeometriesExample.swift */,
 				17483DFC2670113300396F8D /* MultiplePointAnnotationsExample.swift */,
@@ -305,6 +307,7 @@
 				077E3B932581987B00564A3E /* UpdatePointAnnotationPositionExample.swift */,
 				30517C69274BD4D300B706E5 /* ViewAnnotationBasicExample.swift */,
 				304AB3B427439287005B6D09 /* ViewAnnotationMarkerExample.swift */,
+				B57E1BAD27B5B6B900E8E3BA /* ViewportExample.swift */,
 			);
 			path = "All Examples";
 			sourceTree = "<group>";
@@ -620,6 +623,7 @@
 				B5327EBF260277930095B6BD /* Example.swift in Sources */,
 				CADCF736258499170065C51B /* ExampleTableViewController.swift in Sources */,
 				17B4805A2684FB2300CF0D5E /* AnimateImageLayerExample.swift in Sources */,
+				B57E1BAE27B5B6B900E8E3BA /* ViewportExample.swift in Sources */,
 				A4211CE62592549900D215B4 /* RestrictCoordinateBoundsExample.swift in Sources */,
 				0C52BA9825AF8C880054ECA8 /* Custom3DPuckExample.swift in Sources */,
 				CADCF7292584990E0065C51B /* FeaturesAtPointExample.swift in Sources */,

--- a/Apps/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Apps/Examples/Examples.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		B5327EBF260277930095B6BD /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5327EBE260277930095B6BD /* Example.swift */; };
 		B5327EC3260277AC0095B6BD /* ExampleProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5327EC2260277AC0095B6BD /* ExampleProtocol.swift */; };
 		B57E1BAE27B5B6B900E8E3BA /* ViewportExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57E1BAD27B5B6B900E8E3BA /* ViewportExample.swift */; };
+		B58E470927BABE0E00D87FD6 /* AdvancedViewportGesturesExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58E470827BABE0E00D87FD6 /* AdvancedViewportGesturesExample.swift */; };
 		C608C107267BC5B1003C86C3 /* LocalizationExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C608C106267BC5B1003C86C3 /* LocalizationExample.swift */; };
 		CA03F10F26268DF700673961 /* OfflineManagerExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03F10E26268DF700673961 /* OfflineManagerExample.swift */; };
 		CA4F1F7225E815CF00822D2A /* SwiftUIExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A2E03C25CB64E20082BC31 /* SwiftUIExample.swift */; };
@@ -187,6 +188,7 @@
 		B5327EBE260277930095B6BD /* Example.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Example.swift; sourceTree = "<group>"; };
 		B5327EC2260277AC0095B6BD /* ExampleProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleProtocol.swift; sourceTree = "<group>"; };
 		B57E1BAD27B5B6B900E8E3BA /* ViewportExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewportExample.swift; sourceTree = "<group>"; };
+		B58E470827BABE0E00D87FD6 /* AdvancedViewportGesturesExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedViewportGesturesExample.swift; sourceTree = "<group>"; };
 		C608C106267BC5B1003C86C3 /* LocalizationExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationExample.swift; sourceTree = "<group>"; };
 		C64ED3842540A2BE00ADADFB /* CameraAnimationExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraAnimationExample.swift; sourceTree = "<group>"; };
 		C64ED3C42540DD6E00ADADFB /* CustomPointAnnotationExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPointAnnotationExample.swift; sourceTree = "<group>"; };
@@ -308,6 +310,7 @@
 				30517C69274BD4D300B706E5 /* ViewAnnotationBasicExample.swift */,
 				304AB3B427439287005B6D09 /* ViewAnnotationMarkerExample.swift */,
 				B57E1BAD27B5B6B900E8E3BA /* ViewportExample.swift */,
+				B58E470827BABE0E00D87FD6 /* AdvancedViewportGesturesExample.swift */,
 			);
 			path = "All Examples";
 			sourceTree = "<group>";
@@ -578,6 +581,7 @@
 				CADCF73C258499200065C51B /* AppDelegate.swift in Sources */,
 				CADCF7392584991C0065C51B /* UIViewController+Children.swift in Sources */,
 				58248C2F2695FF24009AC598 /* StoryboardMapViewExample.swift in Sources */,
+				B58E470927BABE0E00D87FD6 /* AdvancedViewportGesturesExample.swift in Sources */,
 				30F095BF270B39AF00F368DC /* GlobeViewExample.swift in Sources */,
 				A495049B2667D64F00130A8F /* SkyLayerExample.swift in Sources */,
 				CADCF7262584990E0065C51B /* SnapshotterExample.swift in Sources */,

--- a/Apps/Examples/Examples/All Examples/AdvancedViewportGesturesExample.swift
+++ b/Apps/Examples/Examples/All Examples/AdvancedViewportGesturesExample.swift
@@ -1,6 +1,12 @@
 import UIKit
 @_spi(Experimental) import MapboxMaps
 
+// This example configures the viewport so that when it's in the follow puck state,
+// zoom and pitch gestures work alongside updates coming from the state itself.
+// Single tap on the map to switch to the overview state.
+//
+// When trying this example in the simulator, choose Features > Location > Freeway Drive
+// to get a good sense of the resulting user experience.
 @objc(AdvancedViewportGesturesExample)
 final class AdvancedViewportGesturesExample: UIViewController, ExampleProtocol {
 

--- a/Apps/Examples/Examples/All Examples/AdvancedViewportGesturesExample.swift
+++ b/Apps/Examples/Examples/All Examples/AdvancedViewportGesturesExample.swift
@@ -1,0 +1,139 @@
+import UIKit
+@_spi(Experimental) import MapboxMaps
+
+@objc(AdvancedViewportGesturesExample)
+final class AdvancedViewportGesturesExample: UIViewController, ExampleProtocol {
+
+    private enum State {
+        case following
+        case overview
+    }
+
+    private var state: State = .following {
+        didSet {
+            syncWithState()
+        }
+    }
+
+    private var mapView: MapView!
+    private var followPuckViewportState: FollowPuckViewportState!
+    private var overviewViewportState: OverviewViewportState!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        mapView = MapView(frame: view.bounds)
+        view.addSubview(mapView)
+
+        let cupertino = CLLocationCoordinate2D(latitude: 37.3230, longitude: -122.0322)
+
+        mapView.mapboxMap.setCamera(to: CameraOptions(center: cupertino, zoom: 14))
+
+        mapView.location.options.puckType = .puck2D(.makeDefault(showBearing: true))
+        mapView.location.options.puckBearingSource = .course
+
+        followPuckViewportState = mapView.viewport.makeFollowPuckViewportState(
+            options: FollowPuckViewportStateOptions(
+                bearing: .course))
+
+        overviewViewportState = mapView.viewport.makeOverviewViewportState(
+            options: OverviewViewportStateOptions(
+                geometry: Polygon(
+                    center: cupertino,
+                    radius: 20000,
+                    vertices: 100)))
+
+        mapView.gestures.delegate = self
+
+        syncWithState()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // The below line is used for internal testing purposes only.
+        finish()
+        mapView.viewport.addStatusObserver(self)
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        // break strong reference cycle
+        mapView.viewport.removeStatusObserver(self)
+    }
+
+    private func toggleViewportState() {
+        switch state {
+        case .overview:
+            state = .following
+        case .following:
+            state = .overview
+        }
+    }
+
+    private func syncWithState() {
+        switch state {
+        case .following:
+            mapView.viewport.transition(to: followPuckViewportState)
+        case .overview:
+            mapView.viewport.transition(to: overviewViewportState)
+        }
+
+        mapView.viewport.options.transitionsToIdleUponUserInteraction = state == .overview
+        mapView.gestures.options.panEnabled = state == .overview
+        mapView.gestures.options.pinchEnabled = state == .overview
+    }
+}
+
+extension AdvancedViewportGesturesExample: GestureManagerDelegate {
+    func gestureManager(_ gestureManager: GestureManager, didBegin gestureType: GestureType) {
+        switch gestureType {
+        case .pitch:
+            if state == .following {
+                followPuckViewportState.options.pitch = nil
+            }
+        case .doubleTapToZoomIn, .doubleTouchToZoomOut, .quickZoom:
+            if state == .following {
+                followPuckViewportState.options.zoom = nil
+            }
+        default:
+            break
+        }
+    }
+
+    func gestureManager(_ gestureManager: GestureManager, didEnd gestureType: GestureType, willAnimate: Bool) {
+        switch gestureType {
+        case .pitch:
+            if state == .following {
+                followPuckViewportState.options.pitch = mapView.mapboxMap.cameraState.pitch
+            }
+        case .quickZoom:
+            if state == .following {
+                followPuckViewportState.options.zoom = mapView.mapboxMap.cameraState.zoom
+            }
+        case .singleTap:
+            toggleViewportState()
+        default:
+            break
+        }
+    }
+
+    func gestureManager(_ gestureManager: GestureManager, didEndAnimatingFor gestureType: GestureType) {
+        switch gestureType {
+        case .doubleTapToZoomIn, .doubleTouchToZoomOut:
+            if state == .following {
+                followPuckViewportState.options.zoom = mapView.mapboxMap.cameraState.zoom
+            }
+        default:
+            break
+        }
+    }
+}
+
+extension AdvancedViewportGesturesExample: ViewportStatusObserver {
+    func viewportStatusDidChange(
+        from fromStatus: ViewportStatus,
+        to toStatus: ViewportStatus,
+        reason: ViewportStatusChangeReason) {
+            print("Viewport.status changed\n    from: \(fromStatus)\n    to: \(toStatus)\n    with reason: \(reason)")
+    }
+}

--- a/Apps/Examples/Examples/All Examples/BasicMapExample.swift
+++ b/Apps/Examples/Examples/All Examples/BasicMapExample.swift
@@ -2,12 +2,11 @@ import UIKit
 import MapboxMaps
 
 @objc(BasicMapExample)
+final class BasicMapExample: UIViewController, ExampleProtocol {
 
-public class BasicMapExample: UIViewController, ExampleProtocol {
+    private var mapView: MapView!
 
-    internal var mapView: MapView!
-
-    override public func viewDidLoad() {
+    override func viewDidLoad() {
         super.viewDidLoad()
 
         mapView = MapView(frame: view.bounds)
@@ -17,9 +16,9 @@ public class BasicMapExample: UIViewController, ExampleProtocol {
         view.addSubview(mapView)
     }
 
-    override public func viewDidAppear(_ animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-         // The below line is used for internal testing purposes only.
+        // The below line is used for internal testing purposes only.
         finish()
     }
 }

--- a/Apps/Examples/Examples/All Examples/ViewportExample.swift
+++ b/Apps/Examples/Examples/All Examples/ViewportExample.swift
@@ -1,6 +1,11 @@
 import UIKit
 @_spi(Experimental) import MapboxMaps
 
+// This example shows how to use the viewport API to keep the camera in sync with the puck,
+// show an overview of a region, and toggle between those states with transitions.
+//
+// When trying this example in the simulator, choose Features > Location > Freeway Drive
+// to get a good sense of the resulting user experience.
 @objc(ViewportExample)
 final class ViewportExample: UIViewController, ExampleProtocol {
 

--- a/Apps/Examples/Examples/All Examples/ViewportExample.swift
+++ b/Apps/Examples/Examples/All Examples/ViewportExample.swift
@@ -1,0 +1,107 @@
+import UIKit
+@_spi(Experimental) import MapboxMaps
+
+@objc(ViewportExample)
+final class ViewportExample: UIViewController, ExampleProtocol {
+
+    private enum State {
+        case following
+        case overview
+    }
+
+    private var state: State = .following {
+        didSet {
+            syncWithState()
+        }
+    }
+
+    private var viewportButton = UIButton(type: .system)
+    private var mapView: MapView!
+    private var followPuckViewportState: FollowPuckViewportState!
+    private var overviewViewportState: OverviewViewportState!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        mapView = MapView(frame: view.bounds)
+        view.addSubview(mapView)
+
+        let cupertino = CLLocationCoordinate2D(latitude: 37.3230, longitude: -122.0322)
+
+        mapView.mapboxMap.setCamera(to: CameraOptions(center: cupertino, zoom: 14))
+
+        mapView.location.options.puckType = .puck2D(.makeDefault(showBearing: true))
+        mapView.location.options.puckBearingSource = .course
+
+        followPuckViewportState = mapView.viewport.makeFollowPuckViewportState(
+            options: FollowPuckViewportStateOptions(
+                bearing: .course))
+
+        overviewViewportState = mapView.viewport.makeOverviewViewportState(
+            options: OverviewViewportStateOptions(
+                geometry: Polygon(
+                    center: cupertino,
+                    radius: 20000,
+                    vertices: 100)))
+
+        viewportButton.translatesAutoresizingMaskIntoConstraints = false
+        if #available(iOS 13.0, *) {
+            viewportButton.backgroundColor = .systemBackground
+        } else {
+            viewportButton.backgroundColor = .white
+        }
+        viewportButton.contentEdgeInsets = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
+        view.addSubview(viewportButton)
+        NSLayoutConstraint.activate([
+            viewportButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            viewportButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)])
+        viewportButton.addTarget(
+            self,
+            action: #selector(toggleViewportState),
+            for: .touchUpInside)
+
+        syncWithState()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // The below line is used for internal testing purposes only.
+        finish()
+        mapView.viewport.addStatusObserver(self)
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        // break strong reference cycle
+        mapView.viewport.removeStatusObserver(self)
+    }
+
+    @objc private func toggleViewportState() {
+        switch state {
+        case .overview:
+            state = .following
+        case .following:
+            state = .overview
+        }
+    }
+
+    private func syncWithState() {
+        switch state {
+        case .following:
+            mapView.viewport.transition(to: followPuckViewportState)
+            viewportButton.setTitle("Overview", for: .normal)
+        case .overview:
+            mapView.viewport.transition(to: overviewViewportState)
+            viewportButton.setTitle("Follow", for: .normal)
+        }
+    }
+}
+
+extension ViewportExample: ViewportStatusObserver {
+    func viewportStatusDidChange(
+        from fromStatus: ViewportStatus,
+        to toStatus: ViewportStatus,
+        reason: ViewportStatusChangeReason) {
+            print("Viewport.status changed\n    from: \(fromStatus)\n    to: \(toStatus)\n    with reason: \(reason)")
+    }
+}

--- a/Apps/Examples/Examples/Models/Examples.swift
+++ b/Apps/Examples/Examples/Models/Examples.swift
@@ -1,12 +1,12 @@
 import Foundation
 import MapboxMaps
 
-/**
- To add a new example, create a new `Example` struct
- and place it within the array for the category it belongs to below. Make sure
- the `fileName` is the same name of the new `UIViewController`
- you added in Examples/All Examples. See the README.md for more details.
- */
+// To add a new example, create a new `Example` struct
+// and place it within the array for the category it belongs to below. Make sure
+// the `fileName` is the same name of the new `UIViewController`
+// you added in Examples/All Examples. See the README.md for more details.
+
+// swiftlint:disable:next type_body_length
 public struct Examples {
     public static let all = [
         [

--- a/Apps/Examples/Examples/Models/Examples.swift
+++ b/Apps/Examples/Examples/Models/Examples.swift
@@ -261,5 +261,8 @@ public struct Examples {
         Example(title: "Viewport",
                 description: "Viewport camera showcase",
                 type: ViewportExample.self),
+        Example(title: "Advanced Viewport Gestures",
+                description: "Viewport configured to allow gestures",
+                type: AdvancedViewportGesturesExample.self),
     ]
 }

--- a/Apps/Examples/Examples/Models/Examples.swift
+++ b/Apps/Examples/Examples/Models/Examples.swift
@@ -258,5 +258,8 @@ public struct Examples {
         Example(title: "Globe View",
                 description: "Display map on a globe.",
                 type: GlobeViewExample.self),
+        Example(title: "Viewport",
+                description: "Viewport camera showcase",
+                type: ViewportExample.self),
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Sync viewport and puck animations. ([#1090](https://github.com/mapbox/mapbox-maps-ios/pull/1090))
 * Add puckBearingEnabled property for location ([#1107](https://github.com/mapbox/mapbox-maps-ios/pull/1107))
 * Fix camera change events being fired after map has stopped moving ([#1118])(https://github.com/mapbox/mapbox-maps-ios/pull/1118))
+* Fix issue where single tap and double tap to zoom in gestures could recognize simultaneously. ([#1113](https://github.com/mapbox/mapbox-maps-ios/pull/1113))
 
 ## 10.3.0 - February 10, 2022
 

--- a/Sources/MapboxMaps/Gestures/GestureManager.swift
+++ b/Sources/MapboxMaps/Gestures/GestureManager.swift
@@ -130,6 +130,7 @@ public final class GestureManager: GestureHandlerDelegate {
         pinchGestureHandler.gestureRecognizer.require(toFail: panGestureHandler.gestureRecognizer)
         pitchGestureHandler.gestureRecognizer.require(toFail: panGestureHandler.gestureRecognizer)
         quickZoomGestureHandler.gestureRecognizer.require(toFail: doubleTapToZoomInGestureHandler.gestureRecognizer)
+        singleTapGestureHandler.gestureRecognizer.require(toFail: doubleTapToZoomInGestureHandler.gestureRecognizer)
 
         // Invoke the setter to ensure the defaults are synchronized
         self.options = GestureOptions()

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -151,6 +151,14 @@ final class GestureManagerTests: XCTestCase {
                         === doubleTapToZoomInGestureHandler.gestureRecognizer)
     }
 
+    func testSingleTapGestureRecognizerRequiresDoubleTapToZoomInGestureRecognizerToFail() throws {
+        let singleTapGestureRecognizer = try XCTUnwrap(singleTapGestureHandler.gestureRecognizer as? MockGestureRecognizer)
+
+        XCTAssertEqual(singleTapGestureRecognizer.requireToFailStub.invocations.count, 1)
+        XCTAssertTrue(singleTapGestureRecognizer.requireToFailStub.parameters.first
+                        === doubleTapToZoomInGestureHandler.gestureRecognizer)
+    }
+
     func testGestureBegan() {
         let gestureType = GestureType.allCases.randomElement()!
 


### PR DESCRIPTION
Ported from corresponding examples on Android ([ViewportShowcaseActivity.kt](https://github.com/mapbox/mapbox-maps-android/blob/main/app/src/main/java/com/mapbox/maps/testapp/examples/viewport/ViewportShowcaseActivity.kt), [AdvancedViewportGesturesExample.kt](https://github.com/mapbox/mapbox-maps-android/blob/main/app/src/main/java/com/mapbox/maps/testapp/examples/viewport/AdvancedViewportGesturesExample.kt)) with minor adjustments.

Also fixes an issue where the single tap and double tap to zoom in gestures could recognize simultaneously.