### PR TITLE
Avoid animator-related leaks

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/MapboxMaps.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/MapboxMaps.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1330"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Apps/DebugApp/DebugApp.xcodeproj/project.pbxproj
+++ b/Apps/DebugApp/DebugApp.xcodeproj/project.pbxproj
@@ -119,7 +119,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1100;
-				LastUpgradeCheck = 1320;
+				LastUpgradeCheck = 1330;
 				ORGANIZATIONNAME = "Mapbox Inc";
 				TargetAttributes = {
 					35F08DD72347987700768B9F = {

--- a/Apps/DebugApp/DebugApp.xcodeproj/xcshareddata/xcschemes/DebugApp.xcscheme
+++ b/Apps/DebugApp/DebugApp.xcodeproj/xcshareddata/xcschemes/DebugApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1330"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Apps/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Apps/Examples/Examples.xcodeproj/project.pbxproj
@@ -477,7 +477,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1200;
-				LastUpgradeCheck = 1320;
+				LastUpgradeCheck = 1330;
 				TargetAttributes = {
 					077C4EE9252F7E88007636F1 = {
 						CreatedOnToolsVersion = 12.0;

--- a/Apps/Examples/Examples.xcodeproj/xcshareddata/xcschemes/Examples.xcscheme
+++ b/Apps/Examples/Examples.xcodeproj/xcshareddata/xcschemes/Examples.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1330"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Apps/StressTest/StressTest.xcodeproj/xcshareddata/xcschemes/StressTest.xcscheme
+++ b/Apps/StressTest/StressTest.xcodeproj/xcshareddata/xcschemes/StressTest.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1330"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Add support for app extensions. ([#1183](https://github.com/mapbox/mapbox-maps-ios/pull/1183))
 * `BasicCameraAnimator.cancel()` and `.stopAnimation()` now invoke the completion blocks with `UIViewAnimatingPosition.current` instead of crashing with a `fatalError` when invoked prior to `.startAnimation()` or `.startAnimation(afterDelay:)`. ([#1197](https://github.com/mapbox/mapbox-maps-ios/pull/1197))
 * `CameraAnimationsManager.stopAnimations()` will now cancel all animators regardless of their state. Previously, only animators with `state == .active` were canceled. ([#1197](https://github.com/mapbox/mapbox-maps-ios/pull/1197))
+* Fix animator-related leaks. ([#1200](https://github.com/mapbox/mapbox-maps-ios/pull/1200))
 
 ## 10.4.0-rc.1 - March 9, 2022
 

--- a/Sources/MapboxMaps/Camera/BasicCameraAnimator.swift
+++ b/Sources/MapboxMaps/Camera/BasicCameraAnimator.swift
@@ -50,19 +50,23 @@ public final class BasicCameraAnimator: NSObject, CameraAnimator, CameraAnimator
         impl.delegate = self
     }
 
-    /// Starts the animation if this animator is in `inactive` state. Also used to resume a "paused" animation.
+    /// Starts the animation if this animator is in `inactive` state. Also used to resume a "paused"
+    /// animation. Calling this method on an animator that has already completed or been canceled has
+    /// no effect.
     public func startAnimation() {
         impl.startAnimation()
     }
 
     /// Starts the animation after a delay. This cannot be called on a paused animation.
-    /// If animations are cancelled before the end of the delay, it will also be cancelled.
+    /// If animations are cancelled before the end of the delay, it will also be cancelled. Calling this method
+    /// on an animator that has already completed or been canceled has no effect.
     /// - Parameter delay: Delay (in seconds) after which the animation should start
     public func startAnimation(afterDelay delay: TimeInterval) {
         impl.startAnimation(afterDelay: delay)
     }
 
-    /// Pauses the animation.
+    /// Pauses the animation. Calling this method on an animator that has already completed or been
+    /// canceled has no effect.
     public func pauseAnimation() {
         impl.pauseAnimation()
     }

--- a/Sources/MapboxMaps/Camera/BasicCameraAnimatorImpl.swift
+++ b/Sources/MapboxMaps/Camera/BasicCameraAnimatorImpl.swift
@@ -121,7 +121,7 @@ internal final class BasicCameraAnimatorImpl: BasicCameraAnimatorProtocol {
         cameraView.removeFromSuperview()
     }
 
-    /// Starts the animation if this animator is in `inactive` state. Also used to resume a "paused" animation.
+    /// See ``BasicCameraAnimator/startAnimation()``
     internal func startAnimation() {
         switch internalState {
         case .initial:
@@ -134,23 +134,29 @@ internal final class BasicCameraAnimatorImpl: BasicCameraAnimatorProtocol {
             internalState = .running(transition)
             propertyAnimator.startAnimation()
         case .final:
-            fatalError("Attempt to restart an animation that has already completed.")
+            // animators cannot be restarted
+            break
         }
     }
 
-    /// Starts the animation after a delay. This cannot be called on a paused animation.
-    /// If animations are cancelled before the end of the delay, it will also be cancelled.
-    /// - Parameter delay: Delay (in seconds) after which the animation should start
+    /// See ``BasicCameraAnimator/startAnimation(afterDelay:)``
     internal func startAnimation(afterDelay delay: TimeInterval) {
-        if internalState != .initial {
-            fatalError("startAnimation(afterDelay:) cannot be called on already-delayed, paused, running, or completed animators.")
+        switch internalState {
+        case .initial:
+            internalState = .running(makeTransition())
+            propertyAnimator.startAnimation(afterDelay: delay)
+        case .running:
+            // already running; do nothing
+            break
+        case .paused:
+            fatalError("A paused animator cannot be started with a delay.")
+        case .final:
+            // animators cannot be restarted
+            break
         }
-
-        internalState = .running(makeTransition())
-        propertyAnimator.startAnimation(afterDelay: delay)
     }
 
-    /// Pauses the animation.
+    /// See ``BasicCameraAnimator/pauseAnimation()``
     internal func pauseAnimation() {
         switch internalState {
         case .initial:
@@ -163,7 +169,8 @@ internal final class BasicCameraAnimatorImpl: BasicCameraAnimatorProtocol {
             // already paused; do nothing
             break
         case .final:
-            fatalError("Attempt to pause an animation that has already completed.")
+            // already completed; do nothing
+            break
         }
     }
 

--- a/Sources/MapboxMaps/Camera/CameraAnimator.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimator.swift
@@ -2,28 +2,29 @@ import UIKit
 
 public protocol CameraAnimator: Cancelable {
 
-    /// Stops the animation in its tracks and calls any provided completion
+    /// Stops the animation and calls any provided completion. Does nothing if the animator has already
+    /// completed.
     func stopAnimation()
 
-    /// The current state of the animation
+    /// The current state of the animation.
     var state: UIViewAnimatingState { get }
 }
 
 /// Internal-facing protocol to represent camera animators
 internal protocol CameraAnimatorProtocol: CameraAnimator {
-    /// the animation's owner
+    /// The animation's owner.
     var owner: AnimationOwner { get }
 
-    /// implementations must use a weak reference
+    /// Implementations must use a weak reference.
     var delegate: CameraAnimatorDelegate? { get set }
 
-    /// adds a completion block to the animator
+    /// Adds a completion block to the animator.
     func addCompletion(_ completion: @escaping AnimationCompletion)
 
-    /// starts the animation
+    /// Starts the animation. Does nothing if the animator has already completed.
     func startAnimation()
 
-    /// Called at each display link to allow animators to update the camera
+    /// Called at each display link to allow animators to update the camera.
     func update()
 }
 

--- a/Sources/MapboxMaps/Foundation/Enablable.swift
+++ b/Sources/MapboxMaps/Foundation/Enablable.swift
@@ -1,0 +1,23 @@
+internal protocol EnablableProtocol: AnyObject {
+    var isEnabled: Bool { get }
+}
+
+internal protocol MutableEnablableProtocol: EnablableProtocol {
+    var isEnabled: Bool { get set }
+}
+
+internal final class Enablable: MutableEnablableProtocol {
+    internal var isEnabled = true
+}
+
+internal final class CompositeEnablable: EnablableProtocol {
+    internal var isEnabled: Bool {
+        enablables.allSatisfy(\.isEnabled)
+    }
+
+    private let enablables: [EnablableProtocol]
+
+    internal init(enablables: [EnablableProtocol]) {
+        self.enablables = enablables
+    }
+}

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/AnyTouchGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/AnyTouchGestureHandler.swift
@@ -2,11 +2,11 @@ import UIKit
 
 internal final class AnyTouchGestureHandler: GestureHandler {
 
-    private let cameraAnimatorsRunner: CameraAnimatorsRunnerProtocol
+    private let cameraAnimatorsRunnerEnablable: MutableEnablableProtocol
 
     internal init(gestureRecognizer: UIGestureRecognizer,
-                  cameraAnimatorsRunner: CameraAnimatorsRunnerProtocol) {
-        self.cameraAnimatorsRunner = cameraAnimatorsRunner
+                  cameraAnimatorsRunnerEnablable: MutableEnablableProtocol) {
+        self.cameraAnimatorsRunnerEnablable = cameraAnimatorsRunnerEnablable
         super.init(gestureRecognizer: gestureRecognizer)
         gestureRecognizer.addTarget(self, action: #selector(handleGesture(_:)))
     }
@@ -14,9 +14,9 @@ internal final class AnyTouchGestureHandler: GestureHandler {
     @objc private func handleGesture(_ gestureRecognizer: AnyTouchGestureRecognizer) {
         switch gestureRecognizer.state {
         case .began:
-            cameraAnimatorsRunner.animationsEnabled = false
+            cameraAnimatorsRunnerEnablable.isEnabled = false
         case .ended, .cancelled:
-            cameraAnimatorsRunner.animationsEnabled = true
+            cameraAnimatorsRunnerEnablable.isEnabled = true
         default:
             break
         }

--- a/Tests/MapboxMapsTests/Camera/CameraAnimatorsRunnerTests.swift
+++ b/Tests/MapboxMapsTests/Camera/CameraAnimatorsRunnerTests.swift
@@ -2,19 +2,23 @@ import XCTest
 @testable import MapboxMaps
 
 final class CameraAnimatorsRunnerTests: XCTestCase {
+    var enablable: Enablable!
     var mapboxMap: MockMapboxMap!
     var cameraAnimatorsRunner: CameraAnimatorsRunner!
 
     override func setUp() {
         super.setUp()
+        enablable = Enablable()
         mapboxMap = MockMapboxMap()
         cameraAnimatorsRunner = CameraAnimatorsRunner(
-            mapboxMap: mapboxMap)
+            mapboxMap: mapboxMap,
+            enablable: enablable)
     }
 
     override func tearDown() {
         cameraAnimatorsRunner = nil
         mapboxMap = nil
+        enablable = nil
         super.tearDown()
     }
 
@@ -33,10 +37,10 @@ final class CameraAnimatorsRunnerTests: XCTestCase {
     }
 
     func testUpdateWithAnimationsEnabled() {
-        cameraAnimatorsRunner.animationsEnabled = true
         let animator = MockCameraAnimator()
         cameraAnimatorsRunner.add(animator)
         cameraAnimatorsRunner.cameraAnimatorDidStartRunning(animator)
+        enablable.isEnabled = true
 
         cameraAnimatorsRunner.update()
 
@@ -46,10 +50,10 @@ final class CameraAnimatorsRunnerTests: XCTestCase {
     }
 
     func testUpdateWithAnimationsDisabled() {
-        cameraAnimatorsRunner.animationsEnabled = false
         let animator = MockCameraAnimator()
         cameraAnimatorsRunner.add(animator)
         cameraAnimatorsRunner.cameraAnimatorDidStartRunning(animator)
+        enablable.isEnabled = false
 
         cameraAnimatorsRunner.update()
 
@@ -188,5 +192,27 @@ final class CameraAnimatorsRunnerTests: XCTestCase {
         cameraAnimatorsRunner.cameraAnimatorDidStopRunning(animator2)
         XCTAssertEqual(mapboxMap.beginAnimationStub.invocations.count, 2)
         XCTAssertEqual(mapboxMap.endAnimationStub.invocations.count, 2)
+    }
+
+    func testAddWithAnimationsEnabled() {
+        enablable.isEnabled = true
+
+        let animator = MockCameraAnimator()
+
+        cameraAnimatorsRunner.add(animator)
+
+        XCTAssertIdentical(animator.delegate, cameraAnimatorsRunner)
+        XCTAssertEqual(animator.stopAnimationStub.invocations.count, 0)
+    }
+
+    func testAddWithAnimationsDisabled() {
+        enablable.isEnabled = false
+
+        let animator = MockCameraAnimator()
+
+        cameraAnimatorsRunner.add(animator)
+
+        XCTAssertIdentical(animator.delegate, cameraAnimatorsRunner)
+        XCTAssertEqual(animator.stopAnimationStub.invocations.count, 1)
     }
 }

--- a/Tests/MapboxMapsTests/Camera/GestureDecelerationCameraAnimatorTests.swift
+++ b/Tests/MapboxMapsTests/Camera/GestureDecelerationCameraAnimatorTests.swift
@@ -60,6 +60,23 @@ final class GestureDecelerationCameraAnimatorTests: XCTestCase {
         XCTAssertTrue(delegate.cameraAnimatorDidStartRunningStub.invocations.first?.parameters === animator)
     }
 
+    func testStartAnimationWhenAlreadyRunning() {
+        animator.startAnimation()
+        delegate.cameraAnimatorDidStartRunningStub.reset()
+
+        animator.startAnimation()
+
+        XCTAssertEqual(delegate.cameraAnimatorDidStartRunningStub.invocations.count, 0)
+    }
+
+    func testStartAnimationWhenAlreadyComplete() {
+        animator.stopAnimation()
+
+        animator.startAnimation()
+
+        XCTAssertEqual(delegate.cameraAnimatorDidStartRunningStub.invocations.count, 0)
+    }
+
     func testStopAnimation() {
         animator.startAnimation()
 
@@ -69,6 +86,25 @@ final class GestureDecelerationCameraAnimatorTests: XCTestCase {
         XCTAssertEqual(completion.invocations.map(\.parameters), [.current])
         XCTAssertEqual(delegate.cameraAnimatorDidStopRunningStub.invocations.count, 1)
         XCTAssertTrue(delegate.cameraAnimatorDidStopRunningStub.invocations.first?.parameters === animator)
+    }
+
+    func testStopAnimationWithoutStarting() {
+        animator.stopAnimation()
+
+        XCTAssertEqual(animator.state, .inactive)
+        XCTAssertEqual(completion.invocations.map(\.parameters), [.current])
+        XCTAssertEqual(delegate.cameraAnimatorDidStopRunningStub.invocations.count, 0)
+    }
+
+    func testStopAnimationWhenAlreadyComplete() {
+        animator.stopAnimation()
+        completion.reset()
+
+        animator.stopAnimation()
+
+        XCTAssertEqual(animator.state, .inactive)
+        XCTAssertEqual(completion.invocations.count, 0)
+        XCTAssertEqual(delegate.cameraAnimatorDidStopRunningStub.invocations.count, 0)
     }
 
     func testUpdate() {

--- a/Tests/MapboxMapsTests/Camera/Mocks/MockPropertyAnimator.swift
+++ b/Tests/MapboxMapsTests/Camera/Mocks/MockPropertyAnimator.swift
@@ -19,6 +19,12 @@ final class MockPropertyAnimator: UIViewPropertyAnimator {
         startAnimationStub.call()
     }
 
+    let startAnimationAfterDelayStub = Stub<TimeInterval, Void>()
+    override func startAnimation(afterDelay delay: TimeInterval) {
+        super.startAnimation(afterDelay: delay)
+        startAnimationAfterDelayStub.call(with: delay)
+    }
+
     let pauseAnimationStub = Stub<Void, Void>()
     override func pauseAnimation() {
         super.pauseAnimation()

--- a/Tests/MapboxMapsTests/Foundation/EnablableTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/EnablableTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import MapboxMaps
+
+final class EnablableTests: XCTestCase {
+    func testIsEnabledDefault() {
+        let enablable = Enablable()
+
+        XCTAssertTrue(enablable.isEnabled)
+    }
+}
+
+final class CompositeEnablableTests: XCTestCase {
+
+    func testIsEnabledWithZeroChildren() {
+        let composite = CompositeEnablable(enablables: [])
+
+        XCTAssertTrue(composite.isEnabled)
+    }
+
+    func testIsEnabledWithOneChild() {
+        let child = Enablable()
+        let composite = CompositeEnablable(enablables: [child])
+
+        child.isEnabled = .random()
+
+        XCTAssertEqual(composite.isEnabled, child.isEnabled)
+    }
+
+    func testIsEnabledWithTwoChildrenBothEnabled() {
+        let child1 = Enablable()
+        let child2 = Enablable()
+        let composite = CompositeEnablable(enablables: [child1, child2])
+
+        child1.isEnabled = true
+        child2.isEnabled = true
+
+        XCTAssertTrue(composite.isEnabled)
+    }
+
+    func testIsEnabledWithTwoChildrenOneEnabled() {
+        let child1 = Enablable()
+        let child2 = Enablable()
+        let composite = CompositeEnablable(enablables: [child1, child2])
+
+        child1.isEnabled = .random()
+        child2.isEnabled = !child1.isEnabled
+
+        XCTAssertFalse(composite.isEnabled)
+    }
+
+    func testIsEnabledWithTwoChildrenNeitherEnabled() {
+        let child1 = Enablable()
+        let child2 = Enablable()
+        let composite = CompositeEnablable(enablables: [child1, child2])
+
+        child1.isEnabled = false
+        child2.isEnabled = false
+
+        XCTAssertFalse(composite.isEnabled)
+    }
+}

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
@@ -2,20 +2,13 @@ import Foundation
 @testable import MapboxMaps
 
 final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
-    let makeNotificationCenterStub = Stub<Void, NotificationCenterProtocol>(defaultReturnValue: MockNotificationCenter())
-    func makeNotificationCenter() -> NotificationCenterProtocol {
-        makeNotificationCenterStub.call()
-    }
+    @Stubbed var notificationCenter: NotificationCenterProtocol = MockNotificationCenter()
 
-    let makeBundleStub = Stub<Void, BundleProtocol>(defaultReturnValue: MockBundle())
-    func makeBundle() -> BundleProtocol {
-        makeBundleStub.call()
-    }
+    @Stubbed var bundle: BundleProtocol = MockBundle()
 
-    let makeMapboxObservableProviderStub = Stub<Void, (ObservableProtocol) -> MapboxObservableProtocol>(defaultReturnValue: { _ in MockMapboxObservable() })
-    func makeMapboxObservableProvider() -> (ObservableProtocol) -> MapboxObservableProtocol {
-        makeMapboxObservableProviderStub.call()
-    }
+    @Stubbed var mapboxObservableProvider: (ObservableProtocol) -> MapboxObservableProtocol = { _ in MockMapboxObservable() }
+
+    @Stubbed var cameraAnimatorsRunnerEnablable: MutableEnablableProtocol = Enablable()
 
     struct MakeMetalViewParams {
         var frame: CGRect
@@ -59,8 +52,7 @@ final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
     func makeGestureManager(
         view: UIView,
         mapboxMap: MapboxMapProtocol,
-        cameraAnimationsManager: CameraAnimationsManagerProtocol,
-        cameraAnimatorsRunner: CameraAnimatorsRunnerProtocol) -> GestureManager {
+        cameraAnimationsManager: CameraAnimationsManagerProtocol) -> GestureManager {
         return GestureManager(
             panGestureHandler: MockPanGestureHandler(
                 gestureRecognizer: UIGestureRecognizer()),

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMutableEnablable.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMutableEnablable.swift
@@ -1,0 +1,5 @@
+@testable import MapboxMaps
+
+final class MockMutableEnablable: MutableEnablableProtocol {
+    @Stubbed var isEnabled: Bool = true
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/AnyTouchGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/AnyTouchGestureHandlerTests.swift
@@ -4,21 +4,21 @@ import XCTest
 final class AnyTouchGestureHandlerTests: XCTestCase {
 
     var gestureRecognizer: MockGestureRecognizer!
-    var cameraAnimatorsRunner: MockCameraAnimatorsRunner!
+    var cameraAnimatorsRunnerEnablable: MockMutableEnablable!
     var gestureHandler: AnyTouchGestureHandler!
 
     override func setUp() {
         super.setUp()
         gestureRecognizer = MockGestureRecognizer()
-        cameraAnimatorsRunner = MockCameraAnimatorsRunner()
+        cameraAnimatorsRunnerEnablable = MockMutableEnablable()
         gestureHandler = AnyTouchGestureHandler(
             gestureRecognizer: gestureRecognizer,
-            cameraAnimatorsRunner: cameraAnimatorsRunner)
+            cameraAnimatorsRunnerEnablable: cameraAnimatorsRunnerEnablable)
     }
 
     override func tearDown() {
         gestureHandler = nil
-        cameraAnimatorsRunner = nil
+        cameraAnimatorsRunnerEnablable = nil
         gestureRecognizer = nil
         super.tearDown()
     }
@@ -27,20 +27,20 @@ final class AnyTouchGestureHandlerTests: XCTestCase {
         gestureRecognizer.getStateStub.defaultReturnValue = .began
         gestureRecognizer.sendActions()
 
-        XCTAssertEqual(cameraAnimatorsRunner.$animationsEnabled.setStub.invocations.map(\.parameters), [false])
+        XCTAssertEqual(cameraAnimatorsRunnerEnablable.$isEnabled.setStub.invocations.map(\.parameters), [false])
     }
 
     func testGestureEnded() {
         gestureRecognizer.getStateStub.defaultReturnValue = .ended
         gestureRecognizer.sendActions()
 
-        XCTAssertEqual(cameraAnimatorsRunner.$animationsEnabled.setStub.invocations.map(\.parameters), [true])
+        XCTAssertEqual(cameraAnimatorsRunnerEnablable.$isEnabled.setStub.invocations.map(\.parameters), [true])
     }
 
     func testGestureCancelled() {
         gestureRecognizer.getStateStub.defaultReturnValue = .cancelled
         gestureRecognizer.sendActions()
 
-        XCTAssertEqual(cameraAnimatorsRunner.$animationsEnabled.setStub.invocations.map(\.parameters), [true])
+        XCTAssertEqual(cameraAnimatorsRunnerEnablable.$isEnabled.setStub.invocations.map(\.parameters), [true])
     }
 }

--- a/Tests/MapboxMapsTests/Helpers/Stub.swift
+++ b/Tests/MapboxMapsTests/Helpers/Stub.swift
@@ -77,4 +77,9 @@ final class Stubbed<T> {
             getStub.defaultReturnValue = newValue
         }
     }
+
+    func reset() {
+        getStub.reset()
+        setStub.reset()
+    }
 }


### PR DESCRIPTION
Fixes #1119

* Update `MapView` to disable animations whenever it does not have a display link. See analysis here https://github.com/mapbox/mapbox-maps-ios/issues/1119#issuecomment-1061076964 for more information.
* Update `CameraAnimatorsRunner` to cancel newly-added animators immediately if animations are disabled.
* Introduce `EnablableProtocol` to allow separate components to independently control whether animations are enabled without needing to worry about balancing disable/enable calls. `MapView` and `AnyTouchGestureHandler` are each injected with a unique `MutableEnablableProtocol` that they can use to disable animations, while `CameraAnimatorsRunner` is injected with an `EnablableProtocol` (concretely, a `CompositeEnablable`) that provides it with a view onto the final enabled/disabled decision.
* Relax some constraints on `CameraAnimator` to make it safe for animators to be canceled synchronously when they are being created.
    * Ignore calls to `BasicCameraAnimator.startAnimation()` when the animator is already complete (instead of fatalError).
    * Ignore calls to `BasicCameraAnimator.startAnimation(afterDelay:)` when the animator is running or already complete (instead of fatalError). Calling this method on a paused animator still results in fatalError (matches UIViewPropertyAnimator behavior).
    * Ignore calls to `BasicCameraAnimator.pauseAnimation()` when the animator is already complete (instead of fatalError).
    * Update the documentation for `CameraAnimator.stopAnimation()` and `CameraAnimatorProtocol.startAnimation()` to describe how they should behave when called on animators that are already complete.
    * Update `FlyToCameraAnimator` and `GestureDecelerationCameraAnimator` to behave according to these updated expectations.
* Update `MapViewDependencyProvider` to start to abstract away more of the object graph creation from `MapView`.
* Accept Xcode 13.3 upgrade checks

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
