### PR TITLE
Fix offline region merge error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+* Mitigate `OfflineRegionManager.mergeOfflineDatabase(for:completion)` throwing `TypeConversionError.unexpectedType` on a successfull merge. Introduce `OfflineRegionManager.mergeOfflineDatabase(forPath:completion)` as the correct way to merge offline database. ([#1192](https://github.com/mapbox/mapbox-maps-ios/pull/1192))
+
 ## 10.4.0-rc.1 - March 9, 2022
 
 * Update to MapboxCoreMaps 10.4.0-rc.1 and MapboxCommon 21.2.0-rc.1. ([#1158](https://github.com/mapbox/mapbox-maps-ios/pull/1158))

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/OfflineRegionManager.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/OfflineRegionManager.swift
@@ -27,10 +27,38 @@ extension OfflineRegionManager {
                                                                                         concreteErrorType: MapError.self))
     }
 
+    /// Merges data from the database at `filePath` into the main offline database.
+    ///
+    /// - Warning: This method passes only the first merged offline region to its completion block.
+    /// In case there are no merged offline regions the completion block is called with an error.
+    ///
+    /// - Parameters:
+    ///   - filePath: The path to the database to be merged
+    ///   - completion: The block to execute with the results. This block is executed on the database thread.
+    ///   The block has no return value and takes a `Result` case parameter that indicates the result of merging the offline database.
+    @available(iOS, deprecated, message: "use mergeOfflineDatabase(forPath:completion) instead")
     public func mergeOfflineDatabase(for filePath: String,
-                                     completion: @escaping (Result<OfflineRegion, Error>) -> Void) {
+                                     completion: @escaping (_ result: Result<OfflineRegion, Error>) -> Void) {
         mergeOfflineDatabase(forFilePath: filePath, callback: coreAPIClosureAdapter(for: completion,
-                                                                                    type: OfflineRegion.self,
+                                                                                    type: NSArray.self,
+                                                                                    concreteErrorType: MapError.self,
+                                                                                       converter: { result in
+            // returning the first region here for backwards compatibility
+            (result as? [OfflineRegion])?.first
+        }))
+    }
+
+    /// Merges data from the database at `filePath` into the main offline database.
+    ///
+    /// - Parameters:
+    ///   - filePath: The path to the database to be merged
+    ///   - completion: The block to execute with the results. This block is executed on the database thread.
+    ///   The block has no return value and takes a `Result` case parameter that indicates the result of merging the offline database.
+    public func mergeOfflineDatabase(forPath filePath: String,
+                                     completion: @escaping (Result<[OfflineRegion], Error>) -> Void) {
+        mergeOfflineDatabase(forFilePath: filePath, callback: coreAPIClosureAdapter(for: completion,
+                                                                                    type: NSArray.self,
                                                                                     concreteErrorType: MapError.self))
     }
+
 }

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/OfflineRegionManager.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/OfflineRegionManager.swift
@@ -1,6 +1,5 @@
 @_implementationOnly import MapboxCoreMaps_Private
 
-/// :nodoc:
 @available(*, deprecated)
 extension OfflineRegionManager {
 

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/OfflineRegionManager.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/OfflineRegionManager.swift
@@ -1,5 +1,6 @@
 @_implementationOnly import MapboxCoreMaps_Private
 
+/// :nodoc:
 @available(*, deprecated)
 extension OfflineRegionManager {
 

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/OfflineRegionManager.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/OfflineRegionManager.swift
@@ -3,16 +3,32 @@
 /// :nodoc:
 @available(*, deprecated)
 extension OfflineRegionManager {
+
+    /// Construct a new offline manager.
+    /// - Parameter resourceOptions: The resource options of the manager.
     public convenience init(resourceOptions: ResourceOptions) {
         self.init(resourceOptions: MapboxCoreMaps.ResourceOptions(resourceOptions))
     }
 
+    /// Retrieve all regions in the offline database.
+    ///
+    /// - Parameters:
+    ///   - completion: The block to execute with the results. This block is executed on the database thread.
+    ///   The block has no return value and takes a `Result` case parameter that indicates the result of quering the offline database.
     public func offlineRegions(completion: @escaping (Result<[OfflineRegion], Error>) -> Void) {
         getOfflineRegions(forCallback: coreAPIClosureAdapter(for: completion,
                                                              type: NSArray.self,
                                                              concreteErrorType: MapError.self))
     }
 
+    /// Create an offline region in the offline database.
+    ///
+    /// - Note: The resulting region will be in an inactive download state; to begin downloading resources, call `OfflineRegion.setOfflineRegionDownloadStateFor(_:)`, optionally registering an `OfflineRegionObserver` beforehand.
+    ///
+    /// - Parameters:
+    ///   - geometryDefinition: The offline region geometry definition.
+    ///   - completion: The block to execute with the results. This block is executed on the database thread.
+    ///   The block has no return value and takes a `Result` case parameter that indicates the result of creating the offline region.
     public func createOfflineRegion(for geometryDefinition: OfflineRegionGeometryDefinition,
                                     completion: @escaping (Result<OfflineRegion, Error>) -> Void) {
         createOfflineRegion(for: geometryDefinition, callback: coreAPIClosureAdapter(for: completion,
@@ -20,6 +36,14 @@ extension OfflineRegionManager {
                                                                                      concreteErrorType: MapError.self))
     }
 
+    /// Create an offline region in the offline database.
+    ///
+    /// - Note: The resulting region will be in an inactive download state; to begin downloading resources, call `OfflineRegion.setOfflineRegionDownloadStateFor(_:)`, optionally registering an `OfflineRegionObserver` beforehand.
+    ///
+    /// - Parameters:
+    ///   - tilePyramidDefinition: The offline region tile pymarid definition.
+    ///   - completion: The block to execute with the results. This block is executed on the database thread.
+    ///   The block has no return value and takes a `Result` case parameter that indicates the result of creating the offline region.
     public func createOfflineRegion(for tilePyramidDefinition: OfflineRegionTilePyramidDefinition,
                                     completion: @escaping (Result<OfflineRegion, Error>) -> Void) {
         createOfflineRegion(for: tilePyramidDefinition, callback: coreAPIClosureAdapter(for: completion,

--- a/scripts/doc-generation/.jazzy.yaml
+++ b/scripts/doc-generation/.jazzy.yaml
@@ -229,6 +229,7 @@ custom_categories:
     children:
       - OfflineManager
       - OfflineRegion
+      - OfflineRegionManager
       - OfflineRegionGeometryDefinition
       - OfflineSwitch
       - StylePackError


### PR DESCRIPTION
Apparently the result of merging an offline database is not a single instance of the `OfflineRegion`, but an array of them. 

In order to preserve the existing interface this PR adds a method with the correct signature and a slightly different name(to avoid ambiguity-related build errors) - `mergeOfflineDatabase(forPath:completion:)`. 

The old method for merging is deprecated. And the original issue is addressed by passing the first offline reason as a result. This will make this method to produce the correct result in almost all cases. Only when merging finishes successfully but produces no regions - still `TypeConversionError.unsuccessfulConversion` is returned.

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

Fixes: #1175 
## Pull request checklist:
 - [x] Add documentation comments for any added or updated public APIs.
 - [x] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
