### PR TITLE
Simplify FlyToCameraAnimator init interface

### DIFF
--- a/Sources/MapboxMaps/Camera/CameraAnimationsManager.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimationsManager.swift
@@ -89,12 +89,9 @@ public class CameraAnimationsManager: CameraAnimationsManagerProtocol {
                     completion: AnimationCompletion? = nil) -> Cancelable? {
 
         let flyToAnimator = FlyToCameraAnimator(
-            initial: mapboxMap.cameraState,
-            final: camera,
-            cameraBounds: mapboxMap.cameraBounds,
+            toCamera: camera,
             owner: .cameraAnimationsManager,
             duration: duration,
-            mapSize: mapboxMap.size,
             mapboxMap: mapboxMap,
             dateProvider: DefaultDateProvider())
         flyToAnimator.delegate = self

--- a/Sources/MapboxMaps/Camera/FlyToCameraAnimator.swift
+++ b/Sources/MapboxMaps/Camera/FlyToCameraAnimator.swift
@@ -28,22 +28,23 @@ public class FlyToCameraAnimator: NSObject, CameraAnimator, CameraAnimatorProtoc
 
     internal weak var delegate: CameraAnimatorDelegate?
 
-    internal init(initial: CameraState,
-                  final: CameraOptions,
-                  cameraBounds: CameraBounds,
+    internal init(toCamera: CameraOptions,
                   owner: AnimationOwner,
                   duration: TimeInterval? = nil,
-                  mapSize: CGSize,
                   mapboxMap: MapboxMapProtocol,
                   dateProvider: DateProvider) {
-        let flyToInterpolator = FlyToInterpolator(from: initial, to: final, cameraBounds: cameraBounds, size: mapSize)
+        let flyToInterpolator = FlyToInterpolator(
+                    from: mapboxMap.cameraState,
+                    to: toCamera,
+                    cameraBounds: mapboxMap.cameraBounds,
+                    size: mapboxMap.size)
         if let duration = duration {
             precondition(duration >= 0)
         }
         self.interpolator = flyToInterpolator
         self.mapboxMap = mapboxMap
         self.owner = owner
-        self.finalCameraOptions = final
+        self.finalCameraOptions = toCamera
         self.duration = duration ?? flyToInterpolator.duration()
         self.dateProvider = dateProvider
     }

--- a/Tests/MapboxMapsTests/Camera/FlyToCameraAnimatorTests.swift
+++ b/Tests/MapboxMapsTests/Camera/FlyToCameraAnimatorTests.swift
@@ -38,14 +38,14 @@ final class FlyToCameraAnimatorTests: XCTestCase {
         super.setUp()
         owner = .random()
         mapboxMap = MockMapboxMap()
+        mapboxMap.cameraState = initialCameraState
+        mapboxMap.cameraBounds = .default
+        mapboxMap.size = CGSize(width: 500, height: 500)
         dateProvider = MockDateProvider()
         flyToCameraAnimator = FlyToCameraAnimator(
-            initial: initialCameraState,
-            final: finalCameraOptions,
-            cameraBounds: CameraBounds.default,
+            toCamera: finalCameraOptions,
             owner: owner,
             duration: duration,
-            mapSize: CGSize(width: 500, height: 500),
             mapboxMap: mapboxMap,
             dateProvider: dateProvider)
         delegate = MockCameraAnimatorDelegate()
@@ -65,19 +65,6 @@ final class FlyToCameraAnimatorTests: XCTestCase {
         XCTAssertEqual(flyToCameraAnimator.owner, owner)
         XCTAssertEqual(flyToCameraAnimator.duration, duration)
         XCTAssertEqual(flyToCameraAnimator.state, .inactive)
-    }
-
-    func testInitializationWithANilDurationSetsDurationToCalculatedValue() {
-        let animator = FlyToCameraAnimator(
-            initial: initialCameraState,
-            final: finalCameraOptions,
-            cameraBounds: CameraBounds.default,
-            owner: AnimationOwner(rawValue: "fly-to"),
-            duration: nil,
-            mapSize: CGSize(width: 500, height: 500),
-            mapboxMap: mapboxMap,
-            dateProvider: dateProvider)
-        XCTAssertNotNil(animator.duration)
     }
 
     func testStartAnimationChangesStateToActiveAndInformsDelegate() {


### PR DESCRIPTION
This refactoring is part two of a series that will unlock better unit testability for CameraAnimationsManager. (part 1: #1181)

* 3 of the parameters could be obtained via the injected MapboxMap

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
