### PR TITLE
Increase deceleration cutoff threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Mapbox welcomes participation and contributions from everyone.
 * Introduce `line-trim-offset` property for LineLayer. ([#1231](https://github.com/mapbox/mapbox-maps-ios/pull/1231))
 * Add `MapboxMap.coordinateBoundsUnwrapped`. ([#1241](https://github.com/mapbox/mapbox-maps-ios/pull/1241))
 * Update `DefaultViewportTransition` to solve the moving target problem. ([#1245](https://github.com/mapbox/mapbox-maps-ios/pull/1245))
+* Increase deceleration cutoff threshold from 20 to 35 to prevent camera changes
+ after animation stops. ([#1244](https://github.com/mapbox/mapbox-maps-ios/pull/1244))
 
 ## 10.4.1 - March 28, 2022
 

--- a/Sources/MapboxMaps/Camera/GestureDecelerationCameraAnimator.swift
+++ b/Sources/MapboxMaps/Camera/GestureDecelerationCameraAnimator.swift
@@ -127,7 +127,7 @@ internal final class GestureDecelerationCameraAnimator: NSObject, CameraAnimator
         velocity.x *= pow(decelerationFactor, (elapsedTime * 1000))
         velocity.y *= pow(decelerationFactor, (elapsedTime * 1000))
 
-        if abs(velocity.x) < 20, abs(velocity.y) < 20 {
+        if abs(velocity.x) < 35, abs(velocity.y) < 35 {
             internalState = .final
             invokeCompletionBlocks(with: .end)
         }

--- a/Tests/MapboxMapsTests/Camera/GestureDecelerationCameraAnimatorTests.swift
+++ b/Tests/MapboxMapsTests/Camera/GestureDecelerationCameraAnimatorTests.swift
@@ -17,7 +17,7 @@ final class GestureDecelerationCameraAnimatorTests: XCTestCase {
     override func setUp() {
         super.setUp()
         location = .zero
-        velocity = CGPoint(x: 1000, y: -1000)
+        velocity = CGPoint(x: 2000, y: -2000)
         decelerationFactor = 0.7
         owner = .random()
         locationChangeHandler = MockLocationChangeHandler()
@@ -115,7 +115,7 @@ final class GestureDecelerationCameraAnimatorTests: XCTestCase {
         animator.update()
 
         // Expected value is duration * velocity;
-        XCTAssertEqual(locationChangeHandler.invocations.map(\.parameters), [.init(fromLocation: location, toLocation: CGPoint(x: 10, y: -10))])
+        XCTAssertEqual(locationChangeHandler.invocations.map(\.parameters), [.init(fromLocation: location, toLocation: CGPoint(x: 20, y: -20))])
         // The previous update() should also have reduced the velocity
         // by multiplying it by the decelerationFactor once for each elapsed
         // millisecond. In this simulateion, 10 ms have elapsed.
@@ -142,7 +142,7 @@ final class GestureDecelerationCameraAnimatorTests: XCTestCase {
                        accuracy: 0.0000000001)
         locationChangeHandler.reset()
         // After the previous update() call, the velocity should have also been reduced
-        // to be sufficiently low (< 20 in both x and y) to end the animation.
+        // to be sufficiently low (< 35 in both x and y) to end the animation.
         XCTAssertEqual(animator.state, .inactive)
         XCTAssertEqual(completion.invocations.map(\.parameters), [.end])
         XCTAssertEqual(delegate.cameraAnimatorDidStopRunningStub.invocations.count, 1)


### PR DESCRIPTION
Increase deceleration cutoff threshold from 20 to 35 to prevent camera changes after animation stops. Fixes https://github.com/mapbox/mapbox-maps-ios-internal/issues/1029.

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [x] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
