### PR TITLE
[style] Introduce line-trim-offset property for LineLayer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Remove `FollowPuckViewportStateOptions.animationDuration`, a workaround for the moving target problem. ([#1228](https://github.com/mapbox/mapbox-maps-ios/pull/1228))
 * Deprecate `FollowPuckViewportStateOptions.animationDuration`, a workaround for the moving target problem. ([#1228](https://github.com/mapbox/mapbox-maps-ios/pull/1228))
 * Add map view example with `debugOptions`. ([#1225](https://github.com/mapbox/mapbox-maps-ios/pull/1225))
+* Introduce `line-trim-offset` property for LineLayer. ([#1231](https://github.com/mapbox/mapbox-maps-ios/pull/1231))
 
 ## 10.4.1 - March 28, 2022
 

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -226,6 +226,16 @@ public class PolylineAnnotationManager: AnnotationManagerInternal {
         }
     }
 
+    /// The line trim-off percentage range based on the whole line gradinet range [0.0, 1.0]. The line part between [trim-start, trim-end] will be marked as transparent to make a route vanishing effect. If either 'trim-start' or 'trim-end' offset is out of valid range, the default range will be set.
+    public var lineTrimOffset: [Double]? {
+        get {
+            return layerProperties["line-trim-offset"] as? [Double]
+        }
+        set {
+            layerProperties["line-trim-offset"] = newValue
+        }
+    }
+
     internal func handleQueriedFeatureIds(_ queriedFeatureIds: [String]) {
         // Find if any `queriedFeatureIds` match an annotation's `id`
         let tappedAnnotations = annotations.filter { queriedFeatureIds.contains($0.id) }

--- a/Sources/MapboxMaps/Style/Generated/Layers/LineLayer.swift
+++ b/Sources/MapboxMaps/Style/Generated/Layers/LineLayer.swift
@@ -87,6 +87,9 @@ public struct LineLayer: Layer {
     /// Controls the frame of reference for `line-translate`.
     public var lineTranslateAnchor: Value<LineTranslateAnchor>?
 
+    /// The line trim-off percentage range based on the whole line gradinet range [0.0, 1.0]. The line part between [trim-start, trim-end] will be marked as transparent to make a route vanishing effect. If either 'trim-start' or 'trim-end' offset is out of valid range, the default range will be set.
+    public var lineTrimOffset: Value<[Double]>?
+
     /// Stroke thickness.
     public var lineWidth: Value<Double>?
 
@@ -128,6 +131,7 @@ public struct LineLayer: Layer {
         try paintContainer.encodeIfPresent(lineTranslate, forKey: .lineTranslate)
         try paintContainer.encodeIfPresent(lineTranslateTransition, forKey: .lineTranslateTransition)
         try paintContainer.encodeIfPresent(lineTranslateAnchor, forKey: .lineTranslateAnchor)
+        try paintContainer.encodeIfPresent(lineTrimOffset, forKey: .lineTrimOffset)
         try paintContainer.encodeIfPresent(lineWidth, forKey: .lineWidth)
         try paintContainer.encodeIfPresent(lineWidthTransition, forKey: .lineWidthTransition)
 
@@ -169,6 +173,7 @@ public struct LineLayer: Layer {
             lineTranslate = try paintContainer.decodeIfPresent(Value<[Double]>.self, forKey: .lineTranslate)
             lineTranslateTransition = try paintContainer.decodeIfPresent(StyleTransition.self, forKey: .lineTranslateTransition)
             lineTranslateAnchor = try paintContainer.decodeIfPresent(Value<LineTranslateAnchor>.self, forKey: .lineTranslateAnchor)
+            lineTrimOffset = try paintContainer.decodeIfPresent(Value<[Double]>.self, forKey: .lineTrimOffset)
             lineWidth = try paintContainer.decodeIfPresent(Value<Double>.self, forKey: .lineWidth)
             lineWidthTransition = try paintContainer.decodeIfPresent(StyleTransition.self, forKey: .lineWidthTransition)
         }
@@ -223,6 +228,7 @@ public struct LineLayer: Layer {
         case lineTranslate = "line-translate"
         case lineTranslateTransition = "line-translate-transition"
         case lineTranslateAnchor = "line-translate-anchor"
+        case lineTrimOffset = "line-trim-offset"
         case lineWidth = "line-width"
         case lineWidthTransition = "line-width-transition"
     }

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationIntegrationTests.swift
@@ -194,6 +194,28 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
         XCTAssertEqual(layer.lineTranslateAnchor, .constant(LineTranslateAnchor(rawValue: Style.layerPropertyDefaultValue(for: .line, property: "line-translate-anchor").value as! String)!))
     }
 
+    func testLineTrimOffset() throws {
+        // Test that the setter and getter work
+        let value = Array.random(withLength: 2, generator: { Double.random(in: -100000...100000) })
+        manager.lineTrimOffset = value
+        XCTAssertEqual(manager.lineTrimOffset, value)
+
+        // Test that the value is synced to the layer
+        manager.syncSourceAndLayerIfNeeded()
+        var layer = try style.layer(withId: self.manager.layerId, type: LineLayer.self)
+        XCTAssertEqual(layer.lineTrimOffset, .constant(value.map { Double(Float($0)) }))
+
+        // Test that the property can be reset to nil
+        manager.lineTrimOffset = nil
+        XCTAssertNil(manager.lineTrimOffset)
+
+        // Verify that when the property is reset to nil,
+        // the layer is returned to the default value
+        manager.syncSourceAndLayerIfNeeded()
+        layer = try style.layer(withId: self.manager.layerId, type: LineLayer.self)
+        XCTAssertEqual(layer.lineTrimOffset, .constant(Style.layerPropertyDefaultValue(for: .line, property: "line-trim-offset").value as! [Double]))
+    }
+
     func testLineJoin() throws {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
         var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))

--- a/Tests/MapboxMapsTests/Style/Generated/Layers/LineLayerTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Layers/LineLayerTests.swift
@@ -108,6 +108,7 @@ final class LineLayerTests: XCTestCase {
        layer.lineTranslate = Value<[Double]>.testConstantValue()
        layer.lineTranslateTransition = StyleTransition(duration: 10.0, delay: 10.0)
        layer.lineTranslateAnchor = Value<LineTranslateAnchor>.testConstantValue()
+       layer.lineTrimOffset = Value<[Double]>.testConstantValue()
        layer.lineWidth = Value<Double>.testConstantValue()
        layer.lineWidthTransition = StyleTransition(duration: 10.0, delay: 10.0)
 
@@ -136,6 +137,7 @@ final class LineLayerTests: XCTestCase {
            XCTAssert(layer.linePattern == Value<ResolvedImage>.testConstantValue())
            XCTAssert(layer.lineTranslate == Value<[Double]>.testConstantValue())
            XCTAssert(layer.lineTranslateAnchor == Value<LineTranslateAnchor>.testConstantValue())
+           XCTAssert(layer.lineTrimOffset == Value<[Double]>.testConstantValue())
            XCTAssert(layer.lineWidth == Value<Double>.testConstantValue())
        } catch {
            XCTFail("Failed to decode LineLayer")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

This PR introduces `line-trim-offset` property for `LineLayer`. The `line-trim-offset` property requires presence of `line-gradient` property.

The line trim-off percentage range based on the whole line gradinet range [0.0, 1.0]. The line part between [trim-start, trim-end] will be marked as transparent to make a route vanishing effect. If either 'trim-start' or 'trim-end' offset is out of valid range, the default range will be set.

Android PR at https://github.com/mapbox/mapbox-maps-android/pull/1252

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
