### PR TITLE
Update line gradient example to showcase `line-trim-offset` property. 

### DIFF
--- a/Apps/Examples/Examples/All Examples/LineGradientExample.swift
+++ b/Apps/Examples/Examples/All Examples/LineGradientExample.swift
@@ -5,6 +5,8 @@ import MapboxMaps
 public class LineGradientExample: UIViewController, ExampleProtocol {
 
     internal var mapView: MapView!
+    internal var lastTrimOffset = 0.0
+    let button = UIButton(type: .system)
 
     override public func viewDidLoad() {
         super.viewDidLoad()
@@ -23,6 +25,19 @@ public class LineGradientExample: UIViewController, ExampleProtocol {
             let camera = CameraOptions(center: centerCoordinate, zoom: 12.0)
             self.mapView.mapboxMap.setCamera(to: camera)
         }
+        button.setTitle("Increase trim offset", for: .normal)
+        button.backgroundColor = .white
+        button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(button)
+        NSLayoutConstraint.activate([button.centerXAnchor.constraint(equalTo: view.centerXAnchor), button.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)])
+        button.addTarget(self, action: #selector(increaseTrimOffset), for: .touchUpInside)
+    }
+
+    @objc
+    func increaseTrimOffset() {
+        let trimOffset = (lastTrimOffset + 0.05).wrap(min: 0.0, max: 1.0)
+        try? mapView.mapboxMap.style.setLayerProperty(for: "line-layer", property: "line-trim-offset", value: [0.0, trimOffset])
     }
 
     // Load GeoJSON file from local bundle and decode into a `FeatureCollection`.

--- a/Apps/Examples/Examples/All Examples/LineGradientExample.swift
+++ b/Apps/Examples/Examples/All Examples/LineGradientExample.swift
@@ -36,7 +36,8 @@ public class LineGradientExample: UIViewController, ExampleProtocol {
 
     @objc
     func increaseTrimOffset() {
-        let trimOffset = (lastTrimOffset + 0.05).wrap(min: 0.0, max: 1.0)
+        lastTrimOffset += 0.05
+        let trimOffset = Double.minimum(lastTrimOffset, 1.0)
         try? mapView.mapboxMap.style.setLayerProperty(for: "line-layer", property: "line-trim-offset", value: [0.0, trimOffset])
     }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

This PR updates line gradient example to showcase `line-trim-offset` property. 

https://user-images.githubusercontent.com/2764714/161558460-47063838-d196-46ab-bd73-74820611a6e6.mp4

## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [x] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
