### PR TITLE
Increase test time out for OfflineRegionManagerExample

### DIFF
--- a/Apps/Examples/Examples/Models/Examples.swift
+++ b/Apps/Examples/Examples/Models/Examples.swift
@@ -178,6 +178,7 @@ public struct Examples {
                 type: OfflineManagerExample.self),
         Example(title: "Use OfflineRegionManager to download a region",
                 description: "Use the deprecated OfflineRegionManager to download regions for offline use.",
+                testTimeout: 60,
                 type: OfflineRegionManagerExample.self),
     ]
 


### PR DESCRIPTION
OfflineRegionManagerExample test seems to be timing out on iOS 14.7(only on that version for some reason), let's see if increasing the test timeout helps.
