### PR TITLE
Limit MapboxMap.point(for: CLLocationCoordinate2D) to the bounds of map view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## main
 
 * Mitigate `OfflineRegionManager.mergeOfflineDatabase(for:completion)` throwing `TypeConversionError.unexpectedType` on a successfull merge. Introduce `OfflineRegionManager.mergeOfflineDatabase(forPath:completion)` as the correct way to merge offline database. ([#1192](https://github.com/mapbox/mapbox-maps-ios/pull/1192))
+* Limit MapboxMap.point(for: CLLocationCoordinate2D) to the bounds of map view ([#1195](https://github.com/mapbox/mapbox-maps-ios/pull/1195))
 * Update to MapboxCoreMaps 10.4.1 and MapboxCommon 21.2.0. ([#1190](https://github.com/mapbox/mapbox-maps-ios/pull/1190))
 * Add support for app extensions. ([#1183](https://github.com/mapbox/mapbox-maps-ios/pull/1183))
 * `BasicCameraAnimator.cancel()` and `.stopAnimation()` now invoke the completion blocks with `UIViewAnimatingPosition.current` instead of crashing with a `fatalError` when invoked prior to `.startAnimation()` or `.startAnimation(afterDelay:)`. ([#1197](https://github.com/mapbox/mapbox-maps-ios/pull/1197))

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -436,9 +436,11 @@ public final class MapboxMap: MapboxMapProtocol {
 
     /// Converts a map coordinate to a `CGPoint`, relative to the `MapView`.
     /// - Parameter coordinate: The coordinate to convert.
-    /// - Returns: A `CGPoint` relative to the `UIView`.
+    /// - Returns: A `CGPoint` relative to the `UIView`. If the point is outside of the bounds
+    ///     of `MapView` the returned point contains `-1.0` for both coordinates.
     public func point(for coordinate: CLLocationCoordinate2D) -> CGPoint {
-        return __map.pixelForCoordinate(for: coordinate).point
+        let point = __map.pixelForCoordinate(for: coordinate).point
+        return CGRect(origin: .zero, size: size).contains(point) ? point : CGPoint(x: -1.0, y: -1.0)
     }
 
     /// Converts map coordinates to an array of `CGPoint`, relative to the `MapView`.

--- a/Tests/MapboxMapsTests/Foundation/MapboxMapsFoundationTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapboxMapsFoundationTests.swift
@@ -55,10 +55,23 @@ class MapboxMapsFoundationTests: XCTestCase {
 
     func testCoordinateToPoint() {
         let centerCoordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
-        let convertedPoint = mapView.mapboxMap.point(for: centerCoordinate)
+        var convertedPoint = mapView.mapboxMap.point(for: centerCoordinate)
 
         XCTAssertEqual(convertedPoint.x, mapView.bounds.midX, accuracy: 0.01)
         XCTAssertEqual(convertedPoint.y, mapView.bounds.midY, accuracy: 0.01)
+
+        let maxPoint = CGPoint(x: mapView.bounds.maxX, y: mapView.bounds.maxY)
+        let boundaryCoordinate = mapView.mapboxMap.coordinate(for: maxPoint)
+        convertedPoint = mapView.mapboxMap.point(for: boundaryCoordinate)
+
+        XCTAssertEqual(convertedPoint.x, maxPoint.x, accuracy: 0.01)
+        XCTAssertEqual(convertedPoint.y, maxPoint.y, accuracy: 0.01)
+
+        let outOfBoundsCoordinate = CLLocationCoordinate2D(latitude: boundaryCoordinate.latitude + 1,
+                                                           longitude: boundaryCoordinate.longitude + 1)
+        convertedPoint = mapView.mapboxMap.point(for: outOfBoundsCoordinate)
+        XCTAssertEqual(convertedPoint.x, -1.0)
+        XCTAssertEqual(convertedPoint.y, -1.0)
     }
 
     func testPointToCoordinateInSubviewWithEqualCenter() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

Related to: https://github.com/mapbox/mapbox-maps-ios/issues/788

Currently we cannot guarantee that the returned point of `MapboxMap.point(for: CLLocationCoordinate2D)` is valid outside of the MapView bounds. Originally the underlying implementation was designed to convert points only on the visible parts of the map. Until the GL-Native implementation is reworked we have to limit the public API. 
https://github.com/mapbox/mapbox-gl-native-internal/issues/3062

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [x] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
