### PR TITLE
Remove unused property, reduce optionals in fly-to

### DIFF
--- a/Sources/MapboxMaps/Camera/CameraAnimationsManager.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimationsManager.swift
@@ -38,10 +38,7 @@ public class CameraAnimationsManager: CameraAnimationsManagerProtocol {
     private var runningCameraAnimators = [CameraAnimator]()
 
     /// Internal camera animator used for animated transition
-    internal var internalAnimator: CameraAnimator?
-
-    /// May want to convert to an enum.
-    fileprivate let northBearing: CGFloat = 0
+    private var internalAnimator: CameraAnimator?
 
     internal var animationsEnabled: Bool = true
 
@@ -91,19 +88,16 @@ public class CameraAnimationsManager: CameraAnimationsManagerProtocol {
                     duration: TimeInterval? = nil,
                     completion: AnimationCompletion? = nil) -> Cancelable? {
 
-        guard let flyToAnimator = FlyToCameraAnimator(
-                initial: mapboxMap.cameraState,
-                final: camera,
-                cameraBounds: mapboxMap.cameraBounds,
-                owner: AnimationOwner(rawValue: "com.mapbox.maps.cameraAnimationsManager.flyToAnimator"),
-                duration: duration,
-                mapSize: mapboxMap.size,
-                mapboxMap: mapboxMap,
-                dateProvider: DefaultDateProvider(),
-                delegate: self) else {
-            Log.warning(forMessage: "Unable to start fly-to animation", category: "CameraManager")
-            return nil
-        }
+        let flyToAnimator = FlyToCameraAnimator(
+            initial: mapboxMap.cameraState,
+            final: camera,
+            cameraBounds: mapboxMap.cameraBounds,
+            owner: AnimationOwner(rawValue: "com.mapbox.maps.cameraAnimationsManager.flyToAnimator"),
+            duration: duration,
+            mapSize: mapboxMap.size,
+            mapboxMap: mapboxMap,
+            dateProvider: DefaultDateProvider(),
+            delegate: self)
 
         // Stop the `internalAnimator` before beginning a `flyTo`
         internalAnimator?.stopAnimation()

--- a/Sources/MapboxMaps/Camera/FlyToCameraAnimator.swift
+++ b/Sources/MapboxMaps/Camera/FlyToCameraAnimator.swift
@@ -12,7 +12,7 @@ public class FlyToCameraAnimator: NSObject, CameraAnimator, CameraAnimatorInterf
 
     public private(set) var state: UIViewAnimatingState = .inactive
 
-    private var start: Date?
+    private var startDate: Date?
 
     private let finalCameraOptions: CameraOptions
 
@@ -22,22 +22,18 @@ public class FlyToCameraAnimator: NSObject, CameraAnimator, CameraAnimatorInterf
 
     private weak var delegate: CameraAnimatorDelegate?
 
-    internal init?(initial: CameraState,
-                   final: CameraOptions,
-                   cameraBounds: CameraBounds,
-                   owner: AnimationOwner,
-                   duration: TimeInterval? = nil,
-                   mapSize: CGSize,
-                   mapboxMap: MapboxMapProtocol,
-                   dateProvider: DateProvider,
-                   delegate: CameraAnimatorDelegate) {
-        guard let flyToInterpolator = FlyToInterpolator(from: initial, to: final, cameraBounds: cameraBounds, size: mapSize) else {
-            return nil
-        }
+    internal init(initial: CameraState,
+                  final: CameraOptions,
+                  cameraBounds: CameraBounds,
+                  owner: AnimationOwner,
+                  duration: TimeInterval? = nil,
+                  mapSize: CGSize,
+                  mapboxMap: MapboxMapProtocol,
+                  dateProvider: DateProvider,
+                  delegate: CameraAnimatorDelegate) {
+        let flyToInterpolator = FlyToInterpolator(from: initial, to: final, cameraBounds: cameraBounds, size: mapSize)
         if let duration = duration {
-            guard duration >= 0 else {
-                return nil
-            }
+            precondition(duration >= 0)
         }
         self.interpolator = flyToInterpolator
         self.mapboxMap = mapboxMap
@@ -56,7 +52,7 @@ public class FlyToCameraAnimator: NSObject, CameraAnimator, CameraAnimatorInterf
 
     internal func startAnimation() {
         state = .active
-        start = dateProvider.now
+        startDate = dateProvider.now
         delegate?.cameraAnimatorDidStartRunning(self)
     }
 
@@ -73,10 +69,10 @@ public class FlyToCameraAnimator: NSObject, CameraAnimator, CameraAnimatorInterf
     }
 
     internal func update() {
-        guard state == .active, let start = start else {
+        guard state == .active, let startDate = startDate else {
             return
         }
-        let fractionComplete = min(dateProvider.now.timeIntervalSince(start) / duration, 1)
+        let fractionComplete = min(dateProvider.now.timeIntervalSince(startDate) / duration, 1)
         guard fractionComplete < 1 else {
             state = .inactive
             delegate?.cameraAnimatorDidStopRunning(self)

--- a/Sources/MapboxMaps/Camera/FlyToInterpolator.swift
+++ b/Sources/MapboxMaps/Camera/FlyToInterpolator.swift
@@ -51,7 +51,7 @@ internal struct FlyToInterpolator {
     ///   - dest: End camera (parameters ARE clamped to properties from MapCameraOptions)
     ///   - mapCameraOptions: Camera-specific capabilities of the map, for example, min-zoom, max-pitch
     ///   - size: Map View size in points
-    internal init?(from source: CameraState, to dest: CameraOptions, cameraBounds: CameraBounds, size: CGSize) {
+    internal init(from source: CameraState, to dest: CameraOptions, cameraBounds: CameraBounds, size: CGSize) {
         // Initial conditions
         let sourcePaddingParam   = source.padding
         let sourceCoord          = source.center

--- a/Tests/MapboxMapsTests/Camera/FlyToCameraAnimatorTests.swift
+++ b/Tests/MapboxMapsTests/Camera/FlyToCameraAnimatorTests.swift
@@ -65,21 +65,6 @@ final class FlyToCameraAnimatorTests: XCTestCase {
         XCTAssertEqual(flyToCameraAnimator.state, .inactive)
     }
 
-    func testInitializationWithANegativeDurationReturnsNil() {
-        XCTAssertNil(
-            FlyToCameraAnimator(
-                initial: initialCameraState,
-                final: finalCameraOptions,
-                cameraBounds: CameraBounds.default,
-                owner: AnimationOwner(rawValue: "fly-to"),
-                duration: -1,
-                mapSize: CGSize(width: 500, height: 500),
-                mapboxMap: mapboxMap,
-                dateProvider: dateProvider,
-                delegate: delegate)
-        )
-    }
-
     func testInitializationWithANilDurationSetsDurationToCalculatedValue() {
         let animator = FlyToCameraAnimator(
             initial: initialCameraState,
@@ -91,7 +76,7 @@ final class FlyToCameraAnimatorTests: XCTestCase {
             mapboxMap: mapboxMap,
             dateProvider: dateProvider,
             delegate: delegate)
-        XCTAssertNotNil(animator?.duration)
+        XCTAssertNotNil(animator.duration)
     }
 
     func testStartAnimationChangesStateToActiveAndInformsDelegate() {

--- a/Tests/MapboxMapsTests/Camera/FlyToTests.swift
+++ b/Tests/MapboxMapsTests/Camera/FlyToTests.swift
@@ -40,14 +40,11 @@ internal class FlyToTests: XCTestCase {
             bearing: 0,
             pitch: 0)
 
-        guard let flyTo = FlyToInterpolator(
-                from: source,
-                to: dest,
-                cameraBounds: CameraBounds.default,
-                size: CGSize(width: 1000.0, height: 1000.0)) else {
-            XCTFail("Failed to create interpolator")
-            return
-        }
+        let flyTo = FlyToInterpolator(
+            from: source,
+            to: dest,
+            cameraBounds: CameraBounds.default,
+            size: CGSize(width: 1000.0, height: 1000.0))
 
         let d0 = flyTo.coordinate(at: 0.0)
         let d1 = flyTo.coordinate(at: 0.5)
@@ -99,8 +96,8 @@ internal class FlyToTests: XCTestCase {
                                      bearing: 90,
                                      pitch: 45)
 
-            guard let flyTo = FlyToInterpolator(from: source, to: dest, cameraBounds: CameraBounds.default, size: CGSize(width: 500.0, height: 500.0)),
-                  var boundingBox = BoundingBox(from: [sourceCoord, destCoord]) else {
+            let flyTo = FlyToInterpolator(from: source, to: dest, cameraBounds: CameraBounds.default, size: CGSize(width: 500.0, height: 500.0))
+            guard var boundingBox = BoundingBox(from: [sourceCoord, destCoord]) else {
                 XCTFail("Failed to create interpolator")
                 continue
             }


### PR DESCRIPTION
We noticed some miscellaneous cleanup opportunities while discussing camera animations today

* Removed unused `northBearing` property from `CameraAnimationsManager`
* Made `CameraAnimationsManager.internalAnimator` private (was internal)
* Renamed `FlyToCameraAnimator.start` to `.startDate` for clarity at point of use.
* Made the initializers for `FlyToCameraAnimator` and `FlyToInterpolator` both non-failable.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
