### PR TITLE
Update to match GL-JS example

### DIFF
--- a/Apps/Examples/Examples/All Examples/ExternalVectorSourceExample.swift
+++ b/Apps/Examples/Examples/All Examples/ExternalVectorSourceExample.swift
@@ -24,19 +24,19 @@ public class ExternalVectorSourceExample: UIViewController, ExampleProtocol {
 
     public func drawLineLayer() {
 
-        let sourceIdentifier = "data-source"
+        let sourceIdentifier = "mapillary"
 
         var vectorSource = VectorSource()
 
         // For sources using the {z}/{x}/{y} URL scheme, use the `tiles`
         // property on `VectorSource` to set the URL.
-        vectorSource.tiles = ["https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt"]
+        vectorSource.tiles = ["https://tiles.mapillary.com/maps/vtp/mly1_public/2/{z}/{x}/{y}?access_token=MLY%7C4142433049200173%7C72206abe5035850d6743b23a49c41333"]
         vectorSource.minzoom = 6
         vectorSource.maxzoom = 14
 
         var lineLayer = LineLayer(id: "line-layer")
         lineLayer.source = sourceIdentifier
-        lineLayer.sourceLayer = "mapillary-sequences"
+        lineLayer.sourceLayer = "sequence"
         let lineColor = StyleColor(UIColor(red: 0.21, green: 0.69, blue: 0.43, alpha: 1.00))
         lineLayer.lineColor = .constant(lineColor)
         lineLayer.lineOpacity = .constant(0.6)


### PR DESCRIPTION
Modify URL, source ID, source layer to match [GL-JS example](https://docs.mapbox.com/mapbox-gl-js/example/third-party/) in the external vector source example. This PR will also fix the errors that caused the external vector layer to not load on the map using the workaround for the URL mentioned in this [issue](https://github.com/mapbox/mapbox-maps-ios/issues/1211).

<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [x] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).

cc: @pjleonard37 @azarovalex 