### PR TITLE
Remove `parameters` and `returnedValues` properties from Stub

### DIFF
--- a/Tests/MapboxMapsTests/Annotations/ViewAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/ViewAnnotationManagerTests.swift
@@ -81,11 +81,11 @@ final class ViewAnnotationManagerTests: XCTestCase {
         _ = addTestAnnotationView()
         _ = addTestAnnotationView()
         _ = addTestAnnotationView()
-        let viewIds = mapboxMap.addViewAnnotationStub.parameters.map(\.id)
+        let viewIds = mapboxMap.addViewAnnotationStub.invocations.map(\.parameters.id)
 
         manager.removeAll()
 
-        XCTAssertEqual(Set(mapboxMap.removeViewAnnotationStub.parameters), Set(viewIds))
+        XCTAssertEqual(Set(mapboxMap.removeViewAnnotationStub.invocations.map(\.parameters)), Set(viewIds))
         XCTAssertTrue(container.subviews.isEmpty)
     }
 
@@ -280,7 +280,7 @@ final class ViewAnnotationManagerTests: XCTestCase {
 
         triggerPositionUpdate(forId: id)
 
-        XCTAssertEqual(observer.framesDidChangeStub.parameters.first, [annotationView])
+        XCTAssertEqual(observer.framesDidChangeStub.invocations.first?.parameters, [annotationView])
     }
 
     func testViewAnnotationUpdateObserverNotNotifiedAboutSameFrames() {
@@ -293,7 +293,7 @@ final class ViewAnnotationManagerTests: XCTestCase {
 
         triggerPositionUpdate(forId: id)
 
-        XCTAssertTrue(observer.framesDidChangeStub.parameters.isEmpty)
+        XCTAssertTrue(observer.framesDidChangeStub.invocations.isEmpty)
     }
 
     func testViewAnnotationUpdateObserverNotifiedAboutNewlyHiddenViews() {
@@ -304,7 +304,7 @@ final class ViewAnnotationManagerTests: XCTestCase {
         manager.onViewAnnotationPositionsUpdate(forPositions: [])
 
         XCTAssertTrue(annotationView.isHidden)
-        XCTAssertEqual(observer.visibilityDidChangeStub.parameters.first, [annotationView])
+        XCTAssertEqual(observer.visibilityDidChangeStub.invocations.first?.parameters, [annotationView])
     }
 
     func testViewAnnotationUpdateObserverNotifiedAboutNewlyVisibleViews() {
@@ -317,7 +317,7 @@ final class ViewAnnotationManagerTests: XCTestCase {
         triggerPositionUpdate(forId: id)
 
         XCTAssertFalse(annotationView.isHidden)
-        XCTAssertEqual(observer.visibilityDidChangeStub.parameters.first, [annotationView])
+        XCTAssertEqual(observer.visibilityDidChangeStub.invocations.first?.parameters, [annotationView])
     }
 
     func testRemoveViewAnnotationUpdateObserver() {

--- a/Tests/MapboxMapsTests/Camera/BasicCameraAnimatorIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Camera/BasicCameraAnimatorIntegrationTests.swift
@@ -48,7 +48,7 @@ final class BasicCameraAnimatorIntegrationTests: XCTestCase {
 
         animator.update()
 
-        XCTAssertEqual(mapboxMap.setCameraStub.parameters, [])
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 0)
     }
 
     func testUpdateAfterAnimationsAreFlushed() {
@@ -57,6 +57,6 @@ final class BasicCameraAnimatorIntegrationTests: XCTestCase {
 
         animator.update()
 
-        XCTAssertEqual(mapboxMap.setCameraStub.parameters, [cameraView.presentationCameraOptions])
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.map(\.parameters), [cameraView.presentationCameraOptions])
     }
 }

--- a/Tests/MapboxMapsTests/Camera/BasicCameraAnimatorTests.swift
+++ b/Tests/MapboxMapsTests/Camera/BasicCameraAnimatorTests.swift
@@ -58,18 +58,18 @@ final class BasicCameraAnimatorTests: XCTestCase {
     func testDeinit() {
         animator = nil
         XCTAssertEqual(cameraView.removeFromSuperviewStub.invocations.count, 1)
-        XCTAssertEqual(propertyAnimator.stopAnimationStub.parameters, [true])
+        XCTAssertEqual(propertyAnimator.stopAnimationStub.invocations.map(\.parameters), [true])
         XCTAssertTrue(propertyAnimator.finishAnimationStub.invocations.isEmpty)
     }
 
     func testIsReversed() {
         animator.isReversed = true
 
-        XCTAssertEqual(propertyAnimator.setIsReversedStub.parameters, [true])
+        XCTAssertEqual(propertyAnimator.setIsReversedStub.invocations.map(\.parameters), [true])
 
         animator.isReversed = false
 
-        XCTAssertEqual(propertyAnimator.setIsReversedStub.parameters, [true, false])
+        XCTAssertEqual(propertyAnimator.setIsReversedStub.invocations.map(\.parameters), [true, false])
     }
 
     func testStartAndStopAnimation() {
@@ -85,14 +85,14 @@ final class BasicCameraAnimatorTests: XCTestCase {
         XCTAssertNotNil(animator?.transition)
         XCTAssertEqual(animator?.transition?.toCameraOptions.zoom, 10)
         XCTAssertEqual(delegate.cameraAnimatorDidStartRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.parameters.first === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.invocations.first?.parameters === animator)
 
         animator.stopAnimation()
         XCTAssertEqual(propertyAnimator.stopAnimationStub.invocations.count, 1)
         XCTAssertEqual(propertyAnimator.finishAnimationStub.invocations.count, 1)
         XCTAssertEqual(propertyAnimator.finishAnimationStub.invocations.first?.parameters, .current)
         XCTAssertEqual(delegate.cameraAnimatorDidStopRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.parameters.first === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.invocations.first?.parameters === animator)
     }
 
     func testStartAndStopAnimationAfterDelay() throws {
@@ -250,7 +250,7 @@ final class BasicCameraAnimatorTests: XCTestCase {
 
         animator.startAnimation()
         XCTAssertEqual(delegate.cameraAnimatorDidStartRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.parameters.first === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.invocations.first?.parameters === animator)
     }
 
     func testInformsDelegateWhenStartingAfterDelay() {
@@ -259,7 +259,7 @@ final class BasicCameraAnimatorTests: XCTestCase {
         }
         animator.startAnimation(afterDelay: 1)
         XCTAssertEqual(delegate.cameraAnimatorDidStartRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.parameters.first === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.invocations.first?.parameters === animator)
     }
 
     func testInformsDelegateWhenStartingPausingAndStarting() {
@@ -268,15 +268,15 @@ final class BasicCameraAnimatorTests: XCTestCase {
         }
         animator.startAnimation()
         XCTAssertEqual(delegate.cameraAnimatorDidStartRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.parameters.first === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.invocations.first?.parameters === animator)
 
         animator.pauseAnimation()
         XCTAssertEqual(delegate.cameraAnimatorDidStopRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.parameters.first === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.invocations.first?.parameters === animator)
 
         animator.startAnimation()
         XCTAssertEqual(delegate.cameraAnimatorDidStartRunningStub.invocations.count, 2)
-        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.parameters.last === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.invocations.last?.parameters === animator)
     }
 
     func testInformsDelegateWhenPausingAndContinuing() {
@@ -288,7 +288,7 @@ final class BasicCameraAnimatorTests: XCTestCase {
 
         animator.continueAnimation(withTimingParameters: nil, durationFactor: 1)
         XCTAssertEqual(delegate.cameraAnimatorDidStartRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.parameters.first === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.invocations.first?.parameters === animator)
     }
 
     func testInformsDelegateWhenStartingPausingAndContinuing() {
@@ -297,15 +297,15 @@ final class BasicCameraAnimatorTests: XCTestCase {
         }
         animator.startAnimation()
         XCTAssertEqual(delegate.cameraAnimatorDidStartRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.parameters.first === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.invocations.first?.parameters === animator)
 
         animator.pauseAnimation()
         XCTAssertEqual(delegate.cameraAnimatorDidStopRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.parameters.first === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.invocations.first?.parameters === animator)
 
         animator.continueAnimation(withTimingParameters: nil, durationFactor: 1)
         XCTAssertEqual(delegate.cameraAnimatorDidStartRunningStub.invocations.count, 2)
-        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.parameters.last === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.invocations.last?.parameters === animator)
     }
 
     func testInformsDelegateWhenPausingAndStopping() {
@@ -326,7 +326,7 @@ final class BasicCameraAnimatorTests: XCTestCase {
             transition.zoom.toValue = cameraOptionsTestValue.zoom!
         }
         animator.startAnimation()
-        let completion = try XCTUnwrap(propertyAnimator.addCompletionStub.parameters.first)
+        let completion = try XCTUnwrap(propertyAnimator.addCompletionStub.invocations.first?.parameters)
 
         completion(.end)
 
@@ -338,7 +338,7 @@ final class BasicCameraAnimatorTests: XCTestCase {
             transition.zoom.toValue = cameraOptionsTestValue.zoom!
         }
         animator.startAnimation()
-        let completion = try XCTUnwrap(propertyAnimator.addCompletionStub.parameters.first)
+        let completion = try XCTUnwrap(propertyAnimator.addCompletionStub.invocations.first?.parameters)
 
         completion(.start)
 
@@ -350,7 +350,7 @@ final class BasicCameraAnimatorTests: XCTestCase {
             transition.zoom.toValue = cameraOptionsTestValue.zoom!
         }
         animator.startAnimation()
-        let completion = try XCTUnwrap(propertyAnimator.addCompletionStub.parameters.first)
+        let completion = try XCTUnwrap(propertyAnimator.addCompletionStub.invocations.first?.parameters)
 
         completion(.current)
 
@@ -362,11 +362,11 @@ final class BasicCameraAnimatorTests: XCTestCase {
             transition.zoom.toValue = cameraOptionsTestValue.zoom!
         }
         animator.startAnimation()
-        let completion = try XCTUnwrap(propertyAnimator.addCompletionStub.parameters.first)
+        let completion = try XCTUnwrap(propertyAnimator.addCompletionStub.invocations.first?.parameters)
 
         completion(.current)
 
         XCTAssertEqual(delegate.cameraAnimatorDidStopRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.parameters.first === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.invocations.first?.parameters === animator)
     }
 }

--- a/Tests/MapboxMapsTests/Camera/FlyToCameraAnimatorTests.swift
+++ b/Tests/MapboxMapsTests/Camera/FlyToCameraAnimatorTests.swift
@@ -84,7 +84,7 @@ final class FlyToCameraAnimatorTests: XCTestCase {
 
         XCTAssertEqual(flyToCameraAnimator.state, .active)
         XCTAssertEqual(delegate.cameraAnimatorDidStartRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.parameters.first === flyToCameraAnimator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.invocations.first?.parameters === flyToCameraAnimator)
     }
 
     func testAnimationCompletion() {
@@ -100,7 +100,7 @@ final class FlyToCameraAnimatorTests: XCTestCase {
         XCTAssertEqual(flyToCameraAnimator.state, .inactive)
         XCTAssertEqual(animatingPositions, [.end])
         XCTAssertEqual(delegate.cameraAnimatorDidStopRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.parameters.first === flyToCameraAnimator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.invocations.first?.parameters === flyToCameraAnimator)
     }
 
     func testStopAnimation() {
@@ -115,7 +115,7 @@ final class FlyToCameraAnimatorTests: XCTestCase {
         XCTAssertEqual(animatingPositions, [.current])
         XCTAssertEqual(flyToCameraAnimator.state, .inactive)
         XCTAssertEqual(delegate.cameraAnimatorDidStopRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.parameters.first === flyToCameraAnimator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.invocations.first?.parameters === flyToCameraAnimator)
     }
 
     func testUpdateDoesNotSetCameraIfAnimationIsNotRunning() {

--- a/Tests/MapboxMapsTests/Camera/GestureDecelerationCameraAnimatorTests.swift
+++ b/Tests/MapboxMapsTests/Camera/GestureDecelerationCameraAnimatorTests.swift
@@ -53,7 +53,7 @@ final class GestureDecelerationCameraAnimatorTests: XCTestCase {
 
         XCTAssertEqual(animator.state, .active)
         XCTAssertEqual(delegate.cameraAnimatorDidStartRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.parameters.first === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.invocations.first?.parameters === animator)
     }
 
     func testStopAnimation() {
@@ -64,7 +64,7 @@ final class GestureDecelerationCameraAnimatorTests: XCTestCase {
         XCTAssertEqual(animator.state, .inactive)
         XCTAssertEqual(completion.invocations.count, 1)
         XCTAssertEqual(delegate.cameraAnimatorDidStopRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.parameters.first === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.invocations.first?.parameters === animator)
     }
 
     func testUpdate() {
@@ -75,7 +75,7 @@ final class GestureDecelerationCameraAnimatorTests: XCTestCase {
         animator.update()
 
         // Expected value is duration * velocity;
-        XCTAssertEqual(locationChangeHandler.parameters, [.init(fromLocation: location, toLocation: CGPoint(x: 10, y: -10))])
+        XCTAssertEqual(locationChangeHandler.invocations.map(\.parameters), [.init(fromLocation: location, toLocation: CGPoint(x: 10, y: -10))])
         // The previous update() should also have reduced the velocity
         // by multiplying it by the decelerationFactor once for each elapsed
         // millisecond. In this simulateion, 10 ms have elapsed.
@@ -106,6 +106,6 @@ final class GestureDecelerationCameraAnimatorTests: XCTestCase {
         XCTAssertEqual(animator.state, .inactive)
         XCTAssertEqual(completion.invocations.count, 1)
         XCTAssertEqual(delegate.cameraAnimatorDidStopRunningStub.invocations.count, 1)
-        XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.parameters.first === animator)
+        XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.invocations.first?.parameters === animator)
     }
 }

--- a/Tests/MapboxMapsTests/Foundation/DelegatingDisplayLinkParticipantTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/DelegatingDisplayLinkParticipantTests.swift
@@ -11,6 +11,6 @@ final class DelegatingDisplayLinkParticipantTests: XCTestCase {
         delegatingParticipant.participate()
 
         XCTAssertEqual(delegate.participateStub.invocations.count, 1)
-        XCTAssertTrue(delegate.participateStub.parameters.first === delegatingParticipant)
+        XCTAssertTrue(delegate.participateStub.invocations.first?.parameters === delegatingParticipant)
     }
 }

--- a/Tests/MapboxMapsTests/Foundation/DelegatingMapClientTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/DelegatingMapClientTests.swift
@@ -32,7 +32,7 @@ final class DelegatingMapClientTests: XCTestCase {
         delegatingMapClient.scheduleTask {
             invoked = true
         }
-        delegate.scheduleTaskStub.parameters.first?()
+        delegate.scheduleTaskStub.invocations.first?.parameters()
 
         XCTAssertEqual(delegate.scheduleTaskStub.invocations.count, 1)
         XCTAssertTrue(invoked)
@@ -46,12 +46,11 @@ final class DelegatingMapClientTests: XCTestCase {
         let actualView = delegatingMapClient.getMetalView(for: expectedDevice)
 
         XCTAssertEqual(delegate.getMetalViewStub.invocations.count, 1)
-        guard let actualDevice = delegate.getMetalViewStub.parameters.first else {
+        guard let actualDevice = delegate.getMetalViewStub.invocations.first?.parameters else {
             return
         }
-        if case let .some(actual) = actualDevice,
-           let expected = expectedDevice {
-            XCTAssertTrue(actual === expected)
+        if let expected = expectedDevice {
+            XCTAssertTrue(actualDevice === expected)
         } else {
             XCTAssertNil(actualDevice)
             XCTAssertNil(expectedDevice)

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -26,7 +26,7 @@ final class MapViewTests: XCTestCase {
             dependencyProvider: dependencyProvider)
         window = UIWindow()
         window.addSubview(mapView)
-        metalView = try XCTUnwrap(XCTUnwrap(dependencyProvider.makeMetalViewStub.returnedValues.first))
+        metalView = try XCTUnwrap(XCTUnwrap(dependencyProvider.makeMetalViewStub.invocations.first?.returnValue))
     }
 
     override func tearDown() {
@@ -41,7 +41,7 @@ final class MapViewTests: XCTestCase {
     }
 
     func invokeDisplayLinkCallback() throws {
-        let makeDisplayLinkParams = try XCTUnwrap(dependencyProvider.makeDisplayLinkStub.parameters.first)
+        let makeDisplayLinkParams = try XCTUnwrap(dependencyProvider.makeDisplayLinkStub.invocations.first?.parameters)
         let target = try XCTUnwrap(makeDisplayLinkParams.target as? NSObject)
 
         // Invoke the display link callback while there's an animator; verify that this alone does
@@ -63,14 +63,14 @@ final class MapViewTests: XCTestCase {
         do {
             XCTAssertEqual(dependencyProvider.makeDisplayLinkStub.invocations.count, 1)
             XCTAssertEqual(displayLink.addStub.invocations.count, 1)
-            XCTAssertEqual(displayLink.addStub.parameters.first?.runloop, .current)
-            XCTAssertEqual(displayLink.addStub.parameters.first?.mode, .common)
+            XCTAssertEqual(displayLink.addStub.invocations.first?.parameters.runloop, .current)
+            XCTAssertEqual(displayLink.addStub.invocations.first?.parameters.mode, .common)
         }
 
         do {
             mapView.removeFromSuperview()
-            let displayLink = try XCTUnwrap(dependencyProvider.makeDisplayLinkStub.returnedValues.first)
-            XCTAssertEqual(displayLink?.invalidateStub.invocations.count, 1)
+            let displayLink = try XCTUnwrap(dependencyProvider.makeDisplayLinkStub.invocations.first?.returnValue)
+            XCTAssertEqual(displayLink.invalidateStub.invocations.count, 1)
         }
     }
 
@@ -278,13 +278,13 @@ final class MapViewTests: XCTestCase {
     func testDisplayLinkPausedWhenAppMovingToBackground() {
         notificationCenter.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
 
-        XCTAssertEqual(displayLink.$isPaused.setStub.parameters, [true])
+        XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [true])
     }
 
     func testDisplayLinkResumedWhenAppMovingToForeground() {
         notificationCenter.post(name: UIApplication.willEnterForegroundNotification, object: nil)
 
-        XCTAssertEqual(displayLink.$isPaused.setStub.parameters, [false])
+        XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [false])
     }
 
     func testDisplayLinkResumedWhenSceneMovingToForeground() throws {
@@ -296,7 +296,7 @@ final class MapViewTests: XCTestCase {
 
         notificationCenter.post(name: UIScene.willEnterForegroundNotification, object: window.parentScene)
 
-        XCTAssertEqual(displayLink.$isPaused.setStub.parameters, [false])
+        XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [false])
     }
 
     func testDisplayLinkPausedWhenSceneMovingToBackground() throws {
@@ -308,6 +308,6 @@ final class MapViewTests: XCTestCase {
 
         notificationCenter.post(name: UIScene.didEnterBackgroundNotification, object: window.parentScene)
 
-        XCTAssertEqual(displayLink.$isPaused.setStub.parameters, [true])
+        XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [true])
     }
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/DoubleTapToZoomInGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/DoubleTapToZoomInGestureHandlerTests.swift
@@ -47,19 +47,19 @@ final class DoubleTapToZoomInGestureHandlerTests: XCTestCase {
 
         gestureRecognizer.sendActions()
 
-        let tapLocation = try XCTUnwrap(gestureRecognizer.locationStub.returnedValues.first)
-        XCTAssertEqual(delegate.gestureBeganStub.parameters, [.doubleTapToZoomIn])
+        let tapLocation = try XCTUnwrap(gestureRecognizer.locationStub.invocations.first?.returnValue)
+        XCTAssertEqual(delegate.gestureBeganStub.invocations.map(\.parameters), [.doubleTapToZoomIn])
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.count, 1)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.camera, CameraOptions(anchor: tapLocation, zoom: mapboxMap.cameraState.zoom + 1))
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.duration, 0.3)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.curve, .easeOut)
-        XCTAssertEqual(delegate.gestureEndedStub.parameters.first?.gestureType, .doubleTapToZoomIn)
-        let willAnimate = try XCTUnwrap(delegate.gestureEndedStub.parameters.first?.willAnimate)
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.camera, CameraOptions(anchor: tapLocation, zoom: mapboxMap.cameraState.zoom + 1))
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.duration, 0.3)
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.curve, .easeOut)
+        XCTAssertEqual(delegate.gestureEndedStub.invocations.first?.parameters.gestureType, .doubleTapToZoomIn)
+        let willAnimate = try XCTUnwrap(delegate.gestureEndedStub.invocations.first?.parameters.willAnimate)
         XCTAssertTrue(willAnimate)
 
-        let easeToCompletion = try XCTUnwrap(cameraAnimationsManager.easeToStub.parameters.first?.completion)
+        let easeToCompletion = try XCTUnwrap(cameraAnimationsManager.easeToStub.invocations.first?.parameters.completion)
         easeToCompletion(.end)
-        XCTAssertEqual(delegate.animationEndedStub.parameters, [.doubleTapToZoomIn])
+        XCTAssertEqual(delegate.animationEndedStub.invocations.map(\.parameters), [.doubleTapToZoomIn])
     }
 
     func testFocalPoint() {
@@ -70,6 +70,6 @@ final class DoubleTapToZoomInGestureHandlerTests: XCTestCase {
         gestureRecognizer.sendActions()
 
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.count, 1)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.camera.anchor, focalPoint)
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.camera.anchor, focalPoint)
     }
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/DoubleTouchToZoomOutGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/DoubleTouchToZoomOutGestureHandlerTests.swift
@@ -47,19 +47,19 @@ final class DoubleTouchToZoomOutGestureHandlerTests: XCTestCase {
 
         gestureRecognizer.sendActions()
 
-        let tapLocation = try XCTUnwrap(gestureRecognizer.locationStub.returnedValues.first)
-        XCTAssertEqual(delegate.gestureBeganStub.parameters, [.doubleTouchToZoomOut])
+        let tapLocation = try XCTUnwrap(gestureRecognizer.locationStub.invocations.first?.returnValue)
+        XCTAssertEqual(delegate.gestureBeganStub.invocations.map(\.parameters), [.doubleTouchToZoomOut])
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.count, 1)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.camera, CameraOptions(anchor: tapLocation, zoom: mapboxMap.cameraState.zoom - 1))
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.duration, 0.3)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.curve, .easeOut)
-        XCTAssertEqual(delegate.gestureEndedStub.parameters.first?.gestureType, .doubleTouchToZoomOut)
-        let willAnimate = try XCTUnwrap(delegate.gestureEndedStub.parameters.first?.willAnimate)
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.camera, CameraOptions(anchor: tapLocation, zoom: mapboxMap.cameraState.zoom - 1))
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.duration, 0.3)
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.curve, .easeOut)
+        XCTAssertEqual(delegate.gestureEndedStub.invocations.first?.parameters.gestureType, .doubleTouchToZoomOut)
+        let willAnimate = try XCTUnwrap(delegate.gestureEndedStub.invocations.first?.parameters.willAnimate)
         XCTAssertTrue(willAnimate)
 
-        let easeToCompletion = try XCTUnwrap(cameraAnimationsManager.easeToStub.parameters.first?.completion)
+        let easeToCompletion = try XCTUnwrap(cameraAnimationsManager.easeToStub.invocations.first?.parameters.completion)
         easeToCompletion(.end)
-        XCTAssertEqual(delegate.animationEndedStub.parameters, [.doubleTouchToZoomOut])
+        XCTAssertEqual(delegate.animationEndedStub.invocations.map(\.parameters), [.doubleTouchToZoomOut])
     }
 
     func testFocalPoint() {
@@ -71,6 +71,6 @@ final class DoubleTouchToZoomOutGestureHandlerTests: XCTestCase {
         gestureRecognizer.sendActions()
 
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.count, 1)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.camera.anchor, focalPoint)
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.camera.anchor, focalPoint)
     }
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockLongPressGestureRecognizer.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockLongPressGestureRecognizer.swift
@@ -27,7 +27,7 @@ final class MockLongPressGestureRecognizer: UILongPressGestureRecognizer {
     }
 
     func sendActions() {
-        for param in addTargetStub.parameters {
+        for param in addTargetStub.invocations.map(\.parameters) {
             (param.target as? NSObject)?.perform(param.action, with: self)
         }
     }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockPanGestureRecognizer.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockPanGestureRecognizer.swift
@@ -51,7 +51,7 @@ final class MockPanGestureRecognizer: UIPanGestureRecognizer {
     }
 
     func sendActions() {
-        for param in addTargetStub.parameters {
+        for param in addTargetStub.invocations.map(\.parameters) {
             (param.target as? NSObject)?.perform(param.action, with: self)
         }
     }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockPinchGestureRecognizer.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockPinchGestureRecognizer.swift
@@ -55,7 +55,7 @@ final class MockPinchGestureRecognizer: UIPinchGestureRecognizer {
     }
 
     func sendActions() {
-        for param in addTargetStub.parameters {
+        for param in addTargetStub.invocations.map(\.parameters) {
             (param.target as? NSObject)?.perform(param.action, with: self)
         }
     }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockRotationGestureRecognizer.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockRotationGestureRecognizer.swift
@@ -33,7 +33,7 @@ final class MockRotationGestureRecognizer: UIRotationGestureRecognizer {
     }
 
     func sendActions() {
-        for param in addTargetStub.parameters {
+        for param in addTargetStub.invocations.map(\.parameters) {
             (param.target as? NSObject)?.perform(param.action, with: self)
         }
     }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockTapGestureRecognizer.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/Mocks/MockTapGestureRecognizer.swift
@@ -22,7 +22,7 @@ final class MockTapGestureRecognizer: UITapGestureRecognizer {
     }
 
     func sendActions() {
-        for param in addTargetStub.parameters {
+        for param in addTargetStub.invocations.map(\.parameters) {
             (param.target as? NSObject)?.perform(param.action, with: self)
         }
     }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PanGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PanGestureHandlerTests.swift
@@ -54,8 +54,8 @@ final class PanGestureHandlerTests: XCTestCase {
 
         gestureRecognizer.sendActions()
 
-        XCTAssertEqual(mapboxMap.dragStartStub.parameters, [touchLocation])
-        XCTAssertEqual(delegate.gestureBeganStub.parameters, [.pan])
+        XCTAssertEqual(mapboxMap.dragStartStub.invocations.map(\.parameters), [touchLocation])
+        XCTAssertEqual(delegate.gestureBeganStub.invocations.map(\.parameters), [.pan])
     }
 
     func verifyHandlePanChanged(panMode: PanMode,
@@ -80,10 +80,10 @@ final class PanGestureHandlerTests: XCTestCase {
 
             gestureRecognizer.sendActions()
 
-            XCTAssertEqual(mapboxMap.dragCameraOptionsStub.parameters, [
+            XCTAssertEqual(mapboxMap.dragCameraOptionsStub.invocations.map(\.parameters), [
                 .init(from: clampingFunction(touchLocations[idx - 1]), to: clampingFunction(touchLocations[idx]))], line: line)
-            let dragCameraOptions = try XCTUnwrap(mapboxMap.dragCameraOptionsStub.returnedValues.first, line: line)
-            XCTAssertEqual(mapboxMap.setCameraStub.parameters, [dragCameraOptions], line: line)
+            let dragCameraOptions = try XCTUnwrap(mapboxMap.dragCameraOptionsStub.invocations.first?.returnValue, line: line)
+            XCTAssertEqual(mapboxMap.setCameraStub.invocations.map(\.parameters), [dragCameraOptions], line: line)
         }
     }
 
@@ -159,10 +159,10 @@ final class PanGestureHandlerTests: XCTestCase {
         gestureRecognizer.getStateStub.defaultReturnValue = .ended
         gestureRecognizer.sendActions()
 
-        XCTAssertEqual(delegate.gestureEndedStub.parameters, [.init(gestureType: .pan, willAnimate: true)])
+        XCTAssertEqual(delegate.gestureEndedStub.invocations.map(\.parameters), [.init(gestureType: .pan, willAnimate: true)])
 
         XCTAssertEqual(cameraAnimationsManager.decelerateStub.invocations.count, 1)
-        let decelerateParams = cameraAnimationsManager.decelerateStub.parameters.first
+        let decelerateParams = cameraAnimationsManager.decelerateStub.invocations.first?.parameters
         let expectedDecelerateLocation = CGPoint(
             x: endedTouchLocation.x,
             y: max(endedTouchLocation.y, 3 / 4 * mapboxMap.size.height))
@@ -179,19 +179,19 @@ final class PanGestureHandlerTests: XCTestCase {
             let locationChangeHandler = try XCTUnwrap(decelerateParams?.locationChangeHandler)
             locationChangeHandler(previousLocations[i], interpolatedLocations[i])
             XCTAssertEqual(
-                mapboxMap.dragCameraOptionsStub.parameters,
+                mapboxMap.dragCameraOptionsStub.invocations.map(\.parameters),
                 [.init(
                     from: previousLocations[i],
                     to: interpolatedLocations[i])])
-            let dragCameraOptions = try XCTUnwrap(mapboxMap.dragCameraOptionsStub.returnedValues.first)
-            XCTAssertEqual(mapboxMap.setCameraStub.parameters, [dragCameraOptions])
+            let dragCameraOptions = try XCTUnwrap(mapboxMap.dragCameraOptionsStub.invocations.first?.returnValue)
+            XCTAssertEqual(mapboxMap.setCameraStub.invocations.map(\.parameters), [dragCameraOptions])
         }
 
         let animationEndedCompletion = try XCTUnwrap(decelerateParams?.completion)
         animationEndedCompletion()
 
         XCTAssertEqual(mapboxMap.dragEndStub.invocations.count, 1)
-        XCTAssertEqual(delegate.animationEndedStub.parameters, [.pan])
+        XCTAssertEqual(delegate.animationEndedStub.invocations.map(\.parameters), [.pan])
     }
 
     func testHandlePanEnded() throws {
@@ -230,7 +230,7 @@ final class PanGestureHandlerTests: XCTestCase {
 
         XCTAssertEqual(cameraAnimationsManager.decelerateStub.invocations.count, 0, "Cancelled pan should not trigger deceleration")
         XCTAssertEqual(mapboxMap.dragEndStub.invocations.count, 1)
-        XCTAssertEqual(delegate.gestureEndedStub.parameters, [.init(gestureType: .pan, willAnimate: false)])
+        XCTAssertEqual(delegate.gestureEndedStub.invocations.map(\.parameters), [.init(gestureType: .pan, willAnimate: false)])
     }
 
     func testSecondPanGesturePerformsCorrectlyWhenInterruptingDecelerationFromFirstPanGesture() throws {
@@ -245,7 +245,7 @@ final class PanGestureHandlerTests: XCTestCase {
         mapboxMap.setCameraStub.reset()
 
         // cancel deceleration *after* the second gesture begins
-        let decelerateAnimationCompletion = try XCTUnwrap(cameraAnimationsManager.decelerateStub.parameters.first?.completion)
+        let decelerateAnimationCompletion = try XCTUnwrap(cameraAnimationsManager.decelerateStub.invocations.first?.parameters.completion)
         decelerateAnimationCompletion()
 
         // changed 2 should still result in camera updates. a previous

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PitchGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PitchGestureHandlerTests.swift
@@ -73,7 +73,7 @@ final class PitchGestureHandlerTests: XCTestCase {
 
         gestureRecognizer.sendActions()
 
-        XCTAssertEqual(delegate.gestureBeganStub.parameters, [.pitch])
+        XCTAssertEqual(delegate.gestureBeganStub.invocations.map(\.parameters), [.pitch])
         XCTAssertEqual(gestureRecognizer.locationOfTouchStub.invocations.count, 0)
     }
 
@@ -87,7 +87,7 @@ final class PitchGestureHandlerTests: XCTestCase {
 
         gestureRecognizer.sendActions()
 
-        XCTAssertEqual(mapboxMap.setCameraStub.parameters, [CameraOptions(pitch: mapboxMap.cameraState.pitch - 12.5)])
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.map(\.parameters), [CameraOptions(pitch: mapboxMap.cameraState.pitch - 12.5)])
     }
 
     func testPitchEnded() throws {
@@ -96,9 +96,9 @@ final class PitchGestureHandlerTests: XCTestCase {
         gestureRecognizer.sendActions()
 
         XCTAssertEqual(delegate.gestureEndedStub.invocations.count, 1)
-        XCTAssertEqual(delegate.gestureEndedStub.parameters.first?.gestureType, .pitch)
+        XCTAssertEqual(delegate.gestureEndedStub.invocations.first?.parameters.gestureType, .pitch)
 
-        let willAnimate = try XCTUnwrap(delegate.gestureEndedStub.parameters.first?.willAnimate)
+        let willAnimate = try XCTUnwrap(delegate.gestureEndedStub.invocations.first?.parameters.willAnimate)
         XCTAssertFalse(willAnimate)
     }
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/QuickZoomGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/QuickZoomGestureHandlerTests.swift
@@ -42,7 +42,7 @@ final class QuickZoomGestureHandlerTest: XCTestCase {
 
         gestureRecognizer.sendActions()
 
-        XCTAssertEqual(delegate.gestureBeganStub.parameters, [.quickZoom])
+        XCTAssertEqual(delegate.gestureBeganStub.invocations.map(\.parameters), [.quickZoom])
     }
 
     func testGestureChanged() throws {
@@ -59,10 +59,10 @@ final class QuickZoomGestureHandlerTest: XCTestCase {
         gestureRecognizer.locationStub.defaultReturnValue.y = 175
         gestureRecognizer.sendActions()
 
-        let initialLocation = try XCTUnwrap(gestureRecognizer.locationStub.returnedValues.first)
+        let initialLocation = try XCTUnwrap(gestureRecognizer.locationStub.invocations.first?.returnValue)
 
         XCTAssertEqual(
-            mapboxMap.setCameraStub.parameters,
+            mapboxMap.setCameraStub.invocations.map(\.parameters),
             [CameraOptions(
                 anchor: initialLocation,
                 zoom: initialZoom + 1)])
@@ -74,9 +74,9 @@ final class QuickZoomGestureHandlerTest: XCTestCase {
         gestureRecognizer.sendActions()
 
         XCTAssertEqual(delegate.gestureEndedStub.invocations.count, 1)
-        XCTAssertEqual(delegate.gestureEndedStub.parameters.first?.gestureType, .quickZoom)
+        XCTAssertEqual(delegate.gestureEndedStub.invocations.first?.parameters.gestureType, .quickZoom)
 
-        let willAnimate = try XCTUnwrap(delegate.gestureEndedStub.parameters.first?.willAnimate)
+        let willAnimate = try XCTUnwrap(delegate.gestureEndedStub.invocations.first?.parameters.willAnimate)
         XCTAssertFalse(willAnimate)
     }
 
@@ -92,6 +92,6 @@ final class QuickZoomGestureHandlerTest: XCTestCase {
         gestureRecognizer.sendActions()
 
         XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 1)
-        XCTAssertEqual(mapboxMap.setCameraStub.parameters.first?.anchor, focalPoint)
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.first?.parameters.anchor, focalPoint)
     }
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/SingleTapGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/SingleTapGestureHandlerTests.swift
@@ -39,9 +39,9 @@ final class SingleTapGestureHandlerTests: XCTestCase {
         gestureRecognizer.sendActions()
 
         XCTAssertEqual(cameraAnimationsManager.cancelAnimationsStub.invocations.count, 1)
-        XCTAssertEqual(delegate.gestureBeganStub.parameters, [.singleTap])
+        XCTAssertEqual(delegate.gestureBeganStub.invocations.map(\.parameters), [.singleTap])
         XCTAssertEqual(delegate.gestureEndedStub.invocations.count, 1)
-        XCTAssertEqual(delegate.gestureEndedStub.parameters.first?.gestureType, .singleTap)
-        XCTAssertEqual(delegate.gestureEndedStub.parameters.first?.willAnimate, false)
+        XCTAssertEqual(delegate.gestureEndedStub.invocations.first?.parameters.gestureType, .singleTap)
+        XCTAssertEqual(delegate.gestureEndedStub.invocations.first?.parameters.willAnimate, false)
     }
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -133,7 +133,7 @@ final class GestureManagerTests: XCTestCase {
         let pinchGestureRecognizer = try XCTUnwrap(pinchGestureHandler.gestureRecognizer as? MockGestureRecognizer)
 
         XCTAssertEqual(pinchGestureRecognizer.requireToFailStub.invocations.count, 1)
-        XCTAssertTrue(pinchGestureRecognizer.requireToFailStub.parameters.first
+        XCTAssertTrue(pinchGestureRecognizer.requireToFailStub.invocations.first?.parameters
                         === panGestureHandler.gestureRecognizer)
     }
 
@@ -141,7 +141,7 @@ final class GestureManagerTests: XCTestCase {
         let pitchGestureRecognizer = try XCTUnwrap(pitchGestureHandler.gestureRecognizer as? MockGestureRecognizer)
 
         XCTAssertEqual(pitchGestureRecognizer.requireToFailStub.invocations.count, 1)
-        XCTAssertTrue(pitchGestureRecognizer.requireToFailStub.parameters.first
+        XCTAssertTrue(pitchGestureRecognizer.requireToFailStub.invocations.first?.parameters
                         === panGestureHandler.gestureRecognizer)
     }
 
@@ -149,7 +149,7 @@ final class GestureManagerTests: XCTestCase {
         let quickZoomGestureRecognizer = try XCTUnwrap(quickZoomGestureHandler.gestureRecognizer as? MockGestureRecognizer)
 
         XCTAssertEqual(quickZoomGestureRecognizer.requireToFailStub.invocations.count, 1)
-        XCTAssertTrue(quickZoomGestureRecognizer.requireToFailStub.parameters.first
+        XCTAssertTrue(quickZoomGestureRecognizer.requireToFailStub.invocations.first?.parameters
                         === doubleTapToZoomInGestureHandler.gestureRecognizer)
     }
 
@@ -157,7 +157,7 @@ final class GestureManagerTests: XCTestCase {
         let singleTapGestureRecognizer = try XCTUnwrap(singleTapGestureHandler.gestureRecognizer as? MockGestureRecognizer)
 
         XCTAssertEqual(singleTapGestureRecognizer.requireToFailStub.invocations.count, 1)
-        XCTAssertTrue(singleTapGestureRecognizer.requireToFailStub.parameters.first
+        XCTAssertTrue(singleTapGestureRecognizer.requireToFailStub.invocations.first?.parameters
                         === doubleTapToZoomInGestureHandler.gestureRecognizer)
     }
 
@@ -167,8 +167,8 @@ final class GestureManagerTests: XCTestCase {
         gestureManager.gestureBegan(for: gestureType)
 
         XCTAssertEqual(delegate.gestureDidBeginStub.invocations.count, 1, "GestureBegan should have been invoked once. It was called \(delegate.gestureDidBeginStub.invocations.count) times.")
-        XCTAssertTrue(delegate.gestureDidBeginStub.parameters.first?.gestureManager === gestureManager)
-        XCTAssertEqual(delegate.gestureDidBeginStub.parameters.first?.gestureType, gestureType)
+        XCTAssertTrue(delegate.gestureDidBeginStub.invocations.first?.parameters.gestureManager === gestureManager)
+        XCTAssertEqual(delegate.gestureDidBeginStub.invocations.first?.parameters.gestureType, gestureType)
         XCTAssertEqual(mapboxMap.beginGestureStub.invocations.count, 1)
     }
 
@@ -178,9 +178,9 @@ final class GestureManagerTests: XCTestCase {
         gestureManager.gestureEnded(for: gestureType, willAnimate: willAnimate)
 
         XCTAssertEqual(delegate.gestureDidEndStub.invocations.count, 1, "GestureEnded should have been invoked once. It was called \(delegate.gestureDidEndStub.invocations.count) times.")
-        XCTAssertTrue(delegate.gestureDidEndStub.parameters.first?.gestureManager === gestureManager)
-        XCTAssertEqual(delegate.gestureDidEndStub.parameters.first?.gestureType, gestureType)
-        let willAnimateValue = try XCTUnwrap(delegate.gestureDidEndStub.parameters.first?.willAnimate)
+        XCTAssertTrue(delegate.gestureDidEndStub.invocations.first?.parameters.gestureManager === gestureManager)
+        XCTAssertEqual(delegate.gestureDidEndStub.invocations.first?.parameters.gestureType, gestureType)
+        let willAnimateValue = try XCTUnwrap(delegate.gestureDidEndStub.invocations.first?.parameters.willAnimate)
         XCTAssertEqual(willAnimateValue, willAnimate)
         XCTAssertEqual(mapboxMap.endGestureStub.invocations.count, 1)
     }
@@ -191,8 +191,8 @@ final class GestureManagerTests: XCTestCase {
         gestureManager.animationEnded(for: gestureType)
 
         XCTAssertEqual(delegate.gestureDidEndAnimatingStub.invocations.count, 1, "animationEnded should have been invoked once. It was called \(delegate.gestureDidEndAnimatingStub.invocations.count) times.")
-        XCTAssertTrue(delegate.gestureDidEndAnimatingStub.parameters.first?.gestureManager === gestureManager)
-        XCTAssertEqual(delegate.gestureDidEndAnimatingStub.parameters.first?.gestureType, gestureType)
+        XCTAssertTrue(delegate.gestureDidEndAnimatingStub.invocations.first?.parameters.gestureManager === gestureManager)
+        XCTAssertEqual(delegate.gestureDidEndAnimatingStub.invocations.first?.parameters.gestureType, gestureType)
     }
 
     func testOptionsPanEnabled() {

--- a/Tests/MapboxMapsTests/Gestures/Mocks/MockGestureRecognizer.swift
+++ b/Tests/MapboxMapsTests/Gestures/Mocks/MockGestureRecognizer.swift
@@ -27,7 +27,7 @@ final class MockGestureRecognizer: UIGestureRecognizer {
     }
 
     func sendActions() {
-        for param in addTargetStub.parameters {
+        for param in addTargetStub.invocations.map(\.parameters) {
             _ = (param.target as AnyObject).perform(param.action, with: self)
         }
     }

--- a/Tests/MapboxMapsTests/Helpers/Stub.swift
+++ b/Tests/MapboxMapsTests/Helpers/Stub.swift
@@ -21,14 +21,6 @@ final class Stub<ParametersType, ReturnType> {
         self.defaultReturnValue = defaultReturnValue
     }
 
-    var returnedValues: [ReturnType] {
-        invocations.map(\.returnValue)
-    }
-
-    var parameters: [ParametersType] {
-        invocations.map(\.parameters)
-    }
-
     func call(with parameters: ParametersType) -> ReturnType {
         let invocation = Invocation(parameters: parameters,
                                     returnValue: returnValueQueue.isEmpty ? defaultReturnValue : returnValueQueue.removeFirst())

--- a/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationManagerTests.swift
@@ -106,7 +106,7 @@ final class LocationManagerTests: XCTestCase {
         locationManager.addLocationConsumer(newConsumer: consumer)
 
         XCTAssertEqual(locationProducer.addStub.invocations.count, 1)
-        XCTAssertTrue(locationProducer.addStub.parameters.first === consumer)
+        XCTAssertTrue(locationProducer.addStub.invocations.first?.parameters === consumer)
     }
 
     func testRemoveLocationConsumer() {
@@ -115,7 +115,7 @@ final class LocationManagerTests: XCTestCase {
         locationManager.removeLocationConsumer(consumer: consumer)
 
         XCTAssertEqual(locationProducer.removeStub.invocations.count, 1)
-        XCTAssertTrue(locationProducer.removeStub.parameters.first === consumer)
+        XCTAssertTrue(locationProducer.removeStub.invocations.first?.parameters === consumer)
     }
 
     @available(iOS 14.0, *)
@@ -125,7 +125,7 @@ final class LocationManagerTests: XCTestCase {
         locationManager.requestTemporaryFullAccuracyPermissions(withPurposeKey: purposeKey)
 
         let locationProvider = try XCTUnwrap(locationProducer.locationProvider as? MockLocationProvider)
-        XCTAssertEqual(locationProvider.requestTemporaryFullAccuracyAuthorizationStub.parameters, [purposeKey])
+        XCTAssertEqual(locationProvider.requestTemporaryFullAccuracyAuthorizationStub.invocations.map(\.parameters), [purposeKey])
     }
 
     func testLocationProducerDidFailWithError() {
@@ -136,8 +136,8 @@ final class LocationManagerTests: XCTestCase {
         locationManager.locationProducer(locationProducer, didFailWithError: error)
 
         XCTAssertEqual(delegate.didFailToLocateUserWithErrorStub.invocations.count, 1)
-        XCTAssertTrue(delegate.didFailToLocateUserWithErrorStub.parameters.first?.locationManager === locationManager)
-        XCTAssertTrue(delegate.didFailToLocateUserWithErrorStub.parameters.first?.error as? MockError === error)
+        XCTAssertTrue(delegate.didFailToLocateUserWithErrorStub.invocations.first?.parameters.locationManager === locationManager)
+        XCTAssertTrue(delegate.didFailToLocateUserWithErrorStub.invocations.first?.parameters.error as? MockError === error)
     }
 
     func testLocationProducerDidChangeAccuracyAuthorization() {
@@ -148,7 +148,7 @@ final class LocationManagerTests: XCTestCase {
         locationManager.locationProducer(locationProducer, didChangeAccuracyAuthorization: accuracyAuthorization)
 
         XCTAssertEqual(delegate.didChangeAccuracyAuthorizationStub.invocations.count, 1)
-        XCTAssertTrue(delegate.didChangeAccuracyAuthorizationStub.parameters.first?.locationManager === locationManager)
-        XCTAssertEqual(delegate.didChangeAccuracyAuthorizationStub.parameters.first?.accuracyAuthorization, accuracyAuthorization)
+        XCTAssertTrue(delegate.didChangeAccuracyAuthorizationStub.invocations.first?.parameters.locationManager === locationManager)
+        XCTAssertEqual(delegate.didChangeAccuracyAuthorizationStub.invocations.first?.parameters.accuracyAuthorization, accuracyAuthorization)
     }
 }

--- a/Tests/MapboxMapsTests/Location/LocationProducerTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationProducerTests.swift
@@ -129,11 +129,11 @@ final class LocationProducerTests: XCTestCase {
 
         for c in consumers {
             XCTAssertEqual(c.locationUpdateStub.invocations.count, 1)
-            XCTAssertTrue(c.locationUpdateStub.parameters.first?.location === locations[1])
+            XCTAssertTrue(c.locationUpdateStub.invocations.first?.parameters.location === locations[1])
             // accuracyAuthorization is populated with the value from the locationProvider
             // at the time of initialization. This value is only updated when the provider
             // notifies its delegate that the authorization has changed.
-            XCTAssertTrue(c.locationUpdateStub.parameters.first?.accuracyAuthorization == locationProvider.accuracyAuthorization)
+            XCTAssertTrue(c.locationUpdateStub.invocations.first?.parameters.accuracyAuthorization == locationProvider.accuracyAuthorization)
         }
     }
 
@@ -155,7 +155,7 @@ final class LocationProducerTests: XCTestCase {
 
         for c in consumers {
             XCTAssertEqual(c.locationUpdateStub.invocations.count, 1)
-            XCTAssertTrue(c.locationUpdateStub.parameters.first?.heading === heading)
+            XCTAssertTrue(c.locationUpdateStub.invocations.first?.parameters.heading === heading)
         }
     }
 
@@ -178,7 +178,7 @@ final class LocationProducerTests: XCTestCase {
 
         for c in consumers {
             XCTAssertEqual(c.locationUpdateStub.invocations.count, 1)
-            XCTAssertTrue(c.locationUpdateStub.parameters.first?.accuracyAuthorization == accuracyAuthorization)
+            XCTAssertTrue(c.locationUpdateStub.invocations.first?.parameters.accuracyAuthorization == accuracyAuthorization)
         }
     }
 
@@ -211,11 +211,11 @@ final class LocationProducerTests: XCTestCase {
         locationProducer.locationProvider = otherProvider
 
         XCTAssertEqual(locationProvider.setDelegateStub.invocations.count, 1)
-        let delegate = try XCTUnwrap(locationProvider.setDelegateStub.parameters.first)
+        let delegate = try XCTUnwrap(locationProvider.setDelegateStub.invocations.first?.parameters)
         XCTAssertTrue(delegate is EmptyLocationProviderDelegate)
 
         XCTAssertEqual(otherProvider.setDelegateStub.invocations.count, 1)
-        XCTAssertTrue(otherProvider.setDelegateStub.parameters.first === locationProducer)
+        XCTAssertTrue(otherProvider.setDelegateStub.invocations.first?.parameters === locationProducer)
 
         XCTAssertTrue(locationProvider.startUpdatingLocationStub.invocations.isEmpty)
         XCTAssertTrue(locationProvider.startUpdatingHeadingStub.invocations.isEmpty)
@@ -371,8 +371,8 @@ final class LocationProducerTests: XCTestCase {
         locationProducer.locationProvider(locationProvider, didFailWithError: error)
 
         XCTAssertEqual(delegate.didFailWithErrorStub.invocations.count, 1)
-        XCTAssertTrue(delegate.didFailWithErrorStub.parameters.first?.locationProducer === locationProducer)
-        let actualError = try XCTUnwrap(delegate.didFailWithErrorStub.parameters.first?.error)
+        XCTAssertTrue(delegate.didFailWithErrorStub.invocations.first?.parameters.locationProducer === locationProducer)
+        let actualError = try XCTUnwrap(delegate.didFailWithErrorStub.invocations.first?.parameters.error)
         XCTAssertTrue((actualError as? MockError) === error)
     }
 
@@ -392,8 +392,8 @@ final class LocationProducerTests: XCTestCase {
         locationProducer.locationProviderDidChangeAuthorization(locationProvider)
 
         XCTAssertEqual(delegate.didChangeAccuracyAuthorizationStub.invocations.count, 1)
-        XCTAssertTrue(delegate.didChangeAccuracyAuthorizationStub.parameters.first?.locationProducer === locationProducer)
-        XCTAssertEqual(delegate.didChangeAccuracyAuthorizationStub.parameters.first?.accuracyAuthorization, locationProvider.accuracyAuthorization)
+        XCTAssertTrue(delegate.didChangeAccuracyAuthorizationStub.invocations.first?.parameters.locationProducer === locationProducer)
+        XCTAssertEqual(delegate.didChangeAccuracyAuthorizationStub.invocations.first?.parameters.accuracyAuthorization, locationProvider.accuracyAuthorization)
     }
 
     func testDidChangeAuthorizationDoesNotNotifyDelegateIfAccuracyAuthorizationDidNotChange() {
@@ -419,7 +419,7 @@ final class LocationProducerTests: XCTestCase {
 
         if #available(iOS 14.0, *) {
             XCTAssertEqual(
-                locationProvider.requestTemporaryFullAccuracyAuthorizationStub.parameters,
+                locationProvider.requestTemporaryFullAccuracyAuthorizationStub.invocations.map(\.parameters),
                 ["LocationAccuracyAuthorizationDescription"])
         } else {
             XCTAssertTrue(locationProvider.requestTemporaryFullAccuracyAuthorizationStub.invocations.isEmpty)

--- a/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
@@ -115,7 +115,7 @@ final class Puck2DTests: XCTestCase {
 
     func verifyAddImages(line: UInt = #line) {
         XCTAssertEqual(style.addImageStub.invocations.count, 3, line: line)
-        let parameters = style.addImageStub.parameters
+        let parameters = style.addImageStub.invocations.map(\.parameters)
         for p in parameters {
             XCTAssertFalse(p.sdf, line: line)
             XCTAssertEqual(p.stretchX, [], line: line)
@@ -125,14 +125,14 @@ final class Puck2DTests: XCTestCase {
         guard parameters.count == 3 else {
             return
         }
-        XCTAssertEqual(style.addImageStub.parameters[0].id, "locationIndicatorLayerTopImage", line: line)
-        XCTAssertTrue(style.addImageStub.parameters[0].image === configuration.topImage, line: line)
+        XCTAssertEqual(parameters[0].id, "locationIndicatorLayerTopImage", line: line)
+        XCTAssertTrue(parameters[0].image === configuration.topImage, line: line)
 
-        XCTAssertEqual(style.addImageStub.parameters[1].id, "locationIndicatorLayerBearingImage", line: line)
-        XCTAssertTrue(style.addImageStub.parameters[1].image === configuration.bearingImage, line: line)
+        XCTAssertEqual(parameters[1].id, "locationIndicatorLayerBearingImage", line: line)
+        XCTAssertTrue(parameters[1].image === configuration.bearingImage, line: line)
 
-        XCTAssertEqual(style.addImageStub.parameters[2].id, "locationIndicatorLayerShadowImage", line: line)
-        XCTAssertTrue(style.addImageStub.parameters[2].image === configuration.shadowImage, line: line)
+        XCTAssertEqual(parameters[2].id, "locationIndicatorLayerShadowImage", line: line)
+        XCTAssertTrue(parameters[2].image === configuration.shadowImage, line: line)
     }
 
     func testActivatingPuckDoesNotAddImagesIfLatestLocationIsNil() throws {
@@ -165,17 +165,17 @@ final class Puck2DTests: XCTestCase {
         puck2D.isActive = true
 
         XCTAssertEqual(style.addImageStub.invocations.count, 2)
-        let parameters = style.addImageStub.parameters
+        let parameters = style.addImageStub.invocations.map(\.parameters)
         guard parameters.count >= 2 else {
             return
         }
-        XCTAssertEqual(style.addImageStub.parameters[0].id, "locationIndicatorLayerTopImage")
+        XCTAssertEqual(parameters[0].id, "locationIndicatorLayerTopImage")
         let expectedTopImage = UIImage(named: "location-dot-inner", in: .mapboxMaps, compatibleWith: nil)!
-        XCTAssertTrue(style.addImageStub.parameters[0].image.isEqual(expectedTopImage))
+        XCTAssertTrue(parameters[0].image.isEqual(expectedTopImage))
 
-        XCTAssertEqual(style.addImageStub.parameters[1].id, "locationIndicatorLayerShadowImage")
+        XCTAssertEqual(parameters[1].id, "locationIndicatorLayerShadowImage")
         let expectedBearingImage = UIImage(named: "location-dot-outer", in: .mapboxMaps, compatibleWith: nil)!
-        XCTAssertTrue(style.addImageStub.parameters[1].image.isEqual(expectedBearingImage))
+        XCTAssertTrue(parameters[1].image.isEqual(expectedBearingImage))
     }
 
     func makeExpectedLayerProperties(with location: InterpolatedLocation) -> [String: Any] {
@@ -218,9 +218,9 @@ final class Puck2DTests: XCTestCase {
         let expectedProperties = makeExpectedLayerProperties(with: location)
         XCTAssertEqual(style.addPersistentLayerStub.invocations.count, 0)
         XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.invocations.count, 1)
-        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.parameters.first?.properties)
+        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
-        XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.parameters.first?.layerPosition, nil)
+        XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.layerPosition, nil)
     }
 
     func testReactivatingPuckDoesNotTakeFastPath() throws {
@@ -236,9 +236,9 @@ final class Puck2DTests: XCTestCase {
         let expectedProperties = makeExpectedLayerProperties(with: location)
         XCTAssertEqual(style.addPersistentLayerStub.invocations.count, 0)
         XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.invocations.count, 1)
-        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.parameters.first?.properties)
+        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
-        XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.parameters.first?.layerPosition, nil)
+        XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.layerPosition, nil)
         XCTAssertEqual(style.setLayerPropertiesStub.invocations.count, 0)
     }
 
@@ -254,7 +254,7 @@ final class Puck2DTests: XCTestCase {
 
         var expectedProperties = makeExpectedLayerProperties(with: location)
         expectedProperties.removeValue(forKey: LocationIndicatorLayer.LayoutCodingKeys.bearingImage.rawValue)
-        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.parameters.first?.properties)
+        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
     }
 
@@ -267,7 +267,7 @@ final class Puck2DTests: XCTestCase {
         puck2D.isActive = true
 
         let expectedProperties = makeExpectedLayerProperties(with: location)
-        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.parameters.first?.properties)
+        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
     }
 
@@ -283,7 +283,7 @@ final class Puck2DTests: XCTestCase {
         expectedProperties["accuracy-radius"] = location.horizontalAccuracy
         expectedProperties["accuracy-radius-color"] = StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)).rgbaString
         expectedProperties["accuracy-radius-border-color"] = StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)).rgbaString
-        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.parameters.first?.properties)
+        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
     }
 
@@ -295,7 +295,7 @@ final class Puck2DTests: XCTestCase {
 
         var expectedProperties = makeExpectedLayerProperties(with: location)
         expectedProperties["bearing"] = interpolatedLocationProducer.location!.heading!
-        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.parameters.first?.properties)
+        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
     }
 
@@ -307,7 +307,7 @@ final class Puck2DTests: XCTestCase {
 
         var expectedProperties = makeExpectedLayerProperties(with: location)
         expectedProperties.removeValue(forKey: "bearing")
-        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.parameters.first?.properties)
+        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
     }
 
@@ -320,7 +320,7 @@ final class Puck2DTests: XCTestCase {
 
         var expectedProperties = makeExpectedLayerProperties(with: location)
         expectedProperties.removeValue(forKey: "bearing")
-        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.parameters.first?.properties)
+        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
     }
 
@@ -333,7 +333,7 @@ final class Puck2DTests: XCTestCase {
 
         var expectedProperties = makeExpectedLayerProperties(with: location)
         expectedProperties["bearing"] = interpolatedLocationProducer.location!.course!
-        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.parameters.first?.properties)
+        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
     }
 
@@ -353,7 +353,7 @@ final class Puck2DTests: XCTestCase {
             .bearing: 0
         ]
 
-        let actualProperties = try XCTUnwrap(style.setLayerPropertiesStub.parameters.last?.properties)
+        let actualProperties = try XCTUnwrap(style.setLayerPropertiesStub.invocations.last?.parameters.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties.mapKeys(\.rawValue) as NSDictionary)
     }
 
@@ -373,7 +373,7 @@ final class Puck2DTests: XCTestCase {
             .bearing: 0
         ]
 
-        let actualProperties = try XCTUnwrap(style.setLayerPropertiesStub.parameters.last?.properties)
+        let actualProperties = try XCTUnwrap(style.setLayerPropertiesStub.invocations.last?.parameters.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties.mapKeys(\.rawValue) as NSDictionary)
     }
 
@@ -403,7 +403,7 @@ final class Puck2DTests: XCTestCase {
             5000]
         expectedProperties["accuracy-radius-color"] = StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)).rgbaString
         expectedProperties["accuracy-radius-border-color"] = StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)).rgbaString
-        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.parameters.first?.properties)
+        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
     }
 
@@ -442,7 +442,7 @@ final class Puck2DTests: XCTestCase {
             expectedProperties[key] = Style.layerPropertyDefaultValue(for: .locationIndicator, property: key).value
         }
         XCTAssertEqual(style.setLayerPropertiesStub.invocations.count, 1)
-        let actualProperties = try XCTUnwrap(style.setLayerPropertiesStub.parameters.first?.properties)
+        let actualProperties = try XCTUnwrap(style.setLayerPropertiesStub.invocations.first?.parameters.properties)
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
     }
 

--- a/Tests/MapboxMapsTests/Location/Puck/Puck3DTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/Puck3DTests.swift
@@ -103,18 +103,18 @@ final class Puck3DTests: XCTestCase {
         expectedModel.position = [coordinate.longitude, coordinate.latitude]
         expectedModel.orientation = [0, 0, 0]
         XCTAssertEqual(style.addSourceStub.invocations.count, 1)
-        let actualSource = try XCTUnwrap(style.addSourceStub.parameters.first?.source as? ModelSource)
+        let actualSource = try XCTUnwrap(style.addSourceStub.invocations.first?.parameters.source as? ModelSource)
         XCTAssertEqual(actualSource.type, .model)
         XCTAssertEqual(actualSource.models, ["puck-model": expectedModel])
-        XCTAssertEqual(style.addSourceStub.parameters.first?.id, "puck-model-source")
+        XCTAssertEqual(style.addSourceStub.invocations.first?.parameters.id, "puck-model-source")
 
         XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.invocations.count, 0)
         XCTAssertEqual(style.addPersistentLayerStub.invocations.count, 1)
-        let actualLayer = try XCTUnwrap(style.addPersistentLayerStub.parameters.first?.layer as? ModelLayer)
+        let actualLayer = try XCTUnwrap(style.addPersistentLayerStub.invocations.first?.parameters.layer as? ModelLayer)
         XCTAssertEqual(actualLayer.id, "puck-model-layer")
         XCTAssertEqual(actualLayer.paint?.modelLayerType, .constant(.locationIndicator))
         XCTAssertEqual(actualLayer.source, "puck-model-source")
-        XCTAssertEqual(style.addPersistentLayerStub.parameters.first?.layerPosition, nil)
+        XCTAssertEqual(style.addPersistentLayerStub.invocations.first?.parameters.layerPosition, nil)
     }
 
     func testModelOrientationBasedOnHeading() throws {
@@ -134,7 +134,7 @@ final class Puck3DTests: XCTestCase {
 
         var expectedOrientation = configuration.model.orientation!
         expectedOrientation[2] += heading
-        let actualSource = try XCTUnwrap(style.addSourceStub.parameters.first?.source as? ModelSource)
+        let actualSource = try XCTUnwrap(style.addSourceStub.invocations.first?.parameters.source as? ModelSource)
         XCTAssertEqual(actualSource.models?["puck-model"]?.orientation, expectedOrientation)
     }
 
@@ -154,7 +154,7 @@ final class Puck3DTests: XCTestCase {
 
         var expectedOrientation = configuration.model.orientation!
         expectedOrientation[2] += location.course!
-        let actualSource = try XCTUnwrap(style.addSourceStub.parameters.first?.source as? ModelSource)
+        let actualSource = try XCTUnwrap(style.addSourceStub.invocations.first?.parameters.source as? ModelSource)
         XCTAssertEqual(actualSource.models?["puck-model"]?.orientation, expectedOrientation)
     }
 
@@ -174,7 +174,7 @@ final class Puck3DTests: XCTestCase {
         puck3D.isActive = true
 
         let expectedOrientation = configuration.model.orientation!
-        let actualSource = try XCTUnwrap(style.addSourceStub.parameters.first?.source as? ModelSource)
+        let actualSource = try XCTUnwrap(style.addSourceStub.invocations.first?.parameters.source as? ModelSource)
         XCTAssertEqual(actualSource.models?["puck-model"]?.orientation, expectedOrientation)
     }
 
@@ -193,7 +193,7 @@ final class Puck3DTests: XCTestCase {
         puck3D.isActive = true
 
         let expectedOrientation = configuration.model.orientation!
-        let actualSource = try XCTUnwrap(style.addSourceStub.parameters.first?.source as? ModelSource)
+        let actualSource = try XCTUnwrap(style.addSourceStub.invocations.first?.parameters.source as? ModelSource)
         XCTAssertEqual(actualSource.models?["puck-model"]?.orientation, expectedOrientation)
     }
 
@@ -206,7 +206,7 @@ final class Puck3DTests: XCTestCase {
 
         puck3D.isActive = true
 
-        let actualLayer = try XCTUnwrap(style.addPersistentLayerStub.parameters.first?.layer as? ModelLayer)
+        let actualLayer = try XCTUnwrap(style.addPersistentLayerStub.invocations.first?.parameters.layer as? ModelLayer)
         XCTAssertEqual(actualLayer.paint?.modelScale, configuration.modelScale)
         XCTAssertEqual(actualLayer.paint?.modelRotation, configuration.modelRotation)
     }
@@ -229,10 +229,10 @@ final class Puck3DTests: XCTestCase {
         expectedSource.models = ["puck-model": expectedModel]
         XCTAssertEqual(style.addSourceStub.invocations.count, 0)
         XCTAssertEqual(style.setSourcePropertiesStub.invocations.count, 1)
-        let actualProperties = try XCTUnwrap(style.setSourcePropertiesStub.parameters.first?.properties)
+        let actualProperties = try XCTUnwrap(style.setSourcePropertiesStub.invocations.first?.parameters.properties)
         let expectedProperties = try expectedSource.jsonObject()
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
-        XCTAssertEqual(style.setSourcePropertiesStub.parameters.first?.sourceId, "puck-model-source")
+        XCTAssertEqual(style.setSourcePropertiesStub.invocations.first?.parameters.sourceId, "puck-model-source")
 
         XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.invocations.count, 0)
         XCTAssertEqual(style.addPersistentLayerStub.invocations.count, 0)

--- a/Tests/MapboxMapsTests/Location/Puck/PuckManagerTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/PuckManagerTests.swift
@@ -35,11 +35,11 @@ final class PuckManagerTests: XCTestCase {
         puckManager.puckBearingEnabled = .random()
         puckManager.puckType = .puck2D(configuration)
 
-        XCTAssertEqual(puck2DProvider.parameters, [configuration])
-        let puck = try XCTUnwrap(puck2DProvider.returnedValues.first)
-        XCTAssertEqual(puck.$puckBearingSource.setStub.parameters, [puckManager.puckBearingSource])
-        XCTAssertEqual(puck.$puckBearingEnabled.setStub.parameters, [puckManager.puckBearingEnabled])
-        XCTAssertEqual(puck.$isActive.setStub.parameters, [true])
+        XCTAssertEqual(puck2DProvider.invocations.map(\.parameters), [configuration])
+        let puck = try XCTUnwrap(puck2DProvider.invocations.first?.returnValue)
+        XCTAssertEqual(puck.$puckBearingSource.setStub.invocations.map(\.parameters), [puckManager.puckBearingSource])
+        XCTAssertEqual(puck.$puckBearingEnabled.setStub.invocations.map(\.parameters), [puckManager.puckBearingEnabled])
+        XCTAssertEqual(puck.$isActive.setStub.invocations.map(\.parameters), [true])
 
         // setting the same puck again should have no further effect
         puck2DProvider.reset()
@@ -59,11 +59,11 @@ final class PuckManagerTests: XCTestCase {
         puckManager.puckBearingEnabled = .random()
         puckManager.puckType = .puck3D(configuration)
 
-        XCTAssertEqual(puck3DProvider.parameters, [configuration])
-        let puck = try XCTUnwrap(puck3DProvider.returnedValues.first)
-        XCTAssertEqual(puck.$puckBearingSource.setStub.parameters, [puckManager.puckBearingSource])
-        XCTAssertEqual(puck.$puckBearingEnabled.setStub.parameters, [puckManager.puckBearingEnabled])
-        XCTAssertEqual(puck.$isActive.setStub.parameters, [true])
+        XCTAssertEqual(puck3DProvider.invocations.map(\.parameters), [configuration])
+        let puck = try XCTUnwrap(puck3DProvider.invocations.first?.returnValue)
+        XCTAssertEqual(puck.$puckBearingSource.setStub.invocations.map(\.parameters), [puckManager.puckBearingSource])
+        XCTAssertEqual(puck.$puckBearingEnabled.setStub.invocations.map(\.parameters), [puckManager.puckBearingEnabled])
+        XCTAssertEqual(puck.$isActive.setStub.invocations.map(\.parameters), [true])
 
         // setting the same puck again should have no further effect
         puck3DProvider.reset()
@@ -112,7 +112,7 @@ final class PuckManagerTests: XCTestCase {
 
         XCTAssertTrue(puck2DProvider.invocations.isEmpty)
         XCTAssertTrue(puck3DProvider.invocations.isEmpty)
-        XCTAssertEqual(puck.$isActive.setStub.parameters, [false])
+        XCTAssertEqual(puck.$isActive.setStub.invocations.map(\.parameters), [false])
     }
 
     func testSettingPuckBearingSourceWhenPuckTypeIsNonNil() {
@@ -125,7 +125,7 @@ final class PuckManagerTests: XCTestCase {
 
         puckManager.puckBearingSource = bearingSource
 
-        XCTAssertEqual(puck.$puckBearingSource.setStub.parameters, [bearingSource])
+        XCTAssertEqual(puck.$puckBearingSource.setStub.invocations.map(\.parameters), [bearingSource])
     }
 
     func testSettingPuckBearingEnabledWhenPuckTypeIsNonNil() {
@@ -138,6 +138,6 @@ final class PuckManagerTests: XCTestCase {
         let bearingEnable = Bool.random()
         puckManager.puckBearingEnabled = bearingEnable
 
-        XCTAssertEqual(puck.$puckBearingEnabled.setStub.parameters, [bearingEnable])
+        XCTAssertEqual(puck.$puckBearingEnabled.setStub.invocations.map(\.parameters), [bearingEnable])
     }
 }

--- a/Tests/MapboxMapsTests/Offline/TileStoreObserverCancelableTests.swift
+++ b/Tests/MapboxMapsTests/Offline/TileStoreObserverCancelableTests.swift
@@ -27,7 +27,7 @@ final class TileStoreObserverCancelableTests: XCTestCase {
         cancelable.cancel()
 
         XCTAssertEqual(tileStore.__removeObserverStub.invocations.count, 1)
-        XCTAssertTrue(tileStore.__removeObserverStub.parameters.first === observer)
+        XCTAssertTrue(tileStore.__removeObserverStub.invocations.first?.parameters === observer)
     }
 
     func testSecondCancel() {

--- a/Tests/MapboxMapsTests/Offline/TileStoreObserverWrapperTests.swift
+++ b/Tests/MapboxMapsTests/Offline/TileStoreObserverWrapperTests.swift
@@ -34,8 +34,8 @@ final class TileStoreObserverWrapperTests: XCTestCase {
         wrapper.onRegionLoadProgress(forId: id, progress: progress)
 
         XCTAssertEqual(observer.onRegionLoadProgressStub.invocations.count, 1)
-        XCTAssertEqual(observer.onRegionLoadProgressStub.parameters.first?.id, id)
-        XCTAssertTrue(observer.onRegionLoadProgressStub.parameters.first?.progress === progress)
+        XCTAssertEqual(observer.onRegionLoadProgressStub.invocations.first?.parameters.id, id)
+        XCTAssertTrue(observer.onRegionLoadProgressStub.invocations.first?.parameters.progress === progress)
     }
 
     func testOnRegionLoadFinishedWithValidValue() throws {
@@ -50,7 +50,7 @@ final class TileStoreObserverWrapperTests: XCTestCase {
         wrapper.onRegionLoadFinished(forId: id, region: expected)
 
         XCTAssertEqual(observer.onRegionLoadFinishedStub.invocations.count, 1)
-        let parameters = try XCTUnwrap(observer.onRegionLoadFinishedStub.parameters.first)
+        let parameters = try XCTUnwrap(observer.onRegionLoadFinishedStub.invocations.first?.parameters)
         XCTAssertEqual(parameters.id, id)
         guard case .success(let regionParameter) = parameters.region else {
             XCTFail("Expected region parameter to be Result.success, but found \(parameters.region)")
@@ -65,7 +65,7 @@ final class TileStoreObserverWrapperTests: XCTestCase {
         wrapper.onRegionLoadFinished(forId: id, region: expected)
 
         XCTAssertEqual(observer.onRegionLoadFinishedStub.invocations.count, 1)
-        let parameters = try XCTUnwrap(observer.onRegionLoadFinishedStub.parameters.first)
+        let parameters = try XCTUnwrap(observer.onRegionLoadFinishedStub.invocations.first?.parameters)
         XCTAssertEqual(parameters.id, id)
         guard case .failure(TypeConversionError.unexpectedType) = parameters.region else {
             XCTFail("Expected region parameter to be Result.failure(TypeConversionError.unexpectedType), but found \(parameters.region)")
@@ -81,7 +81,7 @@ final class TileStoreObserverWrapperTests: XCTestCase {
         wrapper.onRegionLoadFinished(forId: id, region: expected)
 
         XCTAssertEqual(observer.onRegionLoadFinishedStub.invocations.count, 1)
-        let parameters = try XCTUnwrap(observer.onRegionLoadFinishedStub.parameters.first)
+        let parameters = try XCTUnwrap(observer.onRegionLoadFinishedStub.invocations.first?.parameters)
         XCTAssertEqual(parameters.id, id)
         guard case .failure(let e) = parameters.region, let tileRegionError = e as? MapboxMaps.TileRegionError else {
             XCTFail("Expected region parameter to be Result.failure with error of type TileRegionError, but found \(parameters.region)")
@@ -95,7 +95,7 @@ final class TileStoreObserverWrapperTests: XCTestCase {
         wrapper.onRegionLoadFinished(forId: id, region: expected)
 
         XCTAssertEqual(observer.onRegionLoadFinishedStub.invocations.count, 1)
-        let parameters = try XCTUnwrap(observer.onRegionLoadFinishedStub.parameters.first)
+        let parameters = try XCTUnwrap(observer.onRegionLoadFinishedStub.invocations.first?.parameters)
         XCTAssertEqual(parameters.id, id)
         guard case .failure(TypeConversionError.unexpectedType) = parameters.region else {
             XCTFail("Expected region parameter to be Result.failure(TypeConversionError.unexpectedType), but found \(parameters.region)")
@@ -106,7 +106,7 @@ final class TileStoreObserverWrapperTests: XCTestCase {
     func testOnRegionRemoved() {
         wrapper.onRegionRemoved(forId: id)
 
-        XCTAssertEqual(observer.onRegionRemovedStub.parameters, [id!])
+        XCTAssertEqual(observer.onRegionRemovedStub.invocations.map(\.parameters), [id!])
     }
 
     func testOnRegionGeometryChanged() {
@@ -115,8 +115,8 @@ final class TileStoreObserverWrapperTests: XCTestCase {
         wrapper.onRegionGeometryChanged(forId: id, geometry: MapboxCommon.Geometry(geometry))
 
         XCTAssertEqual(observer.onRegionGeometryChangedStub.invocations.count, 1)
-        XCTAssertEqual(observer.onRegionGeometryChangedStub.parameters.first?.id, id)
-        XCTAssertEqual(observer.onRegionGeometryChangedStub.parameters.first?.geometry, geometry)
+        XCTAssertEqual(observer.onRegionGeometryChangedStub.invocations.first?.parameters.id, id)
+        XCTAssertEqual(observer.onRegionGeometryChangedStub.invocations.first?.parameters.geometry, geometry)
     }
 
     func testOnRegionMetadataChanged() {
@@ -125,7 +125,7 @@ final class TileStoreObserverWrapperTests: XCTestCase {
         wrapper.onRegionMetadataChanged(forId: id, value: value)
 
         XCTAssertEqual(observer.onRegionMetadataChangedStub.invocations.count, 1)
-        XCTAssertEqual(observer.onRegionMetadataChangedStub.parameters.first?.id, id)
-        XCTAssertEqual(observer.onRegionMetadataChangedStub.parameters.first?.value as? Int, value)
+        XCTAssertEqual(observer.onRegionMetadataChangedStub.invocations.first?.parameters.id, id)
+        XCTAssertEqual(observer.onRegionMetadataChangedStub.invocations.first?.parameters.value as? Int, value)
     }
 }

--- a/Tests/MapboxMapsTests/Ornaments/OrnamentManagerTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/OrnamentManagerTests.swift
@@ -100,18 +100,18 @@ final class OrnamentManagerTests: XCTestCase {
 
         XCTAssertEqual(cameraAnimationsManager.cancelAnimationsStub.invocations.count, 1)
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.count, 1)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.camera, CameraOptions(bearing: 0))
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.duration, 0.3)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.parameters.first?.curve, .easeOut)
-        XCTAssertNil(cameraAnimationsManager.easeToStub.parameters.first?.completion)
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.camera, CameraOptions(bearing: 0))
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.duration, 0.3)
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.curve, .easeOut)
+        XCTAssertNil(cameraAnimationsManager.easeToStub.invocations.first?.parameters.completion)
     }
 
     func testUpdateMapBearing() throws {
         let compass = try XCTUnwrap(view.subviews.compactMap { $0 as? MapboxCompassOrnamentView }.first)
 
         XCTAssertEqual(mapboxMap.onEveryStub.invocations.count, 1)
-        XCTAssertEqual(mapboxMap.onEveryStub.parameters.first?.eventType, .cameraChanged)
-        let onEveryCameraChangeHandler = try XCTUnwrap(mapboxMap.onEveryStub.parameters.first?.handler)
+        XCTAssertEqual(mapboxMap.onEveryStub.invocations.first?.parameters.eventType, .cameraChanged)
+        let onEveryCameraChangeHandler = try XCTUnwrap(mapboxMap.onEveryStub.invocations.first?.parameters.handler)
 
         XCTAssertEqual(mapboxMap.cameraState.bearing, 0)
         XCTAssertTrue(compass.containerView.isHidden, "The compass should be hidden initially")


### PR DESCRIPTION
Remove parameters and returnedValues properties from Stub to prevent confusion. 

## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
