### PR TITLE
Metal view explicit drawing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+* Enable explicit drawing behavior for metal view(call `draw()` explicitly instead of `setNeedsDisplay` when view's content need to be redrawn).([#1157](https://github.com/mapbox/mapbox-maps-ios/pull/1157))
+
 ## 10.4.0-beta.1 - February 23, 2022
 
 * Prevent rendering in background by pausing/resuming display link in response to application or scene lifecycle events. ([#1086](https://github.com/mapbox/mapbox-maps-ios/pull/1086))

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -81,7 +81,6 @@ open class MapView: UIView {
     internal private(set) var resourceOptions: ResourceOptions!
 
     private var needsDisplayRefresh: Bool = false
-    private var displayCallback: (() -> Void)?
     private var displayLink: DisplayLinkProtocol?
 
     /// Holding onto this value that comes from `MapOptions` since there is a race condition between
@@ -467,7 +466,7 @@ open class MapView: UIView {
 
         if needsDisplayRefresh {
             needsDisplayRefresh = false
-            displayCallback?()
+            metalView?.draw()
         }
     }
 
@@ -571,9 +570,6 @@ extension MapView: DelegatingMapClientDelegate {
 
     internal func getMetalView(for metalDevice: MTLDevice?) -> MTKView? {
         let metalView = dependencyProvider.makeMetalView(frame: bounds, device: metalDevice)
-        displayCallback = {
-            metalView.draw()
-        }
 
         metalView.translatesAutoresizingMaskIntoConstraints = false
         metalView.autoResizeDrawable = true

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -572,7 +572,7 @@ extension MapView: DelegatingMapClientDelegate {
     internal func getMetalView(for metalDevice: MTLDevice?) -> MTKView? {
         let metalView = dependencyProvider.makeMetalView(frame: bounds, device: metalDevice)
         displayCallback = {
-            metalView.setNeedsDisplay()
+            metalView.draw()
         }
 
         metalView.translatesAutoresizingMaskIntoConstraints = false
@@ -582,7 +582,7 @@ extension MapView: DelegatingMapClientDelegate {
         metalView.isOpaque = isOpaque
         metalView.layer.isOpaque = isOpaque
         metalView.isPaused = true
-        metalView.enableSetNeedsDisplay = true
+        metalView.enableSetNeedsDisplay = false
         metalView.presentsWithTransaction = false
 
         insertSubview(metalView, at: 0)

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -27,8 +27,6 @@ final class MapViewTests: XCTestCase {
         window = UIWindow()
         window.addSubview(mapView)
         metalView = try XCTUnwrap(XCTUnwrap(dependencyProvider.makeMetalViewStub.returnedValues.first))
-        // reset is required here to ignore the setNeedsDisplay() invocation during initialization
-        metalView.setNeedsDisplayStub.reset()
     }
 
     override func tearDown() {
@@ -136,12 +134,12 @@ final class MapViewTests: XCTestCase {
         XCTAssertEqual(mapView.displayLinkDuration, displayLink.duration)
     }
 
-    func testMetalViewSetNeedsDisplayIsTriggeredByScheduleRepaint() throws {
+    func testMetalViewDrawIsTriggeredByScheduleRepaint() throws {
         mapView.scheduleRepaint()
 
         try invokeDisplayLinkCallback()
 
-        XCTAssertEqual(metalView.setNeedsDisplayStub.invocations.count, 1)
+        XCTAssertEqual(metalView.drawStub.invocations.count, 1)
     }
 
     func testMetalViewDoesFitMapView() {

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMetalView.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMetalView.swift
@@ -1,9 +1,11 @@
 import MetalKit
 
 final class MockMetalView: MTKView {
-    let setNeedsDisplayStub = Stub<Void, Void>()
-    override func setNeedsDisplay() {
-        super.setNeedsDisplay()
-        setNeedsDisplayStub.call()
+    let drawStub = Stub<Void, Void>()
+
+    override func draw() {
+        super.draw()
+
+        drawStub.call()
     }
 }


### PR DESCRIPTION
This PR enables explicit drawing behaviour for `MTKView`. When core asks to repaint the map, instead of calling `setNeedsDisplay()` on the next display link callback, we call directly ask the metal view to redraw itself(`draw()`).

### Before

Core would call schedule repaint on the MapView. Only after the next Vsync(on `CADisplayLink` callback) `MapView` would notify the metal view that its content needs to be redrawn. Then the `MTKView` view is actually redrawn at "the next drawing cycle"(probably at the next VSync) according to the docs.

With this setup we have at least one frame lag on updating the metal view from the moment core requested it.

```mermaid
sequenceDiagram
Core->>MapView: schedule repaint
participant VSync
MapView->>MTKView: set needs display
MTKView->>"the next drawing cycle": draw
```

### After

~Core calls schedule repaint on the `MapView`. `MapView` immediately asks `MTKView` to redraw its content. No lag.~

Core calls schedule repaint on the `MapView`. After the next VSync`MapView` asks `MTKView` to redraw its content.

```mermaid
sequenceDiagram
Core->>MapView: schedule repaint
participant VSync Again
MapView->>MTKView: draw
```
**Both diagrams above assume all invocations are performed instantly.*
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
