### PR TITLE
Add `MapboxMap.coordinateBoundsUnwrapped` method for API consistency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Deprecate `FollowPuckViewportStateOptions.animationDuration`, a workaround for the moving target problem. ([#1228](https://github.com/mapbox/mapbox-maps-ios/pull/1228))
 * Add map view example with `debugOptions`. ([#1225](https://github.com/mapbox/mapbox-maps-ios/pull/1225))
 * Introduce `line-trim-offset` property for LineLayer. ([#1231](https://github.com/mapbox/mapbox-maps-ios/pull/1231))
-* Add `MapboxMap.coordinateBoundsUnwrapped` method for API consistency. ([#1241](https://github.com/mapbox/mapbox-maps-ios/pull/1241))
+* Add `MapboxMap.coordinateBoundsUnwrapped`. ([#1241](https://github.com/mapbox/mapbox-maps-ios/pull/1241))
 
 ## 10.4.1 - March 28, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Deprecate `FollowPuckViewportStateOptions.animationDuration`, a workaround for the moving target problem. ([#1228](https://github.com/mapbox/mapbox-maps-ios/pull/1228))
 * Add map view example with `debugOptions`. ([#1225](https://github.com/mapbox/mapbox-maps-ios/pull/1225))
 * Introduce `line-trim-offset` property for LineLayer. ([#1231](https://github.com/mapbox/mapbox-maps-ios/pull/1231))
+* Add `MapboxMap.coordinateBoundsUnwrapped` method for API consistency. ([#1241](https://github.com/mapbox/mapbox-maps-ios/pull/1241))
 
 ## 10.4.1 - March 28, 2022
 

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -402,6 +402,16 @@ public final class MapboxMap: MapboxMapProtocol {
             forCamera: MapboxCoreMaps.CameraOptions(camera))
     }
 
+    /// Returns the unwrapped coordinate bounds to a given `CameraOptions`.
+    ///
+    /// This function is particularly useful, if the camera shows the antimeridian.
+    ///
+    /// - Parameter camera: The camera for which the coordinate bounds will be returned.
+    /// - Returns: `CoordinateBounds` for the given `CameraOptions`
+    public func coordinateBoundsUnwrapped(for camera: CameraOptions) -> CoordinateBounds {
+        return __map.coordinateBoundsForCameraUnwrapped(forCamera: MapboxCoreMaps.CameraOptions(camera))
+    }
+
     /// Returns the coordinate bounds and zoom for a given `CameraOptions`.
     ///
     /// - Parameter camera: The camera for which the `CoordinateBoundsZoom` will be returned.

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -402,12 +402,12 @@ public final class MapboxMap: MapboxMapProtocol {
             forCamera: MapboxCoreMaps.CameraOptions(camera))
     }
 
-    /// Returns the unwrapped coordinate bounds to a given `CameraOptions`.
+    /// Returns the unwrapped coordinate bounds to a given ``CameraOptions``.
     ///
     /// This function is particularly useful, if the camera shows the antimeridian.
     ///
     /// - Parameter camera: The camera for which the coordinate bounds will be returned.
-    /// - Returns: `CoordinateBounds` for the given `CameraOptions`
+    /// - Returns: `CoordinateBounds` for the given ``CameraOptions``.
     public func coordinateBoundsUnwrapped(for camera: CameraOptions) -> CoordinateBounds {
         return __map.coordinateBoundsForCameraUnwrapped(forCamera: MapboxCoreMaps.CameraOptions(camera))
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

Add `MapboxMap.coordinateBoundsUnwrapped` method for API consistency.

## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
