### PR TITLE
Reset LocationProducer when changing provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 * Update to MapboxCoreMaps 10.4.0-rc.1 and MapboxCommon 21.2.0-rc.1. ([#1158](https://github.com/mapbox/mapbox-maps-ios/pull/1158))
 * Enable explicit drawing behavior for metal view(call `draw()` explicitly instead of `setNeedsDisplay` when view's content need to be redrawn).([#1157](https://github.com/mapbox/mapbox-maps-ios/pull/1157))
-* Restore cancellation of animations on single tap. ([#1166](https://github.com/mapbox/mapbox-maps-ios/pull/1166)) 
+* Restore cancellation of animations on single tap. ([#1166](https://github.com/mapbox/mapbox-maps-ios/pull/1166))
+* Fix issue where invalid locations could be emitted when setting a custom location provider. ([#1172](https://github.com/mapbox/mapbox-maps-ios/pull/1172))
 
 ## 10.4.0-beta.1 - February 23, 2022
 

--- a/Sources/MapboxMaps/Location/LocationProducer.swift
+++ b/Sources/MapboxMaps/Location/LocationProducer.swift
@@ -101,6 +101,10 @@ internal final class LocationProducer: LocationProducerProtocol {
             locationProvider.setDelegate(EmptyLocationProviderDelegate())
         }
         didSet {
+            // reinitialize latest values to mimic setup in init
+            latestCLLocation = nil
+            latestHeading = nil
+            latestAccuracyAuthorization = locationProvider.accuracyAuthorization
             locationProvider.setDelegate(self)
             syncIsUpdating()
         }
@@ -137,6 +141,9 @@ internal final class LocationProducer: LocationProducerProtocol {
     }
 
     private func notifyConsumers() {
+        guard isUpdating else {
+            return
+        }
         if let latestLocation = latestLocation {
             for consumer in _consumers.allObjects {
                 consumer.locationUpdate(newLocation: latestLocation)


### PR DESCRIPTION
In #1145, we noticed that `LocationProducer` was not clearing its internal state when installing a new provider. This could result in delivery of locations with incorrect values.

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
