### PR TITLE
Fix crash in Puck2D when accuracy is reduced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Enable explicit drawing behavior for metal view(call `draw()` explicitly instead of `setNeedsDisplay` when view's content need to be redrawn).([#1157](https://github.com/mapbox/mapbox-maps-ios/pull/1157))
 * Restore cancellation of animations on single tap. ([#1166](https://github.com/mapbox/mapbox-maps-ios/pull/1166))
 * Fix issue where invalid locations could be emitted when setting a custom location provider. ([#1172](https://github.com/mapbox/mapbox-maps-ios/pull/1172))
+* Fix crash in Puck2D when location accuracy authorization is reduced. ([#1173](https://github.com/mapbox/mapbox-maps-ios/pull/1173))
 
 ## 10.4.0-beta.1 - February 23, 2022
 

--- a/Sources/MapboxMaps/Location/Puck/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck2D.swift
@@ -148,8 +148,8 @@ internal final class Puck2D: Puck {
         @unknown default:
             newLayerPaintProperties[.accuracyRadius] = [
                 Expression.Operator.interpolate.rawValue,
-                Expression.Operator.linear.rawValue,
-                Expression.Operator.zoom.rawValue,
+                [Expression.Operator.linear.rawValue],
+                [Expression.Operator.zoom.rawValue],
                 0,
                 400000,
                 4,

--- a/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
@@ -393,8 +393,8 @@ final class Puck2DTests: XCTestCase {
         ]
         expectedProperties["accuracy-radius"] = [
             "interpolate",
-            "linear",
-            "zoom",
+            ["linear"],
+            ["zoom"],
             0,
             400000,
             4,
@@ -428,8 +428,8 @@ final class Puck2DTests: XCTestCase {
         ]
         expectedProperties["accuracy-radius"] = [
             "interpolate",
-            "linear",
-            "zoom",
+            ["linear"],
+            ["zoom"],
             0,
             400000,
             4,


### PR DESCRIPTION
Crash was introduced in #1090 and shipped only in v10.4.0-beta.1.

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
