### PR TITLE
Restore cancellation of animations on single tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 * Update to MapboxCoreMaps 10.4.0-rc.1 and MapboxCommon 21.2.0-rc.1. ([#1158](https://github.com/mapbox/mapbox-maps-ios/pull/1158))
 * Enable explicit drawing behavior for metal view(call `draw()` explicitly instead of `setNeedsDisplay` when view's content need to be redrawn).([#1157](https://github.com/mapbox/mapbox-maps-ios/pull/1157))
+* Restore cancellation of animations on single tap. ([#1166](https://github.com/mapbox/mapbox-maps-ios/pull/1166)) 
 
 ## 10.4.0-beta.1 - February 23, 2022
 

--- a/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
+++ b/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
@@ -97,7 +97,8 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
             cameraAnimationsManager: cameraAnimationsManager)
     }
 
-    func makeQuickZoomGestureHandler(view: UIView, mapboxMap: MapboxMapProtocol) -> FocusableGestureHandlerProtocol {
+    func makeQuickZoomGestureHandler(view: UIView,
+                                     mapboxMap: MapboxMapProtocol) -> FocusableGestureHandlerProtocol {
         let gestureRecognizer = UILongPressGestureRecognizer()
         view.addGestureRecognizer(gestureRecognizer)
         return QuickZoomGestureHandler(
@@ -106,10 +107,12 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
     }
 
     func makeSingleTapGestureHandler(view: UIView,
-                                     mapboxMap: MapboxMapProtocol) -> GestureHandler {
+                                     cameraAnimationsManager: CameraAnimationsManagerProtocol) -> GestureHandler {
         let gestureRecognizer = UITapGestureRecognizer()
         view.addGestureRecognizer(gestureRecognizer)
-        return SingleTapGestureHandler(gestureRecognizer: gestureRecognizer)
+        return SingleTapGestureHandler(
+            gestureRecognizer: gestureRecognizer,
+            cameraAnimationsManager: cameraAnimationsManager)
     }
 
     func makeAnyTouchGestureHandler(view: UIView,
@@ -156,7 +159,7 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
                 mapboxMap: mapboxMap),
             singleTapGestureHandler: makeSingleTapGestureHandler(
                 view: view,
-                mapboxMap: mapboxMap),
+                cameraAnimationsManager: cameraAnimationsManager),
             anyTouchGestureHandler: makeAnyTouchGestureHandler(
                 view: view,
                 cameraAnimationsManager: cameraAnimationsManager),

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/SingleTapGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/SingleTapGestureHandler.swift
@@ -3,9 +3,13 @@ import UIKit
 /// `SingleTapGestureHandler` manages a gesture recognizer looking for single tap touch events
 internal final class SingleTapGestureHandler: GestureHandler {
 
-    internal init(gestureRecognizer: UITapGestureRecognizer) {
+    private let cameraAnimationsManager: CameraAnimationsManagerProtocol
+
+    internal init(gestureRecognizer: UITapGestureRecognizer,
+                  cameraAnimationsManager: CameraAnimationsManagerProtocol) {
         gestureRecognizer.numberOfTapsRequired = 1
         gestureRecognizer.numberOfTouchesRequired = 1
+        self.cameraAnimationsManager = cameraAnimationsManager
         super.init(gestureRecognizer: gestureRecognizer)
         gestureRecognizer.addTarget(self, action: #selector(handleGesture(_:)))
     }
@@ -13,6 +17,7 @@ internal final class SingleTapGestureHandler: GestureHandler {
     @objc private func handleGesture(_ gestureRecognizer: UITapGestureRecognizer) {
         switch gestureRecognizer.state {
         case .recognized:
+            cameraAnimationsManager.cancelAnimations()
             delegate?.gestureBegan(for: .singleTap)
             delegate?.gestureEnded(for: .singleTap, willAnimate: false)
         default:

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/SingleTapGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/SingleTapGestureHandlerTests.swift
@@ -4,6 +4,7 @@ import XCTest
 final class SingleTapGestureHandlerTests: XCTestCase {
 
     var gestureRecognizer: MockTapGestureRecognizer!
+    var cameraAnimationsManager: MockCameraAnimationsManager!
     var gestureHandler: SingleTapGestureHandler!
     // swiftlint:disable:next weak_delegate
     var delegate: MockGestureHandlerDelegate!
@@ -11,7 +12,10 @@ final class SingleTapGestureHandlerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         gestureRecognizer = MockTapGestureRecognizer()
-        gestureHandler = SingleTapGestureHandler(gestureRecognizer: gestureRecognizer)
+        cameraAnimationsManager = MockCameraAnimationsManager()
+        gestureHandler = SingleTapGestureHandler(
+            gestureRecognizer: gestureRecognizer,
+            cameraAnimationsManager: cameraAnimationsManager)
         delegate = MockGestureHandlerDelegate()
         gestureHandler.delegate = delegate
     }
@@ -19,6 +23,7 @@ final class SingleTapGestureHandlerTests: XCTestCase {
     override func tearDown() {
         delegate = nil
         gestureHandler = nil
+        cameraAnimationsManager = nil
         gestureRecognizer = nil
         super.tearDown()
     }
@@ -33,6 +38,7 @@ final class SingleTapGestureHandlerTests: XCTestCase {
         gestureRecognizer.getStateStub.defaultReturnValue = .recognized
         gestureRecognizer.sendActions()
 
+        XCTAssertEqual(cameraAnimationsManager.cancelAnimationsStub.invocations.count, 1)
         XCTAssertEqual(delegate.gestureBeganStub.parameters, [.singleTap])
         XCTAssertEqual(delegate.gestureEndedStub.invocations.count, 1)
         XCTAssertEqual(delegate.gestureEndedStub.parameters.first?.gestureType, .singleTap)


### PR DESCRIPTION
#1058 introduced a delay before disabling animations during gestures to allow short discrete gestures like the double tap, double touch, and single tap gestures to be performed without canceling animations. That resulted in single tap gestures no longer canceling animations.

This PR restores the behavior of single tap gestures canceling animations.

Note: the single tap gesture only recognizes if the double tap gesture fails. Waiting for that failure means there will be a small delay before the tap is recognized and animations are canceled. To avoid this delay, disable the double tap to zoom in gesture: `mapView.gestures.options.doubleTapToZoomInEnabled = false`.

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
