### PR TITLE
Add SimpleCameraAnimator

### DIFF
--- a/Sources/MapboxMaps/Camera/CameraAnimationsManagerImpl.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimationsManagerImpl.swift
@@ -44,6 +44,12 @@ internal protocol CameraAnimationsManagerProtocol: AnyObject {
                       dampingRatio: CGFloat,
                       animationOwner: AnimationOwner,
                       animations: @escaping (inout CameraTransition) -> Void) -> BasicCameraAnimator
+
+    func makeSimpleCameraAnimator(from: CameraOptions,
+                                  to: CameraOptions,
+                                  duration: TimeInterval,
+                                  curve: TimingCurve,
+                                  owner: AnimationOwner) -> SimpleCameraAnimatorProtocol
 }
 
 internal final class CameraAnimationsManagerImpl: CameraAnimationsManagerProtocol {
@@ -205,6 +211,21 @@ internal final class CameraAnimationsManagerImpl: CameraAnimationsManagerProtoco
             animationOwner: animationOwner,
             animations: animations)
         let animator = BasicCameraAnimator(impl: animatorImpl)
+        runner.add(animator)
+        return animator
+    }
+
+    internal func makeSimpleCameraAnimator(from: CameraOptions,
+                                           to: CameraOptions,
+                                           duration: TimeInterval,
+                                           curve: TimingCurve,
+                                           owner: AnimationOwner) -> SimpleCameraAnimatorProtocol {
+        let animator = factory.makeSimpleCameraAnimator(
+            from: from,
+            to: to,
+            duration: duration,
+            curve: curve,
+            owner: owner)
         runner.add(animator)
         return animator
     }

--- a/Sources/MapboxMaps/Camera/CameraAnimatorsFactory.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimatorsFactory.swift
@@ -26,6 +26,11 @@ internal protocol CameraAnimatorsFactoryProtocol: AnyObject {
                                                decelerationFactor: CGFloat,
                                                animationOwner: AnimationOwner,
                                                locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void) -> CameraAnimatorProtocol
+    func makeSimpleCameraAnimator(from: CameraOptions,
+                                  to: CameraOptions,
+                                  duration: TimeInterval,
+                                  curve: TimingCurve,
+                                  owner: AnimationOwner) -> SimpleCameraAnimatorProtocol
 }
 
 internal final class CameraAnimatorsFactory: CameraAnimatorsFactoryProtocol {
@@ -33,13 +38,16 @@ internal final class CameraAnimatorsFactory: CameraAnimatorsFactoryProtocol {
     private let cameraViewContainerView: UIView
     private let mapboxMap: MapboxMapProtocol
     private let dateProvider: DateProvider
+    private let cameraOptionsInterpolator: CameraOptionsInterpolatorProtocol
 
     internal init(cameraViewContainerView: UIView,
                   mapboxMap: MapboxMapProtocol,
-                  dateProvider: DateProvider) {
+                  dateProvider: DateProvider,
+                  cameraOptionsInterpolator: CameraOptionsInterpolatorProtocol) {
         self.cameraViewContainerView = cameraViewContainerView
         self.mapboxMap = mapboxMap
         self.dateProvider = dateProvider
+        self.cameraOptionsInterpolator = cameraOptionsInterpolator
     }
 
     internal func makeFlyToAnimator(toCamera: CameraOptions,
@@ -132,6 +140,22 @@ internal final class CameraAnimatorsFactory: CameraAnimatorsFactoryProtocol {
             decelerationFactor: decelerationFactor,
             owner: animationOwner,
             locationChangeHandler: locationChangeHandler,
+            dateProvider: dateProvider)
+    }
+
+    internal func makeSimpleCameraAnimator(from: CameraOptions,
+                                           to: CameraOptions,
+                                           duration: TimeInterval,
+                                           curve: TimingCurve,
+                                           owner: AnimationOwner) -> SimpleCameraAnimatorProtocol {
+        return SimpleCameraAnimator(
+            from: from,
+            to: to,
+            duration: duration,
+            curve: curve,
+            owner: owner,
+            mapboxMap: mapboxMap,
+            cameraOptionsInterpolator: cameraOptionsInterpolator,
             dateProvider: dateProvider)
     }
 }

--- a/Sources/MapboxMaps/Camera/SimpleCameraAnimator.swift
+++ b/Sources/MapboxMaps/Camera/SimpleCameraAnimator.swift
@@ -172,9 +172,8 @@ internal final class SimpleCameraAnimator: NSObject, SimpleCameraAnimatorProtoco
     }
 
     private func invokeCompletionBlocks(with position: UIViewAnimatingPosition) {
-        let handlers = completionHandlers
-        for handler in handlers {
-            handler(position)
+        for completionHandler in completionHandlers {
+            completionHandler(position)
         }
         completionHandlers.removeAll()
     }

--- a/Sources/MapboxMaps/Camera/SimpleCameraAnimator.swift
+++ b/Sources/MapboxMaps/Camera/SimpleCameraAnimator.swift
@@ -1,0 +1,214 @@
+@_implementationOnly import MapboxCommon_Private
+
+internal protocol SimpleCameraAnimatorProtocol: CameraAnimatorProtocol {
+    var to: CameraOptions { get set }
+    func startAnimation(afterDelay delay: TimeInterval)
+}
+
+/// A camera animator that offers cubic bezier easing, delayed start, and a dynamically-updatable target
+/// camera.
+///
+/// This animator has some overlap in functionality with ``BasicCameraAnimator``; however, since it
+/// uses direct interpolation rather than interpolation via ``CameraView``, it has a simpler implementation
+/// and enables more advanced use cases like dynamically updating ``SimpleCameraAnimator/to``.
+internal final class SimpleCameraAnimator: NSObject, SimpleCameraAnimatorProtocol {
+    private enum InternalState: Equatable {
+        case initial
+        case running(startDate: Date)
+        case final
+    }
+
+    /// The animator's owner
+    internal let owner: AnimationOwner
+
+    private let from: CameraOptions
+
+    /// The target camera.
+    ///
+    /// This property can be updated dynamically while the animation is running, but it should
+    /// generally maintain the same set of non-nil fields since nil fields will not be updated during the
+    /// animation. For best results, the difference between old and new `to` should be small relative
+    /// to the difference between `from` and `to`.
+    internal var to: CameraOptions {
+        didSet {
+            func hasNilMismatch<T>(for keyPath: KeyPath<CameraOptions, T?>) -> Bool {
+                return (oldValue[keyPath: keyPath] == nil) != (to[keyPath: keyPath] == nil)
+            }
+            if hasNilMismatch(for: \.center) ||
+                hasNilMismatch(for: \.zoom) ||
+                hasNilMismatch(for: \.padding) ||
+                hasNilMismatch(for: \.anchor) ||
+                hasNilMismatch(for: \.bearing) ||
+                hasNilMismatch(for: \.pitch) {
+                Log.warning(forMessage: "Animator updated with differing non-nil to-value properties.", category: "maps-ios")
+            }
+        }
+    }
+
+    private let duration: TimeInterval
+    private let unitBezier: UnitBezier
+    private let mapboxMap: MapboxMapProtocol
+    private let cameraOptionsInterpolator: CameraOptionsInterpolatorProtocol
+    private let dateProvider: DateProvider
+    internal weak var delegate: CameraAnimatorDelegate?
+
+    private var completionHandlers = [AnimationCompletion]()
+
+    /// The state of the animation. While the animation is running, the value is `.active`. Otherwise, the
+    /// value is `.inactive`.
+    internal var state: UIViewAnimatingState {
+        switch internalState {
+        case .running:
+            return .active
+        case .initial, .final:
+            return .inactive
+        }
+    }
+
+    private var internalState = InternalState.initial {
+        didSet {
+            switch (oldValue, internalState) {
+            case (.initial, .running):
+                delegate?.cameraAnimatorDidStartRunning(self)
+            case (.running, .final):
+                delegate?.cameraAnimatorDidStopRunning(self)
+            default:
+                // this matches cases where…
+                // * oldValue and internalState are the same
+                // * initial transitions to final
+                // * the transition is invalid…
+                //     * running/final --> initial
+                //     * final --> running
+                break
+            }
+        }
+    }
+
+    /// Initializes a new ``SimpleCameraAnimator``.
+    /// - Parameters:
+    ///   - from: The initial camera.
+    ///   - to: The target camera.
+    ///   - duration: How long the animation should take.
+    ///   - curve: Allows applying easing effects.
+    ///   - mapboxMap: The map whose camera should be updated.
+    ///   - cameraOptionsInterpolator: An object that calculates interpolated camera values.
+    ///   - dateProvider: An object that provides the current date.
+    ///   - delegate: A delegate to inform when the animation starts or stops running.
+    internal init(from: CameraOptions,
+                  to: CameraOptions,
+                  duration: TimeInterval,
+                  curve: TimingCurve,
+                  owner: AnimationOwner,
+                  mapboxMap: MapboxMapProtocol,
+                  cameraOptionsInterpolator: CameraOptionsInterpolatorProtocol,
+                  dateProvider: DateProvider) {
+        self.from = from
+        self.to = to
+        self.duration = duration
+        self.unitBezier = UnitBezier(p1: curve.p1, p2: curve.p2)
+        self.owner = owner
+        self.mapboxMap = mapboxMap
+        self.cameraOptionsInterpolator = cameraOptionsInterpolator
+        self.dateProvider = dateProvider
+        super.init()
+    }
+
+    internal func startAnimation() {
+        startAnimation(afterDelay: 0)
+    }
+
+    /// Starts the animation.
+    ///
+    /// This method sets ``BasicCameraAnimator/state`` to `.active` immediately regardless
+    /// of `delay`. It also call the delegate to indicate that it has started running. Does nothing if `state`
+    /// is not `.inactive`.
+    /// - Parameter delay: An amount of time to wait before beginning to update the map's camera.
+    internal func startAnimation(afterDelay delay: TimeInterval) {
+        switch internalState {
+        case .initial:
+            internalState = .running(startDate: dateProvider.now + delay)
+        case .running:
+            // already running; do nothing
+            break
+        case .final:
+            // animators cannot be restarted
+            break
+        }
+    }
+
+    /// Cancels the animation.
+    ///
+    /// This method sets ``BasicCameraAnimator/state`` to `.inactive`, informs the delegate
+    /// that the animation has stopped running, and clears and invokes
+    /// ``SimpleCameraAnimator/completion``. Does nothing if `state` is not `.active`.
+    internal func cancel() {
+        switch internalState {
+        case .initial, .running:
+            internalState = .final
+            invokeCompletionBlocks(with: .current) // `current` represents an interrupted animation.
+        case .final:
+            // Already stopped, so do nothing
+            break
+        }
+    }
+
+    /// An alias for ``SimpleCameraAnimator/cancel()``.
+    internal func stopAnimation() {
+        cancel()
+    }
+
+    /// Adds completion to the list of completion handlers to be invoked when the animation completes or is
+    /// canceled. If the animation has already completed or been canceled, this method does nothing.
+    /// The animator only holds a strong reference to the handler until it finishes or is canceled.
+    /// - Parameter completion: A handler to invoke when the animator completes.
+    internal func addCompletion(_ completion: @escaping AnimationCompletion) {
+        switch internalState {
+        case .initial, .running:
+            completionHandlers.append(completion)
+        case .final:
+            // already stopped, so do nothing
+            break
+        }
+    }
+
+    private func invokeCompletionBlocks(with position: UIViewAnimatingPosition) {
+        let handlers = completionHandlers
+        for handler in handlers {
+            handler(position)
+        }
+        completionHandlers.removeAll()
+    }
+
+    /// Updates the map camera.
+    ///
+    /// For running animations, this method calculates the elapsed time since
+    /// ``SimpleCameraAnimator/startAnimation(afterDelay:)`` was invoked plus any
+    /// delay, and, if that value is non-negative, applies the timing function to get a fraction complete,
+    /// computes an interpolated camera given that fraction, ``SimpleCameraAnimator/from``, and
+    /// ``SimpleCameraAnimator/to``, and sets the camera on the map.
+    ///
+    /// If the fraction complete is greater than or equal to 1, it sets the camera one final time to `to`,
+    /// sets ``SimpleCameraAnimator/state`` to `.inactive`, informs the delegate that it
+    /// has stopped running, and clears and invokes ``SimpleCameraAnimator/completion``.
+    internal func update() {
+        guard case .running(let startDate) = internalState else {
+            return
+        }
+        let elapsedTime = dateProvider.now.timeIntervalSince(startDate)
+        guard elapsedTime >= 0 else {
+            return
+        }
+        let fractionComplete = unitBezier.solve(min(elapsedTime / duration, 1), 1e-6)
+        guard fractionComplete < 1 else {
+            mapboxMap.setCamera(to: to)
+            internalState = .final
+            invokeCompletionBlocks(with: .end)
+            return
+        }
+        let camera = cameraOptionsInterpolator.interpolate(
+            from: from,
+            to: to,
+            fraction: fractionComplete)
+        mapboxMap.setCamera(to: camera)
+    }
+}

--- a/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
+++ b/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
@@ -57,11 +57,28 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
     internal func makeCameraAnimationsManagerImpl(cameraViewContainerView: UIView,
                                                   mapboxMap: MapboxMapProtocol,
                                                   cameraAnimatorsRunner: CameraAnimatorsRunnerProtocol) -> CameraAnimationsManagerProtocol {
-        CameraAnimationsManagerImpl(
+        let doubleInterpolator = DoubleInterpolator()
+        let wrappingInterpolator = WrappingInterpolator()
+        let longitudeInterpolator = LongitudeInterpolator(
+            wrappingInterpolator: wrappingInterpolator)
+        let coordinateInterpolator = CoordinateInterpolator(
+            doubleInterpolator: doubleInterpolator,
+            longitudeInterpolator: longitudeInterpolator)
+        let uiEdgeInsetsInterpolator = UIEdgeInsetsInterpolator(
+            doubleInterpolator: doubleInterpolator)
+        let directionInterpolator = DirectionInterpolator(
+            wrappingInterpolator: wrappingInterpolator)
+        let cameraOptionsInterpolator = CameraOptionsInterpolator(
+            coordinateInterpolator: coordinateInterpolator,
+            uiEdgeInsetsInterpolator: uiEdgeInsetsInterpolator,
+            doubleInterpolator: doubleInterpolator,
+            directionInterpolator: directionInterpolator)
+        return CameraAnimationsManagerImpl(
             factory: CameraAnimatorsFactory(
                 cameraViewContainerView: cameraViewContainerView,
                 mapboxMap: mapboxMap,
-                dateProvider: DefaultDateProvider()),
+                dateProvider: DefaultDateProvider(),
+                cameraOptionsInterpolator: cameraOptionsInterpolator),
             runner: cameraAnimatorsRunner)
     }
 

--- a/Tests/MapboxMapsTests/Camera/CameraAnimationsManagerImplTests.swift
+++ b/Tests/MapboxMapsTests/Camera/CameraAnimationsManagerImplTests.swift
@@ -377,4 +377,33 @@ final class CameraAnimationsManagerImplTests: XCTestCase {
             animatorImpl: animatorImpl,
             returnedAnimator: animator)
     }
+
+    func testMakeSimpleCameraAnimator() throws {
+        let from = CameraOptions.random()
+        let to = CameraOptions.random()
+        let duration = TimeInterval.random(in: 0...10)
+        let curve = TimingCurve.random()
+        let owner = AnimationOwner.random()
+
+        let animator = impl.makeSimpleCameraAnimator(
+            from: from,
+            to: to,
+            duration: duration,
+            curve: curve,
+            owner: owner)
+
+        // creates animator
+        XCTAssertEqual(factory.makeSimpleCameraAnimatorStub.invocations.count, 1)
+        let factoryInvocation = try XCTUnwrap(factory.makeSimpleCameraAnimatorStub.invocations.first)
+        XCTAssertEqual(factoryInvocation.parameters.from, from)
+        XCTAssertEqual(factoryInvocation.parameters.to, to)
+        XCTAssertEqual(factoryInvocation.parameters.duration, duration)
+        XCTAssertEqual(factoryInvocation.parameters.curve, curve)
+        XCTAssertEqual(factoryInvocation.parameters.owner, owner)
+        let returnedAnimator = try XCTUnwrap(factoryInvocation.returnValue as? MockSimpleCameraAnimator)
+
+        XCTAssertEqual(runner.addStub.invocations.count, 1)
+        XCTAssertIdentical(runner.addStub.invocations.first?.parameters, returnedAnimator)
+        XCTAssertIdentical(animator, returnedAnimator)
+    }
 }

--- a/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimationsManager.swift
+++ b/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimationsManager.swift
@@ -41,6 +41,28 @@ final class MockCameraAnimationsManager: CameraAnimationsManagerProtocol {
                 completion: completion))
     }
 
+    struct DecelerateParams {
+        var location: CGPoint
+        var velocity: CGPoint
+        var decelerationFactor: CGFloat
+        var locationChangeHandler: (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void
+        var completion: AnimationCompletion?
+    }
+    let decelerateStub = Stub<DecelerateParams, Void>()
+    func decelerate(location: CGPoint,
+                    velocity: CGPoint,
+                    decelerationFactor: CGFloat,
+                    locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void,
+                    completion: AnimationCompletion?) {
+        decelerateStub.call(
+            with: DecelerateParams(
+                location: location,
+                velocity: velocity,
+                decelerationFactor: decelerationFactor,
+                locationChangeHandler: locationChangeHandler,
+                completion: completion))
+    }
+
     struct MakeAnimatorWithTimingParametersParams {
         var duration: TimeInterval
         var timingParameters: UITimingCurveProvider
@@ -120,25 +142,27 @@ final class MockCameraAnimationsManager: CameraAnimationsManagerProtocol {
             animations: animations))
     }
 
-    struct DecelerateParameters {
-        var location: CGPoint
-        var velocity: CGPoint
-        var decelerationFactor: CGFloat
-        var locationChangeHandler: (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void
-        var completion: AnimationCompletion?
+    struct MakeSimpleCameraAnimatorParams {
+        var from: CameraOptions
+        var to: CameraOptions
+        var duration: TimeInterval
+        var curve: TimingCurve
+        var owner: AnimationOwner
     }
-    let decelerateStub = Stub<DecelerateParameters, Void>()
-    func decelerate(location: CGPoint,
-                    velocity: CGPoint,
-                    decelerationFactor: CGFloat,
-                    locationChangeHandler: @escaping (_ fromLocation: CGPoint, _ toLocation: CGPoint) -> Void,
-                    completion: AnimationCompletion?) {
-        decelerateStub.call(
-            with: DecelerateParameters(
-                location: location,
-                velocity: velocity,
-                decelerationFactor: decelerationFactor,
-                locationChangeHandler: locationChangeHandler,
-                completion: completion))
+    let makeSimpleCameraAnimatorStub = Stub<
+        MakeSimpleCameraAnimatorParams,
+        SimpleCameraAnimatorProtocol>(
+            defaultReturnValue: MockSimpleCameraAnimator())
+    func makeSimpleCameraAnimator(from: CameraOptions,
+                                  to: CameraOptions,
+                                  duration: TimeInterval,
+                                  curve: TimingCurve,
+                                  owner: AnimationOwner) -> SimpleCameraAnimatorProtocol {
+        makeSimpleCameraAnimatorStub.call(with: .init(
+            from: from,
+            to: to,
+            duration: duration,
+            curve: curve,
+            owner: owner))
     }
 }

--- a/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimatorsFactory.swift
+++ b/Tests/MapboxMapsTests/Camera/Mocks/MockCameraAnimatorsFactory.swift
@@ -127,4 +127,28 @@ final class MockCameraAnimatorsFactory: CameraAnimatorsFactoryProtocol {
             animationOwner: animationOwner,
             locationChangeHandler: locationChangeHandler))
     }
+
+    struct MakeSimpleCameraAnimatorParams {
+        var from: CameraOptions
+        var to: CameraOptions
+        var duration: TimeInterval
+        var curve: TimingCurve
+        var owner: AnimationOwner
+    }
+    let makeSimpleCameraAnimatorStub = Stub<
+        MakeSimpleCameraAnimatorParams,
+        SimpleCameraAnimatorProtocol>(
+            defaultReturnValue: MockSimpleCameraAnimator())
+    func makeSimpleCameraAnimator(from: CameraOptions,
+                                  to: CameraOptions,
+                                  duration: TimeInterval,
+                                  curve: TimingCurve,
+                                  owner: AnimationOwner) -> SimpleCameraAnimatorProtocol {
+        makeSimpleCameraAnimatorStub.call(with: .init(
+            from: from,
+            to: to,
+            duration: duration,
+            curve: curve,
+            owner: owner))
+    }
 }

--- a/Tests/MapboxMapsTests/Camera/Mocks/MockCameraOptionsInterpolator.swift
+++ b/Tests/MapboxMapsTests/Camera/Mocks/MockCameraOptionsInterpolator.swift
@@ -1,0 +1,13 @@
+@testable import MapboxMaps
+
+final class MockCameraOptionsInterpolator: CameraOptionsInterpolatorProtocol {
+    struct InterpolateParams {
+        var from: CameraOptions
+        var to: CameraOptions
+        var fraction: Double
+    }
+    let interpolateStub = Stub<InterpolateParams, CameraOptions>(defaultReturnValue: .random())
+    func interpolate(from: CameraOptions, to: CameraOptions, fraction: Double) -> CameraOptions {
+        interpolateStub.call(with: .init(from: from, to: to, fraction: fraction))
+    }
+}

--- a/Tests/MapboxMapsTests/Camera/Mocks/MockSimpleCameraAnimator.swift
+++ b/Tests/MapboxMapsTests/Camera/Mocks/MockSimpleCameraAnimator.swift
@@ -1,0 +1,41 @@
+@testable import MapboxMaps
+
+final class MockSimpleCameraAnimator: SimpleCameraAnimatorProtocol {
+    @Stubbed var state: UIViewAnimatingState = .inactive
+
+    @Stubbed var owner: AnimationOwner = .random()
+
+    @Stubbed var delegate: CameraAnimatorDelegate?
+
+    @Stubbed var to: CameraOptions = .random()
+
+    let cancelStub = Stub<Void, Void>()
+    func cancel() {
+        cancelStub.call()
+    }
+
+    let stopAnimationStub = Stub<Void, Void>()
+    func stopAnimation() {
+        stopAnimationStub.call()
+    }
+
+    let addCompletionStub = Stub<AnimationCompletion, Void>()
+    func addCompletion(_ completion: @escaping AnimationCompletion) {
+        addCompletionStub.call(with: completion)
+    }
+
+    let startAnimationStub = Stub<Void, Void>()
+    func startAnimation() {
+        startAnimationStub.call()
+    }
+
+    let startAnimationAfterDelayStub = Stub<TimeInterval, Void>()
+    func startAnimation(afterDelay delay: TimeInterval) {
+        startAnimationAfterDelayStub.call(with: delay)
+    }
+
+    let updateStub = Stub<Void, Void>()
+    func update() {
+        updateStub.call()
+    }
+}

--- a/Tests/MapboxMapsTests/Camera/SimpleCameraAnimatorTests.swift
+++ b/Tests/MapboxMapsTests/Camera/SimpleCameraAnimatorTests.swift
@@ -1,0 +1,382 @@
+@testable import MapboxMaps
+import XCTest
+
+final class SimpleCameraAnimatorTests: XCTestCase {
+
+    var from: CameraOptions!
+    var to: CameraOptions!
+    var duration: TimeInterval!
+    var curve: TimingCurve!
+    var owner: AnimationOwner!
+    var mapboxMap: MockMapboxMap!
+    var cameraOptionsInterpolator: MockCameraOptionsInterpolator!
+    var dateProvider: MockDateProvider!
+    var animator: SimpleCameraAnimator!
+    var delegate: MockCameraAnimatorDelegate!
+
+    override func setUp() {
+        super.setUp()
+        from = .random()
+        to = .random()
+        duration = .random(in: 1...10)
+        curve = .random()
+        owner = .random()
+        mapboxMap = MockMapboxMap()
+        cameraOptionsInterpolator = MockCameraOptionsInterpolator()
+        dateProvider = MockDateProvider()
+        animator = SimpleCameraAnimator(
+            from: from,
+            to: to,
+            duration: duration,
+            curve: curve,
+            owner: owner,
+            mapboxMap: mapboxMap,
+            cameraOptionsInterpolator: cameraOptionsInterpolator,
+            dateProvider: dateProvider)
+        delegate = MockCameraAnimatorDelegate()
+        animator.delegate = delegate
+    }
+
+    override func tearDown() {
+        delegate = nil
+        animator = nil
+        dateProvider = nil
+        cameraOptionsInterpolator = nil
+        mapboxMap = nil
+        owner = nil
+        curve = nil
+        duration = nil
+        to = nil
+        from = nil
+        super.tearDown()
+    }
+
+    func recreateAnimator() {
+        animator = SimpleCameraAnimator(
+            from: from,
+            to: to,
+            duration: duration,
+            curve: curve,
+            owner: owner,
+            mapboxMap: mapboxMap,
+            cameraOptionsInterpolator: cameraOptionsInterpolator,
+            dateProvider: dateProvider)
+        animator.delegate = delegate
+    }
+
+    func testOwner() {
+        XCTAssertEqual(animator.owner, owner)
+    }
+
+    func testTo() {
+        XCTAssertEqual(animator.to, to)
+    }
+
+    func testInitialState() {
+        XCTAssertEqual(animator.state, .inactive)
+    }
+
+    func testStartAnimationSetsStateToActive() {
+        animator.startAnimation()
+
+        XCTAssertEqual(animator.state, .active)
+    }
+
+    func testStartAnimationCallsDelegate() {
+        animator.startAnimation()
+
+        XCTAssertEqual(delegate.cameraAnimatorDidStartRunningStub.invocations.count, 1)
+        XCTAssertIdentical(delegate.cameraAnimatorDidStartRunningStub.invocations.first?.parameters, animator)
+    }
+
+    func testStartAnimationAgainWhileItIsRunningDoesNotChangeTheUpdateFraction() {
+        curve = TimingCurve(p1: .zero, p2: .init(x: 1, y: 1))
+        recreateAnimator()
+        animator.startAnimation()
+
+        // set time to half way and start again
+        dateProvider.nowStub.defaultReturnValue += duration / 2
+        animator.startAnimation()
+
+        // now update — the fraction should be 0.5
+        animator.update()
+
+        XCTAssertEqual(cameraOptionsInterpolator.interpolateStub.invocations.count, 1)
+        XCTAssertEqual(cameraOptionsInterpolator.interpolateStub.invocations.first?.parameters.fraction, 0.5)
+    }
+
+    func testStartAnimationWhileItIsCompleteDoesNotChangeTheState() {
+        animator.startAnimation()
+        animator.cancel()
+
+        animator.startAnimation()
+
+        XCTAssertEqual(animator.state, .inactive)
+    }
+
+    func testStartAnimationAfterDelaySetsStateToActive() {
+        animator.startAnimation(afterDelay: .random(in: 0...10))
+
+        XCTAssertEqual(animator.state, .active)
+    }
+
+    func testStartAnimationAfterDelayCallsDelegate() {
+        animator.startAnimation(afterDelay: .random(in: 0...10))
+
+        XCTAssertEqual(delegate.cameraAnimatorDidStartRunningStub.invocations.count, 1)
+        XCTAssertIdentical(delegate.cameraAnimatorDidStartRunningStub.invocations.first?.parameters, animator)
+    }
+
+    func testStartAnimationAfterDelayAgainWhileItIsRunningDoesNotChangeTheUpdateFraction() {
+        curve = TimingCurve(p1: .zero, p2: .init(x: 1, y: 1))
+        recreateAnimator()
+        animator.startAnimation()
+
+        // set time to half way and start again
+        dateProvider.nowStub.defaultReturnValue += duration / 2
+        animator.startAnimation(afterDelay: .random(in: 1...10))
+
+        // now update — the fraction should be 0.5
+        animator.update()
+
+        XCTAssertEqual(cameraOptionsInterpolator.interpolateStub.invocations.count, 1)
+        XCTAssertEqual(cameraOptionsInterpolator.interpolateStub.invocations.first?.parameters.fraction, 0.5)
+    }
+
+    func testStartAnimationAfterDelayWhileItIsCompleteDoesNotChangeTheState() {
+        animator.startAnimation()
+        animator.cancel()
+
+        animator.startAnimation(afterDelay: .random(in: 1...10))
+
+        XCTAssertEqual(animator.state, .inactive)
+    }
+
+    func testUpdateAnimationWhenItHasNotYetStartedDoesNotSetCamera() {
+        animator.update()
+
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 0)
+    }
+
+    func testUpdateAnimationBeforeDelayIsOverDoesNotSetCamera() {
+        animator.startAnimation(afterDelay: .random(in: 1...10))
+
+        animator.update()
+
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 0)
+    }
+
+    func testUpdateAnimationWhenTimeElapsedIsZeroInvokesInterpolator() {
+        animator.startAnimation()
+
+        animator.update()
+
+        XCTAssertEqual(cameraOptionsInterpolator.interpolateStub.invocations.count, 1)
+        XCTAssertEqual(cameraOptionsInterpolator.interpolateStub.invocations.first?.parameters.from, from)
+        XCTAssertEqual(cameraOptionsInterpolator.interpolateStub.invocations.first?.parameters.to, to)
+        XCTAssertEqual(cameraOptionsInterpolator.interpolateStub.invocations.first?.parameters.fraction, 0)
+    }
+
+    func testUpdateAnimationWhenTimeElapsedIsZeroSetsCamera() throws {
+        animator.startAnimation()
+
+        animator.update()
+
+        let returnedValue = try XCTUnwrap(cameraOptionsInterpolator.interpolateStub.invocations.first?.returnValue)
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.map(\.parameters), [returnedValue])
+    }
+
+    func testUpdateAnimationWhenTimeElapsedIsDurationDoesNotInvokeInterpolator() {
+        animator.startAnimation()
+        dateProvider.nowStub.defaultReturnValue = dateProvider.now + duration
+
+        animator.update()
+
+        XCTAssertEqual(cameraOptionsInterpolator.interpolateStub.invocations.count, 0)
+    }
+
+    func testUpdateAnimationWhenTimeElapsedIsDurationSetsCameraToTo() {
+        animator.startAnimation()
+        dateProvider.nowStub.defaultReturnValue = dateProvider.now + duration
+
+        animator.update()
+
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.map(\.parameters), [to])
+    }
+
+    func testUpdateAnimationWhenTimeElapsedIsDurationCallsDelegate() {
+        animator.startAnimation()
+        dateProvider.nowStub.defaultReturnValue = dateProvider.now + duration
+
+        animator.update()
+
+        XCTAssertEqual(delegate.cameraAnimatorDidStopRunningStub.invocations.count, 1)
+        XCTAssertIdentical(delegate.cameraAnimatorDidStopRunningStub.invocations.first?.parameters, animator)
+    }
+
+    func testUpdateAnimationWhenTimeElapsedIsDurationSetsStateToInactive() {
+        animator.startAnimation()
+        dateProvider.nowStub.defaultReturnValue = dateProvider.now + duration
+
+        animator.update()
+
+        XCTAssertEqual(animator.state, .inactive)
+    }
+
+    func testUpdateAnimationWhenTimeElapsedIsDurationInvokesCompletionBlocks() {
+        let completionStub = Stub<UIViewAnimatingPosition, Void>()
+        animator.addCompletion(completionStub.call(with:))
+        animator.startAnimation()
+        dateProvider.nowStub.defaultReturnValue = dateProvider.now + duration
+
+        animator.update()
+
+        XCTAssertEqual(completionStub.invocations.map(\.parameters), [.end])
+    }
+
+    func testCancelAnimationBeforeItStartsSetsItsStateToInactive() {
+        animator.cancel()
+
+        XCTAssertEqual(animator.state, .inactive)
+    }
+
+    func testCancelAnimationBeforeItStartsInvokesCompletionBlocks() {
+        let completionStub = Stub<UIViewAnimatingPosition, Void>()
+        animator.addCompletion(completionStub.call(with:))
+
+        animator.cancel()
+
+        XCTAssertEqual(completionStub.invocations.map(\.parameters), [.current])
+    }
+
+    func testCancelAnimationWhileItIsDelayedSetsItsStateToInactive() {
+        animator.startAnimation(afterDelay: .random(in: 1...10))
+
+        animator.cancel()
+
+        XCTAssertEqual(animator.state, .inactive)
+    }
+
+    func testCancelAnimationWhileItIsDelayedInvokesCompletionBlocks() {
+        let completionStub = Stub<UIViewAnimatingPosition, Void>()
+        animator.addCompletion(completionStub.call(with:))
+        animator.startAnimation(afterDelay: .random(in: 1...10))
+
+        animator.cancel()
+
+        XCTAssertEqual(completionStub.invocations.map(\.parameters), [.current])
+    }
+
+    func testCancelAnimationWhileItIsRunningSetsItsStateToInactive() {
+        animator.startAnimation()
+
+        animator.cancel()
+
+        XCTAssertEqual(animator.state, .inactive)
+    }
+
+    func testCancelAnimationWhileItIsRunningInvokesCompletionBlocks() {
+        let completionStub = Stub<UIViewAnimatingPosition, Void>()
+        animator.addCompletion(completionStub.call(with:))
+        animator.startAnimation()
+
+        animator.cancel()
+
+        XCTAssertEqual(completionStub.invocations.map(\.parameters), [.current])
+    }
+
+    func testCancelAnimationWhileItIsAlreadyFinishedDoesNotCallCompletionBlocksAgain() {
+        let completionStub = Stub<UIViewAnimatingPosition, Void>()
+        animator.addCompletion(completionStub.call(with:))
+        animator.startAnimation()
+        animator.cancel()
+        completionStub.reset()
+
+        animator.cancel()
+
+        XCTAssertEqual(completionStub.invocations.count, 0)
+    }
+
+    func testStopAnimationBeforeItStartsSetsItsStateToInactive() {
+        animator.stopAnimation()
+
+        XCTAssertEqual(animator.state, .inactive)
+    }
+
+    func testStopAnimationBeforeItStartsInvokesCompletionBlocks() {
+        let completionStub = Stub<UIViewAnimatingPosition, Void>()
+        animator.addCompletion(completionStub.call(with:))
+
+        animator.stopAnimation()
+
+        XCTAssertEqual(completionStub.invocations.map(\.parameters), [.current])
+    }
+
+    func testStopAnimationWhileItIsDelayedSetsItsStateToInactive() {
+        animator.startAnimation(afterDelay: .random(in: 1...10))
+
+        animator.stopAnimation()
+
+        XCTAssertEqual(animator.state, .inactive)
+    }
+
+    func testStopAnimationWhileItIsDelayedInvokesCompletionBlocks() {
+        let completionStub = Stub<UIViewAnimatingPosition, Void>()
+        animator.addCompletion(completionStub.call(with:))
+        animator.startAnimation(afterDelay: .random(in: 1...10))
+
+        animator.stopAnimation()
+
+        XCTAssertEqual(completionStub.invocations.map(\.parameters), [.current])
+    }
+
+    func testStopAnimationWhileItIsRunningSetsItsStateToInactive() {
+        animator.startAnimation()
+
+        animator.stopAnimation()
+
+        XCTAssertEqual(animator.state, .inactive)
+    }
+
+    func testStopAnimationWhileItIsRunningInvokesCompletionBlocks() {
+        let completionStub = Stub<UIViewAnimatingPosition, Void>()
+        animator.addCompletion(completionStub.call(with:))
+        animator.startAnimation()
+
+        animator.stopAnimation()
+
+        XCTAssertEqual(completionStub.invocations.map(\.parameters), [.current])
+    }
+
+    func testStopAnimationWhileItIsAlreadyFinishedDoesNotCallCompletionBlocksAgain() {
+        let completionStub = Stub<UIViewAnimatingPosition, Void>()
+        animator.addCompletion(completionStub.call(with:))
+        animator.startAnimation()
+        animator.cancel()
+        completionStub.reset()
+
+        animator.stopAnimation()
+
+        XCTAssertEqual(completionStub.invocations.count, 0)
+    }
+
+    func testAddCompletionWhileTheAnimatorIsRunning() {
+        animator.startAnimation()
+        let completionStub = Stub<UIViewAnimatingPosition, Void>()
+
+        animator.addCompletion(completionStub.call(with:))
+
+        animator.cancel()
+        XCTAssertEqual(completionStub.invocations.map(\.parameters), [.current])
+    }
+
+    func testAddCompletionAfterTheAnimatorIsComplete() {
+        animator.startAnimation()
+        animator.cancel()
+
+        let completionStub = Stub<UIViewAnimatingPosition, Void>()
+        animator.addCompletion(completionStub.call(with:))
+
+        XCTAssertEqual(completionStub.invocations.count, 0)
+    }
+}

--- a/Tests/MapboxMapsTests/Camera/SimpleCameraAnimatorTests.swift
+++ b/Tests/MapboxMapsTests/Camera/SimpleCameraAnimatorTests.swift
@@ -379,4 +379,18 @@ final class SimpleCameraAnimatorTests: XCTestCase {
 
         XCTAssertEqual(completionStub.invocations.count, 0)
     }
+
+    func testCompletionHandlerAddedInsideOtherCompletionHandlerIsNotInvoked() {
+        let completionStub1 = Stub<UIViewAnimatingPosition, Void>()
+        let completionStub2 = Stub<UIViewAnimatingPosition, Void>()
+        completionStub1.defaultSideEffect = { _ in
+            self.animator.addCompletion(completionStub2.call(with:))
+        }
+        animator.addCompletion(completionStub1.call(with:))
+
+        animator.cancel()
+
+        XCTAssertEqual(completionStub1.invocations.count, 1)
+        XCTAssertEqual(completionStub2.invocations.count, 0)
+    }
 }

--- a/Tests/MapboxMapsTests/Foundation/Interpolators/Random/TimingCurve+Random.swift
+++ b/Tests/MapboxMapsTests/Foundation/Interpolators/Random/TimingCurve+Random.swift
@@ -1,0 +1,7 @@
+@testable import MapboxMaps
+
+extension TimingCurve {
+    static func random() -> Self {
+        return TimingCurve(p1: .random(), p2: .random())
+    }
+}


### PR DESCRIPTION
`SimpleCameraAnimator` is a camera animator that offers cubic bezier easing, delayed start, and a dynamically-updatable target camera.

This animator has some overlap in functionality with `BasicCameraAnimator`; however, since it uses direct interpolation rather than interpolation via `CameraView`, it has a simpler implementation and enables more advanced use cases like dynamically updating `SimpleCameraAnimator.to`.

This animator will be used in a subsequent PR to solve the moving target problem in the Viewport API.

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
