### PR TITLE
Deprecate workaround from FollowPuckViewportState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Improve AnyTouchGestureRecognizer's interaction with other gesture recognizers. ([#1210](https://github.com/mapbox/mapbox-maps-ios/pull/1210))
 * Update annotation examples. ([#1215](https://github.com/mapbox/mapbox-maps-ios/pull/1215))
 * Remove `FollowPuckViewportStateOptions.animationDuration`, a workaround for the moving target problem. ([#1228](https://github.com/mapbox/mapbox-maps-ios/pull/1228))
+* Deprecate `FollowPuckViewportStateOptions.animationDuration`, a workaround for the moving target problem. ([#1228](https://github.com/mapbox/mapbox-maps-ios/pull/1228))
 
 ## 10.4.1 - March 28, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Fix animator-related leaks. ([#1200](https://github.com/mapbox/mapbox-maps-ios/pull/1200))
 * Improve AnyTouchGestureRecognizer's interaction with other gesture recognizers. ([#1210](https://github.com/mapbox/mapbox-maps-ios/pull/1210))
 * Update annotation examples. ([#1215](https://github.com/mapbox/mapbox-maps-ios/pull/1215))
+* Remove `FollowPuckViewportStateOptions.animationDuration`, a workaround for the moving target problem. ([#1228](https://github.com/mapbox/mapbox-maps-ios/pull/1228))
 
 ## 10.4.1 - March 28, 2022
 

--- a/Sources/MapboxMaps/Viewport/States/FollowPuck/FollowPuckViewportState.swift
+++ b/Sources/MapboxMaps/Viewport/States/FollowPuck/FollowPuckViewportState.swift
@@ -19,8 +19,6 @@
 
     private let dataSource: FollowPuckViewportStateDataSourceProtocol
 
-    private let cameraAnimationsManager: CameraAnimationsManagerProtocol
-
     private let mapboxMap: MapboxMapProtocol
 
     // MARK: - Private State
@@ -30,10 +28,8 @@
     // MARK: - Initialization
 
     internal init(dataSource: FollowPuckViewportStateDataSourceProtocol,
-                  cameraAnimationsManager: CameraAnimationsManagerProtocol,
                   mapboxMap: MapboxMapProtocol) {
         self.dataSource = dataSource
-        self.cameraAnimationsManager = cameraAnimationsManager
         self.mapboxMap = mapboxMap
     }
 }
@@ -51,27 +47,11 @@ extension FollowPuckViewportState: ViewportState {
         guard updatingCameraCancelable == nil else {
             return
         }
-        var animationStarted = false
-        var animationComplete = false
 
-        let compositeCancelable = CompositeCancelable()
-
-        updatingCameraCancelable = compositeCancelable
-
-        compositeCancelable.add(dataSource.observe { [mapboxMap, cameraAnimationsManager, options] cameraOptions in
-            if animationComplete {
-                mapboxMap.setCamera(to: cameraOptions)
-            } else if !animationStarted {
-                animationStarted = true
-                compositeCancelable.add(cameraAnimationsManager.ease(
-                    to: cameraOptions,
-                    duration: options.animationDuration,
-                    curve: .linear) { _ in
-                        animationComplete = true
-                    })
-            }
+        updatingCameraCancelable = dataSource.observe { [mapboxMap] cameraOptions in
+            mapboxMap.setCamera(to: cameraOptions)
             return true
-        })
+        }
     }
 
     /// :nodoc:

--- a/Sources/MapboxMaps/Viewport/States/FollowPuck/FollowPuckViewportStateOptions.swift
+++ b/Sources/MapboxMaps/Viewport/States/FollowPuck/FollowPuckViewportStateOptions.swift
@@ -23,18 +23,6 @@
     /// not be modified.
     public var pitch: CGFloat?
 
-    /// The duration of an animation that happens once when
-    /// ``FollowPuckViewportState/startUpdatingCamera()`` is invoked.
-    ///
-    /// - Note: This option and the animation that it influences may be removed in a future update after
-    ///         a solution to the "moving target problem" is implemented in
-    ///         ``DefaultViewportTransition``. At the moment,
-    ///         ``DefaultViewportTransition`` calculates its animations based on the puck
-    ///         location at the *beginning* of the transition, so the farther the puck moves while the
-    ///         transition is in progress, the larger the jump when it completes and control is transferred
-    ///         to the target state. Tune this value for your use case to reduce the visibility of that jump.
-    public var animationDuration: TimeInterval
-
     /// Memberwise initializer for `FollowPuckViewportStateOptions`.
     ///
     /// All parameters have default values.
@@ -44,17 +32,14 @@
     ///   - zoom: Defaults to 16.35.
     ///   - bearing: Defaults to ``FollowPuckViewportStateBearing/heading``.
     ///   - pitch: Defaults to 45.
-    ///   - animationDuration: Defaults to 1.
     public init(padding: UIEdgeInsets? = .zero,
                 zoom: CGFloat? = 16.35,
                 bearing: FollowPuckViewportStateBearing? = .heading,
-                pitch: CGFloat? = 45,
-                animationDuration: TimeInterval = 1) {
+                pitch: CGFloat? = 45) {
         self.padding = padding
         self.zoom = zoom
         self.bearing = bearing
         self.pitch = pitch
-        self.animationDuration = animationDuration
     }
 
     /// Combines all fields into `hasher`
@@ -66,6 +51,5 @@
         hasher.combine(zoom)
         hasher.combine(bearing)
         hasher.combine(pitch)
-        hasher.combine(animationDuration)
     }
 }

--- a/Sources/MapboxMaps/Viewport/States/FollowPuck/FollowPuckViewportStateOptions.swift
+++ b/Sources/MapboxMaps/Viewport/States/FollowPuck/FollowPuckViewportStateOptions.swift
@@ -23,6 +23,10 @@
     /// not be modified.
     public var pitch: CGFloat?
 
+    /// :nodoc:
+    @available(*, deprecated, message: "This option is no longer used and will be removed in a future release.")
+    public var animationDuration: TimeInterval = 1
+
     /// Memberwise initializer for `FollowPuckViewportStateOptions`.
     ///
     /// All parameters have default values.
@@ -36,6 +40,22 @@
                 zoom: CGFloat? = 16.35,
                 bearing: FollowPuckViewportStateBearing? = .heading,
                 pitch: CGFloat? = 45) {
+        self.padding = padding
+        self.zoom = zoom
+        self.bearing = bearing
+        self.pitch = pitch
+    }
+
+    /// :nodoc:
+    @available(*,
+                deprecated,
+                message: "animationDuration parameter is ignored. This initializer will be removed in a future release.",
+                renamed: "init(padding:zoom:bearing:pitch:)")
+    public init(padding: UIEdgeInsets? = .zero,
+                zoom: CGFloat? = 16.35,
+                bearing: FollowPuckViewportStateBearing? = .heading,
+                pitch: CGFloat? = 45,
+                animationDuration: TimeInterval = 1) {
         self.padding = padding
         self.zoom = zoom
         self.bearing = bearing

--- a/Sources/MapboxMaps/Viewport/Viewport.swift
+++ b/Sources/MapboxMaps/Viewport/Viewport.swift
@@ -120,7 +120,6 @@
                 options: options,
                 interpolatedLocationProducer: interpolatedLocationProducer,
                 observableCameraOptions: ObservableCameraOptions()),
-            cameraAnimationsManager: cameraAnimationsManager,
             mapboxMap: mapboxMap)
     }
 

--- a/Tests/MapboxMapsTests/Viewport/States/FollowPuck/FollowPuckViewportStateOptionsTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/States/FollowPuck/FollowPuckViewportStateOptionsTests.swift
@@ -9,7 +9,6 @@ final class FollowPuckViewportStateOptionsTests: XCTestCase {
         XCTAssertEqual(options.zoom, 16.35)
         XCTAssertEqual(options.bearing, .heading)
         XCTAssertEqual(options.pitch, 45)
-        XCTAssertEqual(options.animationDuration, 1)
     }
 
     func testInitializer() {
@@ -17,20 +16,17 @@ final class FollowPuckViewportStateOptionsTests: XCTestCase {
         let zoom = CGFloat.random(in: 0...20)
         let bearing = FollowPuckViewportStateBearing.random()
         let pitch = CGFloat.random(in: 0...80)
-        let animationDuration = TimeInterval.random(in: 0...10)
 
         let options = FollowPuckViewportStateOptions(
             padding: padding,
             zoom: zoom,
             bearing: bearing,
-            pitch: pitch,
-            animationDuration: animationDuration)
+            pitch: pitch)
 
         XCTAssertEqual(options.padding, padding)
         XCTAssertEqual(options.zoom, zoom)
         XCTAssertEqual(options.bearing, bearing)
         XCTAssertEqual(options.pitch, pitch)
-        XCTAssertEqual(options.animationDuration, animationDuration)
     }
 
     func verifyEqual(_ lhs: FollowPuckViewportStateOptions, _ rhs: FollowPuckViewportStateOptions) {
@@ -49,8 +45,7 @@ final class FollowPuckViewportStateOptionsTests: XCTestCase {
             padding: .random(),
             zoom: .random(in: 0...20),
             bearing: .constant(0),
-            pitch: .random(in: 0...80),
-            animationDuration: .random(in: -2...2))
+            pitch: .random(in: 0...80))
         var options2 = options1
         verifyEqual(options1, options1)
 
@@ -81,10 +76,6 @@ final class FollowPuckViewportStateOptionsTests: XCTestCase {
         options2 = options1
         options2.pitch? += .random(in: 1...10)
         verifyNotEqual(options1, options2)
-
-        options2 = options1
-        options2.animationDuration += .random(in: 1...10)
-        verifyNotEqual(options1, options2)
     }
 
     func testEquatableAndHashableWithNils() {
@@ -92,8 +83,7 @@ final class FollowPuckViewportStateOptionsTests: XCTestCase {
             padding: nil,
             zoom: nil,
             bearing: nil,
-            pitch: nil,
-            animationDuration: .random(in: -2...2))
+            pitch: nil)
         var options2 = options1
         verifyEqual(options1, options1)
 
@@ -111,10 +101,6 @@ final class FollowPuckViewportStateOptionsTests: XCTestCase {
 
         options2 = options1
         options2.pitch = .random(in: 1...10)
-        verifyNotEqual(options1, options2)
-
-        options2 = options1
-        options2.animationDuration += .random(in: 1...10)
         verifyNotEqual(options1, options2)
     }
 }

--- a/Tests/MapboxMapsTests/Viewport/States/FollowPuck/Random/FollowPuckViewportStateOptions+Random.swift
+++ b/Tests/MapboxMapsTests/Viewport/States/FollowPuck/Random/FollowPuckViewportStateOptions+Random.swift
@@ -6,7 +6,6 @@ extension FollowPuckViewportStateOptions {
             padding: .random(.random()),
             zoom: .random(.random(in: 0...20)),
             bearing: .random(.random()),
-            pitch: .random(.random(in: 0...80)),
-            animationDuration: .random(in: -2...2))
+            pitch: .random(.random(in: 0...80)))
     }
 }


### PR DESCRIPTION
FollowPuckViewportState originally ran an animation for its first camera update and then updated the camera immediately for each subsequent update. This was done to minimize the effects of the unsolved moving target problem. We're removing the workaround (and deprecating the associated config) in preparation for providing a more complete solution to the moving target problem.

This PR deprecates `FollowPuckViewportStateOptions.animationDuration`.

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
