### PR TITLE
Refactor CameraAnimationsManager for testability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 * Update to MapboxCoreMaps 10.4.1 and MapboxCommon 21.2.0. ([#1190](https://github.com/mapbox/mapbox-maps-ios/pull/1190))
 * Add support for app extensions. ([#1183](https://github.com/mapbox/mapbox-maps-ios/pull/1183))
+* `BasicCameraAnimator.cancel()` and `.stopAnimation()` now invoke the completion blocks with `UIViewAnimatingPosition.current` instead of crashing with a `fatalError` when invoked prior to `.startAnimation()` or `.startAnimation(afterDelay:)`. ([#1197](https://github.com/mapbox/mapbox-maps-ios/pull/1197))
+* `CameraAnimationsManager.stopAnimations()` will now cancel all animators regardless of their state. Previously, only animators with `state == .active` were canceled. ([#1197](https://github.com/mapbox/mapbox-maps-ios/pull/1197))
 
 ## 10.4.0-rc.1 - March 9, 2022
 

--- a/Sources/MapboxMaps/Camera/BasicCameraAnimatorImpl.swift
+++ b/Sources/MapboxMaps/Camera/BasicCameraAnimatorImpl.swift
@@ -75,8 +75,8 @@ internal final class BasicCameraAnimatorImpl: BasicCameraAnimatorProtocol {
                 // * oldValue and internalState are the same
                 // * initial transitions to paused
                 // * paused transitions to final
+                // * initial transitions to final
                 // * the transition is invalid…
-                //     * initial --> final
                 //     * running/paused/final --> initial
                 //     * final --> running/paused
                 break
@@ -171,7 +171,11 @@ internal final class BasicCameraAnimatorImpl: BasicCameraAnimatorProtocol {
     internal func stopAnimation() {
         switch internalState {
         case .initial:
-            fatalError("Attempt to stop an animation that has not started.")
+            internalState = .final
+            for completion in completions {
+                completion(.current)
+            }
+            completions.removeAll()
         case .running, .paused:
             propertyAnimator.stopAnimation(false)
             // this invokes the completion block which updates internalState

--- a/Sources/MapboxMaps/Camera/CameraAnimationsManager.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimationsManager.swift
@@ -1,77 +1,28 @@
 import UIKit
-@_implementationOnly import MapboxCommon_Private
 
-internal protocol CameraAnimationsManagerProtocol: AnyObject {
-    @discardableResult
-    func internalEase(to camera: CameraOptions,
-                      duration: TimeInterval,
-                      curve: UIView.AnimationCurve,
-                      completion: AnimationCompletion?) -> Cancelable
+/// APIs for animating the camera.
+public final class CameraAnimationsManager {
 
-    func decelerate(location: CGPoint,
-                    velocity: CGPoint,
-                    decelerationFactor: CGFloat,
-                    locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void,
-                    completion: AnimationCompletion?)
+    private let impl: CameraAnimationsManagerProtocol
 
-    func makeAnimator(duration: TimeInterval,
-                      curve: UIView.AnimationCurve,
-                      animationOwner: AnimationOwner,
-                      animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator
-
-    func cancelAnimations()
-
-    var animationsEnabled: Bool { get set }
-}
-
-/// An object that manages a camera's view lifecycle.
-public class CameraAnimationsManager: CameraAnimationsManagerProtocol {
+    internal init(impl: CameraAnimationsManagerProtocol) {
+        self.impl = impl
+    }
 
     /// List of animators currently alive
     public var cameraAnimators: [CameraAnimator] {
-        return cameraAnimatorsSet.allObjects
+        return impl.cameraAnimators
     }
-
-    /// Pointer HashTable for holding camera animators
-    private let cameraAnimatorsSet = WeakSet<CameraAnimatorProtocol>()
-
-    private var runningCameraAnimators = [CameraAnimator]()
-
-    /// Internal camera animator used for animated transition
-    private var internalAnimator: CameraAnimator?
-
-    internal var animationsEnabled: Bool = true
-
-    private let cameraViewContainerView: UIView
-
-    private let mapboxMap: MapboxMapProtocol
-
-    internal init(cameraViewContainerView: UIView, mapboxMap: MapboxMapProtocol) {
-        self.cameraViewContainerView = cameraViewContainerView
-        self.mapboxMap = mapboxMap
-    }
-
-    internal func update() {
-        guard animationsEnabled else {
-            cancelAnimations()
-            return
-        }
-        for animator in cameraAnimatorsSet.allObjects {
-            animator.update()
-        }
-    }
-
-    // MARK: Setting a new camera
 
     /// Interrupts all `active` animation.
     /// The camera remains at the last point before the cancel request was invoked, i.e.,
     /// the camera is not reset or fast-forwarded to the end of the transition.
     /// Canceled animations cannot be restarted / resumed. The animator must be recreated.
     public func cancelAnimations() {
-        for animator in cameraAnimators where animator.state == .active {
-            animator.stopAnimation()
-        }
+        impl.cancelAnimations()
     }
+
+    // MARK: High-Level Animation APIs
 
     /// Moves the viewpoint to a different location using a transition animation that
     /// evokes powered flight and an optional transition duration and timing function
@@ -79,291 +30,142 @@ public class CameraAnimationsManager: CameraAnimationsManagerProtocol {
     /// the user find his or her bearings even after traversing a great distance.
     ///
     /// - Parameters:
-    ///   - camera: The camera options at the end of the animation. Any camera parameters that are nil will not be animated.
-    ///   - duration: Duration of the animation, measured in seconds. If nil, a suitable calculated duration is used.
+    ///   - to: The camera options at the end of the animation. Any camera parameters that are nil will
+    ///         not be animated.
+    ///   - duration: Duration of the animation, measured in seconds. If nil, a suitable calculated
+    ///               duration is used.
     ///   - completion: Completion handler called when the animation stops
     /// - Returns: An instance of `Cancelable` which can be canceled if necessary
     @discardableResult
-    public func fly(to camera: CameraOptions,
+    public func fly(to: CameraOptions,
                     duration: TimeInterval? = nil,
                     completion: AnimationCompletion? = nil) -> Cancelable? {
-
-        let flyToAnimator = FlyToCameraAnimator(
-            toCamera: camera,
-            owner: .cameraAnimationsManager,
-            duration: duration,
-            mapboxMap: mapboxMap,
-            dateProvider: DefaultDateProvider())
-        flyToAnimator.delegate = self
-
-        // Stop the `internalAnimator` before beginning a `flyTo`
-        internalAnimator?.stopAnimation()
-
-        cameraAnimatorsSet.add(flyToAnimator)
-
-        flyToAnimator.addCompletion { [weak self, weak flyToAnimator] (position) in
-            if self?.internalAnimator === flyToAnimator {
-                self?.internalAnimator = nil
-            }
-            // Call the developer-provided completion (if present)
-            completion?(position)
-        }
-
-        flyToAnimator.startAnimation()
-        internalAnimator = flyToAnimator
-        return internalAnimator
+        return impl.fly(to: to, duration: duration, completion: completion)
     }
 
     /// Ease the camera to a destination
     /// - Parameters:
-    ///   - camera: the target camera after animation; if `camera.anchor` is non-nil, it is use for both
-    ///             the `fromValue` and the `toValue` of the underlying animation such that the
-    ///             value specified will not be interpolated, but will be passed as-is to each camera update
-    ///             during the animation. To animate `anchor` itself, use the `makeAnimator` APIs.
+    ///   - to: the target camera after animation; if `camera.anchor` is non-nil, it is use for both
+    ///         the `fromValue` and the `toValue` of the underlying animation such that the
+    ///         value specified will not be interpolated, but will be passed as-is to each camera update
+    ///         during the animation. To animate `anchor` itself, use the `makeAnimator` APIs.
     ///   - duration: duration of the animation
+    ///   - curve: the easing curve for the animation
     ///   - completion: completion to be called after animation
     /// - Returns: An instance of `Cancelable` which can be canceled if necessary
     @discardableResult
-    public func ease(to camera: CameraOptions,
+    public func ease(to: CameraOptions,
                      duration: TimeInterval,
                      curve: UIView.AnimationCurve = .easeOut,
                      completion: AnimationCompletion? = nil) -> Cancelable? {
-        return internalEase(to: camera, duration: duration, curve: curve, completion: completion)
+        return impl.ease(
+            to: to,
+            duration: duration,
+            curve: curve,
+            completion: completion)
     }
 
-    /// Ease to implementation that returns non-optional cancelable. The public API should have
-    /// been like this, but we have to wait until the next major version to change it. This internal API
-    /// allows us to avoid force-unwrapping for internal use.
-    @discardableResult
-    internal func internalEase(to camera: CameraOptions,
-                               duration: TimeInterval,
-                               curve: UIView.AnimationCurve,
-                               completion: AnimationCompletion?) -> Cancelable {
+    // MARK: Low-Level Animation APIs
 
-        internalAnimator?.stopAnimation()
-
-        let animator = makeAnimator(duration: duration, curve: curve, animationOwner: .cameraAnimationsManager) { (transition) in
-            transition.center.toValue = camera.center
-            transition.padding.toValue = camera.padding
-            // don't animate the anchor since that's unlikely to be the caller's intent
-            if let anchor = camera.anchor {
-                transition.anchor.fromValue = anchor
-                transition.anchor.toValue = anchor
-            }
-            transition.zoom.toValue = camera.zoom
-            transition.bearing.toValue = camera.bearing
-            transition.pitch.toValue = camera.pitch
-        }
-
-        // Nil out the `internalAnimator` once the "ease to" finishes
-        animator.addCompletion { [weak self, weak animator] (position) in
-            if self?.internalAnimator === animator {
-                self?.internalAnimator = nil
-            }
-            completion?(position)
-        }
-
-        animator.startAnimation()
-        internalAnimator = animator
-
-        return animator
-    }
-
-    // MARK: Animator Functions
-
-    /// Convenience to create a `BasicCameraAnimator` and will add it to a list of `BasicCameraAnimator`s to track the lifecycle of that animation.
+    /// Creates a ``BasicCameraAnimator``.
     ///
-    /// NOTE: Keep in mind the lifecycle of a `BasicCameraAnimator`. If a `BasicCameraAnimator` is destroyed, before the animation is finished,
-    /// the animation will be interrupted and completion handlers will not be called.
+    /// - Note: `CameraAnimationsManager` only keeps animators alive while their
+    ///         ``CameraAnimator/state`` is `.active`.
     ///
     /// - Parameters:
-    ///   - duration: The duration of the animation, in seconds.
-    ///   - timingParameters: The object providing the timing information. This object must adopt the `UITimingCurveProvider` protocol.
-    ///   - animationOwner: Property that conforms to `AnimationOwner` to represent who owns that animation.
-    /// - Returns: A class that represents an animator with the provided configuration.
+    ///   - duration: The duration of the animation.
+    ///   - timingParameters: The object providing the timing information. This object must adopt
+    ///                       the `UITimingCurveProvider` protocol.
+    ///   - animationOwner: An `AnimationOwner` that can be used to identify what component
+    ///                     initiated an animation.
+    ///   - animations: a closure that configures the animation's to and from values via a
+    ///                 ``CameraTransition``.
+    /// - Returns: A new ``BasicCameraAnimator``.
     public func makeAnimator(duration: TimeInterval,
-                             timingParameters parameters: UITimingCurveProvider,
+                             timingParameters: UITimingCurveProvider,
                              animationOwner: AnimationOwner = .unspecified,
                              animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator {
-        let propertyAnimator = UIViewPropertyAnimator(duration: duration, timingParameters: parameters)
-        let impl = BasicCameraAnimatorImpl(
-            propertyAnimator: propertyAnimator,
-            owner: animationOwner,
-            mapboxMap: mapboxMap,
-            cameraView: makeCameraView())
-        impl.addAnimations(animations)
-        let cameraAnimator = BasicCameraAnimator(impl: impl)
-        cameraAnimator.delegate = self
-        cameraAnimatorsSet.add(cameraAnimator)
-        return cameraAnimator
+        return impl.makeAnimator(
+            duration: duration,
+            timingParameters: timingParameters,
+            animationOwner: animationOwner,
+            animations: animations)
     }
 
-    /// Convenience to create a `BasicCameraAnimator` and will add it to a list of `BasicCameraAnimator` to track the lifecycle of that animation.
+    /// Creates a ``BasicCameraAnimator``.
     ///
-    /// NOTE: Keep in mind the lifecycle of a `BasicCameraAnimator`. If a `BasicCameraAnimator` is destroyed, before the animation is finished,
-    /// the animation will be interrupted and completion handlers will not be called.
+    /// - Note: `CameraAnimationsManager` only keeps animators alive while their
+    ///         ``CameraAnimator/state`` is `.active`.
     ///
     /// - Parameters:
-    ///   - duration: The duration of the animation, in seconds.
-    ///   - curve: The UIKit timing curve to apply to the animation.
-    ///   - animationOwner: Property that conforms to `AnimationOwner` to represent who owns that animation.
-    ///   - animations: The block containing the animations. This block has no return value and takes no parameters.
-    ///                 Use this block to modify any animatable view properties. When you start the animations,
-    ///                 those properties are animated from their current values to the new values using the specified animation parameters.
-    /// - Returns: A class that represents an animator with the provided configuration.
+    ///   - duration: The duration of the animation.
+    ///   - curve: One of UIKit's predefined timing curves to apply to the animation.
+    ///   - animationOwner: An `AnimationOwner` that can be used to identify what component
+    ///                     initiated an animation.
+    ///   - animations: a closure that configures the animation's to and from values via a
+    ///                 ``CameraTransition``.
+    /// - Returns: A new ``BasicCameraAnimator``.
     public func makeAnimator(duration: TimeInterval,
                              curve: UIView.AnimationCurve,
                              animationOwner: AnimationOwner = .unspecified,
                              animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator {
-        let propertyAnimator = UIViewPropertyAnimator(duration: duration, curve: curve)
-        let impl = BasicCameraAnimatorImpl(
-            propertyAnimator: propertyAnimator,
-            owner: animationOwner,
-            mapboxMap: mapboxMap,
-            cameraView: makeCameraView())
-        impl.addAnimations(animations)
-        let cameraAnimator = BasicCameraAnimator(impl: impl)
-        cameraAnimator.delegate = self
-        cameraAnimatorsSet.add(cameraAnimator)
-        return cameraAnimator
+        return impl.makeAnimator(
+            duration: duration,
+            curve: curve,
+            animationOwner: animationOwner,
+            animations: animations)
     }
 
-    /// Convenience to create a `BasicCameraAnimator` and will add it to a list of `BasicCameraAnimator` to track the lifecycle of that animation.
+    /// Creates a ``BasicCameraAnimator``.
     ///
-    /// NOTE: Keep in mind the lifecycle of a `BasicCameraAnimator`. If a `BasicCameraAnimator` is destroyed, before the animation is finished,
-    /// the animation will be interrupted and completion handlers will not be called.
+    /// - Note: `CameraAnimationsManager` only keeps animators alive while their
+    ///         ``CameraAnimator/state`` is `.active`.
     ///
     /// - Parameters:
-    ///   - duration: The duration of the animation, in seconds.
+    ///   - duration: The duration of the animation.
     ///   - controlPoint1: The first control point for the cubic Bézier timing curve.
     ///   - controlPoint2: The second control point for the cubic Bézier timing curve.
-    ///   - animationOwner: Property that conforms to `AnimationOwner` to represent who owns that animation.
-    ///   - animations: The block containing the animations. This block has no return value and takes no parameters.
-    ///                 Use this block to modify any animatable view properties. When you start the animations,
-    ///                 those properties are animated from their current values to the new values using the specified animation parameters.
-    /// - Returns: A class that represents an animator with the provided configuration.
+    ///   - animationOwner: An `AnimationOwner` that can be used to identify what component
+    ///                     initiated an animation.
+    ///   - animations: a closure that configures the animation's to and from values via a
+    ///                 ``CameraTransition``.
+    /// - Returns: A new ``BasicCameraAnimator``.
     public func makeAnimator(duration: TimeInterval,
-                             controlPoint1 point1: CGPoint,
-                             controlPoint2 point2: CGPoint,
+                             controlPoint1: CGPoint,
+                             controlPoint2: CGPoint,
                              animationOwner: AnimationOwner = .unspecified,
                              animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator {
-        let propertyAnimator = UIViewPropertyAnimator(duration: duration, controlPoint1: point1, controlPoint2: point2)
-        let impl = BasicCameraAnimatorImpl(
-            propertyAnimator: propertyAnimator,
-            owner: animationOwner,
-            mapboxMap: mapboxMap,
-            cameraView: makeCameraView())
-        impl.addAnimations(animations)
-        let cameraAnimator = BasicCameraAnimator(impl: impl)
-        cameraAnimator.delegate = self
-        cameraAnimatorsSet.add(cameraAnimator)
-        return cameraAnimator
+        return impl.makeAnimator(
+            duration: duration,
+            controlPoint1: controlPoint1,
+            controlPoint2: controlPoint2,
+            animationOwner: animationOwner,
+            animations: animations)
     }
 
-    /// Convenience to create a `BasicCameraAnimator` and will add it to a list of `BasicCameraAnimator` to track the lifecycle of that animation.
+    /// Creates a ``BasicCameraAnimator``.
     ///
-    /// NOTE: Keep in mind the lifecycle of a `BasicCameraAnimator`. If a `BasicCameraAnimator` is destroyed, before the animation is finished,
-    /// the animation will be interrupted and completion handlers will not be called.
+    /// - Note: `CameraAnimationsManager` only keeps animators alive while their
+    ///         ``CameraAnimator/state`` is `.active`.
     ///
     /// - Parameters:
-    ///   - duration: The duration of the animation, in seconds.
-    ///   - dampingRatio: The damping ratio to apply to the initial acceleration and oscillation. To smoothly decelerate the animation without oscillation, specify a value of 1.
+    ///   - duration: The duration of the animation.
+    ///   - dampingRatio: The damping ratio to apply to the initial acceleration and oscillation. To
+    ///                   smoothly decelerate the animation without oscillation, specify a value of 1.
     ///                   Specify values closer to 0 to create less damping and more oscillation.
-    ///   - animationOwner: Property that conforms to `AnimationOwner` to represent who owns that animation.
-    ///   - animations: The block containing the animations. This block has no return value and takes no parameters.
-    ///                 Use this block to modify any animatable view properties. When you start the animations,
-    ///                 those properties are animated from their current values to the new values using the specified animation parameters.
-    /// - Returns: A class that represents an animator with the provided configuration.
+    ///   - animationOwner: An `AnimationOwner` that can be used to identify what component
+    ///                     initiated an animation.
+    ///   - animations: a closure that configures the animation's to and from values via a
+    ///                 ``CameraTransition``.
+    /// - Returns: A new ``BasicCameraAnimator``.
     public func makeAnimator(duration: TimeInterval,
-                             dampingRatio ratio: CGFloat,
+                             dampingRatio: CGFloat,
                              animationOwner: AnimationOwner = .unspecified,
                              animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator {
-        let propertyAnimator = UIViewPropertyAnimator(duration: duration, dampingRatio: ratio)
-        let impl = BasicCameraAnimatorImpl(
-            propertyAnimator: propertyAnimator,
-            owner: animationOwner,
-            mapboxMap: mapboxMap,
-            cameraView: makeCameraView())
-        impl.addAnimations(animations)
-        let cameraAnimator = BasicCameraAnimator(impl: impl)
-        cameraAnimator.delegate = self
-        cameraAnimatorsSet.add(cameraAnimator)
-        return cameraAnimator
-    }
-
-    private func makeCameraView() -> CameraView {
-        let cameraView = CameraView()
-        cameraViewContainerView.addSubview(cameraView)
-        return cameraView
-    }
-
-    /// This function will handle the natural decelration of a gesture when there is a velocity provided. A use case for this is the pan gesture.
-    /// - Parameters:
-    ///   - location: The initial location. This location will be simulated based on velocity and decelerationFactor.
-    ///   - velocity: The initial velocity.
-    ///   - decelerationFactor: A factor by which the velocity is multiplied once per millisecond. Typically slightly less than 1 so that the velocity slowly decreases over time.
-    ///   - locationChangeHandler: A block that is called at each frame which provides the updated from and to location.
-    ///   - completion: A completion block that is called when the animation finishes.
-    internal func decelerate(location: CGPoint,
-                             velocity: CGPoint,
-                             decelerationFactor: CGFloat,
-                             locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void,
-                             completion: AnimationCompletion?) {
-
-        // Stop the `internalAnimator` before beginning a deceleration
-        internalAnimator?.stopAnimation()
-
-        let decelerateAnimator = GestureDecelerationCameraAnimator(
-            location: location,
-            velocity: velocity,
-            decelerationFactor: decelerationFactor,
-            owner: .cameraAnimationsManager,
-            locationChangeHandler: locationChangeHandler,
-            dateProvider: DefaultDateProvider())
-        decelerateAnimator.delegate = self
-
-        decelerateAnimator.addCompletion { [weak self, weak decelerateAnimator] (position) in
-           if self?.internalAnimator === decelerateAnimator {
-               self?.internalAnimator = nil
-           }
-           completion?(position)
-        }
-
-        cameraAnimatorsSet.add(decelerateAnimator)
-        decelerateAnimator.startAnimation()
-        internalAnimator = decelerateAnimator
-    }
-}
-
-extension CameraAnimationsManager: CameraAnimatorDelegate {
-    /// When an animator starts running, `CameraAnimationsManager` takes a strong reference to it
-    /// so that it stays alive while it is running. It also calls `beginAnimation` on `MapboxMap`.
-    ///
-    /// This solution replaces a previous implementation in which each animator was responsible for
-    /// keeping itself alive while it was running (if desired). That approach was problematic because
-    /// it was possible for it to result in a memory leak if the owning `MapView` (and corresponding display
-    /// link) was deallocated, resulting in no more calls to `update()` which would prevent some
-    /// animators from ever breaking their strong self references.
-    ///
-    /// Moving this responsibility to `CameraAnimationsManager` means that if the `MapView` is
-    /// deallocated, these strong references will be released as well.
-    func cameraAnimatorDidStartRunning(_ cameraAnimator: CameraAnimatorProtocol) {
-        if !runningCameraAnimators.contains(where: { $0 === cameraAnimator }) {
-            runningCameraAnimators.append(cameraAnimator)
-            mapboxMap.beginAnimation()
-        }
-    }
-
-    /// When an animator stops running, `CameraAnimationsManager` releases its strong reference to
-    /// it so that it can be deinited if there are no other owning references. It also calls `endAnimation`
-    /// on `MapboxMap`.
-    ///
-    /// See `cameraAnimatorDidStartRunning(_:)` for further discussion of the rationale for this
-    /// architecture.
-    func cameraAnimatorDidStopRunning(_ cameraAnimator: CameraAnimatorProtocol) {
-        if runningCameraAnimators.contains(where: { $0 === cameraAnimator }) {
-            runningCameraAnimators.removeAll { $0 === cameraAnimator }
-            mapboxMap.endAnimation()
-        }
+        return impl.makeAnimator(
+            duration: duration,
+            dampingRatio: dampingRatio,
+            animationOwner: animationOwner,
+            animations: animations)
     }
 }

--- a/Sources/MapboxMaps/Camera/CameraAnimationsManagerImpl.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimationsManagerImpl.swift
@@ -1,0 +1,211 @@
+import UIKit
+@_implementationOnly import MapboxCommon_Private
+
+internal protocol CameraAnimationsManagerProtocol: AnyObject {
+
+    var cameraAnimators: [CameraAnimator] { get }
+
+    func cancelAnimations()
+
+    @discardableResult
+    func fly(to: CameraOptions,
+             duration: TimeInterval?,
+             completion: AnimationCompletion?) -> Cancelable
+
+    @discardableResult
+    func ease(to: CameraOptions,
+              duration: TimeInterval,
+              curve: UIView.AnimationCurve,
+              completion: AnimationCompletion?) -> Cancelable
+
+    func decelerate(location: CGPoint,
+                    velocity: CGPoint,
+                    decelerationFactor: CGFloat,
+                    locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void,
+                    completion: AnimationCompletion?)
+
+    func makeAnimator(duration: TimeInterval,
+                      timingParameters: UITimingCurveProvider,
+                      animationOwner: AnimationOwner,
+                      animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator
+
+    func makeAnimator(duration: TimeInterval,
+                      curve: UIView.AnimationCurve,
+                      animationOwner: AnimationOwner,
+                      animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator
+
+    func makeAnimator(duration: TimeInterval,
+                      controlPoint1: CGPoint,
+                      controlPoint2: CGPoint,
+                      animationOwner: AnimationOwner,
+                      animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator
+
+    func makeAnimator(duration: TimeInterval,
+                      dampingRatio: CGFloat,
+                      animationOwner: AnimationOwner,
+                      animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator
+}
+
+internal final class CameraAnimationsManagerImpl: CameraAnimationsManagerProtocol {
+
+    private let factory: CameraAnimatorsFactoryProtocol
+    private let runner: CameraAnimatorsRunnerProtocol
+
+    /// See ``CameraAnimationsManager/cameraAnimators``.
+    internal var cameraAnimators: [CameraAnimator] {
+        return runner.cameraAnimators
+    }
+
+    internal init(factory: CameraAnimatorsFactoryProtocol,
+                  runner: CameraAnimatorsRunnerProtocol) {
+        self.factory = factory
+        self.runner = runner
+    }
+
+    /// See ``CameraAnimationsManager/cancelAnimations()``.
+    internal func cancelAnimations() {
+        runner.cancelAnimations()
+    }
+
+    // MARK: - High-Level Animation APIs
+
+    /// See ``CameraAnimationsManager/fly(to:duration:completion:)``.
+    @discardableResult
+    internal func fly(to: CameraOptions,
+                      duration: TimeInterval?,
+                      completion: AnimationCompletion?) -> Cancelable {
+        runner.cancelAnimations(withOwners: [.cameraAnimationsManager])
+        let animator = factory.makeFlyToAnimator(
+            toCamera: to,
+            animationOwner: .cameraAnimationsManager,
+            duration: duration)
+        if let completion = completion {
+            animator.addCompletion(completion)
+        }
+        runner.add(animator)
+        animator.startAnimation()
+        return animator
+    }
+
+    /// See ``CameraAnimationsManager/ease(to:duration:curve:completion:)``.
+    @discardableResult
+    internal func ease(to: CameraOptions,
+                       duration: TimeInterval,
+                       curve: UIView.AnimationCurve,
+                       completion: AnimationCompletion?) -> Cancelable {
+        runner.cancelAnimations(withOwners: [.cameraAnimationsManager])
+        let animatorImpl = factory.makeBasicCameraAnimator(
+            duration: duration,
+            curve: curve,
+            animationOwner: .cameraAnimationsManager,
+            animations: { (transition) in
+                transition.center.toValue = to.center
+                transition.padding.toValue = to.padding
+                // don't animate the anchor since that's unlikely to be the caller's intent
+                if let anchor = to.anchor {
+                    transition.anchor.fromValue = anchor
+                    transition.anchor.toValue = anchor
+                }
+                transition.zoom.toValue = to.zoom
+                transition.bearing.toValue = to.bearing
+                transition.pitch.toValue = to.pitch
+            })
+        let animator = BasicCameraAnimator(impl: animatorImpl)
+        if let completion = completion {
+            animator.addCompletion(completion)
+        }
+        runner.add(animator)
+        animator.startAnimation()
+        return animator
+    }
+
+    /// This function will handle the natural decelration of a gesture when there is a velocity provided. A use case for this is the pan gesture.
+    /// - Parameters:
+    ///   - location: The initial location. This location will be simulated based on velocity and decelerationFactor.
+    ///   - velocity: The initial velocity.
+    ///   - decelerationFactor: A factor by which the velocity is multiplied once per millisecond. Typically slightly less than 1 so that the velocity slowly decreases over time.
+    ///   - locationChangeHandler: A block that is called at each frame which provides the updated from and to location.
+    ///   - completion: A completion block that is called when the animation finishes.
+    internal func decelerate(location: CGPoint,
+                             velocity: CGPoint,
+                             decelerationFactor: CGFloat,
+                             locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void,
+                             completion: AnimationCompletion?) {
+        runner.cancelAnimations(withOwners: [.cameraAnimationsManager])
+        let animator = factory.makeGestureDecelerationCameraAnimator(
+            location: location,
+            velocity: velocity,
+            decelerationFactor: decelerationFactor,
+            animationOwner: .cameraAnimationsManager,
+            locationChangeHandler: locationChangeHandler)
+        if let completion = completion {
+            animator.addCompletion(completion)
+        }
+        runner.add(animator)
+        animator.startAnimation()
+    }
+
+    // MARK: - Low-Level Animation APIs
+
+    /// See ``CameraAnimationsManager/makeAnimator(duration:timingParameters:animationOwner:animations:)``.
+    internal func makeAnimator(duration: TimeInterval,
+                               timingParameters: UITimingCurveProvider,
+                               animationOwner: AnimationOwner,
+                               animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator {
+        let animatorImpl = factory.makeBasicCameraAnimator(
+            duration: duration,
+            timingParameters: timingParameters,
+            animationOwner: animationOwner,
+            animations: animations)
+        let animator = BasicCameraAnimator(impl: animatorImpl)
+        runner.add(animator)
+        return animator
+    }
+
+    /// See ``CameraAnimationsManager/makeAnimator(duration:curve:animationOwner:animations:)``.
+    internal func makeAnimator(duration: TimeInterval,
+                               curve: UIView.AnimationCurve,
+                               animationOwner: AnimationOwner,
+                               animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator {
+        let animatorImpl = factory.makeBasicCameraAnimator(
+            duration: duration,
+            curve: curve,
+            animationOwner: animationOwner,
+            animations: animations)
+        let animator = BasicCameraAnimator(impl: animatorImpl)
+        runner.add(animator)
+        return animator
+    }
+
+    /// See ``CameraAnimationsManager/makeAnimator(duration:controlPoint1:controlPoint2:animationOwner:animations:)``.
+    internal func makeAnimator(duration: TimeInterval,
+                               controlPoint1: CGPoint,
+                               controlPoint2: CGPoint,
+                               animationOwner: AnimationOwner,
+                               animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator {
+        let animatorImpl = factory.makeBasicCameraAnimator(
+            duration: duration,
+            controlPoint1: controlPoint1,
+            controlPoint2: controlPoint2,
+            animationOwner: animationOwner,
+            animations: animations)
+        let animator = BasicCameraAnimator(impl: animatorImpl)
+        runner.add(animator)
+        return animator
+    }
+
+    /// See ``CameraAnimationsManager/makeAnimator(duration:dampingRatio:animationOwner:animations:)``.
+    internal func makeAnimator(duration: TimeInterval,
+                               dampingRatio: CGFloat,
+                               animationOwner: AnimationOwner,
+                               animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator {
+        let animatorImpl = factory.makeBasicCameraAnimator(
+            duration: duration,
+            dampingRatio: dampingRatio,
+            animationOwner: animationOwner,
+            animations: animations)
+        let animator = BasicCameraAnimator(impl: animatorImpl)
+        runner.add(animator)
+        return animator
+    }
+}

--- a/Sources/MapboxMaps/Camera/CameraAnimatorsFactory.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimatorsFactory.swift
@@ -1,0 +1,137 @@
+import UIKit
+
+internal protocol CameraAnimatorsFactoryProtocol: AnyObject {
+    func makeFlyToAnimator(toCamera: CameraOptions,
+                           animationOwner: AnimationOwner,
+                           duration: TimeInterval?) -> CameraAnimatorProtocol
+    func makeBasicCameraAnimator(duration: TimeInterval,
+                                 timingParameters: UITimingCurveProvider,
+                                 animationOwner: AnimationOwner,
+                                 animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimatorProtocol
+    func makeBasicCameraAnimator(duration: TimeInterval,
+                                 curve: UIView.AnimationCurve,
+                                 animationOwner: AnimationOwner,
+                                 animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimatorProtocol
+    func makeBasicCameraAnimator(duration: TimeInterval,
+                                 controlPoint1: CGPoint,
+                                 controlPoint2: CGPoint,
+                                 animationOwner: AnimationOwner,
+                                 animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimatorProtocol
+    func makeBasicCameraAnimator(duration: TimeInterval,
+                                 dampingRatio: CGFloat,
+                                 animationOwner: AnimationOwner,
+                                 animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimatorProtocol
+    func makeGestureDecelerationCameraAnimator(location: CGPoint,
+                                               velocity: CGPoint,
+                                               decelerationFactor: CGFloat,
+                                               animationOwner: AnimationOwner,
+                                               locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void) -> CameraAnimatorProtocol
+}
+
+internal final class CameraAnimatorsFactory: CameraAnimatorsFactoryProtocol {
+
+    private let cameraViewContainerView: UIView
+    private let mapboxMap: MapboxMapProtocol
+    private let dateProvider: DateProvider
+
+    internal init(cameraViewContainerView: UIView,
+                  mapboxMap: MapboxMapProtocol,
+                  dateProvider: DateProvider) {
+        self.cameraViewContainerView = cameraViewContainerView
+        self.mapboxMap = mapboxMap
+        self.dateProvider = dateProvider
+    }
+
+    internal func makeFlyToAnimator(toCamera: CameraOptions,
+                                    animationOwner: AnimationOwner,
+                                    duration: TimeInterval?) -> CameraAnimatorProtocol {
+        return FlyToCameraAnimator(
+            toCamera: toCamera,
+            owner: animationOwner,
+            duration: duration,
+            mapboxMap: mapboxMap,
+            dateProvider: dateProvider)
+    }
+
+    internal func makeBasicCameraAnimator(duration: TimeInterval,
+                                          timingParameters: UITimingCurveProvider,
+                                          animationOwner: AnimationOwner,
+                                          animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimatorProtocol {
+        let propertyAnimator = UIViewPropertyAnimator(
+            duration: duration,
+            timingParameters: timingParameters)
+        return makeBasicCameraAnimator(
+            propertyAnimator: propertyAnimator,
+            animationOwner: animationOwner,
+            animations: animations)
+    }
+
+    internal func makeBasicCameraAnimator(duration: TimeInterval,
+                                          curve: UIView.AnimationCurve,
+                                          animationOwner: AnimationOwner,
+                                          animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimatorProtocol {
+        let propertyAnimator = UIViewPropertyAnimator(
+            duration: duration,
+            curve: curve)
+        return makeBasicCameraAnimator(
+            propertyAnimator: propertyAnimator,
+            animationOwner: animationOwner,
+            animations: animations)
+    }
+
+    internal func makeBasicCameraAnimator(duration: TimeInterval,
+                                          controlPoint1: CGPoint,
+                                          controlPoint2: CGPoint,
+                                          animationOwner: AnimationOwner,
+                                          animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimatorProtocol {
+        let propertyAnimator = UIViewPropertyAnimator(
+            duration: duration,
+            controlPoint1: controlPoint1,
+            controlPoint2: controlPoint2)
+        return makeBasicCameraAnimator(
+            propertyAnimator: propertyAnimator,
+            animationOwner: animationOwner,
+            animations: animations)
+    }
+
+    internal func makeBasicCameraAnimator(duration: TimeInterval,
+                                          dampingRatio: CGFloat,
+                                          animationOwner: AnimationOwner,
+                                          animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimatorProtocol {
+        let propertyAnimator = UIViewPropertyAnimator(
+            duration: duration,
+            dampingRatio: dampingRatio)
+        return makeBasicCameraAnimator(
+            propertyAnimator: propertyAnimator,
+            animationOwner: animationOwner,
+            animations: animations)
+    }
+
+    private func makeBasicCameraAnimator(propertyAnimator: UIViewPropertyAnimator,
+                                         animationOwner: AnimationOwner,
+                                         animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimatorProtocol {
+        let cameraView = CameraView()
+        cameraViewContainerView.addSubview(cameraView)
+        let cameraAnimator = BasicCameraAnimatorImpl(
+            propertyAnimator: propertyAnimator,
+            owner: animationOwner,
+            mapboxMap: mapboxMap,
+            cameraView: cameraView)
+        cameraAnimator.addAnimations(animations)
+        return cameraAnimator
+    }
+
+    internal func makeGestureDecelerationCameraAnimator(location: CGPoint,
+                                                        velocity: CGPoint,
+                                                        decelerationFactor: CGFloat,
+                                                        animationOwner: AnimationOwner,
+                                                        locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void) -> CameraAnimatorProtocol {
+        return GestureDecelerationCameraAnimator(
+            location: location,
+            velocity: velocity,
+            decelerationFactor: decelerationFactor,
+            owner: animationOwner,
+            locationChangeHandler: locationChangeHandler,
+            dateProvider: dateProvider)
+    }
+}

--- a/Sources/MapboxMaps/Camera/CameraAnimatorsRunner.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimatorsRunner.swift
@@ -1,0 +1,94 @@
+import UIKit
+
+internal protocol CameraAnimatorsRunnerProtocol: AnyObject {
+    var animationsEnabled: Bool { get set }
+    var cameraAnimators: [CameraAnimator] { get }
+    func update()
+    func cancelAnimations()
+    func cancelAnimations(withOwners owners: [AnimationOwner])
+    func add(_ animator: CameraAnimatorProtocol)
+}
+
+final class CameraAnimatorsRunner: CameraAnimatorsRunnerProtocol {
+
+    /// When set to `false`, all animations will be canceled at each invocation of ``CameraAnimationsManagerImpl/update()``
+    internal var animationsEnabled = true
+
+    /// See ``CameraAnimationsManager/cameraAnimators``.
+    internal var cameraAnimators: [CameraAnimator] {
+        return allCameraAnimators.allObjects
+    }
+
+    /// Weak references to all camera animators
+    private let allCameraAnimators = WeakSet<CameraAnimatorProtocol>()
+
+    /// Strong references only to running camera animators
+    private var runningCameraAnimators = [CameraAnimatorProtocol]()
+
+    private let mapboxMap: MapboxMapProtocol
+
+    internal init(mapboxMap: MapboxMapProtocol) {
+        self.mapboxMap = mapboxMap
+    }
+
+    internal func update() {
+        guard animationsEnabled else {
+            cancelAnimations()
+            return
+        }
+        for animator in runningCameraAnimators {
+            animator.update()
+        }
+    }
+
+    /// See ``CameraAnimationsManager/cancelAnimations()``.
+    internal func cancelAnimations() {
+        for animator in cameraAnimators {
+            animator.stopAnimation()
+        }
+    }
+
+    internal func cancelAnimations(withOwners owners: [AnimationOwner]) {
+        for animator in allCameraAnimators.allObjects where owners.contains(animator.owner) {
+            animator.stopAnimation()
+        }
+    }
+
+    internal func add(_ animator: CameraAnimatorProtocol) {
+        animator.delegate = self
+        allCameraAnimators.add(animator)
+    }
+}
+
+extension CameraAnimatorsRunner: CameraAnimatorDelegate {
+    /// When an animator starts running, `CameraAnimationsRunner` takes a strong reference to it
+    /// so that it stays alive while it is running. It also calls `beginAnimation` on `MapboxMap`.
+    ///
+    /// This solution replaces a previous implementation in which each animator was responsible for
+    /// keeping itself alive while it was running (if desired). That approach was problematic because
+    /// it was possible for it to result in a memory leak if the owning `MapView` (and corresponding display
+    /// link) was deallocated, resulting in no more calls to `update()` which would prevent some
+    /// animators from ever breaking their strong self references.
+    ///
+    /// Moving this responsibility to `CameraAnimationsRunner` means that if the `MapView` is
+    /// deallocated, these strong references will be released as well.
+    internal func cameraAnimatorDidStartRunning(_ cameraAnimator: CameraAnimatorProtocol) {
+        if !runningCameraAnimators.contains(where: { $0 === cameraAnimator }) {
+            runningCameraAnimators.append(cameraAnimator)
+            mapboxMap.beginAnimation()
+        }
+    }
+
+    /// When an animator stops running, `CameraAnimationsRunner` releases its strong reference to
+    /// it so that it can be deinited if there are no other owning references. It also calls `endAnimation`
+    /// on `MapboxMap`.
+    ///
+    /// See `cameraAnimatorDidStartRunning(_:)` for further discussion of the rationale for this
+    /// architecture.
+    internal func cameraAnimatorDidStopRunning(_ cameraAnimator: CameraAnimatorProtocol) {
+        if runningCameraAnimators.contains(where: { $0 === cameraAnimator }) {
+            runningCameraAnimators.removeAll { $0 === cameraAnimator }
+            mapboxMap.endAnimation()
+        }
+    }
+}

--- a/Sources/MapboxMaps/Camera/CameraAnimatorsRunner.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimatorsRunner.swift
@@ -9,7 +9,7 @@ internal protocol CameraAnimatorsRunnerProtocol: AnyObject {
     func add(_ animator: CameraAnimatorProtocol)
 }
 
-final class CameraAnimatorsRunner: CameraAnimatorsRunnerProtocol {
+internal final class CameraAnimatorsRunner: CameraAnimatorsRunnerProtocol {
 
     /// When set to `false`, all animations will be canceled at each invocation of ``CameraAnimationsManagerImpl/update()``
     internal var animationsEnabled = true

--- a/Sources/MapboxMaps/Camera/FlyToCameraAnimator.swift
+++ b/Sources/MapboxMaps/Camera/FlyToCameraAnimator.swift
@@ -5,7 +5,7 @@ import UIKit
 /// traversing a great distance.
 ///
 /// - SeeAlso: ``CameraAnimationsManager/fly(to:duration:completion:)``
-public class FlyToCameraAnimator: NSObject, CameraAnimator, CameraAnimatorProtocol {
+public final class FlyToCameraAnimator: NSObject, CameraAnimator, CameraAnimatorProtocol {
 
     private let mapboxMap: MapboxMapProtocol
 
@@ -34,10 +34,10 @@ public class FlyToCameraAnimator: NSObject, CameraAnimator, CameraAnimatorProtoc
                   mapboxMap: MapboxMapProtocol,
                   dateProvider: DateProvider) {
         let flyToInterpolator = FlyToInterpolator(
-                    from: mapboxMap.cameraState,
-                    to: toCamera,
-                    cameraBounds: mapboxMap.cameraBounds,
-                    size: mapboxMap.size)
+            from: mapboxMap.cameraState,
+            to: toCamera,
+            cameraBounds: mapboxMap.cameraBounds,
+            size: mapboxMap.size)
         if let duration = duration {
             precondition(duration >= 0)
         }

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/AnyTouchGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/AnyTouchGestureHandler.swift
@@ -2,11 +2,11 @@ import UIKit
 
 internal final class AnyTouchGestureHandler: GestureHandler {
 
-    private let cameraAnimationsManager: CameraAnimationsManagerProtocol
+    private let cameraAnimatorsRunner: CameraAnimatorsRunnerProtocol
 
     internal init(gestureRecognizer: UIGestureRecognizer,
-                  cameraAnimationsManager: CameraAnimationsManagerProtocol) {
-        self.cameraAnimationsManager = cameraAnimationsManager
+                  cameraAnimatorsRunner: CameraAnimatorsRunnerProtocol) {
+        self.cameraAnimatorsRunner = cameraAnimatorsRunner
         super.init(gestureRecognizer: gestureRecognizer)
         gestureRecognizer.addTarget(self, action: #selector(handleGesture(_:)))
     }
@@ -14,9 +14,9 @@ internal final class AnyTouchGestureHandler: GestureHandler {
     @objc private func handleGesture(_ gestureRecognizer: AnyTouchGestureRecognizer) {
         switch gestureRecognizer.state {
         case .began:
-            cameraAnimationsManager.animationsEnabled = false
+            cameraAnimatorsRunner.animationsEnabled = false
         case .ended, .cancelled:
-            cameraAnimationsManager.animationsEnabled = true
+            cameraAnimatorsRunner.animationsEnabled = true
         default:
             break
         }

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/DoubleTapToZoomInGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/DoubleTapToZoomInGestureHandler.swift
@@ -27,7 +27,7 @@ internal final class DoubleTapToZoomInGestureHandler: GestureHandler, FocusableG
             delegate?.gestureEnded(for: .doubleTapToZoomIn, willAnimate: true)
 
             let anchor = focalPoint ?? gestureRecognizer.location(in: view)
-            cameraAnimationsManager.internalEase(
+            cameraAnimationsManager.ease(
                 to: CameraOptions(anchor: anchor, zoom: mapboxMap.cameraState.zoom + 1),
                 duration: 0.3,
                 curve: .easeOut) { _ in

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/DoubleTouchToZoomOutGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/DoubleTouchToZoomOutGestureHandler.swift
@@ -27,7 +27,7 @@ internal final class DoubleTouchToZoomOutGestureHandler: GestureHandler, Focusab
             delegate?.gestureEnded(for: .doubleTouchToZoomOut, willAnimate: true)
 
             let anchor = focalPoint ?? gestureRecognizer.location(in: view)
-            cameraAnimationsManager.internalEase(
+            cameraAnimationsManager.ease(
                 to: CameraOptions(anchor: anchor, zoom: mapboxMap.cameraState.zoom - 1),
                 duration: 0.3,
                 curve: .easeOut) { _ in

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -92,7 +92,7 @@ public class OrnamentsManager: NSObject {
         compassView.translatesAutoresizingMaskIntoConstraints = false
         compassView.tapAction = {
             cameraAnimationsManager.cancelAnimations()
-            cameraAnimationsManager.internalEase(
+            cameraAnimationsManager.ease(
                 to: CameraOptions(bearing: 0),
                 duration: 0.3,
                 curve: .easeOut,

--- a/Sources/MapboxMaps/Viewport/States/FollowPuck/FollowPuckViewportState.swift
+++ b/Sources/MapboxMaps/Viewport/States/FollowPuck/FollowPuckViewportState.swift
@@ -63,7 +63,7 @@ extension FollowPuckViewportState: ViewportState {
                 mapboxMap.setCamera(to: cameraOptions)
             } else if !animationStarted {
                 animationStarted = true
-                compositeCancelable.add(cameraAnimationsManager.internalEase(
+                compositeCancelable.add(cameraAnimationsManager.ease(
                     to: cameraOptions,
                     duration: options.animationDuration,
                     curve: .linear) { _ in

--- a/Sources/MapboxMaps/Viewport/States/Overview/OverviewViewportState.swift
+++ b/Sources/MapboxMaps/Viewport/States/Overview/OverviewViewportState.swift
@@ -58,7 +58,7 @@ import Turf
 
     private func animate(to cameraOptions: CameraOptions) {
         cameraAnimationCancelable?.cancel()
-        cameraAnimationCancelable = cameraAnimationsManager.internalEase(
+        cameraAnimationCancelable = cameraAnimationsManager.ease(
             to: cameraOptions,
             duration: max(0, options.animationDuration),
             curve: .linear,

--- a/Tests/MapboxMapsTests/Camera/BasicCameraAnimatorImplTests.swift
+++ b/Tests/MapboxMapsTests/Camera/BasicCameraAnimatorImplTests.swift
@@ -79,6 +79,15 @@ final class BasicCameraAnimatorImplTests: XCTestCase {
         XCTAssertEqual(propertyAnimator.setIsReversedStub.invocations.map(\.parameters), [true, false])
     }
 
+    func testStopAnimationWithoutStarting() {
+        let completion = Stub<UIViewAnimatingPosition, Void>()
+        animator.addCompletion(completion.call(with:))
+
+        animator.stopAnimation()
+
+        XCTAssertEqual(completion.invocations.map(\.parameters), [.current])
+    }
+
     func testStartAndStopAnimation() {
         animator.addAnimations { (transition) in
             transition.zoom.toValue = cameraOptionsTestValue.zoom!

--- a/Tests/MapboxMapsTests/Camera/CameraAnimationsManagerImplTests.swift
+++ b/Tests/MapboxMapsTests/Camera/CameraAnimationsManagerImplTests.swift
@@ -1,0 +1,380 @@
+import XCTest
+@testable import MapboxMaps
+
+final class CameraAnimationsManagerImplTests: XCTestCase {
+
+    var factory: MockCameraAnimatorsFactory!
+    var runner: MockCameraAnimatorsRunner!
+    var impl: CameraAnimationsManagerImpl!
+
+    override func setUp() {
+        super.setUp()
+        factory = MockCameraAnimatorsFactory()
+        runner = MockCameraAnimatorsRunner()
+        impl = CameraAnimationsManagerImpl(
+            factory: factory,
+            runner: runner)
+    }
+
+    override func tearDown() {
+        impl = nil
+        runner = nil
+        factory = nil
+        super.tearDown()
+    }
+
+    func testCameraAnimators() {
+        runner.cameraAnimators = .random(
+            withLength: .random(in: 0...10),
+            generator: MockCameraAnimator.init)
+
+        XCTAssertEqual(impl.cameraAnimators.count, runner.cameraAnimators.count)
+        XCTAssertTrue(
+            zip(impl.cameraAnimators, runner.cameraAnimators).allSatisfy(===))
+    }
+
+    func testCancelAnimations() {
+        impl.cancelAnimations()
+
+        XCTAssertEqual(runner.cancelAnimationsStub.invocations.count, 1)
+    }
+
+    func testFlyTo() throws {
+        let camera = CameraOptions.random()
+        let duration = TimeInterval?.random(.random(in: 0...10))
+        let completion = Stub<UIViewAnimatingPosition, Void>()
+
+        let cancelable = impl.fly(
+            to: camera,
+            duration: duration,
+            completion: completion.call(with:))
+
+        // cancels any existing high-level animator (identified based on the owner)
+        XCTAssertEqual(
+            runner.cancelAnimationsWithOwnersStub.invocations.map(\.parameters),
+            [[.cameraAnimationsManager]])
+
+        // creates the new animator
+        XCTAssertEqual(factory.makeFlyToAnimatorStub.invocations.count, 1)
+        let factoryInvocation = try XCTUnwrap(factory.makeFlyToAnimatorStub.invocations.first)
+        XCTAssertEqual(factoryInvocation.parameters.toCamera, camera)
+        XCTAssertEqual(factoryInvocation.parameters.animationOwner, .cameraAnimationsManager)
+        XCTAssertEqual(factoryInvocation.parameters.duration, duration)
+        let animator = try XCTUnwrap(factoryInvocation.returnValue as? MockCameraAnimator)
+
+        // adds the completion block to the animator (exercise it to verify)
+        XCTAssertEqual(animator.addCompletionStub.invocations.count, 1)
+        let addedCompletion = try XCTUnwrap(animator.addCompletionStub.invocations.first?.parameters)
+        let position = UIViewAnimatingPosition.random()
+        addedCompletion(position)
+        XCTAssertEqual(completion.invocations.map(\.parameters), [position])
+
+        // adds the animator to the runner and starts it
+        XCTAssertEqual(runner.addStub.invocations.count, 1)
+        XCTAssertIdentical(runner.addStub.invocations.first?.parameters, animator)
+        XCTAssertEqual(animator.startAnimationStub.invocations.count, 1)
+
+        // the returned cancelable is the animator
+        XCTAssertIdentical(cancelable, animator)
+    }
+
+    func testFlyToWithNilCompletion() throws {
+        impl.fly(to: .random(), duration: nil, completion: nil)
+
+        // creates the new animator
+        XCTAssertEqual(factory.makeFlyToAnimatorStub.invocations.count, 1)
+        let animator = try XCTUnwrap(factory.makeFlyToAnimatorStub.invocations.first?.returnValue as? MockCameraAnimator)
+
+        // no completion block to add
+        XCTAssertEqual(animator.addCompletionStub.invocations.count, 0)
+    }
+
+    func testEaseToWithNonNilAnchor() throws {
+        var camera = CameraOptions.random()
+        camera.anchor = .random()
+        let duration = TimeInterval.random(in: 0...10)
+        let curve = UIView.AnimationCurve.random()
+        let completion = Stub<UIViewAnimatingPosition, Void>()
+
+        let cancelable = impl.ease(
+            to: camera,
+            duration: duration,
+            curve: curve,
+            completion: completion.call(with:))
+
+        // cancels any existing high-level animator (identified based on the owner)
+        XCTAssertEqual(
+            runner.cancelAnimationsWithOwnersStub.invocations.map(\.parameters),
+            [[.cameraAnimationsManager]])
+
+        // creates the new animator
+        XCTAssertEqual(factory.makeBasicCameraAnimatorWithCurveStub.invocations.count, 1)
+        let factoryInvocation = try XCTUnwrap(factory.makeBasicCameraAnimatorWithCurveStub.invocations.first)
+        XCTAssertEqual(factoryInvocation.parameters.duration, duration)
+        XCTAssertEqual(factoryInvocation.parameters.curve, curve)
+        XCTAssertEqual(factoryInvocation.parameters.animationOwner, .cameraAnimationsManager)
+        let animatorImpl = try XCTUnwrap(factoryInvocation.returnValue as? MockBasicCameraAnimator)
+
+        // configures the transition in the animations block
+        let cameraState = CameraState.random()
+        let initialAnchor = CGPoint.random()
+        var transition = CameraTransition(cameraState: cameraState, initialAnchor: initialAnchor)
+        factoryInvocation.parameters.animations(&transition)
+        XCTAssertEqual(transition.center.fromValue, cameraState.center)
+        XCTAssertEqual(transition.center.toValue, camera.center)
+        XCTAssertEqual(transition.padding.fromValue, cameraState.padding)
+        XCTAssertEqual(transition.padding.toValue, camera.padding)
+        XCTAssertEqual(transition.anchor.fromValue, camera.anchor)
+        XCTAssertEqual(transition.anchor.toValue, camera.anchor)
+        XCTAssertEqual(transition.zoom.fromValue, cameraState.zoom)
+        XCTAssertEqual(transition.zoom.toValue, camera.zoom)
+        XCTAssertEqual(transition.bearing.fromValue, cameraState.bearing)
+        XCTAssertEqual(transition.bearing.toValue, camera.bearing)
+        XCTAssertEqual(transition.pitch.fromValue, cameraState.pitch)
+        XCTAssertEqual(transition.pitch.toValue, camera.pitch)
+        XCTAssertTrue(transition.shouldOptimizeBearingPath)
+
+        // adds the completion block to the animator (exercise it to verify)
+        XCTAssertEqual(animatorImpl.addCompletionStub.invocations.count, 1)
+        let addedCompletion = try XCTUnwrap(animatorImpl.addCompletionStub.invocations.first?.parameters)
+        let position = UIViewAnimatingPosition.random()
+        addedCompletion(position)
+        XCTAssertEqual(completion.invocations.map(\.parameters), [position])
+
+        // adds the animator to the runner and starts it; since the added
+        // animator is a wrapper around animatorImpl, verify indirectly
+        XCTAssertEqual(runner.addStub.invocations.count, 1)
+        let addedAnimator = try XCTUnwrap(runner.addStub.invocations.first?.parameters)
+        animatorImpl.owner = .random()
+        XCTAssertEqual(addedAnimator.owner, animatorImpl.owner)
+        XCTAssertEqual(animatorImpl.startAnimationStub.invocations.count, 1)
+
+        // the returned cancelable is the added animator
+        XCTAssertIdentical(cancelable, addedAnimator)
+    }
+
+    func testEaseToWithNilAnchorAndNilCompletion() throws {
+        var camera = CameraOptions.random()
+        camera.anchor = nil
+
+        impl.ease(
+            to: camera,
+            duration: .random(in: 0...10),
+            curve: .random(),
+            completion: nil)
+
+        // creates the new animator
+        XCTAssertEqual(factory.makeBasicCameraAnimatorWithCurveStub.invocations.count, 1)
+        let factoryInvocation = try XCTUnwrap(factory.makeBasicCameraAnimatorWithCurveStub.invocations.first)
+
+        // does not modify the transition's anchor to/from
+        let initialAnchor = CGPoint.random()
+        var transition = CameraTransition(cameraState: .random(), initialAnchor: initialAnchor)
+        factoryInvocation.parameters.animations(&transition)
+        XCTAssertEqual(transition.anchor.fromValue, initialAnchor)
+        XCTAssertNil(transition.anchor.toValue)
+
+        // no completion block to add
+        let animatorImpl = try XCTUnwrap(factoryInvocation.returnValue as? MockBasicCameraAnimator)
+        XCTAssertEqual(animatorImpl.addCompletionStub.invocations.count, 0)
+    }
+
+    func testDecelerate() throws {
+        let location = CGPoint.random()
+        let velocity = CGPoint.random()
+        let decelerationFactor = CGFloat.random(in: 0..<1)
+        let locationChangeHander = Stub<(CGPoint, CGPoint), Void>()
+        let completion = Stub<UIViewAnimatingPosition, Void>()
+
+        impl.decelerate(
+            location: location,
+            velocity: velocity,
+            decelerationFactor: decelerationFactor,
+            locationChangeHandler: { locationChangeHander.call(with: ($0, $1)) },
+            completion: completion.call(with:))
+
+        // cancels any existing high-level animator (identified based on the owner)
+        XCTAssertEqual(
+            runner.cancelAnimationsWithOwnersStub.invocations.map(\.parameters),
+            [[.cameraAnimationsManager]])
+
+        // creates the new animator
+        XCTAssertEqual(factory.makeGestureDecelerationCameraAnimatorStub.invocations.count, 1)
+        let factoryInvocation = try XCTUnwrap(factory.makeGestureDecelerationCameraAnimatorStub.invocations.first)
+        XCTAssertEqual(factoryInvocation.parameters.location, location)
+        XCTAssertEqual(factoryInvocation.parameters.velocity, velocity)
+        XCTAssertEqual(factoryInvocation.parameters.decelerationFactor, decelerationFactor)
+        XCTAssertEqual(factoryInvocation.parameters.animationOwner, .cameraAnimationsManager)
+
+        // verify the location change handler is passed through by invoking it
+        let fromLocation = CGPoint.random()
+        let toLocation = CGPoint.random()
+        factoryInvocation.parameters.locationChangeHandler(fromLocation, toLocation)
+        XCTAssertEqual(locationChangeHander.invocations.map(\.parameters.0), [fromLocation])
+        XCTAssertEqual(locationChangeHander.invocations.map(\.parameters.1), [toLocation])
+
+        let animator = try XCTUnwrap(factoryInvocation.returnValue as? MockCameraAnimator)
+
+        // adds the completion block to the animator (exercise it to verify)
+        XCTAssertEqual(animator.addCompletionStub.invocations.count, 1)
+        let addedCompletion = try XCTUnwrap(animator.addCompletionStub.invocations.first?.parameters)
+        let position = UIViewAnimatingPosition.random()
+        addedCompletion(position)
+        XCTAssertEqual(completion.invocations.map(\.parameters), [position])
+
+        // adds the animator to the runner and starts it
+        XCTAssertEqual(runner.addStub.invocations.count, 1)
+        XCTAssertIdentical(runner.addStub.invocations.first?.parameters, animator)
+        XCTAssertEqual(animator.startAnimationStub.invocations.count, 1)
+    }
+
+    func testDecelerateWithNilCompletion() throws {
+        impl.decelerate(
+            location: .random(),
+            velocity: .random(),
+            decelerationFactor: .random(in: 0..<1),
+            locationChangeHandler: { _, _ in },
+            completion: nil)
+
+        // creates the new animator
+        XCTAssertEqual(factory.makeGestureDecelerationCameraAnimatorStub.invocations.count, 1)
+        let animator = try XCTUnwrap(factory.makeGestureDecelerationCameraAnimatorStub.invocations.first?.returnValue as? MockCameraAnimator)
+
+        // no completion block to add
+        XCTAssertEqual(animator.addCompletionStub.invocations.count, 0)
+    }
+
+    func verifyMakeAnimator(animationsClosure: (inout CameraTransition) -> Void,
+                            animationsStub: Stub<CameraTransition, Void>,
+                            animatorImpl: MockBasicCameraAnimator,
+                            returnedAnimator: BasicCameraAnimator) throws {
+        // invoke the animations block to verify that it was passed through
+        var cameraTransition = CameraTransition(cameraState: .random(), initialAnchor: .random())
+        animationsClosure(&cameraTransition)
+        XCTAssertEqual(animationsStub.invocations.map(\.parameters), [cameraTransition])
+
+        // adds the animator to the runner; since the added
+        // animator is a wrapper around animatorImpl, verify indirectly
+        XCTAssertEqual(runner.addStub.invocations.count, 1)
+        let addedAnimator = try XCTUnwrap(runner.addStub.invocations.first?.parameters)
+        animatorImpl.owner = .random()
+        XCTAssertEqual(addedAnimator.owner, animatorImpl.owner)
+
+        // does not start the animator
+        XCTAssertEqual(animatorImpl.startAnimationStub.invocations.count, 0)
+
+        // the returned animator is the one that was added to the runner
+        XCTAssertIdentical(returnedAnimator, addedAnimator)
+    }
+
+    func testMakeAnimatorWithTimingParameters() throws {
+        let duration = TimeInterval.random(in: 0...10)
+        let timingParameters = MockTimingCurveProvider()
+        let animationOwner = AnimationOwner.random()
+        let animations = Stub<CameraTransition, Void>()
+
+        let animator = impl.makeAnimator(
+            duration: duration,
+            timingParameters: timingParameters,
+            animationOwner: animationOwner,
+            animations: { animations.call(with: $0) })
+
+        // creates the new animator
+        XCTAssertEqual(factory.makeBasicCameraAnimatorWithTimingParametersStub.invocations.count, 1)
+        let factoryInvocation = try XCTUnwrap(factory.makeBasicCameraAnimatorWithTimingParametersStub.invocations.first)
+        XCTAssertEqual(factoryInvocation.parameters.duration, duration)
+        XCTAssertIdentical(factoryInvocation.parameters.timingParameters, timingParameters)
+        XCTAssertEqual(factoryInvocation.parameters.animationOwner, animationOwner)
+        let animatorImpl = try XCTUnwrap(factoryInvocation.returnValue as? MockBasicCameraAnimator)
+
+        try verifyMakeAnimator(
+            animationsClosure: factoryInvocation.parameters.animations,
+            animationsStub: animations,
+            animatorImpl: animatorImpl,
+            returnedAnimator: animator)
+    }
+
+    func testMakeAnimatorWithCurve() throws {
+        let duration = TimeInterval.random(in: 0...10)
+        let curve = UIView.AnimationCurve.random()
+        let animationOwner = AnimationOwner.random()
+        let animations = Stub<CameraTransition, Void>()
+
+        let animator = impl.makeAnimator(
+            duration: duration,
+            curve: curve,
+            animationOwner: animationOwner,
+            animations: { animations.call(with: $0) })
+
+        // creates the new animator
+        XCTAssertEqual(factory.makeBasicCameraAnimatorWithCurveStub.invocations.count, 1)
+        let factoryInvocation = try XCTUnwrap(factory.makeBasicCameraAnimatorWithCurveStub.invocations.first)
+        XCTAssertEqual(factoryInvocation.parameters.duration, duration)
+        XCTAssertEqual(factoryInvocation.parameters.curve, curve)
+        XCTAssertEqual(factoryInvocation.parameters.animationOwner, animationOwner)
+        let animatorImpl = try XCTUnwrap(factoryInvocation.returnValue as? MockBasicCameraAnimator)
+
+        try verifyMakeAnimator(
+            animationsClosure: factoryInvocation.parameters.animations,
+            animationsStub: animations,
+            animatorImpl: animatorImpl,
+            returnedAnimator: animator)
+    }
+
+    func testMakeAnimatorWithControlPoints() throws {
+        let duration = TimeInterval.random(in: 0...10)
+        let controlPoint1 = CGPoint.random()
+        let controlPoint2 = CGPoint.random()
+        let animationOwner = AnimationOwner.random()
+        let animations = Stub<CameraTransition, Void>()
+
+        let animator = impl.makeAnimator(
+            duration: duration,
+            controlPoint1: controlPoint1,
+            controlPoint2: controlPoint2,
+            animationOwner: animationOwner,
+            animations: { animations.call(with: $0) })
+
+        // creates the new animator
+        XCTAssertEqual(factory.makeBasicCameraAnimatorWithControlPointsStub.invocations.count, 1)
+        let factoryInvocation = try XCTUnwrap(factory.makeBasicCameraAnimatorWithControlPointsStub.invocations.first)
+        XCTAssertEqual(factoryInvocation.parameters.duration, duration)
+        XCTAssertEqual(factoryInvocation.parameters.controlPoint1, controlPoint1)
+        XCTAssertEqual(factoryInvocation.parameters.controlPoint2, controlPoint2)
+        XCTAssertEqual(factoryInvocation.parameters.animationOwner, animationOwner)
+        let animatorImpl = try XCTUnwrap(factoryInvocation.returnValue as? MockBasicCameraAnimator)
+
+        try verifyMakeAnimator(
+            animationsClosure: factoryInvocation.parameters.animations,
+            animationsStub: animations,
+            animatorImpl: animatorImpl,
+            returnedAnimator: animator)
+    }
+
+    func testMakeAnimatorWithDampingRatio() throws {
+        let duration = TimeInterval.random(in: 0...10)
+        let dampingRatio = CGFloat.random(in: 0..<1)
+        let animationOwner = AnimationOwner.random()
+        let animations = Stub<CameraTransition, Void>()
+
+        let animator = impl.makeAnimator(
+            duration: duration,
+            dampingRatio: dampingRatio,
+            animationOwner: animationOwner,
+            animations: { animations.call(with: $0) })
+
+        // creates the new animator
+        XCTAssertEqual(factory.makeBasicCameraAnimatorWithDampingRatioStub.invocations.count, 1)
+        let factoryInvocation = try XCTUnwrap(factory.makeBasicCameraAnimatorWithDampingRatioStub.invocations.first)
+        XCTAssertEqual(factoryInvocation.parameters.duration, duration)
+        XCTAssertEqual(factoryInvocation.parameters.dampingRatio, dampingRatio)
+        XCTAssertEqual(factoryInvocation.parameters.animationOwner, animationOwner)
+        let animatorImpl = try XCTUnwrap(factoryInvocation.returnValue as? MockBasicCameraAnimator)
+
+        try verifyMakeAnimator(
+            animationsClosure: factoryInvocation.parameters.animations,
+            animationsStub: animations,
+            animatorImpl: animatorImpl,
+            returnedAnimator: animator)
+    }
+}

--- a/Tests/MapboxMapsTests/Camera/CameraAnimationsManagerTests.swift
+++ b/Tests/MapboxMapsTests/Camera/CameraAnimationsManagerTests.swift
@@ -25,6 +25,12 @@ final class CameraAnimationsManagerTests: XCTestCase {
         XCTAssertTrue(zip(cameraAnimationsManager.cameraAnimators, impl.cameraAnimators).allSatisfy(===))
     }
 
+    func testCancelAnimations() {
+        cameraAnimationsManager.cancelAnimations()
+
+        XCTAssertEqual(impl.cancelAnimationsStub.invocations.count, 1)
+    }
+
     func testFlyTo() throws {
         let cameraOptions = CameraOptions.random()
         let duration = TimeInterval?.random(.random(in: 0...10))

--- a/Tests/MapboxMapsTests/Camera/CameraAnimationsManagerTests.swift
+++ b/Tests/MapboxMapsTests/Camera/CameraAnimationsManagerTests.swift
@@ -3,97 +3,229 @@ import XCTest
 
 final class CameraAnimationsManagerTests: XCTestCase {
 
-    var window: UIWindow!
-    var view: UIView!
-    var mapboxMap: MockMapboxMap!
+    var impl: MockCameraAnimationsManager!
     var cameraAnimationsManager: CameraAnimationsManager!
 
     override func setUp() {
         super.setUp()
-        window = UIWindow()
-        view = UIView()
-        window.addSubview(view)
-        window.makeKeyAndVisible()
-        mapboxMap = MockMapboxMap()
-        cameraAnimationsManager = CameraAnimationsManager(
-            cameraViewContainerView: view,
-            mapboxMap: mapboxMap)
+        impl = MockCameraAnimationsManager()
+        cameraAnimationsManager = CameraAnimationsManager(impl: impl)
     }
 
     override func tearDown() {
         cameraAnimationsManager = nil
-        mapboxMap = nil
-        view = nil
-        window.resignKey()
-        window = nil
+        impl = nil
         super.tearDown()
     }
 
-    func testUpdateWithAnimationsEnabled() {
-        cameraAnimationsManager.animationsEnabled = true
-        let animator = cameraAnimationsManager.makeAnimator(duration: 1, curve: .linear) { (transition) in
-            transition.bearing.toValue = 180
-        }
-        animator.startAnimation()
-        // flush animations to populate the underlying camera view's
-        // presentation layer so that update() will run
-        // also requires view to be in a window.
-        CATransaction.flush()
+    func testCameraAnimators() {
+        impl.cameraAnimators = .random(withLength: .random(in: 0...10), generator: MockCameraAnimator.init)
 
-        cameraAnimationsManager.update()
-
-        XCTAssertEqual(animator.state, .active)
-        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 1)
+        XCTAssertEqual(cameraAnimationsManager.cameraAnimators.count, impl.cameraAnimators.count)
+        XCTAssertTrue(zip(cameraAnimationsManager.cameraAnimators, impl.cameraAnimators).allSatisfy(===))
     }
 
-    func testUpdateWithAnimationsDisabled() {
-        cameraAnimationsManager.animationsEnabled = false
-        let animator = cameraAnimationsManager.makeAnimator(duration: 1, curve: .linear) { _ in }
-        animator.startAnimation()
+    func testFlyTo() throws {
+        let cameraOptions = CameraOptions.random()
+        let duration = TimeInterval?.random(.random(in: 0...10))
+        let completion = Stub<UIViewAnimatingPosition, Void>()
 
-        cameraAnimationsManager.update()
+        let cancelable = cameraAnimationsManager.fly(
+            to: cameraOptions,
+            duration: duration,
+            completion: completion.call(with:))
 
-        XCTAssertEqual(animator.state, .inactive)
-        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 0)
+        XCTAssertEqual(impl.flyToStub.invocations.count, 1)
+        let invocation = try XCTUnwrap(impl.flyToStub.invocations.first)
+        XCTAssertEqual(invocation.parameters.to, cameraOptions)
+        XCTAssertEqual(invocation.parameters.duration, duration)
+        XCTAssertIdentical(cancelable, invocation.returnValue)
+
+        let position = UIViewAnimatingPosition.random()
+        invocation.parameters.completion?(position)
+        XCTAssertEqual(completion.invocations.map(\.parameters), [position])
     }
 
-    func testCameraAnimatorDelegate() {
-        let animator1 = MockCameraAnimator()
-        let animator2 = MockCameraAnimator()
+    func testFlyToWithDefaultArguments() {
+        cameraAnimationsManager.fly(
+            to: .random())
 
-        // stopping before starting should have no effect
-        cameraAnimationsManager.cameraAnimatorDidStopRunning(animator1)
-        XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 0)
-        XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 0)
+        XCTAssertEqual(impl.flyToStub.invocations.count, 1)
+        XCTAssertNil(impl.flyToStub.invocations.first?.parameters.duration)
+        XCTAssertNil(impl.flyToStub.invocations.first?.parameters.completion)
+    }
 
-        // start once
-        cameraAnimationsManager.cameraAnimatorDidStartRunning(animator1)
-        XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 1)
-        XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 0)
+    func testEaseTo() throws {
+        let cameraOptions = CameraOptions.random()
+        let duration = TimeInterval.random(in: 0...10)
+        let curve = UIView.AnimationCurve.random()
+        let completion = Stub<UIViewAnimatingPosition, Void>()
 
-        // start twice
-        cameraAnimationsManager.cameraAnimatorDidStartRunning(animator1)
-        XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 1)
-        XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 0)
+        let cancelable = cameraAnimationsManager.ease(
+            to: cameraOptions,
+            duration: duration,
+            curve: curve,
+            completion: completion.call(with:))
 
-        // start a second
-        cameraAnimationsManager.cameraAnimatorDidStartRunning(animator2)
-        XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 2)
-        XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 0)
+        XCTAssertEqual(impl.easeToStub.invocations.count, 1)
+        let invocation = try XCTUnwrap(impl.easeToStub.invocations.first)
+        XCTAssertEqual(invocation.parameters.to, cameraOptions)
+        XCTAssertEqual(invocation.parameters.duration, duration)
+        XCTAssertEqual(invocation.parameters.curve, curve)
+        XCTAssertIdentical(cancelable, invocation.returnValue)
 
-        // end the first
-        cameraAnimationsManager.cameraAnimatorDidStopRunning(animator1)
-        XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 2)
-        XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 1)
+        let position = UIViewAnimatingPosition.random()
+        invocation.parameters.completion?(position)
+        XCTAssertEqual(completion.invocations.map(\.parameters), [position])
+    }
 
-        // end the first again
-        cameraAnimationsManager.cameraAnimatorDidStopRunning(animator1)
-        XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 2)
-        XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 1)
+    func testEaseToWithDefaultArguments() {
+        cameraAnimationsManager.ease(
+            to: .random(),
+            duration: .random(in: 0...10))
 
-        // end the second
-        cameraAnimationsManager.cameraAnimatorDidStopRunning(animator2)
-        XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 2)
-        XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 2)
+        XCTAssertEqual(impl.easeToStub.invocations.count, 1)
+        XCTAssertEqual(impl.easeToStub.invocations.first?.parameters.curve, .easeOut)
+        XCTAssertNil(impl.easeToStub.invocations.first?.parameters.completion)
+    }
+
+    func testMakeAnimatorWithTimingParameters() throws {
+        let duration = TimeInterval.random(in: 0...10)
+        let timingParameters = MockTimingCurveProvider()
+        let animationOwner = AnimationOwner.random()
+        let animations = Stub<CameraTransition, Void>()
+
+        let animator = cameraAnimationsManager.makeAnimator(
+            duration: duration,
+            timingParameters: timingParameters,
+            animationOwner: animationOwner,
+            animations: { animations.call(with: $0) })
+
+        XCTAssertEqual(impl.makeAnimatorWithTimingParametersStub.invocations.count, 1)
+        let invocation = try XCTUnwrap(impl.makeAnimatorWithTimingParametersStub.invocations.first)
+        XCTAssertEqual(invocation.parameters.duration, duration)
+        XCTAssertIdentical(invocation.parameters.timingParameters, timingParameters)
+        XCTAssertEqual(invocation.parameters.animationOwner, animationOwner)
+        XCTAssertIdentical(animator, invocation.returnValue)
+
+        var cameraTransition = CameraTransition(cameraState: .random(), initialAnchor: .random())
+        invocation.parameters.animations(&cameraTransition)
+        XCTAssertEqual(animations.invocations.map(\.parameters), [cameraTransition])
+    }
+
+    func testMakeAnimatorWithTimingParametersWithDefaultArguments() {
+        _ = cameraAnimationsManager.makeAnimator(
+            duration: .random(in: 0...10),
+            timingParameters: MockTimingCurveProvider(),
+            animations: { _ in })
+
+        XCTAssertEqual(impl.makeAnimatorWithTimingParametersStub.invocations.count, 1)
+        XCTAssertEqual(impl.makeAnimatorWithTimingParametersStub.invocations.first?.parameters.animationOwner, .unspecified)
+    }
+
+    func testMakeAnimatorWithCurve() throws {
+        let duration = TimeInterval.random(in: 0...10)
+        let curve = UIView.AnimationCurve.random()
+        let animationOwner = AnimationOwner.random()
+        let animations = Stub<CameraTransition, Void>()
+
+        let animator = cameraAnimationsManager.makeAnimator(
+            duration: duration,
+            curve: curve,
+            animationOwner: animationOwner,
+            animations: { animations.call(with: $0) })
+
+        XCTAssertEqual(impl.makeAnimatorWithCurveStub.invocations.count, 1)
+        let invocation = try XCTUnwrap(impl.makeAnimatorWithCurveStub.invocations.first)
+        XCTAssertEqual(invocation.parameters.duration, duration)
+        XCTAssertEqual(invocation.parameters.curve, curve)
+        XCTAssertEqual(invocation.parameters.animationOwner, animationOwner)
+        XCTAssertIdentical(animator, invocation.returnValue)
+
+        var cameraTransition = CameraTransition(cameraState: .random(), initialAnchor: .random())
+        invocation.parameters.animations(&cameraTransition)
+        XCTAssertEqual(animations.invocations.map(\.parameters), [cameraTransition])
+    }
+
+    func testMakeAnimatorWithCurveWithDefaultArguments() {
+        _ = cameraAnimationsManager.makeAnimator(
+            duration: .random(in: 0...10),
+            curve: .random(),
+            animations: { _ in })
+
+        XCTAssertEqual(impl.makeAnimatorWithCurveStub.invocations.count, 1)
+        XCTAssertEqual(impl.makeAnimatorWithCurveStub.invocations.first?.parameters.animationOwner, .unspecified)
+    }
+
+    func testMakeAnimatorWithControlPoints() throws {
+        let duration = TimeInterval.random(in: 0...10)
+        let controlPoint1 = CGPoint.random()
+        let controlPoint2 = CGPoint.random()
+        let animationOwner = AnimationOwner.random()
+        let animations = Stub<CameraTransition, Void>()
+
+        let animator = cameraAnimationsManager.makeAnimator(
+            duration: duration,
+            controlPoint1: controlPoint1,
+            controlPoint2: controlPoint2,
+            animationOwner: animationOwner,
+            animations: { animations.call(with: $0) })
+
+        XCTAssertEqual(impl.makeAnimatorWithControlPointsStub.invocations.count, 1)
+        let invocation = try XCTUnwrap(impl.makeAnimatorWithControlPointsStub.invocations.first)
+        XCTAssertEqual(invocation.parameters.duration, duration)
+        XCTAssertEqual(invocation.parameters.controlPoint1, controlPoint1)
+        XCTAssertEqual(invocation.parameters.controlPoint2, controlPoint2)
+        XCTAssertEqual(invocation.parameters.animationOwner, animationOwner)
+        XCTAssertIdentical(animator, invocation.returnValue)
+
+        var cameraTransition = CameraTransition(cameraState: .random(), initialAnchor: .random())
+        invocation.parameters.animations(&cameraTransition)
+        XCTAssertEqual(animations.invocations.map(\.parameters), [cameraTransition])
+    }
+
+    func testMakeAnimatorWithControlPointsWithDefaultArguments() {
+        _ = cameraAnimationsManager.makeAnimator(
+            duration: .random(in: 0...10),
+            controlPoint1: .random(),
+            controlPoint2: .random(),
+            animations: { _ in })
+
+        XCTAssertEqual(impl.makeAnimatorWithControlPointsStub.invocations.count, 1)
+        XCTAssertEqual(impl.makeAnimatorWithControlPointsStub.invocations.first?.parameters.animationOwner, .unspecified)
+    }
+
+    func testMakeAnimatorWithDampingRatio() throws {
+        let duration = TimeInterval.random(in: 0...10)
+        let dampingRatio = CGFloat.random(in: 0...10)
+        let animationOwner = AnimationOwner.random()
+        let animations = Stub<CameraTransition, Void>()
+
+        let animator = cameraAnimationsManager.makeAnimator(
+            duration: duration,
+            dampingRatio: dampingRatio,
+            animationOwner: animationOwner,
+            animations: { animations.call(with: $0) })
+
+        XCTAssertEqual(impl.makeAnimatorWithDampingRatioStub.invocations.count, 1)
+        let invocation = try XCTUnwrap(impl.makeAnimatorWithDampingRatioStub.invocations.first)
+        XCTAssertEqual(invocation.parameters.duration, duration)
+        XCTAssertEqual(invocation.parameters.dampingRatio, dampingRatio)
+        XCTAssertEqual(invocation.parameters.animationOwner, animationOwner)
+        XCTAssertIdentical(animator, invocation.returnValue)
+
+        var cameraTransition = CameraTransition(cameraState: .random(), initialAnchor: .random())
+        invocation.parameters.animations(&cameraTransition)
+        XCTAssertEqual(animations.invocations.map(\.parameters), [cameraTransition])
+    }
+
+    func testMakeAnimatorWithDampingRatioWithDefaultArguments() {
+        _ = cameraAnimationsManager.makeAnimator(
+            duration: .random(in: 0...10),
+            dampingRatio: .random(in: 0...10),
+            animations: { _ in })
+
+        XCTAssertEqual(impl.makeAnimatorWithDampingRatioStub.invocations.count, 1)
+        XCTAssertEqual(impl.makeAnimatorWithDampingRatioStub.invocations.first?.parameters.animationOwner, .unspecified)
     }
 }

--- a/Tests/MapboxMapsTests/Camera/CameraAnimatorsRunnerTests.swift
+++ b/Tests/MapboxMapsTests/Camera/CameraAnimatorsRunnerTests.swift
@@ -1,0 +1,224 @@
+import XCTest
+@testable import MapboxMaps
+
+final class CameraAnimatorsRunnerTests: XCTestCase {
+    var mapboxMap: MockMapboxMap!
+    var cameraAnimatorsRunner: CameraAnimatorsRunner!
+
+    override func setUp() {
+        super.setUp()
+        mapboxMap = MockMapboxMap()
+        cameraAnimatorsRunner = CameraAnimatorsRunner(
+            mapboxMap: mapboxMap)
+    }
+
+    override func tearDown() {
+        cameraAnimatorsRunner = nil
+        mapboxMap = nil
+        super.tearDown()
+    }
+
+    func testCameraAnimators() {
+        let animators = [MockCameraAnimator].random(
+            withLength: 10,
+            generator: MockCameraAnimator.init)
+
+        for animator in animators {
+            cameraAnimatorsRunner.add(animator)
+        }
+
+        XCTAssertEqual(
+            Set(cameraAnimatorsRunner.cameraAnimators.map(ObjectIdentifier.init(_:))),
+            Set(animators.map(ObjectIdentifier.init(_:))))
+    }
+
+    func testKeepsWeakRefToAnimatorsThatAreNotRunning() {
+        // held strongly
+        let animator1 = MockCameraAnimator()
+        weak var weakAnimator2: MockCameraAnimator?
+        do {
+            cameraAnimatorsRunner.add(animator1)
+
+            // held weakly, but running
+            let animator2 = MockCameraAnimator()
+            weakAnimator2 = animator2
+            cameraAnimatorsRunner.add(animator2)
+            cameraAnimatorsRunner.cameraAnimatorDidStartRunning(animator2)
+
+            // held weakly, not running
+            let animator3 = MockCameraAnimator()
+            cameraAnimatorsRunner.add(animator3)
+        }
+
+        if let animator2 = weakAnimator2 {
+            autoreleasepool {
+                XCTAssertEqual(cameraAnimatorsRunner.cameraAnimators.count, 2)
+                XCTAssertTrue(cameraAnimatorsRunner.cameraAnimators.contains { $0 === animator1 })
+                XCTAssertTrue(cameraAnimatorsRunner.cameraAnimators.contains { $0 === animator2 })
+            }
+            cameraAnimatorsRunner.cameraAnimatorDidStopRunning(animator2)
+        }
+
+        XCTAssertEqual(
+            Set(cameraAnimatorsRunner.cameraAnimators.map(ObjectIdentifier.init(_:))),
+            Set([animator1].map(ObjectIdentifier.init(_:))))
+    }
+
+    func testUpdateWithAnimationsEnabled() {
+        cameraAnimatorsRunner.animationsEnabled = true
+        let animator = MockCameraAnimator()
+        cameraAnimatorsRunner.add(animator)
+        cameraAnimatorsRunner.cameraAnimatorDidStartRunning(animator)
+
+        cameraAnimatorsRunner.update()
+
+        XCTAssertEqual(animator.stopAnimationStub.invocations.count, 0)
+        XCTAssertEqual(animator.cancelStub.invocations.count, 0)
+        XCTAssertEqual(animator.updateStub.invocations.count, 1)
+    }
+
+    func testUpdateWithAnimationsDisabled() {
+        cameraAnimatorsRunner.animationsEnabled = false
+        let animator = MockCameraAnimator()
+        cameraAnimatorsRunner.add(animator)
+        cameraAnimatorsRunner.cameraAnimatorDidStartRunning(animator)
+
+        cameraAnimatorsRunner.update()
+
+        XCTAssertEqual(animator.stopAnimationStub.invocations.count, 1)
+        XCTAssertEqual(animator.cancelStub.invocations.count, 0)
+        XCTAssertEqual(animator.updateStub.invocations.count, 0)
+    }
+
+    func testCancelAnimations() {
+        let animator = MockCameraAnimator()
+        animator.state = .random()
+        animator.owner = .random()
+        cameraAnimatorsRunner.add(animator)
+
+        cameraAnimatorsRunner.cancelAnimations()
+
+        XCTAssertEqual(animator.stopAnimationStub.invocations.count, 1)
+        XCTAssertEqual(animator.cancelStub.invocations.count, 0)
+    }
+
+    func testCancelAnimationsWithEmptyOwnersArray() {
+        let animators = [MockCameraAnimator].random(withLength: 10) {
+            let animator = MockCameraAnimator()
+            animator.state = .random()
+            animator.owner = .random()
+            return animator
+        }
+
+        for animator in animators {
+            cameraAnimatorsRunner.add(animator)
+        }
+
+        cameraAnimatorsRunner.cancelAnimations(withOwners: [])
+
+        for animator in animators {
+            XCTAssertEqual(animator.stopAnimationStub.invocations.count, 0)
+            XCTAssertEqual(animator.cancelStub.invocations.count, 0)
+        }
+    }
+
+    func testCancelAnimationsWithSingleOwner() {
+        let owner = AnimationOwner.random()
+
+        let animators = [MockCameraAnimator].random(withLength: 10) {
+            let animator = MockCameraAnimator()
+            animator.state = .random()
+            animator.owner = owner
+            return animator
+        }
+
+        animators[9].owner = AnimationOwner(rawValue: owner.rawValue + "-other")
+
+        for animator in animators {
+            cameraAnimatorsRunner.add(animator)
+        }
+
+        cameraAnimatorsRunner.cancelAnimations(withOwners: [owner])
+
+        for animator in animators[0..<9] {
+            XCTAssertEqual(animator.stopAnimationStub.invocations.count, 1)
+            XCTAssertEqual(animator.cancelStub.invocations.count, 0)
+        }
+
+        XCTAssertEqual(animators[9].stopAnimationStub.invocations.count, 0)
+        XCTAssertEqual(animators[9].cancelStub.invocations.count, 0)
+    }
+
+    func testCancelAnimationsWithSingleMultipleOwners() {
+        let owner1 = AnimationOwner.random()
+        let owner2 = AnimationOwner.random()
+
+        let animators: [MockCameraAnimator] = .random(withLength: 5) {
+            let animator = MockCameraAnimator()
+            animator.state = .random()
+            animator.owner = owner1
+            return animator
+        } + .random(withLength: 6) {
+            let animator = MockCameraAnimator()
+            animator.state = .random()
+            animator.owner = owner2
+            return animator
+        }
+
+        animators[10].owner = AnimationOwner(rawValue: owner1.rawValue + owner2.rawValue)
+
+        for animator in animators {
+            cameraAnimatorsRunner.add(animator)
+        }
+
+        cameraAnimatorsRunner.cancelAnimations(withOwners: [owner1, owner2])
+
+        for animator in animators[0..<10] {
+            XCTAssertEqual(animator.stopAnimationStub.invocations.count, 1)
+            XCTAssertEqual(animator.cancelStub.invocations.count, 0)
+        }
+
+        XCTAssertEqual(animators[10].stopAnimationStub.invocations.count, 0)
+        XCTAssertEqual(animators[10].cancelStub.invocations.count, 0)
+    }
+
+    func testCameraAnimatorDelegate() {
+        let animator1 = MockCameraAnimator()
+        let animator2 = MockCameraAnimator()
+
+        // stopping before starting should have no effect
+        cameraAnimatorsRunner.cameraAnimatorDidStopRunning(animator1)
+        XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 0)
+        XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 0)
+
+        // start once
+        cameraAnimatorsRunner.cameraAnimatorDidStartRunning(animator1)
+        XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 1)
+        XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 0)
+
+        // start twice
+        cameraAnimatorsRunner.cameraAnimatorDidStartRunning(animator1)
+        XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 1)
+        XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 0)
+
+        // start a second
+        cameraAnimatorsRunner.cameraAnimatorDidStartRunning(animator2)
+        XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 2)
+        XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 0)
+
+        // end the first
+        cameraAnimatorsRunner.cameraAnimatorDidStopRunning(animator1)
+        XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 2)
+        XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 1)
+
+        // end the first again
+        cameraAnimatorsRunner.cameraAnimatorDidStopRunning(animator1)
+        XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 2)
+        XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 1)
+
+        // end the second
+        cameraAnimatorsRunner.cameraAnimatorDidStopRunning(animator2)
+        XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 2)
+        XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 2)
+    }
+}

--- a/Tests/MapboxMapsTests/Camera/CameraAnimatorsRunnerTests.swift
+++ b/Tests/MapboxMapsTests/Camera/CameraAnimatorsRunnerTests.swift
@@ -32,38 +32,6 @@ final class CameraAnimatorsRunnerTests: XCTestCase {
             Set(animators.map(ObjectIdentifier.init(_:))))
     }
 
-    func testKeepsWeakRefToAnimatorsThatAreNotRunning() {
-        // held strongly
-        let animator1 = MockCameraAnimator()
-        weak var weakAnimator2: MockCameraAnimator?
-        do {
-            cameraAnimatorsRunner.add(animator1)
-
-            // held weakly, but running
-            let animator2 = MockCameraAnimator()
-            weakAnimator2 = animator2
-            cameraAnimatorsRunner.add(animator2)
-            cameraAnimatorsRunner.cameraAnimatorDidStartRunning(animator2)
-
-            // held weakly, not running
-            let animator3 = MockCameraAnimator()
-            cameraAnimatorsRunner.add(animator3)
-        }
-
-        if let animator2 = weakAnimator2 {
-            autoreleasepool {
-                XCTAssertEqual(cameraAnimatorsRunner.cameraAnimators.count, 2)
-                XCTAssertTrue(cameraAnimatorsRunner.cameraAnimators.contains { $0 === animator1 })
-                XCTAssertTrue(cameraAnimatorsRunner.cameraAnimators.contains { $0 === animator2 })
-            }
-            cameraAnimatorsRunner.cameraAnimatorDidStopRunning(animator2)
-        }
-
-        XCTAssertEqual(
-            Set(cameraAnimatorsRunner.cameraAnimators.map(ObjectIdentifier.init(_:))),
-            Set([animator1].map(ObjectIdentifier.init(_:))))
-    }
-
     func testUpdateWithAnimationsEnabled() {
         cameraAnimatorsRunner.animationsEnabled = true
         let animator = MockCameraAnimator()

--- a/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimationsManager.swift
+++ b/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimationsManager.swift
@@ -3,31 +3,122 @@ import Foundation
 
 final class MockCameraAnimationsManager: CameraAnimationsManagerProtocol {
 
-    struct EaseToParameters {
-        var camera: CameraOptions
-        var duration: TimeInterval
-        var curve: UIView.AnimationCurve
-        var completion: AnimationCompletion?
-    }
-    let easeToStub = Stub<EaseToParameters, Cancelable>(defaultReturnValue: MockCancelable())
-    func internalEase(to camera: CameraOptions,
-                      duration: TimeInterval,
-                      curve: UIView.AnimationCurve,
-                      completion: AnimationCompletion?) -> Cancelable {
-        return easeToStub.call(
-            with: EaseToParameters(
-                camera: camera,
-                duration: duration,
-                curve: curve,
-                completion: completion))
-    }
+    @Stubbed var cameraAnimators: [CameraAnimator] = []
 
     let cancelAnimationsStub = Stub<Void, Void>()
     func cancelAnimations() {
         cancelAnimationsStub.call()
     }
 
-    var animationsEnabled: Bool = true
+    struct FlyToParams {
+        var to: CameraOptions
+        var duration: TimeInterval?
+        var completion: AnimationCompletion?
+    }
+    let flyToStub = Stub<FlyToParams, Cancelable>(defaultReturnValue: MockCancelable())
+    func fly(to: CameraOptions,
+             duration: TimeInterval?,
+             completion: AnimationCompletion?) -> Cancelable {
+        flyToStub.call(with: .init(to: to, duration: duration, completion: completion))
+    }
+
+   struct EaseToParams {
+        var to: CameraOptions
+        var duration: TimeInterval
+        var curve: UIView.AnimationCurve
+        var completion: AnimationCompletion?
+    }
+    let easeToStub = Stub<EaseToParams, Cancelable>(defaultReturnValue: MockCancelable())
+    func ease(to: CameraOptions,
+              duration: TimeInterval,
+              curve: UIView.AnimationCurve,
+              completion: AnimationCompletion?) -> Cancelable {
+        easeToStub.call(
+            with: EaseToParams(
+                to: to,
+                duration: duration,
+                curve: curve,
+                completion: completion))
+    }
+
+    struct MakeAnimatorWithTimingParametersParams {
+        var duration: TimeInterval
+        var timingParameters: UITimingCurveProvider
+        var animationOwner: AnimationOwner
+        var animations: (inout CameraTransition) -> Void
+    }
+    let makeAnimatorWithTimingParametersStub = Stub<MakeAnimatorWithTimingParametersParams, BasicCameraAnimator>(
+        defaultReturnValue: BasicCameraAnimator(impl: MockBasicCameraAnimator()))
+    func makeAnimator(duration: TimeInterval,
+                      timingParameters: UITimingCurveProvider,
+                      animationOwner: AnimationOwner,
+                      animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator {
+        makeAnimatorWithTimingParametersStub.call(with: .init(
+            duration: duration,
+            timingParameters: timingParameters,
+            animationOwner: animationOwner,
+            animations: animations))
+    }
+
+    struct MakeAnimatorWithCurveParams {
+        var duration: TimeInterval
+        var curve: UIView.AnimationCurve
+        var animationOwner: AnimationOwner
+        var animations: (inout CameraTransition) -> Void
+    }
+    let makeAnimatorWithCurveStub = Stub<MakeAnimatorWithCurveParams, BasicCameraAnimator>(
+        defaultReturnValue: BasicCameraAnimator(impl: MockBasicCameraAnimator()))
+    func makeAnimator(duration: TimeInterval,
+                      curve: UIView.AnimationCurve,
+                      animationOwner: AnimationOwner,
+                      animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator {
+        makeAnimatorWithCurveStub.call(with: .init(
+            duration: duration,
+            curve: curve,
+            animationOwner: animationOwner,
+            animations: animations))
+    }
+
+    struct MakeAnimatorWithControlPointsParams {
+        var duration: TimeInterval
+        var controlPoint1: CGPoint
+        var controlPoint2: CGPoint
+        var animationOwner: AnimationOwner
+        var animations: (inout CameraTransition) -> Void
+    }
+    let makeAnimatorWithControlPointsStub = Stub<MakeAnimatorWithControlPointsParams, BasicCameraAnimator>(
+        defaultReturnValue: BasicCameraAnimator(impl: MockBasicCameraAnimator()))
+    func makeAnimator(duration: TimeInterval,
+                      controlPoint1: CGPoint,
+                      controlPoint2: CGPoint,
+                      animationOwner: AnimationOwner,
+                      animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator {
+        makeAnimatorWithControlPointsStub.call(with: .init(
+            duration: duration,
+            controlPoint1: controlPoint1,
+            controlPoint2: controlPoint2,
+            animationOwner: animationOwner,
+            animations: animations))
+    }
+
+    struct MakeAnimatorWithDampingRatioParams {
+        var duration: TimeInterval
+        var dampingRatio: CGFloat
+        var animationOwner: AnimationOwner
+        var animations: (inout CameraTransition) -> Void
+    }
+    let makeAnimatorWithDampingRatioStub = Stub<MakeAnimatorWithDampingRatioParams, BasicCameraAnimator>(
+        defaultReturnValue: BasicCameraAnimator(impl: MockBasicCameraAnimator()))
+    func makeAnimator(duration: TimeInterval,
+                      dampingRatio: CGFloat,
+                      animationOwner: AnimationOwner,
+                      animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator {
+        makeAnimatorWithDampingRatioStub.call(with: .init(
+            duration: duration,
+            dampingRatio: dampingRatio,
+            animationOwner: animationOwner,
+            animations: animations))
+    }
 
     struct DecelerateParameters {
         var location: CGPoint
@@ -42,32 +133,12 @@ final class MockCameraAnimationsManager: CameraAnimationsManagerProtocol {
                     decelerationFactor: CGFloat,
                     locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void,
                     completion: AnimationCompletion?) {
-
-        return decelerateStub.call(
+        decelerateStub.call(
             with: DecelerateParameters(
                 location: location,
                 velocity: velocity,
                 decelerationFactor: decelerationFactor,
                 locationChangeHandler: locationChangeHandler,
                 completion: completion))
-    }
-
-    struct MakeAnimatorParams {
-        var duration: TimeInterval
-        var curve: UIView.AnimationCurve
-        var animationOwner: AnimationOwner
-        var animations: (inout CameraTransition) -> Void
-    }
-    let makeAnimatorStub = Stub<MakeAnimatorParams, BasicCameraAnimator>(
-        defaultReturnValue: BasicCameraAnimator(impl: MockBasicCameraAnimator()))
-    func makeAnimator(duration: TimeInterval,
-                      curve: UIView.AnimationCurve,
-                      animationOwner: AnimationOwner,
-                      animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator {
-        makeAnimatorStub.call(with: .init(
-            duration: duration,
-            curve: curve,
-            animationOwner: animationOwner,
-            animations: animations))
     }
 }

--- a/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimatorsFactory.swift
+++ b/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimatorsFactory.swift
@@ -1,0 +1,130 @@
+@testable import MapboxMaps
+
+final class MockCameraAnimatorsFactory: CameraAnimatorsFactoryProtocol {
+    struct MakeFlyToAnimatorParams {
+        var toCamera: CameraOptions
+        var animationOwner: AnimationOwner
+        var duration: TimeInterval?
+    }
+    let makeFlyToAnimatorStub = Stub<MakeFlyToAnimatorParams, CameraAnimatorProtocol>(
+        defaultReturnValue: MockCameraAnimator())
+    func makeFlyToAnimator(toCamera: CameraOptions,
+                           animationOwner: AnimationOwner,
+                           duration: TimeInterval?) -> CameraAnimatorProtocol {
+        makeFlyToAnimatorStub.call(with: .init(
+            toCamera: toCamera,
+            animationOwner: animationOwner,
+            duration: duration))
+    }
+
+    struct MakeBasicCameraAnimatorWithTimingParametersParams {
+        var duration: TimeInterval
+        var timingParameters: UITimingCurveProvider
+        var animationOwner: AnimationOwner
+        var animations: (inout CameraTransition) -> Void
+    }
+    let makeBasicCameraAnimatorWithTimingParametersStub = Stub<
+        MakeBasicCameraAnimatorWithTimingParametersParams,
+        BasicCameraAnimatorProtocol>(
+            defaultReturnValue: MockBasicCameraAnimator())
+    func makeBasicCameraAnimator(duration: TimeInterval,
+                                 timingParameters: UITimingCurveProvider,
+                                 animationOwner: AnimationOwner,
+                                 animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimatorProtocol {
+        makeBasicCameraAnimatorWithTimingParametersStub.call(with: .init(
+            duration: duration,
+            timingParameters: timingParameters,
+            animationOwner: animationOwner,
+            animations: animations))
+    }
+
+    struct MakeBasicCameraAnimatorWithCurveParams {
+        var duration: TimeInterval
+        var curve: UIView.AnimationCurve
+        var animationOwner: AnimationOwner
+        var animations: (inout CameraTransition) -> Void
+    }
+    let makeBasicCameraAnimatorWithCurveStub = Stub<
+        MakeBasicCameraAnimatorWithCurveParams,
+        BasicCameraAnimatorProtocol>(
+            defaultReturnValue: MockBasicCameraAnimator())
+    func makeBasicCameraAnimator(duration: TimeInterval,
+                                 curve: UIView.AnimationCurve,
+                                 animationOwner: AnimationOwner,
+                                 animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimatorProtocol {
+        makeBasicCameraAnimatorWithCurveStub.call(with: .init(
+            duration: duration,
+            curve: curve,
+            animationOwner: animationOwner,
+            animations: animations))
+    }
+
+    struct MakeBasicCameraAnimatorWithControlPointsParams {
+        var duration: TimeInterval
+        var controlPoint1: CGPoint
+        var controlPoint2: CGPoint
+        var animationOwner: AnimationOwner
+        var animations: (inout CameraTransition) -> Void
+    }
+    let makeBasicCameraAnimatorWithControlPointsStub = Stub<
+        MakeBasicCameraAnimatorWithControlPointsParams,
+        BasicCameraAnimatorProtocol>(
+            defaultReturnValue: MockBasicCameraAnimator())
+    func makeBasicCameraAnimator(duration: TimeInterval,
+                                 controlPoint1: CGPoint,
+                                 controlPoint2: CGPoint,
+                                 animationOwner: AnimationOwner,
+                                 animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimatorProtocol {
+        makeBasicCameraAnimatorWithControlPointsStub.call(with: .init(
+            duration: duration,
+            controlPoint1: controlPoint1,
+            controlPoint2: controlPoint2,
+            animationOwner: animationOwner,
+            animations: animations))
+    }
+
+    struct MakeBasicCameraAnimatorWithDampingRatioParams {
+        var duration: TimeInterval
+        var dampingRatio: CGFloat
+        var animationOwner: AnimationOwner
+        var animations: (inout CameraTransition) -> Void
+    }
+    let makeBasicCameraAnimatorWithDampingRatioStub = Stub<
+        MakeBasicCameraAnimatorWithDampingRatioParams,
+        BasicCameraAnimatorProtocol>(
+            defaultReturnValue: MockBasicCameraAnimator())
+    func makeBasicCameraAnimator(duration: TimeInterval,
+                                 dampingRatio: CGFloat,
+                                 animationOwner: AnimationOwner,
+                                 animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimatorProtocol {
+        makeBasicCameraAnimatorWithDampingRatioStub.call(with: .init(
+            duration: duration,
+            dampingRatio: dampingRatio,
+            animationOwner: animationOwner,
+            animations: animations))
+    }
+
+    struct MakeGestureDecelerationCameraAnimatorParams {
+        var location: CGPoint
+        var velocity: CGPoint
+        var decelerationFactor: CGFloat
+        var animationOwner: AnimationOwner
+        var locationChangeHandler: (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void
+    }
+    let makeGestureDecelerationCameraAnimatorStub = Stub<
+        MakeGestureDecelerationCameraAnimatorParams,
+        CameraAnimatorProtocol>(
+            defaultReturnValue: MockCameraAnimator())
+    func makeGestureDecelerationCameraAnimator(location: CGPoint,
+                                               velocity: CGPoint,
+                                               decelerationFactor: CGFloat,
+                                               animationOwner: AnimationOwner,
+                                               locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void) -> CameraAnimatorProtocol {
+        makeGestureDecelerationCameraAnimatorStub.call(with: .init(
+            location: location,
+            velocity: velocity,
+            decelerationFactor: decelerationFactor,
+            animationOwner: animationOwner,
+            locationChangeHandler: locationChangeHandler))
+    }
+}

--- a/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimatorsRunner.swift
+++ b/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimatorsRunner.swift
@@ -1,0 +1,27 @@
+@testable import MapboxMaps
+
+final class MockCameraAnimatorsRunner: CameraAnimatorsRunnerProtocol {
+    @Stubbed var animationsEnabled: Bool = true
+
+    @Stubbed var cameraAnimators: [CameraAnimator] = []
+
+    let updateStub = Stub<Void, Void>()
+    func update() {
+        updateStub.call()
+    }
+
+    let cancelAnimationsStub = Stub<Void, Void>()
+    func cancelAnimations() {
+        cancelAnimationsStub.call()
+    }
+
+    let cancelAnimationsWithOwnersStub = Stub<[AnimationOwner], Void>()
+    func cancelAnimations(withOwners owners: [AnimationOwner]) {
+        cancelAnimationsWithOwnersStub.call(with: owners)
+    }
+
+    let addStub = Stub<CameraAnimatorProtocol, Void>()
+    func add(_ animator: CameraAnimatorProtocol) {
+        addStub.call(with: animator)
+    }
+}

--- a/Tests/MapboxMapsTests/Foundation/InterfaceOrientationProviderTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/InterfaceOrientationProviderTests.swift
@@ -54,34 +54,19 @@ final class UIApplicationInterfaceOrientationProviderTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 final class DefaultInterfaceOrientationProviderTests: XCTestCase {
-    var provider: DefaultInterfaceOrientationProvider!
-    var view: UIView!
-    var window: UIWindow!
-
-    override func setUp() {
-        super.setUp()
-
-        view = UIView()
-        window = UIWindow()
-        let viewController = UIViewController()
-        viewController.view.addSubview(view)
-        window.rootViewController = viewController
-        window.makeKeyAndVisible()
-        provider = DefaultInterfaceOrientationProvider()
-    }
-
-    override func tearDown() {
-        provider = nil
-        view = nil
-        super.tearDown()
-    }
-
     func testOrientationProvider() throws {
         guard #available(iOS 13.0, *) else {
             throw XCTSkip("Test requires iOS 13 or higher.")
         }
+
+        let view = UIView()
+        let window = UIWindow()
+        let viewController = UIViewController()
+        viewController.view.addSubview(view)
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        let provider = DefaultInterfaceOrientationProvider()
 
         let orientation = provider.interfaceOrientation(for: view)
 

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -200,6 +200,15 @@ final class MapViewTests: XCTestCase {
         XCTAssertEqual(participant2.participateStub.invocations.count, 1)
     }
 
+    func testDisplayLinkInvokesCameraAnimatorsRunner() throws {
+        XCTAssertEqual(dependencyProvider.makeCameraAnimatorsRunnerStub.invocations.count, 1)
+        let runner = try XCTUnwrap(dependencyProvider.makeCameraAnimatorsRunnerStub.invocations.first?.returnValue as? MockCameraAnimatorsRunner)
+
+        try invokeDisplayLinkCallback()
+
+        XCTAssertEqual(runner.updateStub.invocations.count, 1)
+    }
+
     func testAppLifecycleNotificationSubscribedWhenDidMoveToNewWindow() {
         let notificationCenter = MockNotificationCenter()
         let bundle = MockBundle()

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
@@ -44,10 +44,23 @@ final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
                 selector: selector))
     }
 
+    let makeCameraAnimatorsRunnerStub = Stub<MapboxMapProtocol, CameraAnimatorsRunnerProtocol>(
+        defaultReturnValue: MockCameraAnimatorsRunner())
+    func makeCameraAnimatorsRunner(mapboxMap: MapboxMapProtocol) -> CameraAnimatorsRunnerProtocol {
+        makeCameraAnimatorsRunnerStub.call(with: mapboxMap)
+    }
+
+    func makeCameraAnimationsManagerImpl(cameraViewContainerView: UIView,
+                                         mapboxMap: MapboxMapProtocol,
+                                         cameraAnimatorsRunner: CameraAnimatorsRunnerProtocol) -> CameraAnimationsManagerProtocol {
+        MockCameraAnimationsManager()
+    }
+
     func makeGestureManager(
         view: UIView,
         mapboxMap: MapboxMapProtocol,
-        cameraAnimationsManager: CameraAnimationsManagerProtocol) -> GestureManager {
+        cameraAnimationsManager: CameraAnimationsManagerProtocol,
+        cameraAnimatorsRunner: CameraAnimatorsRunnerProtocol) -> GestureManager {
         return GestureManager(
             panGestureHandler: MockPanGestureHandler(
                 gestureRecognizer: UIGestureRecognizer()),

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/AnyTouchGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/AnyTouchGestureHandlerTests.swift
@@ -4,49 +4,43 @@ import XCTest
 final class AnyTouchGestureHandlerTests: XCTestCase {
 
     var gestureRecognizer: MockGestureRecognizer!
-    var cameraAnimationsManager: MockCameraAnimationsManager!
+    var cameraAnimatorsRunner: MockCameraAnimatorsRunner!
     var gestureHandler: AnyTouchGestureHandler!
 
     override func setUp() {
         super.setUp()
         gestureRecognizer = MockGestureRecognizer()
-        cameraAnimationsManager = MockCameraAnimationsManager()
+        cameraAnimatorsRunner = MockCameraAnimatorsRunner()
         gestureHandler = AnyTouchGestureHandler(
             gestureRecognizer: gestureRecognizer,
-            cameraAnimationsManager: cameraAnimationsManager)
+            cameraAnimatorsRunner: cameraAnimatorsRunner)
     }
 
     override func tearDown() {
         gestureHandler = nil
-        cameraAnimationsManager = nil
+        cameraAnimatorsRunner = nil
         gestureRecognizer = nil
         super.tearDown()
     }
 
     func testGestureBegan() {
-        cameraAnimationsManager.animationsEnabled = true
-
         gestureRecognizer.getStateStub.defaultReturnValue = .began
         gestureRecognizer.sendActions()
 
-        XCTAssertFalse(cameraAnimationsManager.animationsEnabled)
+        XCTAssertEqual(cameraAnimatorsRunner.$animationsEnabled.setStub.invocations.map(\.parameters), [false])
     }
 
     func testGestureEnded() {
-        cameraAnimationsManager.animationsEnabled = false
-
         gestureRecognizer.getStateStub.defaultReturnValue = .ended
         gestureRecognizer.sendActions()
 
-        XCTAssertTrue(cameraAnimationsManager.animationsEnabled)
+        XCTAssertEqual(cameraAnimatorsRunner.$animationsEnabled.setStub.invocations.map(\.parameters), [true])
     }
 
     func testGestureCancelled() {
-        cameraAnimationsManager.animationsEnabled = false
-
         gestureRecognizer.getStateStub.defaultReturnValue = .cancelled
         gestureRecognizer.sendActions()
 
-        XCTAssertTrue(cameraAnimationsManager.animationsEnabled)
+        XCTAssertEqual(cameraAnimatorsRunner.$animationsEnabled.setStub.invocations.map(\.parameters), [true])
     }
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/DoubleTapToZoomInGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/DoubleTapToZoomInGestureHandlerTests.swift
@@ -50,7 +50,7 @@ final class DoubleTapToZoomInGestureHandlerTests: XCTestCase {
         let tapLocation = try XCTUnwrap(gestureRecognizer.locationStub.invocations.first?.returnValue)
         XCTAssertEqual(delegate.gestureBeganStub.invocations.map(\.parameters), [.doubleTapToZoomIn])
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.count, 1)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.camera, CameraOptions(anchor: tapLocation, zoom: mapboxMap.cameraState.zoom + 1))
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.to, CameraOptions(anchor: tapLocation, zoom: mapboxMap.cameraState.zoom + 1))
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.duration, 0.3)
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.curve, .easeOut)
         XCTAssertEqual(delegate.gestureEndedStub.invocations.first?.parameters.gestureType, .doubleTapToZoomIn)
@@ -70,6 +70,6 @@ final class DoubleTapToZoomInGestureHandlerTests: XCTestCase {
         gestureRecognizer.sendActions()
 
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.count, 1)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.camera.anchor, focalPoint)
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.to.anchor, focalPoint)
     }
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/DoubleTouchToZoomOutGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/DoubleTouchToZoomOutGestureHandlerTests.swift
@@ -50,7 +50,7 @@ final class DoubleTouchToZoomOutGestureHandlerTests: XCTestCase {
         let tapLocation = try XCTUnwrap(gestureRecognizer.locationStub.invocations.first?.returnValue)
         XCTAssertEqual(delegate.gestureBeganStub.invocations.map(\.parameters), [.doubleTouchToZoomOut])
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.count, 1)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.camera, CameraOptions(anchor: tapLocation, zoom: mapboxMap.cameraState.zoom - 1))
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.to, CameraOptions(anchor: tapLocation, zoom: mapboxMap.cameraState.zoom - 1))
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.duration, 0.3)
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.curve, .easeOut)
         XCTAssertEqual(delegate.gestureEndedStub.invocations.first?.parameters.gestureType, .doubleTouchToZoomOut)
@@ -71,6 +71,6 @@ final class DoubleTouchToZoomOutGestureHandlerTests: XCTestCase {
         gestureRecognizer.sendActions()
 
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.count, 1)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.camera.anchor, focalPoint)
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.to.anchor, focalPoint)
     }
 }

--- a/Tests/MapboxMapsTests/Helpers/Random/UIView-AnimationCurve+Random.swift
+++ b/Tests/MapboxMapsTests/Helpers/Random/UIView-AnimationCurve+Random.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+extension UIView.AnimationCurve {
+    static func random() -> Self {
+        return [.linear, .easeIn, .easeOut, .easeInOut].randomElement()!
+    }
+}

--- a/Tests/MapboxMapsTests/Ornaments/OrnamentManagerTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/OrnamentManagerTests.swift
@@ -100,7 +100,7 @@ final class OrnamentManagerTests: XCTestCase {
 
         XCTAssertEqual(cameraAnimationsManager.cancelAnimationsStub.invocations.count, 1)
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.count, 1)
-        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.camera, CameraOptions(bearing: 0))
+        XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.to, CameraOptions(bearing: 0))
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.duration, 0.3)
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.first?.parameters.curve, .easeOut)
         XCTAssertNil(cameraAnimationsManager.easeToStub.invocations.first?.parameters.completion)

--- a/Tests/MapboxMapsTests/Viewport/States/FollowPuck/FollowPuckViewportStateTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/States/FollowPuck/FollowPuckViewportStateTests.swift
@@ -89,7 +89,7 @@ final class FollowPuckViewportStateTest: XCTestCase {
         // verify that an animation was started
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.count, 1)
         let easeToInvocation = try XCTUnwrap(cameraAnimationsManager.easeToStub.invocations.first)
-        XCTAssertEqual(easeToInvocation.parameters.camera, cameraOptions0)
+        XCTAssertEqual(easeToInvocation.parameters.to, cameraOptions0)
         XCTAssertEqual(easeToInvocation.parameters.duration, state.options.animationDuration)
         XCTAssertEqual(easeToInvocation.parameters.curve, .linear)
         let easeToCompletion = try XCTUnwrap(easeToInvocation.parameters.completion)

--- a/Tests/MapboxMapsTests/Viewport/States/Overview/OverviewViewportStateTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/States/Overview/OverviewViewportStateTests.swift
@@ -30,7 +30,7 @@ final class OverviewViewportStateTest: XCTestCase {
     func verifyEaseTo(with expectedCamera: CameraOptions) throws -> MockCancelable {
         XCTAssertEqual(cameraAnimationsManager.easeToStub.invocations.count, 1)
         let easeToInvocation = try XCTUnwrap(cameraAnimationsManager.easeToStub.invocations.first)
-        XCTAssertEqual(easeToInvocation.parameters.camera, expectedCamera)
+        XCTAssertEqual(easeToInvocation.parameters.to, expectedCamera)
         XCTAssertEqual(easeToInvocation.parameters.duration,
                        max(0, state.options.animationDuration))
         XCTAssertEqual(easeToInvocation.parameters.curve, .linear)


### PR DESCRIPTION
This refactoring is part four of a series that will unlock better unit testability for CameraAnimationsManager. (part 3: https://github.com/mapbox/mapbox-maps-ios/pull/1189)

* `BasicCameraAnimator` has been updated so that if its `cancel()` or `stopAnimation()` methods are invoked prior to its `startAnimation()` and `startAnimation(afterDelay:)` methods, it will invoke its completion blocks with `UIViewAnimatingPosition.current` instead of crashing with a `fatalError`. This change makes it consistent with the other animator implementations and removes a surprising pitfall from the SDK's behavior.
* `CameraAnimationsManager.stopAnimations()` will now cancel all animators regardless of their `.state`. Previously, only animators with `state == .active` were canceled.
* `CameraAnimationsManager` has been refactored into 4 parts for testability:
  * `CameraAnimationsManager`: a thin public wrapper around an internal implementation
  * `CameraAnimationsManagerImpl`: the main internal implementation that coordinates between a factory and a runner
  * `CameraAnimatorsFactory`: a simple factory for creating animators that does not contain any conditional logic or transformations.
  * `CameraAnimatorsRunner`: a component that is responsible for managing animators once they've been created.
* `MapView` has been updated to integrate the camera into the display link via `CameraAnimatorsRunner` instead of via `CameraAnimationsManager` directly.

These changes have enabled thorough testing of `CameraAnimationsManager` (and its new subcomponents) and testing of `MapView`'s display link integration with the camera. These were both areas that were not previously tested (at least via unit tests).

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
