### PR TITLE
Update to MapboxCoreMaps 10.4.0-beta.1

### DIFF
--- a/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "d0adb996dfad19ed1edc611ee640e6c7506951a0",
-          "version": "21.1.0"
+          "revision": "90d62ad816567d31bdee5c9182e4abce7d862c51",
+          "version": "21.2.0-beta.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "f346a9880cf92ea5e8bc15a4034bb18d3d4c079c",
-          "version": "10.3.2"
+          "revision": "435ab6d7fb1e7b0cc7ec4aa53bff4d42fcc59abe",
+          "version": "10.4.0-beta.1"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Fix camera change events being fired after map has stopped moving. ([#1118])(https://github.com/mapbox/mapbox-maps-ios/pull/1118))
 * Fix issue where single tap and double tap to zoom in gestures could recognize simultaneously. ([#1113](https://github.com/mapbox/mapbox-maps-ios/pull/1113))
 * Remove experimental GestureOptions.pinchBehavior property. ([#1125](https://github.com/mapbox/mapbox-maps-ios/pull/1125))
+* Update to MapboxCoreMaps 10.4.0-beta.1 and MapboxCommon 21.2.0-beta.1. ([#1126](https://github.com/mapbox/mapbox-maps-ios/pull/1126))
 
 ## 10.3.0 - February 10, 2022
 

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -21,8 +21,8 @@ Pod::Spec.new do |m|
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
   m.resources = ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json']
 
-  m.dependency 'MapboxCoreMaps', '10.3.2'
-  m.dependency 'MapboxCommon', '21.1.0'
+  m.dependency 'MapboxCoreMaps', '10.4.0-beta.1'
+  m.dependency 'MapboxCommon', '21.2.0-beta.1'
   m.dependency 'MapboxMobileEvents', '1.0.7'
   m.dependency 'Turf', '~> 2.0'
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "d0adb996dfad19ed1edc611ee640e6c7506951a0",
-          "version": "21.1.0"
+          "revision": "90d62ad816567d31bdee5c9182e4abce7d862c51",
+          "version": "21.2.0-beta.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "f346a9880cf92ea5e8bc15a4034bb18d3d4c079c",
-          "version": "10.3.2"
+          "revision": "435ab6d7fb1e7b0cc7ec4aa53bff4d42fcc59abe",
+          "version": "10.4.0-beta.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
             targets: ["MapboxMaps"]),
     ],
     dependencies: [
-        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.3.2")),
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("21.1.0")),
+        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.4.0-beta.1")),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("21.2.0-beta.1")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", .exact("1.0.7")),
         .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.0.0"),
         .package(name: "CocoaImageHashing", url: "https://github.com/ameingast/cocoaimagehashing", .exact("1.9.0"))

--- a/scripts/release/packager/versions.json
+++ b/scripts/release/packager/versions.json
@@ -1,6 +1,6 @@
 {
-	"MapboxCoreMaps": "10.3.2",
-	"MapboxCommon": "21.1.0",
+	"MapboxCoreMaps": "10.4.0-beta.1",
+	"MapboxCommon": "21.2.0-beta.1",
 	"Turf": "v2.1.0",
 	"MapboxMobileEvents": "v1.0.7"
 }


### PR DESCRIPTION
## Features ✨ and improvements 🏁

* When the renderer thread is enabled, this change allows for coalescing the map updates that are performed on the client thread within the same run loop spin. Thus it helps to avoid rendering the map in inconsistent state
* Add 'StyleManager::hasStyleImage' method that checks whether an image is in the style 
* Snapshotter uses a lightweight scheduler instead of platform runloop  
* Added support for conditionally styling most paint properties according to the presence or absence of specific sprites in the style. Map now waits on sprite sheet loading before rendering
* Add PBR basic maps to models: occlusion, emission, normals and metallic-roughness. Also modified model lighting computation 
* Avoid transition calculations for non-transitional layer paint properties and thus improve performance on updating their values 
* Enable using of tile pack scheme from TileJSON 
* Decrease de/allocations in placement code
* Avoid layer properties transition calculation when duration is set to 0 
* Enable tile packs for DEM terrain tiles, it includes both Offline API and TileStoreUsageMode::ReadAndUpdate resource option
* Render tiles with partial content while the glyph dependencies are loading 
* Update mapbox-common to v21.2.0-beta.1
* Canonicalize URLs and enable Offline API usage for the 3dtiles/v1 tiles

## Bug fixes 🐞

* Fix screen coordinate queries when using zero pitch and high zoom values 
* Add .xcframework bundle name 
* Avoid possible crash at program exit caused by dummy tracer accessed after destruction
* Fix division by zero at Frustum::fromInvProjMatrix()
* Fix crash for the case when a map event is handled by an Observer of a destructed map
* Fix shimmering artifact when pitched raster tiles with compressed textures are rendered 
* Deliver event to observable subscribers even if observable is already destructed 
