### PR TITLE
Fix CircleCI CLI install path to support M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ JOBS             ?= $(shell sysctl -n hw.ncpu)
 APP_NAME         ?= $(SCHEME)
 
 # Circle
-CIRCLE_CI_CLI       ?= /usr/local/bin/circleci
+CIRCLE_CI_CLI       ?= /tmp/circleci
 CIRCLE_CI_BRANCH    ?= main
 CIRCLE_BUILD_NUM    ?= 0
 
@@ -461,4 +461,4 @@ validate: $(CIRCLE_CI_CLI)
 	$(CIRCLE_CI_CLI) config validate -c .circleci/config.yml
 
 $(CIRCLE_CI_CLI):
-	curl -fLSs https://circle.ci/cli | bash
+	curl -fLSs https://circle.ci/cli | DESTDIR=/tmp bash


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->
`/usr/local/bin` is not accessible for users on Apple Silicon machines – you have to use `sudo`. This PR changes installation path to `/tmp/circleci` to support both Intel and Apple Silicon.
There is a caveat – the previous installation make it reusable across the whole system on Intel machines. Also, it was a one-time install. We have workarounds for both of these:
1. `CircleCI` cli tool would be automatically reinstalled on each reboot (as soon as `/tmp/circleci` dismiss).
2. It is possible to install system-wide tool with Homebrew: `brew install circleci`

## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
