### PR TITLE
Improve AnyTouchGestureRecognizer state management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.
 * `BasicCameraAnimator.cancel()` and `.stopAnimation()` now invoke the completion blocks with `UIViewAnimatingPosition.current` instead of crashing with a `fatalError` when invoked prior to `.startAnimation()` or `.startAnimation(afterDelay:)`. ([#1197](https://github.com/mapbox/mapbox-maps-ios/pull/1197))
 * `CameraAnimationsManager.stopAnimations()` will now cancel all animators regardless of their state. Previously, only animators with `state == .active` were canceled. ([#1197](https://github.com/mapbox/mapbox-maps-ios/pull/1197))
 * Fix animator-related leaks. ([#1200](https://github.com/mapbox/mapbox-maps-ios/pull/1200))
+* Improve AnyTouchGestureRecognizer's interaction with other gesture recognizers. ([#1210](https://github.com/mapbox/mapbox-maps-ios/pull/1210))
 
 ## 10.4.0-rc.1 - March 9, 2022
 

--- a/Sources/MapboxMaps/Gestures/GestureRecognizers/AnyTouchGestureRecognizer.swift
+++ b/Sources/MapboxMaps/Gestures/GestureRecognizers/AnyTouchGestureRecognizer.swift
@@ -26,6 +26,7 @@ internal final class AnyTouchGestureRecognizer: UIGestureRecognizer {
                 case .began, .changed:
                     state = .ended
                 default:
+                    state = .failed
                     break
                 }
             }

--- a/Sources/MapboxMaps/Gestures/GestureRecognizers/AnyTouchGestureRecognizer.swift
+++ b/Sources/MapboxMaps/Gestures/GestureRecognizers/AnyTouchGestureRecognizer.swift
@@ -27,7 +27,6 @@ internal final class AnyTouchGestureRecognizer: UIGestureRecognizer {
                     state = .ended
                 default:
                     state = .failed
-                    break
                 }
             }
         }

--- a/Tests/MapboxMapsTests/Gestures/GestureRecognizers/AnyTouchGestureRecognizerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureRecognizers/AnyTouchGestureRecognizerTests.swift
@@ -104,10 +104,10 @@ final class AnyTouchGestureRecognizerTests: XCTestCase {
         // touch ends
         gestureRecognizer.touchesEnded([touch], with: event)
 
-        // the timer is invalidated and the state does not change
+        // the timer is invalidated and the state is set to .failed
         let timer = try XCTUnwrap(makeTimerInvocation.returnValue as? MockTimer)
         XCTAssertEqual(timer.invalidateStub.invocations.count, 1)
-        XCTAssertEqual(gestureRecognizer.state, .possible)
+        XCTAssertEqual(gestureRecognizer.state, .failed)
     }
 
     func testTouchHandlingWithChangedTouches() throws {


### PR DESCRIPTION
* Sets AnyTouchGestureRecognizer.state to .failed if touches last less
  than the minimumPressDuration. This improves interaction with other
  gesture recognizers.

Fixes #1194

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
