### PR TITLE
Use union merge for CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 #
 *.pbxproj merge=union
+CHANGELOG.md merge=union
 
 # Mark files as generated in Github PRs
 Sources/MapboxMaps/Style/Generated/** linguist-generated=true


### PR DESCRIPTION
This should help reduce the need to rebase after someone else merges their PR that also updates the changelog.