### PR TITLE
Fix DefaultInterfaceOrientationProviderTests failing on iOS 12

### DIFF
--- a/Tests/MapboxMapsTests/Foundation/InterfaceOrientationProviderTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/InterfaceOrientationProviderTests.swift
@@ -78,7 +78,11 @@ final class DefaultInterfaceOrientationProviderTests: XCTestCase {
         super.tearDown()
     }
 
-    func testOrientationProvider() {
+    func testOrientationProvider() throws {
+        guard #available(iOS 13.0, *) else {
+            throw XCTSkip("Test requires iOS 13 or higher.")
+        }
+
         let orientation = provider.interfaceOrientation(for: view)
 
         XCTAssertNotNil(orientation)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
