### PR TITLE
App extensions support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Fix issue where invalid locations could be emitted when setting a custom location provider. ([#1172](https://github.com/mapbox/mapbox-maps-ios/pull/1172))
 * Fix crash in Puck2D when location accuracy authorization is reduced. ([#1173](https://github.com/mapbox/mapbox-maps-ios/pull/1173))
 * Fix an issue where plain text source attribution was not populated in attribution dialog.([1163](https://github.com/mapbox/mapbox-maps-ios/pull/1163))
+* Add app extensions support. ([#1183](https://github.com/mapbox/mapbox-maps-ios/pull/1183))
 
 ## 10.4.0-beta.1 - February 23, 2022
 

--- a/Sources/MapboxMaps/Foundation/AttributionURLOpener.swift
+++ b/Sources/MapboxMaps/Foundation/AttributionURLOpener.swift
@@ -14,7 +14,7 @@ public protocol AttributionURLOpener {
 
 @available(iOSApplicationExtension, unavailable)
 internal final class DefaultAttributionURLOpener: AttributionURLOpener {
-    let application: UIApplicationProtocol
+    private let application: UIApplicationProtocol
 
     init(application: UIApplicationProtocol = UIApplication.shared) {
         self.application = application

--- a/Sources/MapboxMaps/Foundation/AttributionURLOpener.swift
+++ b/Sources/MapboxMaps/Foundation/AttributionURLOpener.swift
@@ -1,0 +1,19 @@
+import Foundation
+import UIKit
+
+public protocol AttributionURLOpener {
+    func openAttributionURL(_ url: URL)
+}
+
+@available(iOSApplicationExtension, unavailable)
+internal final class DefaultAttributionURLOpener: AttributionURLOpener {
+    let application: UIApplication
+
+    init(application: UIApplication = .shared) {
+        self.application = application
+    }
+
+    func openAttributionURL(_ url: URL) {
+        application.open(url)
+    }
+}

--- a/Sources/MapboxMaps/Foundation/AttributionURLOpener.swift
+++ b/Sources/MapboxMaps/Foundation/AttributionURLOpener.swift
@@ -7,9 +7,9 @@ public protocol AttributionURLOpener {
 
 @available(iOSApplicationExtension, unavailable)
 internal final class DefaultAttributionURLOpener: AttributionURLOpener {
-    let application: UIApplication
+    let application: UIApplicationProtocol
 
-    init(application: UIApplication = .shared) {
+    init(application: UIApplicationProtocol = UIApplication.shared) {
         self.application = application
     }
 

--- a/Sources/MapboxMaps/Foundation/AttributionURLOpener.swift
+++ b/Sources/MapboxMaps/Foundation/AttributionURLOpener.swift
@@ -1,7 +1,14 @@
 import Foundation
 import UIKit
 
+/// A protocol to open attribution URLs.
+///
+/// Use this protocol when the map view is used in non-application target(e.g. application extension target).
 public protocol AttributionURLOpener {
+
+    /// Asks the opener to open the provided URL.
+    /// - Parameters:
+    ///   - url: The URL to be opened.
     func openAttributionURL(_ url: URL)
 }
 

--- a/Sources/MapboxMaps/Foundation/InterfaceOrientationProvider.swift
+++ b/Sources/MapboxMaps/Foundation/InterfaceOrientationProvider.swift
@@ -2,8 +2,18 @@ import Foundation
 import UIKit
 import CoreLocation
 
+/// A protocol that supplies current interface orientation for the specified view.
+///
+/// Use this protocol when the map view is used in non-application target(e.g. application extension target).
 @available(iOS, deprecated: 13)
 public protocol InterfaceOrientationProvider {
+
+    /// Asks the provider for the interface orientation of the provided view.
+    ///
+    /// When a device is rotated map view passes current interface orientation to its location producer in order to ensure heading is displayed correctly.
+    /// - Parameters:
+    ///   - view: The view to get interface orientation from.
+    /// - Returns: The interface orientation for the provided view.
     func interfaceOrientation(for view: UIView) -> UIInterfaceOrientation?
 }
 

--- a/Sources/MapboxMaps/Foundation/InterfaceOrientationProvider.swift
+++ b/Sources/MapboxMaps/Foundation/InterfaceOrientationProvider.swift
@@ -33,8 +33,14 @@ extension InterfaceOrientationProvider {
 @available(iOS, deprecated: 13)
 @available(iOSApplicationExtension, unavailable)
 internal final class UIApplicationInterfaceOrientationProvider: InterfaceOrientationProvider {
+    private let application: UIApplicationProtocol
+
+    init(application: UIApplicationProtocol = UIApplication.shared) {
+        self.application = application
+    }
+
     func interfaceOrientation(for view: UIView) -> UIInterfaceOrientation? {
-        return UIApplication.shared.statusBarOrientation
+        return application.statusBarOrientation
     }
 }
 

--- a/Sources/MapboxMaps/Foundation/InterfaceOrientationProvider.swift
+++ b/Sources/MapboxMaps/Foundation/InterfaceOrientationProvider.swift
@@ -1,0 +1,57 @@
+import Foundation
+import UIKit
+import CoreLocation
+
+@available(iOS, deprecated: 13)
+public protocol InterfaceOrientationProvider {
+    func interfaceOrientation(for view: UIView) -> UIInterfaceOrientation?
+}
+
+extension InterfaceOrientationProvider {
+    internal func headingOrientation(for view: UIView) -> CLDeviceOrientation? {
+        // locationProvider.headingOrientation should be adjusted based on the
+        // current UIInterfaceOrientation of the containing window, not the
+        // device orientation
+        guard let interfaceOrientation = interfaceOrientation(for: view) else {
+            return nil
+        }
+
+        return CLDeviceOrientation(interfaceOrientation: interfaceOrientation)
+    }
+}
+
+@available(iOS, deprecated: 13)
+@available(iOSApplicationExtension, unavailable)
+internal final class UIApplicationInterfaceOrientationProvider: InterfaceOrientationProvider {
+    func interfaceOrientation(for view: UIView) -> UIInterfaceOrientation? {
+        return UIApplication.shared.statusBarOrientation
+    }
+}
+
+@available(iOS 13.0, *)
+internal final class DefaultInterfaceOrientationProvider: InterfaceOrientationProvider {
+    func interfaceOrientation(for view: UIView) -> UIInterfaceOrientation? {
+        return view.window?.windowScene?.interfaceOrientation
+    }
+}
+
+internal extension CLDeviceOrientation {
+    init(interfaceOrientation: UIInterfaceOrientation) {
+        // UIInterfaceOrientation.landscape{Right,Left} correspond to
+        // CLDeviceOrientation.landscape{Left,Right}, respectively. The reason
+        // for this, according to the UIInterfaceOrientation docs is that
+        //
+        //    > …rotating the device requires rotating the content in the
+        //    > opposite direction.
+        switch interfaceOrientation {
+        case .landscapeLeft:
+            self = .landscapeRight
+        case .landscapeRight:
+            self = .landscapeLeft
+        case .portraitUpsideDown:
+            self = .portraitUpsideDown
+        default:
+            self = .portrait
+        }
+    }
+}

--- a/Sources/MapboxMaps/Foundation/InterfaceOrientationProvider.swift
+++ b/Sources/MapboxMaps/Foundation/InterfaceOrientationProvider.swift
@@ -4,7 +4,7 @@ import CoreLocation
 
 /// A protocol that supplies current interface orientation for the specified view.
 ///
-/// Use this protocol when the map view is used in non-application target(e.g. application extension target).
+/// Use this protocol when the map view is used in non-application target (e.g. application extension target).
 @available(iOS, deprecated: 13)
 public protocol InterfaceOrientationProvider {
 

--- a/Sources/MapboxMaps/Foundation/MapView+Attribution.swift
+++ b/Sources/MapboxMaps/Foundation/MapView+Attribution.swift
@@ -1,7 +1,6 @@
 @_implementationOnly import MapboxCommon_Private
 import UIKit
 
-@available(iOSApplicationExtension, unavailable)
 extension MapView: AttributionDialogManagerDelegate {
     func viewControllerForPresenting(_ attributionDialogManager: AttributionDialogManager) -> UIViewController {
         return parentViewController!
@@ -11,11 +10,11 @@ extension MapView: AttributionDialogManagerDelegate {
         switch attribution.kind {
         case .actionable(let url):
             Log.debug(forMessage: "Open url: \(url))", category: "Attribution")
-            UIApplication.shared.open(url)
+            attributionUrlOpener.openAttributionURL(url)
         case .feedback:
             let url = mapboxFeedbackURL()
             Log.debug(forMessage: "Open url: \(url))", category: "Attribution")
-            UIApplication.shared.open(url)
+            attributionUrlOpener.openAttributionURL(url)
         case .nonActionable:
             break
         }

--- a/Sources/MapboxMaps/Foundation/MapView+Snapshot.swift
+++ b/Sources/MapboxMaps/Foundation/MapView+Snapshot.swift
@@ -1,7 +1,6 @@
 @_implementationOnly import MapboxCommon_Private
 import UIKit
 
-@available(iOSApplicationExtension, unavailable)
 extension MapView {
 
     /// Errors related to rendered snapshots

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -196,6 +196,13 @@ open class MapView: UIView {
                   urlOpener: DefaultAttributionURLOpener())
     }
 
+    /// Initialize a MapView
+    /// - Parameters:
+    ///   - frame: frame for the MapView.
+    ///   - mapInitOptions: `MapInitOptions`; default uses
+    ///    `ResourceOptionsManager.default` to retrieve a shared default resource option, including the access token.
+    ///   - orientationProvider: User interface orientation provider
+    ///   - urlOpener: Attribution URL opener
     @available(iOS, deprecated: 13, message: "Use init(frame:mapInitOptions:urlOpener:) instead")
     public convenience init(frame: CGRect,
                             mapInitOptions: MapInitOptions = MapInitOptions(),
@@ -208,6 +215,12 @@ open class MapView: UIView {
                   urlOpener: urlOpener)
     }
 
+    /// Initialize a MapView
+    /// - Parameters:
+    ///   - frame: frame for the MapView.
+    ///   - mapInitOptions: `MapInitOptions`; default uses
+    ///    `ResourceOptionsManager.default` to retrieve a shared default resource option, including the access token.
+    ///   - urlOpener: Attribution URL opener
     @available(iOS 13.0, *)
     public convenience init(frame: CGRect,
                             mapInitOptions: MapInitOptions = MapInitOptions(),

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -204,15 +204,17 @@ open class MapView: UIView {
     ///   - orientationProvider: User interface orientation provider
     ///   - urlOpener: Attribution URL opener
     @available(iOS, deprecated: 13, message: "Use init(frame:mapInitOptions:urlOpener:) instead")
-    public convenience init(frame: CGRect,
-                            mapInitOptions: MapInitOptions = MapInitOptions(),
-                            orientationProvider: InterfaceOrientationProvider,
-                            urlOpener: AttributionURLOpener) {
-        self.init(frame: frame,
-                  mapInitOptions: mapInitOptions,
-                  dependencyProvider: MapViewDependencyProvider(),
-                  orientationProvider: orientationProvider,
-                  urlOpener: urlOpener)
+    public init(frame: CGRect,
+                mapInitOptions: MapInitOptions = MapInitOptions(),
+                orientationProvider: InterfaceOrientationProvider,
+                urlOpener: AttributionURLOpener) {
+        self.dependencyProvider = MapViewDependencyProvider()
+        self.interfaceOrientationProvider = orientationProvider
+        self.attributionUrlOpener = urlOpener
+        notificationCenter = dependencyProvider.makeNotificationCenter()
+        bundle = dependencyProvider.makeBundle()
+        super.init(frame: frame)
+        commonInit(mapInitOptions: mapInitOptions, overridingStyleURI: nil)
     }
 
     /// Initialize a MapView
@@ -222,14 +224,16 @@ open class MapView: UIView {
     ///    `ResourceOptionsManager.default` to retrieve a shared default resource option, including the access token.
     ///   - urlOpener: Attribution URL opener
     @available(iOS 13.0, *)
-    public convenience init(frame: CGRect,
-                            mapInitOptions: MapInitOptions = MapInitOptions(),
-                            urlOpener: AttributionURLOpener) {
-        self.init(frame: frame,
-                  mapInitOptions: mapInitOptions,
-                  dependencyProvider: MapViewDependencyProvider(),
-                  orientationProvider: DefaultInterfaceOrientationProvider(),
-                  urlOpener: urlOpener)
+    public init(frame: CGRect,
+                mapInitOptions: MapInitOptions = MapInitOptions(),
+                urlOpener: AttributionURLOpener) {
+        self.dependencyProvider = MapViewDependencyProvider()
+        self.interfaceOrientationProvider = DefaultInterfaceOrientationProvider()
+        self.attributionUrlOpener = urlOpener
+        notificationCenter = dependencyProvider.makeNotificationCenter()
+        bundle = dependencyProvider.makeBundle()
+        super.init(frame: frame)
+        commonInit(mapInitOptions: mapInitOptions, overridingStyleURI: nil)
     }
 
     @available(iOSApplicationExtension, unavailable)

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -182,18 +182,21 @@ open class MapView: UIView {
     ///   - mapInitOptions: `MapInitOptions`; default uses
     ///    `ResourceOptionsManager.default` to retrieve a shared default resource option, including the access token.
     @available(iOSApplicationExtension, unavailable)
-    public convenience init(frame: CGRect, mapInitOptions: MapInitOptions = MapInitOptions()) {
+    public init(frame: CGRect, mapInitOptions: MapInitOptions = MapInitOptions()) {
         let orientationProvider: InterfaceOrientationProvider
         if #available(iOS 13, *) {
             orientationProvider = DefaultInterfaceOrientationProvider()
         } else {
             orientationProvider = UIApplicationInterfaceOrientationProvider()
         }
-        self.init(frame: frame,
-                  mapInitOptions: mapInitOptions,
-                  dependencyProvider: MapViewDependencyProvider(),
-                  orientationProvider: orientationProvider,
-                  urlOpener: DefaultAttributionURLOpener())
+
+        self.dependencyProvider = MapViewDependencyProvider()
+        self.interfaceOrientationProvider = orientationProvider
+        self.attributionUrlOpener = DefaultAttributionURLOpener()
+        notificationCenter = dependencyProvider.makeNotificationCenter()
+        bundle = dependencyProvider.makeBundle()
+        super.init(frame: frame)
+        commonInit(mapInitOptions: mapInitOptions, overridingStyleURI: nil)
     }
 
     /// Initialize a MapView

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 // swiftlint:disable type_body_length
-@available(iOSApplicationExtension, unavailable)
 open class MapView: UIView {
 
     // `mapboxMap` depends on `MapInitOptions`, which is not available until
@@ -174,30 +173,77 @@ open class MapView: UIView {
         return mapboxMap.anchor
     }
 
+    private let interfaceOrientationProvider: InterfaceOrientationProvider
+    internal let attributionUrlOpener: AttributionURLOpener
+
     /// Initialize a MapView
     /// - Parameters:
     ///   - frame: frame for the MapView.
     ///   - mapInitOptions: `MapInitOptions`; default uses
     ///    `ResourceOptionsManager.default` to retrieve a shared default resource option, including the access token.
-    public init(frame: CGRect, mapInitOptions: MapInitOptions = MapInitOptions()) {
-        dependencyProvider = MapViewDependencyProvider()
-        notificationCenter = dependencyProvider.makeNotificationCenter()
-        bundle = dependencyProvider.makeBundle()
-        super.init(frame: frame)
-        commonInit(mapInitOptions: mapInitOptions, overridingStyleURI: nil)
+    @available(iOSApplicationExtension, unavailable)
+    public convenience init(frame: CGRect, mapInitOptions: MapInitOptions = MapInitOptions()) {
+        let orientationProvider: InterfaceOrientationProvider
+        if #available(iOS 13, *) {
+            orientationProvider = DefaultInterfaceOrientationProvider()
+        } else {
+            orientationProvider = UIApplicationInterfaceOrientationProvider()
+        }
+        self.init(frame: frame,
+                  mapInitOptions: mapInitOptions,
+                  dependencyProvider: MapViewDependencyProvider(),
+                  orientationProvider: orientationProvider,
+                  urlOpener: DefaultAttributionURLOpener())
     }
 
+    @available(iOS, deprecated: 13, message: "Use init(frame:mapInitOptions:urlOpener:) instead")
+    public convenience init(frame: CGRect,
+                            mapInitOptions: MapInitOptions = MapInitOptions(),
+                            orientationProvider: InterfaceOrientationProvider,
+                            urlOpener: AttributionURLOpener) {
+        self.init(frame: frame,
+                  mapInitOptions: mapInitOptions,
+                  dependencyProvider: MapViewDependencyProvider(),
+                  orientationProvider: orientationProvider,
+                  urlOpener: urlOpener)
+    }
+
+    @available(iOS 13.0, *)
+    public convenience init(frame: CGRect,
+                            mapInitOptions: MapInitOptions = MapInitOptions(),
+                            urlOpener: AttributionURLOpener) {
+        self.init(frame: frame,
+                  mapInitOptions: mapInitOptions,
+                  dependencyProvider: MapViewDependencyProvider(),
+                  orientationProvider: DefaultInterfaceOrientationProvider(),
+                  urlOpener: urlOpener)
+    }
+
+    @available(iOSApplicationExtension, unavailable)
     required public init?(coder: NSCoder) {
+        let orientationProvider: InterfaceOrientationProvider
+        if #available(iOS 13, *) {
+            orientationProvider = DefaultInterfaceOrientationProvider()
+        } else {
+            orientationProvider = UIApplicationInterfaceOrientationProvider()
+        }
+
         dependencyProvider = MapViewDependencyProvider()
         notificationCenter = dependencyProvider.makeNotificationCenter()
         bundle = dependencyProvider.makeBundle()
+        self.interfaceOrientationProvider = orientationProvider
+        self.attributionUrlOpener = DefaultAttributionURLOpener()
         super.init(coder: coder)
     }
 
     internal init(frame: CGRect,
                   mapInitOptions: MapInitOptions,
-                  dependencyProvider: MapViewDependencyProviderProtocol) {
+                  dependencyProvider: MapViewDependencyProviderProtocol,
+                  orientationProvider: InterfaceOrientationProvider,
+                  urlOpener: AttributionURLOpener) {
         self.dependencyProvider = dependencyProvider
+        self.interfaceOrientationProvider = orientationProvider
+        self.attributionUrlOpener = urlOpener
         notificationCenter = dependencyProvider.makeNotificationCenter()
         bundle = dependencyProvider.makeBundle()
         super.init(frame: frame)
@@ -512,36 +558,8 @@ open class MapView: UIView {
     // MARK: Location
 
     private func updateHeadingOrientationIfNeeded() {
-        // locationProvider.headingOrientation should be adjusted based on the
-        // current UIInterfaceOrientation of the containing window, not the
-        // device orientation
-        let optionalInterfaceOrientation: UIInterfaceOrientation?
-        if #available(iOS 13.0, *) {
-            optionalInterfaceOrientation = window?.windowScene?.interfaceOrientation
-        } else {
-            optionalInterfaceOrientation =  UIApplication.shared.statusBarOrientation
-        }
-
-        guard let interfaceOrientation = optionalInterfaceOrientation else {
+        guard let headingOrientation = interfaceOrientationProvider.headingOrientation(for: self) else {
             return
-        }
-
-        // UIInterfaceOrientation.landscape{Right,Left} correspond to
-        // CLDeviceOrientation.landscape{Left,Right}, respectively. The reason
-        // for this, according to the UIInterfaceOrientation docs is that
-        //
-        //    > …rotating the device requires rotating the content in the
-        //    > opposite direction.
-        var headingOrientation: CLDeviceOrientation
-        switch interfaceOrientation {
-        case .landscapeLeft:
-            headingOrientation = .landscapeRight
-        case .landscapeRight:
-            headingOrientation = .landscapeLeft
-        case .portraitUpsideDown:
-            headingOrientation = .portraitUpsideDown
-        default:
-            headingOrientation = .portrait
         }
 
         // We check for heading changes during the display link, but setting it
@@ -558,7 +576,6 @@ open class MapView: UIView {
     }
 }
 
-@available(iOSApplicationExtension, unavailable)
 extension MapView: DelegatingMapClientDelegate {
     internal func scheduleRepaint() {
         needsDisplayRefresh = true

--- a/Sources/MapboxMaps/Foundation/UIApplicationProtocol.swift
+++ b/Sources/MapboxMaps/Foundation/UIApplicationProtocol.swift
@@ -1,0 +1,12 @@
+import Foundation
+import UIKit
+
+internal protocol UIApplicationProtocol: AnyObject {
+    func open(_ url: URL)
+}
+
+extension UIApplication: UIApplicationProtocol {
+    func open(_ url: URL) {
+        open(url, options: [:], completionHandler: nil)
+    }
+}

--- a/Sources/MapboxMaps/Foundation/UIApplicationProtocol.swift
+++ b/Sources/MapboxMaps/Foundation/UIApplicationProtocol.swift
@@ -2,9 +2,12 @@ import Foundation
 import UIKit
 
 internal protocol UIApplicationProtocol: AnyObject {
+    var statusBarOrientation: UIInterfaceOrientation { get set }
+
     func open(_ url: URL)
 }
 
+@available(iOSApplicationExtension, unavailable)
 extension UIApplication: UIApplicationProtocol {
     func open(_ url: URL) {
         open(url, options: [:], completionHandler: nil)

--- a/Sources/MapboxMaps/Ornaments/InfoButtonOrnament.swift
+++ b/Sources/MapboxMaps/Ornaments/InfoButtonOrnament.swift
@@ -1,12 +1,10 @@
 import UIKit
 @_implementationOnly import MapboxCommon_Private
 
-@available(iOSApplicationExtension, unavailable)
 internal protocol InfoButtonOrnamentDelegate: AnyObject {
     func didTap(_ infoButtonOrnament: InfoButtonOrnament)
 }
 
-@available(iOSApplicationExtension, unavailable)
 internal class InfoButtonOrnament: UIView {
 
     public override var isHidden: Bool {

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -19,7 +19,6 @@ internal struct Ornaments {
     static let telemetryURL = "https://www.mapbox.com/telemetry/"
 }
 
-@available(iOSApplicationExtension, unavailable)
 public class OrnamentsManager: NSObject {
 
     /// The `OrnamentOptions` object that is used to set up and update the required ornaments on the map.

--- a/Sources/MapboxMaps/Style/AttributionDialogManager.swift
+++ b/Sources/MapboxMaps/Style/AttributionDialogManager.swift
@@ -3,13 +3,11 @@ internal protocol AttributionDataSource: AnyObject {
     func attributions() -> [Attribution]
 }
 
-@available(iOSApplicationExtension, unavailable)
 internal protocol AttributionDialogManagerDelegate: AnyObject {
     func viewControllerForPresenting(_ attributionDialogManager: AttributionDialogManager) -> UIViewController
     func attributionDialogManager(_ attributionDialogManager: AttributionDialogManager, didTriggerActionFor attribution: Attribution)
 }
 
-@available(iOSApplicationExtension, unavailable)
 internal class AttributionDialogManager {
 
     private weak var dataSource: AttributionDataSource?
@@ -92,7 +90,7 @@ internal class AttributionDialogManager {
                                           comment: "Telemetry prompt button")
         let moreAction = UIAlertAction(title: moreTitle, style: .default) { _ in
             guard let url = URL(string: Ornaments.telemetryURL) else { return }
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            self.delegate?.attributionDialogManager(self, didTriggerActionFor: Attribution(title: "", url: url))
         }
         alert.addAction(moreAction)
 
@@ -109,7 +107,6 @@ internal class AttributionDialogManager {
 }
 
 // MARK: InfoButtonOrnamentDelegate Implementation
-@available(iOSApplicationExtension, unavailable)
 extension AttributionDialogManager: InfoButtonOrnamentDelegate {
     func didTap(_ infoButtonOrnament: InfoButtonOrnament) {
         guard let viewController = delegate?.viewControllerForPresenting(self) else {

--- a/Tests/MapboxMapsTests/Foundation/AttributionURLOpenerTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/AttributionURLOpenerTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+@testable import MapboxMaps
+import XCTest
+
+final class AttributionURLOpenerTests: XCTestCase {
+    var urlOpener: DefaultAttributionURLOpener!
+    var application: MockUIApplication!
+
+    override func setUp() {
+        super.setUp()
+
+        application = MockUIApplication()
+        urlOpener = DefaultAttributionURLOpener(application: application)
+    }
+
+    override func tearDown() {
+        urlOpener = nil
+        application = nil
+        super.tearDown()
+    }
+
+    func testURLOpener() {
+        let url = URL(string: "http://example.com")!
+
+        urlOpener.openAttributionURL(url)
+
+        XCTAssertEqual(application.openURLStub.invocations.count, 1)
+        XCTAssertEqual(application.openURLStub.invocations.first?.parameters, url)
+    }
+}

--- a/Tests/MapboxMapsTests/Foundation/InterfaceOrientationProviderTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/InterfaceOrientationProviderTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+@testable import MapboxMaps
+import XCTest
+
+final class UIApplicationInterfaceOrientationProviderTests: XCTestCase {
+    var provider: UIApplicationInterfaceOrientationProvider!
+    var view: UIView!
+
+    override func setUp() {
+        super.setUp()
+
+        view = UIView()
+        provider = UIApplicationInterfaceOrientationProvider()
+    }
+
+    override func tearDown() {
+        provider = nil
+        view = nil
+        super.tearDown()
+    }
+
+    func testOrientationProvider() {
+        let orientations: [UIInterfaceOrientation] = [.portrait, .landscapeLeft, .landscapeRight, .portraitUpsideDown]
+
+        for orientation in orientations {
+            UIApplication.shared.statusBarOrientation = orientation
+            let resolvedOrientation = provider.interfaceOrientation(for: view)
+
+            XCTAssertEqual(resolvedOrientation, UIApplication.shared.statusBarOrientation)
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+final class DefaultInterfaceOrientationProviderTests: XCTestCase {
+    var provider: DefaultInterfaceOrientationProvider!
+    var view: UIView!
+    var window: UIWindow!
+
+    override func setUp() {
+        super.setUp()
+
+        view = UIView()
+        window = UIWindow()
+        let viewController = UIViewController()
+        viewController.view.addSubview(view)
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        provider = DefaultInterfaceOrientationProvider()
+    }
+
+    override func tearDown() {
+        provider = nil
+        view = nil
+        super.tearDown()
+    }
+
+    func testOrientationProvider() {
+        let orientation = provider.interfaceOrientation(for: view)
+
+        XCTAssertNotNil(orientation)
+        XCTAssertEqual(orientation, view.window?.windowScene?.interfaceOrientation)
+    }
+}

--- a/Tests/MapboxMapsTests/Foundation/MapViewSubclassingTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewSubclassingTests.swift
@@ -67,4 +67,3 @@ private final class MapViewSubclass: MapView {
         super.init(coder: coder)
     }
 }
-

--- a/Tests/MapboxMapsTests/Foundation/MapViewSubclassingTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewSubclassingTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+import MapboxMaps
+
+final class MapViewSubclassingTests: XCTestCase {
+
+    var orientationProvider: MockInterfaceOrientationProvider!
+    var attributionURLOpener: MockAttributionURLOpener!
+
+    override func setUp() {
+        super.setUp()
+
+        orientationProvider = MockInterfaceOrientationProvider()
+        attributionURLOpener = MockAttributionURLOpener()
+    }
+
+    override func tearDown() {
+        orientationProvider = nil
+        attributionURLOpener = nil
+        super.tearDown()
+    }
+
+    func testMapViewIsCreated() {
+        // These are just dummies so that `MapViewSubclass` won't get deleted as unused.
+        // The real test happens at compile time and checks if
+        // each `MapViewSubclass` initializer override a corresponding designated initializer
+        _ = MapViewSubclass(
+            frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)),
+            mapInitOptions: MapInitOptions())
+
+        if #available(iOS 13.0, *) {
+            _ = MapViewSubclass(
+                frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)),
+                mapInitOptions: MapInitOptions(),
+                urlOpener: attributionURLOpener)
+        }
+
+        _ = MapViewSubclass(
+            frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)),
+            mapInitOptions: MapInitOptions(),
+            orientationProvider: orientationProvider,
+            urlOpener: attributionURLOpener)
+    }
+}
+
+private final class MapViewSubclass: MapView {
+
+    override init(frame: CGRect, mapInitOptions: MapInitOptions = MapInitOptions()) {
+        super.init(frame: frame, mapInitOptions: mapInitOptions)
+    }
+
+    @available(iOS 13.0, *)
+    override init(frame: CGRect, mapInitOptions: MapInitOptions = MapInitOptions(), urlOpener: AttributionURLOpener) {
+        super.init(frame: frame, mapInitOptions: mapInitOptions, urlOpener: urlOpener)
+    }
+
+    override init(frame: CGRect,
+                  mapInitOptions: MapInitOptions = MapInitOptions(),
+                  orientationProvider: InterfaceOrientationProvider,
+                  urlOpener: AttributionURLOpener) {
+        super.init(frame: frame,
+                   mapInitOptions: mapInitOptions,
+                   orientationProvider: orientationProvider,
+                   urlOpener: urlOpener)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -10,20 +10,29 @@ final class MapViewTests: XCTestCase {
     var mapView: MapView!
     var window: UIWindow!
     var metalView: MockMetalView!
+    var locationProducer: MockLocationProducer!
+    var orientationProvider: MockInterfaceOrientationProvider!
+    var attributionURLOpener: MockAttributionURLOpener!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         displayLink = MockDisplayLink()
         notificationCenter = MockNotificationCenter()
         bundle = MockBundle()
+        locationProducer = MockLocationProducer()
         dependencyProvider = MockMapViewDependencyProvider()
         dependencyProvider.makeDisplayLinkStub.defaultReturnValue = displayLink
         dependencyProvider.makeNotificationCenterStub.defaultReturnValue = notificationCenter
         dependencyProvider.makeBundleStub.defaultReturnValue = bundle
+        dependencyProvider.makeLocationProducerStub.defaultReturnValue = locationProducer
+        orientationProvider = MockInterfaceOrientationProvider()
+        attributionURLOpener = MockAttributionURLOpener()
         mapView = MapView(
             frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)),
             mapInitOptions: MapInitOptions(),
-            dependencyProvider: dependencyProvider)
+            dependencyProvider: dependencyProvider,
+            orientationProvider: orientationProvider,
+            urlOpener: attributionURLOpener)
         window = UIWindow()
         window.addSubview(mapView)
         metalView = try XCTUnwrap(XCTUnwrap(dependencyProvider.makeMetalViewStub.invocations.first?.returnValue))
@@ -37,6 +46,9 @@ final class MapViewTests: XCTestCase {
         displayLink = nil
         bundle = nil
         notificationCenter = nil
+        orientationProvider = nil
+        attributionURLOpener = nil
+        locationProducer = nil
         super.tearDown()
     }
 
@@ -197,7 +209,9 @@ final class MapViewTests: XCTestCase {
         let mapView = MapView(
             frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)),
             mapInitOptions: MapInitOptions(),
-            dependencyProvider: dependencyProvider)
+            dependencyProvider: dependencyProvider,
+            orientationProvider: orientationProvider,
+            urlOpener: attributionURLOpener)
 
         window.addSubview(mapView)
 
@@ -226,7 +240,9 @@ final class MapViewTests: XCTestCase {
         let mapView = MapView(
             frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)),
             mapInitOptions: MapInitOptions(),
-            dependencyProvider: dependencyProvider)
+            dependencyProvider: dependencyProvider,
+            orientationProvider: orientationProvider,
+            urlOpener: attributionURLOpener)
 
         window.addSubview(mapView)
 
@@ -254,7 +270,9 @@ final class MapViewTests: XCTestCase {
         let mapView = MapView(
             frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)),
             mapInitOptions: MapInitOptions(),
-            dependencyProvider: dependencyProvider)
+            dependencyProvider: dependencyProvider,
+            orientationProvider: orientationProvider,
+            urlOpener: attributionURLOpener)
         window.addSubview(mapView)
         notificationCenter.removeObserverStub.reset()
 
@@ -309,5 +327,39 @@ final class MapViewTests: XCTestCase {
         notificationCenter.post(name: UIScene.didEnterBackgroundNotification, object: window.parentScene)
 
         XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [true])
+    }
+
+    func testOrientationProviderIsUsed() throws {
+        try invokeDisplayLinkCallback()
+
+        XCTAssertEqual(orientationProvider.interfaceOrientationStub.invocations.count, 1)
+    }
+
+    func testOrientationChangeIsPropagated() throws {
+        let orientations: [UIInterfaceOrientation] = [.portrait, .landscapeLeft, .landscapeRight, .portraitUpsideDown]
+        for orientation in orientations {
+            orientationProvider.interfaceOrientationStub.defaultReturnValue = orientation
+
+            try invokeDisplayLinkCallback()
+
+            XCTAssertEqual(locationProducer.headingOrientation, CLDeviceOrientation(interfaceOrientation: orientation))
+        }
+    }
+
+    func testURLOpener() {
+        let manager = AttributionDialogManager(dataSource: self, delegate: mapView)
+        let url = URL(string: "http://example.com")!
+        let attribution = Attribution(title: .randomASCII(withLength: 10), url: url)
+
+        mapView.attributionDialogManager(manager, didTriggerActionFor: attribution)
+
+        XCTAssertEqual(attributionURLOpener.openAttributionURLStub.invocations.count, 1)
+        XCTAssertEqual(attributionURLOpener.openAttributionURLStub.invocations.first?.parameters, url)
+    }
+}
+
+extension MapViewTests: AttributionDataSource {
+    func attributions() -> [Attribution] {
+        return []
     }
 }

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -347,7 +347,7 @@ final class MapViewTests: XCTestCase {
     }
 
     func testURLOpener() {
-        let manager = AttributionDialogManager(dataSource: self, delegate: mapView)
+        let manager = AttributionDialogManager(dataSource: MockAttributionDataSource(), delegate: MockAttributionDialogManagerDelegate())
         let url = URL(string: "http://example.com")!
         let attribution = Attribution(title: .randomASCII(withLength: 10), url: url)
 
@@ -355,11 +355,5 @@ final class MapViewTests: XCTestCase {
 
         XCTAssertEqual(attributionURLOpener.openAttributionURLStub.invocations.count, 1)
         XCTAssertEqual(attributionURLOpener.openAttributionURLStub.invocations.first?.parameters, url)
-    }
-}
-
-extension MapViewTests: AttributionDataSource {
-    func attributions() -> [Attribution] {
-        return []
     }
 }

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockAttributionURLOpener.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockAttributionURLOpener.swift
@@ -1,0 +1,9 @@
+import Foundation
+@testable import MapboxMaps
+
+final class MockAttributionURLOpener: AttributionURLOpener {
+    let openAttributionURLStub = Stub<URL, Void>()
+    func openAttributionURL(_ url: URL) {
+        openAttributionURLStub.call(with: url)
+    }
+}

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockInterfaceOrientationProvider.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockInterfaceOrientationProvider.swift
@@ -1,0 +1,10 @@
+import Foundation
+@testable import MapboxMaps
+
+final class MockInterfaceOrientationProvider: InterfaceOrientationProvider {
+    let interfaceOrientationStub = Stub<UIView, UIInterfaceOrientation?>(defaultReturnValue: .portrait)
+    func interfaceOrientation(for view: UIView) -> UIInterfaceOrientation? {
+        return interfaceOrientationStub.call(with: view)
+
+    }
+}

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
@@ -67,8 +67,9 @@ final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
         return GestureHandler(gestureRecognizer: UIGestureRecognizer())
     }
 
+    let makeLocationProducerStub = Stub<Bool, MockLocationProducer>(defaultReturnValue: MockLocationProducer())
     func makeLocationProducer(mayRequestWhenInUseAuthorization: Bool) -> LocationProducerProtocol {
-        return MockLocationProducer()
+        return makeLocationProducerStub.call(with: mayRequestWhenInUseAuthorization)
     }
 
     func makeInterpolatedLocationProducer(locationProducer: LocationProducerProtocol,

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockUIApplication.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockUIApplication.swift
@@ -4,7 +4,7 @@ import UIKit
 
 final class MockUIApplication: UIApplicationProtocol {
     var statusBarOrientation: UIInterfaceOrientation = .unknown
-    
+
     let openURLStub = Stub<URL, Void>()
     func open(_ url: URL) {
         openURLStub.call(with: url)

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockUIApplication.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockUIApplication.swift
@@ -3,7 +3,8 @@ import UIKit
 @testable import MapboxMaps
 
 final class MockUIApplication: UIApplicationProtocol {
-
+    var statusBarOrientation: UIInterfaceOrientation = .unknown
+    
     let openURLStub = Stub<URL, Void>()
     func open(_ url: URL) {
         openURLStub.call(with: url)

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockUIApplication.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockUIApplication.swift
@@ -1,0 +1,11 @@
+import Foundation
+import UIKit
+@testable import MapboxMaps
+
+final class MockUIApplication: UIApplicationProtocol {
+
+    let openURLStub = Stub<URL, Void>()
+    func open(_ url: URL) {
+        openURLStub.call(with: url)
+    }
+}

--- a/scripts/api-compatibility-check/breakage_allowlist.txt
+++ b/scripts/api-compatibility-check/breakage_allowlist.txt
@@ -5,3 +5,7 @@ Func MapView.willMove(toWindow:) has been removed
 // _spi(Experimental)
 Enum PinchGestureBehavior has been removed
 Var GestureOptions.pinchBehavior has been removed
+
+// https://github.com/mapbox/mapbox-maps-ios/pull/1183
+Constructor MapView.init(frame:mapInitOptions:orientationProvider:urlOpener:) has been added as a designated initializer to an open class
+Constructor MapView.init(frame:mapInitOptions:urlOpener:) has been added as a designated initializer to an open class

--- a/scripts/doc-generation/.jazzy.yaml
+++ b/scripts/doc-generation/.jazzy.yaml
@@ -21,6 +21,8 @@ custom_categories:
       - ResourceOptionsManager
       - MapOptions
       - GlyphsRasterizationOptions
+      - InterfaceOrientationProvider
+      - AttributionURLOpener
 
   - name: Snapshotter
     children:


### PR DESCRIPTION
This PR makes possible to use `MapView` inside an application extension 🎉 

### Preconditions

The limitation of being able to only mark certain methods/entities being unavailable in application extensions with `@available(iOSApplicationExtension, unavailable)`(not vice versa). Plus the absence of run/compile -time app extension check (`if #available(iOSApplicationExtension)`). Has certainly made an impact on the design of the affected public API. 

### Changes

In order to be able to isolate `UIApplication`-specific behaviour, the map view is injected with `InterfaceOrientationProvider` and `AttributionURLOpener`. 

`InterfaceOrientationProvider` is a protocol the map view uses to obtain the current interface orientation. The interface orientation is used to ensure the map view gets correct heading data from its location producer.
`AttributionURLOpener` is a protocol the map view uses to open attribution-related web pages.

In order to preserve the existing map view's public initialiser, I created internal `DefaultAttributionURLOpener`, as well as `UIApplicationInterfaceOrientationProvider` and `DefaultInterfaceOrientationProvider`. 

`UIApplicationInterfaceOrientationProvider` and `DefaultAttributionURLOpener` are using `UIApplication.shared`, thus they are available only in app context. 

In case the map view is used in an app extension context - developers are required to provide their own `AttributionURLOpener`(utilising `NSExtensionContext.open(_:completionHandler:)`). And their own `InterfaceOrientationProvider` in case they are targeting iOS 11 or 12.

And finally this PR removes all `@available(iOSApplicationExtension, unavailable)` annotations from the top level. Instead it marks the existing initialiser with being unavailable in an app extension. And creates two alternative initialisers to be used in app extensions.

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [x] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
