### PR TITLE
Fix flaky attribution test for good

### DIFF
--- a/Tests/MapboxMapsTests/Helpers/Random/String+Random.swift
+++ b/Tests/MapboxMapsTests/Helpers/Random/String+Random.swift
@@ -1,4 +1,10 @@
+import Foundation
 extension String {
+    static func randomAlphanumeric(withLength length: UInt) -> Self {
+        let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        return (0..<length).reduce(into: "") { s, _ in s.append(letters.randomElement()!) }
+    }
+
     static func randomASCII(withLength length: UInt) -> Self {
         return (0..<length).reduce(into: "") { s, _ in s.append(.randomASCII()) }
     }

--- a/Tests/MapboxMapsTests/Style/AttributionTests.swift
+++ b/Tests/MapboxMapsTests/Style/AttributionTests.swift
@@ -59,7 +59,7 @@ class AttributionTests: XCTestCase {
     }
 
     func testPlainTextAttributionParsing() throws {
-        let attributionString = String.randomASCII(withLength: 10).trimmingCharacters(in: .whitespacesAndNewlines)
+        let attributionString = String.randomAlphanumeric(withLength: 10).trimmingCharacters(in: .whitespacesAndNewlines)
 
         let attributions = Attribution.parse([attributionString])
 


### PR DESCRIPTION
The `testPlainTextAttributionParsing` test is failing because the `String.randomASCII(withLength:)` method returns a string containing HTML-reserved characters. This PR adds `String. randomAlphanumeric(withLength:)` to be used in tests expecting only alphanumeric strings.

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
