### PR TITLE
Refactor CameraAnimatorInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Mapbox welcomes participation and contributions from everyone.
 * Fix issue where invalid locations could be emitted when setting a custom location provider. ([#1172](https://github.com/mapbox/mapbox-maps-ios/pull/1172))
 * Fix crash in Puck2D when location accuracy authorization is reduced. ([#1173](https://github.com/mapbox/mapbox-maps-ios/pull/1173))
 * Fix an issue where plain text source attribution was not populated in attribution dialog.([1163](https://github.com/mapbox/mapbox-maps-ios/pull/1163))
+* `BasicCameraAnimator.owner` is now public. ([#1181](https://github.com/mapbox/mapbox-maps-ios/pull/1181))
+* The animation owner for ease-to and fly-to animations is now `"com.mapbox.maps.cameraAnimationsManager"`. ([#1181](https://github.com/mapbox/mapbox-maps-ios/pull/1181))
 
 ## 10.4.0-beta.1 - February 23, 2022
 

--- a/Sources/MapboxMaps/Camera/AnimationOwner.swift
+++ b/Sources/MapboxMaps/Camera/AnimationOwner.swift
@@ -8,5 +8,8 @@ public struct AnimationOwner: RawRepresentable, Equatable {
     }
 
     public static let gestures = AnimationOwner(rawValue: "com.mapbox.maps.gestures")
+
     public static let unspecified = AnimationOwner(rawValue: "com.mapbox.maps.unspecified")
+
+    internal static let cameraAnimationsManager = AnimationOwner(rawValue: "com.mapbox.maps.cameraAnimationsManager")
 }

--- a/Sources/MapboxMaps/Camera/BasicCameraAnimator.swift
+++ b/Sources/MapboxMaps/Camera/BasicCameraAnimator.swift
@@ -2,7 +2,7 @@ import UIKit
 import CoreLocation
 
 // MARK: CameraAnimator Class
-public class BasicCameraAnimator: NSObject, CameraAnimator, CameraAnimatorInterface {
+public class BasicCameraAnimator: NSObject, CameraAnimator, CameraAnimatorProtocol {
     private enum InternalState: Equatable {
         case initial
         case running(CameraTransition)
@@ -14,14 +14,14 @@ public class BasicCameraAnimator: NSObject, CameraAnimator, CameraAnimatorInterf
     private let propertyAnimator: UIViewPropertyAnimator
 
     /// The ID of the owner of this `CameraAnimator`.
-    private let owner: AnimationOwner
+    public let owner: AnimationOwner
 
     /// The `CameraView` owned by this animator
     private let cameraView: CameraView
 
     private let mapboxMap: MapboxMapProtocol
 
-    private weak var delegate: CameraAnimatorDelegate?
+    internal weak var delegate: CameraAnimatorDelegate?
 
     /// Represents the animation that this animator is attempting to execute
     private var animation: ((inout CameraTransition) -> Void)?
@@ -87,13 +87,11 @@ public class BasicCameraAnimator: NSObject, CameraAnimator, CameraAnimatorInterf
     internal init(propertyAnimator: UIViewPropertyAnimator,
                   owner: AnimationOwner,
                   mapboxMap: MapboxMapProtocol,
-                  cameraView: CameraView,
-                  delegate: CameraAnimatorDelegate) {
+                  cameraView: CameraView) {
         self.propertyAnimator = propertyAnimator
         self.owner = owner
         self.mapboxMap = mapboxMap
         self.cameraView = cameraView
-        self.delegate = delegate
     }
 
     deinit {

--- a/Sources/MapboxMaps/Camera/CameraAnimationsManager.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimationsManager.swift
@@ -89,12 +89,9 @@ public class CameraAnimationsManager: CameraAnimationsManagerProtocol {
                     completion: AnimationCompletion? = nil) -> Cancelable? {
 
         let flyToAnimator = FlyToCameraAnimator(
-            initial: mapboxMap.cameraState,
-            final: camera,
-            cameraBounds: mapboxMap.cameraBounds,
+            toCamera: camera,
             owner: .cameraAnimationsManager,
             duration: duration,
-            mapSize: mapboxMap.size,
             mapboxMap: mapboxMap,
             dateProvider: DefaultDateProvider())
         flyToAnimator.delegate = self

--- a/Sources/MapboxMaps/Camera/CameraAnimator.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimator.swift
@@ -10,11 +10,24 @@ public protocol CameraAnimator: Cancelable {
 }
 
 /// Internal-facing protocol to represent camera animators
-internal protocol CameraAnimatorInterface: CameraAnimator {
+internal protocol CameraAnimatorProtocol: CameraAnimator {
+    /// the animation's owner
+    var owner: AnimationOwner { get }
+
+    /// implementations must use a weak reference
+    var delegate: CameraAnimatorDelegate? { get set }
+
+    /// adds a completion block to the animator
+    func addCompletion(_ completion: @escaping AnimationCompletion)
+
+    /// starts the animation
+    func startAnimation()
+
+    /// Called at each display link to allow animators to update the camera
     func update()
 }
 
 internal protocol CameraAnimatorDelegate: AnyObject {
-    func cameraAnimatorDidStartRunning(_ cameraAnimator: CameraAnimator)
-    func cameraAnimatorDidStopRunning(_ cameraAnimator: CameraAnimator)
+    func cameraAnimatorDidStartRunning(_ cameraAnimator: CameraAnimatorProtocol)
+    func cameraAnimatorDidStopRunning(_ cameraAnimator: CameraAnimatorProtocol)
 }

--- a/Sources/MapboxMaps/Camera/FlyToCameraAnimator.swift
+++ b/Sources/MapboxMaps/Camera/FlyToCameraAnimator.swift
@@ -1,10 +1,16 @@
 import UIKit
 
-public class FlyToCameraAnimator: NSObject, CameraAnimator, CameraAnimatorInterface {
+/// An animator that evokes powered flight and an optional transition duration and timing function
+/// It seamlessly incorporates zooming and panning to help the user find their bearings even after
+/// traversing a great distance.
+///
+/// - SeeAlso: ``CameraAnimationsManager/fly(to:duration:completion:)``
+public class FlyToCameraAnimator: NSObject, CameraAnimator, CameraAnimatorProtocol {
 
     private let mapboxMap: MapboxMapProtocol
 
-    public private(set) var owner: AnimationOwner
+    /// The animator's owner
+    public let owner: AnimationOwner
 
     private let interpolator: FlyToInterpolator
 
@@ -20,7 +26,7 @@ public class FlyToCameraAnimator: NSObject, CameraAnimator, CameraAnimatorInterf
 
     private let dateProvider: DateProvider
 
-    private weak var delegate: CameraAnimatorDelegate?
+    internal weak var delegate: CameraAnimatorDelegate?
 
     internal init(initial: CameraState,
                   final: CameraOptions,
@@ -29,8 +35,7 @@ public class FlyToCameraAnimator: NSObject, CameraAnimator, CameraAnimatorInterf
                   duration: TimeInterval? = nil,
                   mapSize: CGSize,
                   mapboxMap: MapboxMapProtocol,
-                  dateProvider: DateProvider,
-                  delegate: CameraAnimatorDelegate) {
+                  dateProvider: DateProvider) {
         let flyToInterpolator = FlyToInterpolator(from: initial, to: final, cameraBounds: cameraBounds, size: mapSize)
         if let duration = duration {
             precondition(duration >= 0)
@@ -41,7 +46,6 @@ public class FlyToCameraAnimator: NSObject, CameraAnimator, CameraAnimatorInterf
         self.finalCameraOptions = final
         self.duration = duration ?? flyToInterpolator.duration()
         self.dateProvider = dateProvider
-        self.delegate = delegate
     }
 
     public func stopAnimation() {

--- a/Sources/MapboxMaps/Camera/FlyToCameraAnimator.swift
+++ b/Sources/MapboxMaps/Camera/FlyToCameraAnimator.swift
@@ -28,22 +28,23 @@ public class FlyToCameraAnimator: NSObject, CameraAnimator, CameraAnimatorProtoc
 
     internal weak var delegate: CameraAnimatorDelegate?
 
-    internal init(initial: CameraState,
-                  final: CameraOptions,
-                  cameraBounds: CameraBounds,
+    internal init(toCamera: CameraOptions,
                   owner: AnimationOwner,
                   duration: TimeInterval? = nil,
-                  mapSize: CGSize,
                   mapboxMap: MapboxMapProtocol,
                   dateProvider: DateProvider) {
-        let flyToInterpolator = FlyToInterpolator(from: initial, to: final, cameraBounds: cameraBounds, size: mapSize)
+        let flyToInterpolator = FlyToInterpolator(
+                    from: mapboxMap.cameraState,
+                    to: toCamera,
+                    cameraBounds: mapboxMap.cameraBounds,
+                    size: mapboxMap.size)
         if let duration = duration {
             precondition(duration >= 0)
         }
         self.interpolator = flyToInterpolator
         self.mapboxMap = mapboxMap
         self.owner = owner
-        self.finalCameraOptions = final
+        self.finalCameraOptions = toCamera
         self.duration = duration ?? flyToInterpolator.duration()
         self.dateProvider = dateProvider
     }

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/PanGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/PanGestureHandler.swift
@@ -112,7 +112,9 @@ internal final class PanGestureHandler: GestureHandler, PanGestureHandlerProtoco
                 velocity: velocity.clamped(to: .zero, panMode: panMode),
                 decelerationFactor: decelerationFactor,
                 locationChangeHandler: pan(from:to:),
-                completion: endAnimation)
+                completion: { _ in
+                    self.endAnimation()
+                })
             endInteraction(willAnimate: true)
         case .cancelled:
             endInteraction(willAnimate: false)

--- a/Tests/MapboxMapsTests/Camera/AnimationOwnerTests.swift
+++ b/Tests/MapboxMapsTests/Camera/AnimationOwnerTests.swift
@@ -1,0 +1,19 @@
+@testable import MapboxMaps
+import XCTest
+
+final class AnimationOwnerTests: XCTestCase {
+
+    func testInitialization() {
+        let rawValue = String.randomASCII(withLength: .random(in: 0...10))
+
+        let owner = AnimationOwner(rawValue: rawValue)
+
+        XCTAssertEqual(owner.rawValue, rawValue)
+    }
+
+    func testStaticValues() {
+        XCTAssertEqual(AnimationOwner.gestures.rawValue, "com.mapbox.maps.gestures")
+        XCTAssertEqual(AnimationOwner.unspecified.rawValue, "com.mapbox.maps.unspecified")
+        XCTAssertEqual(AnimationOwner.cameraAnimationsManager.rawValue, "com.mapbox.maps.cameraAnimationsManager")
+    }
+}

--- a/Tests/MapboxMapsTests/Camera/BasicCameraAnimatorIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Camera/BasicCameraAnimatorIntegrationTests.swift
@@ -6,9 +6,9 @@ final class BasicCameraAnimatorIntegrationTests: XCTestCase {
     var window: UIWindow!
     var cameraView: CameraView!
     var mapboxMap: MockMapboxMap!
+    var animator: BasicCameraAnimator!
     // swiftlint:disable:next weak_delegate
     var delegate: MockCameraAnimatorDelegate!
-    var animator: BasicCameraAnimator!
 
     override func setUp() {
         super.setUp()
@@ -17,13 +17,13 @@ final class BasicCameraAnimatorIntegrationTests: XCTestCase {
         window.addSubview(cameraView)
         window.makeKeyAndVisible()
         mapboxMap = MockMapboxMap()
-        delegate = MockCameraAnimatorDelegate()
         animator = BasicCameraAnimator(
             propertyAnimator: UIViewPropertyAnimator(),
             owner: .unspecified,
             mapboxMap: mapboxMap,
-            cameraView: cameraView,
-            delegate: delegate)
+            cameraView: cameraView)
+        delegate = MockCameraAnimatorDelegate()
+        animator.delegate = delegate
         animator.addAnimations { (transition) in
             transition.zoom.toValue = cameraOptionsTestValue.zoom!
             transition.center.toValue = cameraOptionsTestValue.center!
@@ -35,8 +35,8 @@ final class BasicCameraAnimatorIntegrationTests: XCTestCase {
     }
 
     override func tearDown() {
-        animator = nil
         delegate = nil
+        animator = nil
         mapboxMap = nil
         cameraView = nil
         window = nil

--- a/Tests/MapboxMapsTests/Camera/BasicCameraAnimatorTests.swift
+++ b/Tests/MapboxMapsTests/Camera/BasicCameraAnimatorTests.swift
@@ -26,33 +26,40 @@ let cameraStateTestValue = CameraState(
 final class BasicCameraAnimatorTests: XCTestCase {
 
     var propertyAnimator: MockPropertyAnimator!
+    var owner: AnimationOwner!
     var cameraView: MockCameraView!
     var mapboxMap: MockMapboxMap!
+    var animator: BasicCameraAnimator!
     // swiftlint:disable:next weak_delegate
     var delegate: MockCameraAnimatorDelegate!
-    var animator: BasicCameraAnimator!
 
     override func setUp() {
         super.setUp()
         propertyAnimator = MockPropertyAnimator()
+        owner = .random()
         cameraView = MockCameraView()
         mapboxMap = MockMapboxMap()
-        delegate = MockCameraAnimatorDelegate()
         animator = BasicCameraAnimator(
             propertyAnimator: propertyAnimator,
-            owner: .unspecified,
+            owner: owner,
             mapboxMap: mapboxMap,
-            cameraView: cameraView,
-            delegate: delegate)
+            cameraView: cameraView)
+        delegate = MockCameraAnimatorDelegate()
+        animator.delegate = delegate
     }
 
     override func tearDown() {
-        animator = nil
         delegate = nil
+        animator = nil
         mapboxMap = nil
         cameraView = nil
+        owner = nil
         propertyAnimator = nil
         super.tearDown()
+    }
+
+    func testOwner() {
+        XCTAssertEqual(animator.owner, owner)
     }
 
     func testDeinit() {

--- a/Tests/MapboxMapsTests/Camera/FlyToCameraAnimatorTests.swift
+++ b/Tests/MapboxMapsTests/Camera/FlyToCameraAnimatorTests.swift
@@ -38,14 +38,14 @@ final class FlyToCameraAnimatorTests: XCTestCase {
         super.setUp()
         owner = .random()
         mapboxMap = MockMapboxMap()
+        mapboxMap.cameraState = initialCameraState
+        mapboxMap.cameraBounds = .default
+        mapboxMap.size = CGSize(width: 500, height: 500)
         dateProvider = MockDateProvider()
         flyToCameraAnimator = FlyToCameraAnimator(
-            initial: initialCameraState,
-            final: finalCameraOptions,
-            cameraBounds: CameraBounds.default,
+            toCamera: finalCameraOptions,
             owner: owner,
             duration: duration,
-            mapSize: CGSize(width: 500, height: 500),
             mapboxMap: mapboxMap,
             dateProvider: dateProvider)
         delegate = MockCameraAnimatorDelegate()
@@ -65,19 +65,6 @@ final class FlyToCameraAnimatorTests: XCTestCase {
         XCTAssertEqual(flyToCameraAnimator.owner, owner)
         XCTAssertEqual(flyToCameraAnimator.duration, duration)
         XCTAssertEqual(flyToCameraAnimator.state, .inactive)
-    }
-
-    func testInitializationWithANilDurationSetsDurationToCalculatedValue() {
-        let animator = FlyToCameraAnimator(
-            initial: initialCameraState,
-            final: finalCameraOptions,
-            cameraBounds: CameraBounds.default,
-            owner: AnimationOwner(rawValue: "fly-to"),
-            duration: nil,
-            mapSize: CGSize(width: 500, height: 500),
-            mapboxMap: mapboxMap,
-            dateProvider: dateProvider)
-        XCTAssertNotNil(animator.duration)
     }
 
     func testStartAnimationChangesStateToActiveAndInformsDelegate() {

--- a/Tests/MapboxMapsTests/Camera/FlyToCameraAnimatorTests.swift
+++ b/Tests/MapboxMapsTests/Camera/FlyToCameraAnimatorTests.swift
@@ -26,41 +26,43 @@ final class FlyToCameraAnimatorTests: XCTestCase {
         bearing: 10,
         pitch: 10)
 
-    let animationOwner = AnimationOwner(rawValue: "fly-to")
     let duration: TimeInterval = 10
+    var owner: AnimationOwner!
     var mapboxMap: MockMapboxMap!
     var dateProvider: MockDateProvider!
+    var flyToCameraAnimator: FlyToCameraAnimator!
     // swiftlint:disable:next weak_delegate
     var delegate: MockCameraAnimatorDelegate!
-    var flyToCameraAnimator: FlyToCameraAnimator!
 
     override func setUp() {
         super.setUp()
+        owner = .random()
         mapboxMap = MockMapboxMap()
         dateProvider = MockDateProvider()
-        delegate = MockCameraAnimatorDelegate()
         flyToCameraAnimator = FlyToCameraAnimator(
             initial: initialCameraState,
             final: finalCameraOptions,
             cameraBounds: CameraBounds.default,
-            owner: AnimationOwner(rawValue: "fly-to"),
+            owner: owner,
             duration: duration,
             mapSize: CGSize(width: 500, height: 500),
             mapboxMap: mapboxMap,
-            dateProvider: dateProvider,
-            delegate: delegate)
+            dateProvider: dateProvider)
+        delegate = MockCameraAnimatorDelegate()
+        flyToCameraAnimator.delegate = delegate
     }
 
     override func tearDown() {
-        flyToCameraAnimator = nil
         delegate = nil
+        flyToCameraAnimator = nil
         dateProvider = nil
         mapboxMap = nil
+        owner = nil
         super.tearDown()
     }
 
     func testInitializationWithValidOptions() {
-        XCTAssertEqual(flyToCameraAnimator.owner, animationOwner)
+        XCTAssertEqual(flyToCameraAnimator.owner, owner)
         XCTAssertEqual(flyToCameraAnimator.duration, duration)
         XCTAssertEqual(flyToCameraAnimator.state, .inactive)
     }
@@ -74,8 +76,7 @@ final class FlyToCameraAnimatorTests: XCTestCase {
             duration: nil,
             mapSize: CGSize(width: 500, height: 500),
             mapboxMap: mapboxMap,
-            dateProvider: dateProvider,
-            delegate: delegate)
+            dateProvider: dateProvider)
         XCTAssertNotNil(animator.duration)
     }
 

--- a/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimationsManager.swift
+++ b/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimationsManager.swift
@@ -34,14 +34,14 @@ final class MockCameraAnimationsManager: CameraAnimationsManagerProtocol {
         var velocity: CGPoint
         var decelerationFactor: CGFloat
         var locationChangeHandler: (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void
-        var completion: () -> Void
+        var completion: AnimationCompletion?
     }
     let decelerateStub = Stub<DecelerateParameters, Void>()
     func decelerate(location: CGPoint,
                     velocity: CGPoint,
                     decelerationFactor: CGFloat,
                     locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void,
-                    completion: @escaping () -> Void) {
+                    completion: AnimationCompletion?) {
 
         return decelerateStub.call(
             with: DecelerateParameters(
@@ -64,8 +64,7 @@ final class MockCameraAnimationsManager: CameraAnimationsManagerProtocol {
             propertyAnimator: MockPropertyAnimator(),
             owner: .unspecified,
             mapboxMap: MockMapboxMap(),
-            cameraView: MockCameraView(),
-            delegate: MockCameraAnimatorDelegate()))
+            cameraView: MockCameraView()))
     func makeAnimator(duration: TimeInterval,
                       curve: UIView.AnimationCurve,
                       animationOwner: AnimationOwner,

--- a/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimatorDelegate.swift
+++ b/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimatorDelegate.swift
@@ -1,13 +1,13 @@
 @testable import MapboxMaps
 
 final class MockCameraAnimatorDelegate: CameraAnimatorDelegate {
-    let cameraAnimatorDidStartRunningStub = Stub<CameraAnimator, Void>()
-    func cameraAnimatorDidStartRunning(_ cameraAnimator: CameraAnimator) {
+    let cameraAnimatorDidStartRunningStub = Stub<CameraAnimatorProtocol, Void>()
+    func cameraAnimatorDidStartRunning(_ cameraAnimator: CameraAnimatorProtocol) {
         cameraAnimatorDidStartRunningStub.call(with: cameraAnimator)
     }
 
-    let cameraAnimatorDidStopRunningStub = Stub<CameraAnimator, Void>()
-    func cameraAnimatorDidStopRunning(_ cameraAnimator: CameraAnimator) {
+    let cameraAnimatorDidStopRunningStub = Stub<CameraAnimatorProtocol, Void>()
+    func cameraAnimatorDidStopRunning(_ cameraAnimator: CameraAnimatorProtocol) {
         cameraAnimatorDidStopRunningStub.call(with: cameraAnimator)
     }
 }

--- a/Tests/MapboxMapsTests/Camera/Random/AnimationOwner+Random.swift
+++ b/Tests/MapboxMapsTests/Camera/Random/AnimationOwner+Random.swift
@@ -1,0 +1,7 @@
+import MapboxMaps
+
+extension AnimationOwner {
+    static func random() -> Self {
+        return AnimationOwner(rawValue: .randomASCII(withLength: .random(in: 0...10)))
+    }
+}

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockCameraAnimator.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockCameraAnimator.swift
@@ -1,15 +1,35 @@
 import Foundation
 @testable import MapboxMaps
 
-final class MockCameraAnimator: NSObject, CameraAnimatorInterface {
+final class MockCameraAnimator: NSObject, CameraAnimatorProtocol {
+    let cancelStub = Stub<Void, Void>()
     func cancel() {
+        cancelStub.call()
     }
 
-    func update() {
-    }
-
-    var state: UIViewAnimatingState = .inactive
-
+    let stopAnimationStub = Stub<Void, Void>()
     func stopAnimation() {
+        stopAnimationStub.call()
+    }
+
+    @Stubbed var state: UIViewAnimatingState = .inactive
+
+    @Stubbed var owner: AnimationOwner = .random()
+
+    @Stubbed var delegate: CameraAnimatorDelegate?
+
+    let addCompletionStub = Stub<AnimationCompletion, Void>()
+    func addCompletion(_ completion: @escaping AnimationCompletion) {
+        addCompletionStub.call(with: completion)
+    }
+
+    let startAnimationStub = Stub<Void, Void>()
+    func startAnimation() {
+        startAnimationStub.call()
+    }
+
+    let updateStub = Stub<Void, Void>()
+    func update() {
+        updateStub.call()
     }
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/PanGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/PanGestureHandlerTests.swift
@@ -188,7 +188,7 @@ final class PanGestureHandlerTests: XCTestCase {
         }
 
         let animationEndedCompletion = try XCTUnwrap(decelerateParams?.completion)
-        animationEndedCompletion()
+        animationEndedCompletion(.end)
 
         XCTAssertEqual(mapboxMap.dragEndStub.invocations.count, 1)
         XCTAssertEqual(delegate.animationEndedStub.invocations.map(\.parameters), [.pan])
@@ -246,7 +246,7 @@ final class PanGestureHandlerTests: XCTestCase {
 
         // cancel deceleration *after* the second gesture begins
         let decelerateAnimationCompletion = try XCTUnwrap(cameraAnimationsManager.decelerateStub.invocations.first?.parameters.completion)
-        decelerateAnimationCompletion()
+        decelerateAnimationCompletion(.current)
 
         // changed 2 should still result in camera updates. a previous
         // implementation had a bug here where the cancellation of the animation


### PR DESCRIPTION
This refactoring is part one of a series that will unlock better unit testability for `CameraAnimationsManager`.

* The animation owner for ease-to, fly-to, and gesture-deceleration animations is now `"com.mapbox.maps.cameraAnimationsManager"`.
* `BasicCameraAnimator.owner` property is now public.
* Animator delegates are now always internal and set after initialization.
* Animators now have a standard completion block signature and standard interface for adding completion blocks.
* `CameraAnimatorInterface` has been renamed to `CameraAnimatorProtocol`.
* `CameraAnimatorDelegate` is now written in terms of `CameraAnimatorProtocol` instead of in terms of `CameraAnimator`.

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
