### PR TITLE
Add initial solution to moving target problem

### DIFF
--- a/Sources/MapboxMaps/Camera/AnimationOwner.swift
+++ b/Sources/MapboxMaps/Camera/AnimationOwner.swift
@@ -12,4 +12,6 @@ public struct AnimationOwner: RawRepresentable, Equatable {
     public static let unspecified = AnimationOwner(rawValue: "com.mapbox.maps.unspecified")
 
     internal static let cameraAnimationsManager = AnimationOwner(rawValue: "com.mapbox.maps.cameraAnimationsManager")
+
+    internal static let defaultViewportTransition = AnimationOwner(rawValue: "com.mapbox.maps.viewport.defaultTransition")
 }

--- a/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
+++ b/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
@@ -27,6 +27,7 @@ internal protocol MapViewDependencyProviderProtocol: AnyObject {
                           doubleTouchGestureRecognizer: UIGestureRecognizer) -> ViewportImplProtocol
 }
 
+// swiftlint:disable:next type_body_length
 internal final class MapViewDependencyProvider: MapViewDependencyProviderProtocol {
     internal let notificationCenter: NotificationCenterProtocol = NotificationCenter.default
 
@@ -259,14 +260,28 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
                                    anyTouchGestureRecognizer: UIGestureRecognizer,
                                    doubleTapGestureRecognizer: UIGestureRecognizer,
                                    doubleTouchGestureRecognizer: UIGestureRecognizer) -> ViewportImplProtocol {
+        let lowZoomToHighZoomAnimationSpecProvider = LowZoomToHighZoomAnimationSpecProvider(
+            mapboxMap: mapboxMap)
+        let highZoomToLowZoomAnimationSpecProvider = HighZoomToLowZoomAnimationSpecProvider(
+            mapboxMap: mapboxMap)
+        let animationSpecProvider = DefaultViewportTransitionAnimationSpecProvider(
+            mapboxMap: mapboxMap,
+            lowZoomToHighZoomAnimationSpecProvider: lowZoomToHighZoomAnimationSpecProvider,
+            highZoomToLowZoomAnimationSpecProvider: highZoomToLowZoomAnimationSpecProvider)
+        let animationFactory = DefaultViewportTransitionAnimationFactory(
+            mapboxMap: mapboxMap)
+        let animationHelper = DefaultViewportTransitionAnimationHelper(
+            mapboxMap: mapboxMap,
+            animationSpecProvider: animationSpecProvider,
+            cameraAnimationsManager: cameraAnimationsManager,
+            animationFactory: animationFactory)
+        let defaultViewportTransition = DefaultViewportTransition(
+            options: .init(),
+            animationHelper: animationHelper)
         return ViewportImpl(
             options: .init(),
             mainQueue: MainQueue(),
-            defaultTransition: DefaultViewportTransition(
-                options: .init(),
-                animationHelper: DefaultViewportTransitionAnimationHelper(
-                    mapboxMap: mapboxMap,
-                    cameraAnimationsManager: cameraAnimationsManager)),
+            defaultTransition: defaultViewportTransition,
             anyTouchGestureRecognizer: anyTouchGestureRecognizer,
             doubleTapGestureRecognizer: doubleTapGestureRecognizer,
             doubleTouchGestureRecognizer: doubleTouchGestureRecognizer)

--- a/Sources/MapboxMaps/Viewport/Transitions/Default/CameraOptionsComponent.swift
+++ b/Sources/MapboxMaps/Viewport/Transitions/Default/CameraOptionsComponent.swift
@@ -1,0 +1,21 @@
+internal protocol CameraOptionsComponentProtocol {
+    var cameraOptions: CameraOptions { get }
+    func updated(with cameraOptions: CameraOptions) -> CameraOptionsComponentProtocol?
+}
+
+internal struct CameraOptionsComponent<T>: CameraOptionsComponentProtocol {
+    internal let keyPath: WritableKeyPath<CameraOptions, T?>
+    internal let value: T
+
+    internal var cameraOptions: CameraOptions {
+        var cameraOptions = CameraOptions()
+        cameraOptions[keyPath: keyPath] = value
+        return cameraOptions
+    }
+
+    internal func updated(with cameraOptions: CameraOptions) -> CameraOptionsComponentProtocol? {
+        cameraOptions[keyPath: keyPath].map {
+            CameraOptionsComponent(keyPath: keyPath, value: $0)
+        }
+    }
+}

--- a/Sources/MapboxMaps/Viewport/Transitions/Default/DefaultViewportTransitionAnimation.swift
+++ b/Sources/MapboxMaps/Viewport/Transitions/Default/DefaultViewportTransitionAnimation.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+internal protocol DefaultViewportTransitionAnimationProtocol: Cancelable {
+    func updateTargetCamera(with cameraOptions: CameraOptions)
+    func start(with completion: @escaping (Bool) -> Void)
+}
+
+internal final class DefaultViewportTransitionAnimation: DefaultViewportTransitionAnimationProtocol {
+    private let components: [DefaultViewportTransitionAnimationProtocol]
+
+    internal init(components: [DefaultViewportTransitionAnimationProtocol]) {
+        self.components = components
+    }
+
+    func start(with completion: @escaping (Bool) -> Void) {
+        let group = DispatchGroup()
+        var allFinished = true
+        for component in components {
+            group.enter()
+            component.start { isFinished in
+                allFinished = allFinished && isFinished
+                group.leave()
+            }
+        }
+        group.notify(queue: .main) {
+            completion(allFinished)
+        }
+    }
+
+    internal func updateTargetCamera(with cameraOptions: CameraOptions) {
+        for component in components {
+            component.updateTargetCamera(with: cameraOptions)
+        }
+    }
+
+    internal func cancel() {
+        for component in components {
+            component.cancel()
+        }
+    }
+}
+
+internal final class DefaultViewportTransitionAnimationComponent: DefaultViewportTransitionAnimationProtocol {
+    private let animator: SimpleCameraAnimatorProtocol
+    private let delay: TimeInterval
+    private let cameraOptionsComponent: CameraOptionsComponentProtocol
+    private let mapboxMap: MapboxMapProtocol
+
+    internal init(animator: SimpleCameraAnimatorProtocol,
+                  delay: TimeInterval,
+                  cameraOptionsComponent: CameraOptionsComponentProtocol,
+                  mapboxMap: MapboxMapProtocol) {
+        self.animator = animator
+        self.delay = delay
+        self.cameraOptionsComponent = cameraOptionsComponent
+        self.mapboxMap = mapboxMap
+    }
+
+    func start(with completion: @escaping (Bool) -> Void) {
+        animator.addCompletion { position in
+            completion(position != .current)
+        }
+        animator.startAnimation(afterDelay: delay)
+    }
+
+    internal func updateTargetCamera(with cameraOptions: CameraOptions) {
+        guard let updatedComponent = cameraOptionsComponent.updated(with: cameraOptions) else {
+            return
+        }
+        let isComplete = animator.state == .inactive
+        if isComplete {
+            mapboxMap.setCamera(to: updatedComponent.cameraOptions)
+        } else {
+            animator.to = updatedComponent.cameraOptions
+        }
+    }
+
+    internal func cancel() {
+        animator.cancel()
+    }
+}

--- a/Sources/MapboxMaps/Viewport/Transitions/Default/DefaultViewportTransitionAnimationFactory.swift
+++ b/Sources/MapboxMaps/Viewport/Transitions/Default/DefaultViewportTransitionAnimationFactory.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+internal protocol DefaultViewportTransitionAnimationFactoryProtocol: AnyObject {
+    func makeAnimationComponent(animator: SimpleCameraAnimatorProtocol,
+                                delay: TimeInterval,
+                                cameraOptionsComponent: CameraOptionsComponentProtocol) -> DefaultViewportTransitionAnimationProtocol
+
+    func makeAnimation(components: [DefaultViewportTransitionAnimationProtocol]) -> DefaultViewportTransitionAnimationProtocol
+}
+
+internal final class DefaultViewportTransitionAnimationFactory: DefaultViewportTransitionAnimationFactoryProtocol {
+    private let mapboxMap: MapboxMapProtocol
+
+    internal init(mapboxMap: MapboxMapProtocol) {
+        self.mapboxMap = mapboxMap
+    }
+
+    internal func makeAnimation(components: [DefaultViewportTransitionAnimationProtocol]) -> DefaultViewportTransitionAnimationProtocol {
+        return DefaultViewportTransitionAnimation(components: components)
+    }
+
+    internal func makeAnimationComponent(animator: SimpleCameraAnimatorProtocol,
+                                         delay: TimeInterval,
+                                         cameraOptionsComponent: CameraOptionsComponentProtocol) -> DefaultViewportTransitionAnimationProtocol {
+        return DefaultViewportTransitionAnimationComponent(
+            animator: animator,
+            delay: delay,
+            cameraOptionsComponent: cameraOptionsComponent,
+            mapboxMap: mapboxMap)
+    }
+}

--- a/Sources/MapboxMaps/Viewport/Transitions/Default/DefaultViewportTransitionAnimationHelper.swift
+++ b/Sources/MapboxMaps/Viewport/Transitions/Default/DefaultViewportTransitionAnimationHelper.swift
@@ -1,189 +1,55 @@
+import UIKit
+
 internal protocol DefaultViewportTransitionAnimationHelperProtocol: AnyObject {
-    func animate(to cameraOptions: CameraOptions,
-                 maxDuration: TimeInterval,
-                 completion: @escaping (Bool) -> Void) -> Cancelable
+    func makeAnimation(cameraOptions: CameraOptions,
+                       maxDuration: TimeInterval) -> DefaultViewportTransitionAnimationProtocol
 }
 
 internal final class DefaultViewportTransitionAnimationHelper: DefaultViewportTransitionAnimationHelperProtocol {
 
     private let mapboxMap: MapboxMapProtocol
+    private let animationSpecProvider: DefaultViewportTransitionAnimationSpecProviderProtocol
     private let cameraAnimationsManager: CameraAnimationsManagerProtocol
+    private let animationFactory: DefaultViewportTransitionAnimationFactoryProtocol
 
     internal init(mapboxMap: MapboxMapProtocol,
-                  cameraAnimationsManager: CameraAnimationsManagerProtocol) {
+                  animationSpecProvider: DefaultViewportTransitionAnimationSpecProviderProtocol,
+                  cameraAnimationsManager: CameraAnimationsManagerProtocol,
+                  animationFactory: DefaultViewportTransitionAnimationFactoryProtocol) {
         self.mapboxMap = mapboxMap
+        self.animationSpecProvider = animationSpecProvider
         self.cameraAnimationsManager = cameraAnimationsManager
+        self.animationFactory = animationFactory
     }
 
-    internal func animate(to cameraOptions: CameraOptions,
-                          maxDuration: TimeInterval,
-                          completion: @escaping (Bool) -> Void) -> Cancelable {
+    internal func makeAnimation(cameraOptions: CameraOptions,
+                                maxDuration: TimeInterval) -> DefaultViewportTransitionAnimationProtocol {
 
-        var animations: [Animation]
+        var animationSpecs = animationSpecProvider.makeAnimationSpecs(
+            cameraOptions: cameraOptions)
 
-        let currentZoom = mapboxMap.cameraState.zoom
-        if let targetZoom = cameraOptions.zoom, currentZoom < targetZoom {
-            animations = makeAnimationsForLowZoomToHighZoom(cameraOptions: cameraOptions)
-        } else {
-            animations = makeAnimationsForHighZoomToLowZoom(cameraOptions: cameraOptions)
-        }
-
-        if let longestAnimation = animations.max(by: { $0.total <= $1.total }),
-           longestAnimation.total > maxDuration {
-            let adjustmentFactor = maxDuration / longestAnimation.total
-            animations = animations.map {
-                Animation(
-                    duration: $0.duration * adjustmentFactor,
-                    delay: $0.delay * adjustmentFactor,
-                    cameraOptions: $0.cameraOptions)
+        // scale the animation durations and delays if the total exceeds the max duration
+        if let longestTotal = animationSpecs.map(\.total).max(),
+           longestTotal > maxDuration {
+            let adjustmentFactor = maxDuration / longestTotal
+            animationSpecs = animationSpecs.map {
+                $0.scaled(by: adjustmentFactor)
             }
         }
 
-        let cancelable = CompositeCancelable()
-        let group = DispatchGroup()
-        var isFinished = true
-        for animation in animations {
-            group.enter()
-            let animator = cameraAnimationsManager.makeAnimator(
-                duration: animation.duration,
+        // create animations
+        let animationComponents: [DefaultViewportTransitionAnimationProtocol] = animationSpecs.map { animationSpec in
+            let animator = cameraAnimationsManager.makeSimpleCameraAnimator(
+                from: CameraOptions(cameraState: mapboxMap.cameraState),
+                to: animationSpec.cameraOptionsComponent.cameraOptions,
+                duration: animationSpec.duration,
                 curve: .easeInOut,
-                animationOwner: AnimationOwner(rawValue: "Viewport")) {
-                    $0.center.toValue = animation.cameraOptions.center
-                    $0.zoom.toValue = animation.cameraOptions.zoom
-                    $0.bearing.toValue = animation.cameraOptions.bearing
-                    $0.pitch.toValue = animation.cameraOptions.pitch
-                    $0.padding.toValue = animation.cameraOptions.padding
-                }
-            animator.addCompletion { position in
-                isFinished = isFinished && (position != .current)
-                group.leave()
-            }
-            animator.startAnimation(afterDelay: animation.delay)
-            cancelable.add(animator)
+                owner: .defaultViewportTransition)
+            return animationFactory.makeAnimationComponent(
+                animator: animator,
+                delay: animationSpec.delay,
+                cameraOptionsComponent: animationSpec.cameraOptionsComponent)
         }
-        group.notify(queue: .main) {
-            completion(isFinished)
-        }
-        return cancelable
-    }
-
-    private func distanceInViewSpace(from fromCoordinate: CLLocationCoordinate2D,
-                                     to toCoordinate: CLLocationCoordinate2D) -> CGFloat {
-        let fromPoint = mapboxMap.point(for: fromCoordinate)
-        let toPoint = mapboxMap.point(for: toCoordinate)
-        return hypot(fromPoint.x - toPoint.x, fromPoint.y - toPoint.y)
-    }
-
-    private struct Animation {
-        var duration: TimeInterval
-        var delay: TimeInterval
-        var cameraOptions: CameraOptions
-
-        var total: TimeInterval {
-            delay + duration
-        }
-    }
-
-    private func makeAnimationsForLowZoomToHighZoom(cameraOptions: CameraOptions) -> [Animation] {
-
-        var animations = [Animation]()
-
-        let maxDuration: TimeInterval = 3
-        let cameraState = mapboxMap.cameraState
-
-        var centerDuration: TimeInterval = 0
-        if let center = cameraOptions.center {
-            let distance = distanceInViewSpace(from: cameraState.center, to: center)
-            // points / s
-            let centerAnimationRate: Double = 500
-            centerDuration = min(Double(distance) / centerAnimationRate, maxDuration)
-            animations.append(Animation(
-                duration: centerDuration,
-                delay: 0,
-                cameraOptions: CameraOptions(center: center)))
-        }
-
-        var zoomDelay: TimeInterval = 0
-        var zoomDuration: TimeInterval = 0
-        if let zoom = cameraOptions.zoom {
-            let currentMapCameraZoom = cameraState.zoom
-            let zoomDelta = abs(zoom - currentMapCameraZoom)
-            // zoom level / s
-            let zoomAnimationRate = 2.2
-            zoomDelay = centerDuration / 2
-            zoomDuration = min(Double(zoomDelta) / zoomAnimationRate, maxDuration)
-            animations.append(Animation(
-                duration: zoomDuration,
-                delay: zoomDelay,
-                cameraOptions: CameraOptions(zoom: zoom)))
-        }
-
-        if let bearing = cameraOptions.bearing {
-            let bearingDuration: TimeInterval = 1.8
-            let bearingDelay: TimeInterval = max(zoomDelay + zoomDuration - bearingDuration, 0)
-            animations.append(Animation(
-                duration: bearingDuration,
-                delay: bearingDelay,
-                cameraOptions: CameraOptions(bearing: bearing)))
-        }
-
-        let pitchAndPaddingDuration: TimeInterval = 1.2
-        let pitchAndPaddingDelay: TimeInterval = max(zoomDelay + zoomDuration - pitchAndPaddingDuration + 0.1, 0)
-        if let pitch = cameraOptions.pitch {
-            animations.append(Animation(
-                duration: pitchAndPaddingDuration,
-                delay: pitchAndPaddingDelay,
-                cameraOptions: CameraOptions(pitch: pitch)))
-        }
-
-        if let padding = cameraOptions.padding {
-            animations.append(Animation(
-                duration: pitchAndPaddingDuration,
-                delay: pitchAndPaddingDelay,
-                cameraOptions: CameraOptions(padding: padding)))
-        }
-
-        return animations
-    }
-
-    private func makeAnimationsForHighZoomToLowZoom(cameraOptions: CameraOptions) -> [Animation] {
-        var animations = [Animation]()
-
-        if let center = cameraOptions.center {
-            animations.append(Animation(
-                duration: 1,
-                delay: 0.8,
-                cameraOptions: CameraOptions(center: center)))
-        }
-
-        if let zoom = cameraOptions.zoom {
-            animations.append(Animation(
-                duration: 1.8,
-                delay: 0,
-                cameraOptions: CameraOptions(zoom: zoom)))
-        }
-
-        if let bearing = cameraOptions.bearing {
-            animations.append(Animation(
-                duration: 1.2,
-                delay: 0.6,
-                cameraOptions: CameraOptions(bearing: bearing)))
-        }
-
-        if let pitch = cameraOptions.pitch {
-            animations.append(Animation(
-                duration: 1,
-                delay: 0,
-                cameraOptions: CameraOptions(pitch: pitch)))
-        }
-
-        if let padding = cameraOptions.padding {
-            animations.append(Animation(
-                duration: 1.2,
-                delay: 0,
-                cameraOptions: CameraOptions(padding: padding)))
-        }
-
-        return animations
+        return animationFactory.makeAnimation(components: animationComponents)
     }
 }

--- a/Sources/MapboxMaps/Viewport/Transitions/Default/DefaultViewportTransitionAnimationSpec.swift
+++ b/Sources/MapboxMaps/Viewport/Transitions/Default/DefaultViewportTransitionAnimationSpec.swift
@@ -1,0 +1,16 @@
+internal struct DefaultViewportTransitionAnimationSpec {
+    internal var duration: TimeInterval
+    internal var delay: TimeInterval
+    internal var cameraOptionsComponent: CameraOptionsComponentProtocol
+
+    internal var total: TimeInterval {
+        delay + duration
+    }
+
+    internal func scaled(by factor: Double) -> Self {
+        var updatedSpec = self
+        updatedSpec.duration *= factor
+        updatedSpec.delay *= factor
+        return updatedSpec
+    }
+}

--- a/Sources/MapboxMaps/Viewport/Transitions/Default/DefaultViewportTransitionAnimationSpecProvider.swift
+++ b/Sources/MapboxMaps/Viewport/Transitions/Default/DefaultViewportTransitionAnimationSpecProvider.swift
@@ -1,0 +1,29 @@
+internal protocol DefaultViewportTransitionAnimationSpecProviderProtocol: AnyObject {
+    func makeAnimationSpecs(cameraOptions: CameraOptions) -> [DefaultViewportTransitionAnimationSpec]
+}
+
+internal final class DefaultViewportTransitionAnimationSpecProvider: DefaultViewportTransitionAnimationSpecProviderProtocol {
+
+    private let mapboxMap: MapboxMapProtocol
+    private let lowZoomToHighZoomAnimationSpecProvider: DefaultViewportTransitionAnimationSpecProviderProtocol
+    private let highZoomToLowZoomAnimationSpecProvider: DefaultViewportTransitionAnimationSpecProviderProtocol
+
+    internal init(mapboxMap: MapboxMapProtocol,
+                  lowZoomToHighZoomAnimationSpecProvider: DefaultViewportTransitionAnimationSpecProviderProtocol,
+                  highZoomToLowZoomAnimationSpecProvider: DefaultViewportTransitionAnimationSpecProviderProtocol) {
+        self.mapboxMap = mapboxMap
+        self.lowZoomToHighZoomAnimationSpecProvider = lowZoomToHighZoomAnimationSpecProvider
+        self.highZoomToLowZoomAnimationSpecProvider = highZoomToLowZoomAnimationSpecProvider
+    }
+
+    func makeAnimationSpecs(cameraOptions: CameraOptions) -> [DefaultViewportTransitionAnimationSpec] {
+        let provider: DefaultViewportTransitionAnimationSpecProviderProtocol
+        let currentZoom = mapboxMap.cameraState.zoom
+        if let targetZoom = cameraOptions.zoom, currentZoom < targetZoom {
+            provider = lowZoomToHighZoomAnimationSpecProvider
+        } else {
+            provider = highZoomToLowZoomAnimationSpecProvider
+        }
+        return provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+    }
+}

--- a/Sources/MapboxMaps/Viewport/Transitions/Default/HighZoomToLowZoomAnimationSpecProvider.swift
+++ b/Sources/MapboxMaps/Viewport/Transitions/Default/HighZoomToLowZoomAnimationSpecProvider.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+internal final class HighZoomToLowZoomAnimationSpecProvider: DefaultViewportTransitionAnimationSpecProviderProtocol {
+    private let mapboxMap: MapboxMapProtocol
+
+    internal init(mapboxMap: MapboxMapProtocol) {
+        self.mapboxMap = mapboxMap
+    }
+
+    internal func makeAnimationSpecs(cameraOptions: CameraOptions) -> [DefaultViewportTransitionAnimationSpec] {
+        var animationSpecs = [DefaultViewportTransitionAnimationSpec]()
+
+        if let center = cameraOptions.center {
+            animationSpecs.append(DefaultViewportTransitionAnimationSpec(
+                duration: 1,
+                delay: 0.8,
+                cameraOptionsComponent: CameraOptionsComponent(
+                    keyPath: \.center,
+                    value: center)))
+        }
+
+        if let zoom = cameraOptions.zoom {
+            animationSpecs.append(DefaultViewportTransitionAnimationSpec(
+                duration: 1.8,
+                delay: 0,
+                cameraOptionsComponent: CameraOptionsComponent(
+                    keyPath: \.zoom,
+                    value: zoom)))
+        }
+
+        if let bearing = cameraOptions.bearing {
+            animationSpecs.append(DefaultViewportTransitionAnimationSpec(
+                duration: 1.2,
+                delay: 0.6,
+                cameraOptionsComponent: CameraOptionsComponent(
+                    keyPath: \.bearing,
+                    value: bearing)))
+        }
+
+        if let pitch = cameraOptions.pitch {
+            animationSpecs.append(DefaultViewportTransitionAnimationSpec(
+                duration: 1,
+                delay: 0,
+                cameraOptionsComponent: CameraOptionsComponent(
+                    keyPath: \.pitch,
+                    value: pitch)))
+        }
+
+        if let padding = cameraOptions.padding {
+            animationSpecs.append(DefaultViewportTransitionAnimationSpec(
+                duration: 1.2,
+                delay: 0,
+                cameraOptionsComponent: CameraOptionsComponent(
+                    keyPath: \.padding,
+                    value: padding)))
+        }
+
+        return animationSpecs
+    }
+}

--- a/Sources/MapboxMaps/Viewport/Transitions/Default/LowZoomToHighZoomAnimationSpecProvider.swift
+++ b/Sources/MapboxMaps/Viewport/Transitions/Default/LowZoomToHighZoomAnimationSpecProvider.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+internal final class LowZoomToHighZoomAnimationSpecProvider: DefaultViewportTransitionAnimationSpecProviderProtocol {
+    private let mapboxMap: MapboxMapProtocol
+
+    internal init(mapboxMap: MapboxMapProtocol) {
+        self.mapboxMap = mapboxMap
+    }
+
+    internal func makeAnimationSpecs(cameraOptions: CameraOptions) -> [DefaultViewportTransitionAnimationSpec] {
+        var animationSpecs = [DefaultViewportTransitionAnimationSpec]()
+
+        let maxDuration: TimeInterval = 3
+        let cameraState = mapboxMap.cameraState
+
+        var centerDuration: TimeInterval = 0
+        if let center = cameraOptions.center {
+            let distance = distanceInViewSpace(from: cameraState.center, to: center)
+            // points / s
+            let centerAnimationRate: Double = 500
+            centerDuration = min(Double(distance) / centerAnimationRate, maxDuration)
+            animationSpecs.append(DefaultViewportTransitionAnimationSpec(
+                duration: centerDuration,
+                delay: 0,
+                cameraOptionsComponent: CameraOptionsComponent(
+                    keyPath: \.center,
+                    value: center)))
+        }
+
+        var zoomDelay: TimeInterval = 0
+        var zoomDuration: TimeInterval = 0
+        if let zoom = cameraOptions.zoom {
+            let currentMapCameraZoom = cameraState.zoom
+            let zoomDelta = abs(zoom - currentMapCameraZoom)
+            // zoom level / s
+            let zoomAnimationRate = 2.2
+            zoomDelay = centerDuration / 2
+            zoomDuration = min(Double(zoomDelta) / zoomAnimationRate, maxDuration)
+            animationSpecs.append(DefaultViewportTransitionAnimationSpec(
+                duration: zoomDuration,
+                delay: zoomDelay,
+                cameraOptionsComponent: CameraOptionsComponent(
+                    keyPath: \.zoom,
+                    value: zoom)))
+        }
+
+        if let bearing = cameraOptions.bearing {
+            let bearingDuration: TimeInterval = 1.8
+            let bearingDelay: TimeInterval = max(zoomDelay + zoomDuration - bearingDuration, 0)
+            animationSpecs.append(DefaultViewportTransitionAnimationSpec(
+                duration: bearingDuration,
+                delay: bearingDelay,
+                cameraOptionsComponent: CameraOptionsComponent(
+                    keyPath: \.bearing,
+                    value: bearing)))
+        }
+
+        let pitchAndPaddingDuration: TimeInterval = 1.2
+        let pitchAndPaddingDelay: TimeInterval = max(zoomDelay + zoomDuration - pitchAndPaddingDuration + 0.1, 0)
+        if let pitch = cameraOptions.pitch {
+            animationSpecs.append(DefaultViewportTransitionAnimationSpec(
+                duration: pitchAndPaddingDuration,
+                delay: pitchAndPaddingDelay,
+                cameraOptionsComponent: CameraOptionsComponent(
+                    keyPath: \.pitch,
+                    value: pitch)))
+        }
+
+        if let padding = cameraOptions.padding {
+            animationSpecs.append(DefaultViewportTransitionAnimationSpec(
+                duration: pitchAndPaddingDuration,
+                delay: pitchAndPaddingDelay,
+                cameraOptionsComponent: CameraOptionsComponent(
+                    keyPath: \.padding,
+                    value: padding)))
+        }
+
+        return animationSpecs
+    }
+
+    func distanceInViewSpace(from fromCoordinate: CLLocationCoordinate2D,
+                             to toCoordinate: CLLocationCoordinate2D) -> CGFloat {
+        let fromPoint = mapboxMap.point(for: fromCoordinate)
+        let toPoint = mapboxMap.point(for: toCoordinate)
+        return hypot(fromPoint.x - toPoint.x, fromPoint.y - toPoint.y)
+    }
+}

--- a/Sources/MapboxMaps/Viewport/Viewport.swift
+++ b/Sources/MapboxMaps/Viewport/Viewport.swift
@@ -139,11 +139,24 @@
     ///                      ``DefaultViewportTransitionOptions/init(maxDuration:)`` with the default value specified for all parameters
     /// - Returns: The newly-created ``DefaultViewportTransition``.
     public func makeDefaultViewportTransition(options: DefaultViewportTransitionOptions = .init()) -> DefaultViewportTransition {
+        let lowZoomToHighZoomAnimationSpecProvider = LowZoomToHighZoomAnimationSpecProvider(
+            mapboxMap: mapboxMap)
+        let highZoomToLowZoomAnimationSpecProvider = HighZoomToLowZoomAnimationSpecProvider(
+            mapboxMap: mapboxMap)
+        let animationSpecProvider = DefaultViewportTransitionAnimationSpecProvider(
+            mapboxMap: mapboxMap,
+            lowZoomToHighZoomAnimationSpecProvider: lowZoomToHighZoomAnimationSpecProvider,
+            highZoomToLowZoomAnimationSpecProvider: highZoomToLowZoomAnimationSpecProvider)
+        let animationFactory = DefaultViewportTransitionAnimationFactory(
+            mapboxMap: mapboxMap)
+        let animationHelper = DefaultViewportTransitionAnimationHelper(
+            mapboxMap: mapboxMap,
+            animationSpecProvider: animationSpecProvider,
+            cameraAnimationsManager: cameraAnimationsManager,
+            animationFactory: animationFactory)
         return DefaultViewportTransition(
             options: options,
-            animationHelper: DefaultViewportTransitionAnimationHelper(
-                mapboxMap: mapboxMap,
-                cameraAnimationsManager: cameraAnimationsManager))
+            animationHelper: animationHelper)
     }
 
     /// Creates a new instance of ``ImmediateViewportTransition``.

--- a/Tests/MapboxMapsTests/Camera/AnimationOwnerTests.swift
+++ b/Tests/MapboxMapsTests/Camera/AnimationOwnerTests.swift
@@ -15,5 +15,6 @@ final class AnimationOwnerTests: XCTestCase {
         XCTAssertEqual(AnimationOwner.gestures.rawValue, "com.mapbox.maps.gestures")
         XCTAssertEqual(AnimationOwner.unspecified.rawValue, "com.mapbox.maps.unspecified")
         XCTAssertEqual(AnimationOwner.cameraAnimationsManager.rawValue, "com.mapbox.maps.cameraAnimationsManager")
+        XCTAssertEqual(AnimationOwner.defaultViewportTransition.rawValue, "com.mapbox.maps.viewport.defaultTransition")
     }
 }

--- a/Tests/MapboxMapsTests/Viewport/Transitions/Default/CameraOptionsComponentTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/Transitions/Default/CameraOptionsComponentTests.swift
@@ -1,0 +1,160 @@
+@testable import MapboxMaps
+import XCTest
+
+final class CameraOptionsComponentTests: XCTestCase {
+    func testCameraOptionsForCenter() {
+        let value = CLLocationCoordinate2D.random()
+        let component = CameraOptionsComponent(keyPath: \.center, value: value)
+
+        XCTAssertEqual(component.cameraOptions, CameraOptions(center: value))
+    }
+
+    func testCameraOptionsForPadding() {
+        let value = UIEdgeInsets.random()
+        let component = CameraOptionsComponent(keyPath: \.padding, value: value)
+
+        XCTAssertEqual(component.cameraOptions, CameraOptions(padding: value))
+    }
+
+    func testCameraOptionsForAnchor() {
+        let value = CGPoint.random()
+        let component = CameraOptionsComponent(keyPath: \.anchor, value: value)
+
+        XCTAssertEqual(component.cameraOptions, CameraOptions(anchor: value))
+    }
+
+    func testCameraOptionsForZoom() {
+        let value = CGFloat.random(in: 0...20)
+        let component = CameraOptionsComponent(keyPath: \.zoom, value: value)
+
+        XCTAssertEqual(component.cameraOptions, CameraOptions(zoom: value))
+    }
+
+    func testCameraOptionsForBearing() {
+        let value = CLLocationDirection.random(in: 0..<360)
+        let component = CameraOptionsComponent(keyPath: \.bearing, value: value)
+
+        XCTAssertEqual(component.cameraOptions, CameraOptions(bearing: value))
+    }
+
+    func testCameraOptionsForPitch() {
+        let value = CGFloat.random(in: 0...80)
+        let component = CameraOptionsComponent(keyPath: \.pitch, value: value)
+
+        XCTAssertEqual(component.cameraOptions, CameraOptions(pitch: value))
+    }
+
+    func testUpdatedForCenterNonNil() throws {
+        let component = CameraOptionsComponent(keyPath: \.center, value: .random())
+        let cameraOptions = CameraOptions.random()
+
+        let updatedComponent = try XCTUnwrap(
+            component.updated(with: cameraOptions) as? CameraOptionsComponent<CLLocationCoordinate2D>)
+
+        XCTAssertEqual(updatedComponent.keyPath, component.keyPath)
+        XCTAssertEqual(updatedComponent.value, cameraOptions.center)
+    }
+
+    func testUpdatedForCenterNil() {
+        let component = CameraOptionsComponent(keyPath: \.center, value: .random())
+        var cameraOptions = CameraOptions.random()
+        cameraOptions.center = nil
+
+        XCTAssertNil(component.updated(with: cameraOptions))
+    }
+
+    func testUpdatedForPaddingNonNil() throws {
+        let component = CameraOptionsComponent(keyPath: \.padding, value: .random())
+        let cameraOptions = CameraOptions.random()
+
+        let updatedComponent = try XCTUnwrap(
+            component.updated(with: cameraOptions) as? CameraOptionsComponent<UIEdgeInsets>)
+
+        XCTAssertEqual(updatedComponent.keyPath, component.keyPath)
+        XCTAssertEqual(updatedComponent.value, cameraOptions.padding)
+    }
+
+    func testUpdatedForPaddingNil() {
+        let component = CameraOptionsComponent(keyPath: \.padding, value: .random())
+        var cameraOptions = CameraOptions.random()
+        cameraOptions.padding = nil
+
+        XCTAssertNil(component.updated(with: cameraOptions))
+    }
+
+    func testUpdatedForAnchorNonNil() throws {
+        let component = CameraOptionsComponent(keyPath: \.anchor, value: .random())
+        let cameraOptions = CameraOptions.random()
+
+        let updatedComponent = try XCTUnwrap(
+            component.updated(with: cameraOptions) as? CameraOptionsComponent<CGPoint>)
+
+        XCTAssertEqual(updatedComponent.keyPath, component.keyPath)
+        XCTAssertEqual(updatedComponent.value, cameraOptions.anchor)
+    }
+
+    func testUpdatedForAnchorNil() {
+        let component = CameraOptionsComponent(keyPath: \.anchor, value: .random())
+        var cameraOptions = CameraOptions.random()
+        cameraOptions.anchor = nil
+
+        XCTAssertNil(component.updated(with: cameraOptions))
+    }
+
+    func testUpdatedForZoomNonNil() throws {
+        let component = CameraOptionsComponent(keyPath: \.zoom, value: .random(in: 0...20))
+        let cameraOptions = CameraOptions.random()
+
+        let updatedComponent = try XCTUnwrap(
+            component.updated(with: cameraOptions) as? CameraOptionsComponent<CGFloat>)
+
+        XCTAssertEqual(updatedComponent.keyPath, component.keyPath)
+        XCTAssertEqual(updatedComponent.value, cameraOptions.zoom)
+    }
+
+    func testUpdatedForZoomNil() {
+        let component = CameraOptionsComponent(keyPath: \.zoom, value: .random(in: 0...20))
+        var cameraOptions = CameraOptions.random()
+        cameraOptions.zoom = nil
+
+        XCTAssertNil(component.updated(with: cameraOptions))
+    }
+
+    func testUpdatedForBearingNonNil() throws {
+        let component = CameraOptionsComponent(keyPath: \.bearing, value: .random(in: 0..<360))
+        let cameraOptions = CameraOptions.random()
+
+        let updatedComponent = try XCTUnwrap(
+            component.updated(with: cameraOptions) as? CameraOptionsComponent<CLLocationDirection>)
+
+        XCTAssertEqual(updatedComponent.keyPath, component.keyPath)
+        XCTAssertEqual(updatedComponent.value, cameraOptions.bearing)
+    }
+
+    func testUpdatedForBearingNil() {
+        let component = CameraOptionsComponent(keyPath: \.bearing, value: .random(in: 0..<360))
+        var cameraOptions = CameraOptions.random()
+        cameraOptions.bearing = nil
+
+        XCTAssertNil(component.updated(with: cameraOptions))
+    }
+
+    func testUpdatedForPitchNonNil() throws {
+        let component = CameraOptionsComponent(keyPath: \.pitch, value: .random(in: 0...80))
+        let cameraOptions = CameraOptions.random()
+
+        let updatedComponent = try XCTUnwrap(
+            component.updated(with: cameraOptions) as? CameraOptionsComponent<CGFloat>)
+
+        XCTAssertEqual(updatedComponent.keyPath, component.keyPath)
+        XCTAssertEqual(updatedComponent.value, cameraOptions.pitch)
+    }
+
+    func testUpdatedForPitchNil() {
+        let component = CameraOptionsComponent(keyPath: \.pitch, value: .random(in: 0...80))
+        var cameraOptions = CameraOptions.random()
+        cameraOptions.pitch = nil
+
+        XCTAssertNil(component.updated(with: cameraOptions))
+    }
+}

--- a/Tests/MapboxMapsTests/Viewport/Transitions/Default/DefaultViewportTransitionAnimationHelperTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/Transitions/Default/DefaultViewportTransitionAnimationHelperTests.swift
@@ -1,0 +1,136 @@
+@testable import MapboxMaps
+import XCTest
+
+final class DefaultViewportTransitionAnimationHelperTests: XCTestCase {
+    var mapboxMap: MockMapboxMap!
+    var animationSpecProvider: MockDefaultViewportTransitionAnimationSpecProvider!
+    var cameraAnimationsManager: MockCameraAnimationsManager!
+    var animationFactory: MockDefaultViewportTransitionAnimationFactory!
+    var helper: DefaultViewportTransitionAnimationHelper!
+
+    override func setUp() {
+        super.setUp()
+        mapboxMap = MockMapboxMap()
+        animationSpecProvider = MockDefaultViewportTransitionAnimationSpecProvider()
+        cameraAnimationsManager = MockCameraAnimationsManager()
+        animationFactory = MockDefaultViewportTransitionAnimationFactory()
+        helper = DefaultViewportTransitionAnimationHelper(
+            mapboxMap: mapboxMap,
+            animationSpecProvider: animationSpecProvider,
+            cameraAnimationsManager: cameraAnimationsManager,
+            animationFactory: animationFactory)
+    }
+
+    override func tearDown() {
+        helper = nil
+        animationFactory = nil
+        cameraAnimationsManager = nil
+        animationSpecProvider = nil
+        mapboxMap = nil
+        super.tearDown()
+    }
+
+    func testMakeAnimationWithZeroSpecs() throws {
+        let cameraOptions = CameraOptions.random()
+        animationSpecProvider.makeAnimationSpecsStub.defaultReturnValue = []
+
+        let animation = helper.makeAnimation(
+            cameraOptions: cameraOptions,
+            maxDuration: .random(in: 0...100))
+
+        XCTAssertEqual(animationSpecProvider.makeAnimationSpecsStub.invocations.map(\.parameters), [cameraOptions])
+
+        XCTAssertEqual(animationFactory.makeAnimationStub.invocations.count, 1)
+        let makeAnimationInvocation = try XCTUnwrap(animationFactory.makeAnimationStub.invocations.first)
+        XCTAssertEqual(makeAnimationInvocation.parameters.count, 0)
+        XCTAssertIdentical(animation, makeAnimationInvocation.returnValue)
+    }
+
+    func verifyAnimationCreation(spec: DefaultViewportTransitionAnimationSpec, index: Int) throws {
+        guard index < cameraAnimationsManager.makeSimpleCameraAnimatorStub.invocations.count,
+              index < animationFactory.makeAnimationComponentStub.invocations.count else {
+                  XCTFail("index out of bounds")
+                  return
+              }
+
+        let makeSimpleCameraAnimatorInvocation = cameraAnimationsManager.makeSimpleCameraAnimatorStub.invocations[index]
+        let makeAnimationComponentInvocation = animationFactory.makeAnimationComponentStub.invocations[index]
+
+        XCTAssertEqual(makeSimpleCameraAnimatorInvocation.parameters.from, CameraOptions(cameraState: mapboxMap.cameraState))
+        XCTAssertEqual(makeSimpleCameraAnimatorInvocation.parameters.to, spec.cameraOptionsComponent.cameraOptions)
+        XCTAssertEqual(makeSimpleCameraAnimatorInvocation.parameters.duration, spec.duration)
+        XCTAssertEqual(makeSimpleCameraAnimatorInvocation.parameters.curve, .easeInOut)
+        XCTAssertEqual(makeSimpleCameraAnimatorInvocation.parameters.owner, .defaultViewportTransition)
+
+        XCTAssertIdentical(makeAnimationComponentInvocation.parameters.animator, makeSimpleCameraAnimatorInvocation.returnValue)
+        XCTAssertEqual(makeAnimationComponentInvocation.parameters.delay, spec.delay)
+        XCTAssertIdentical(
+            makeAnimationComponentInvocation.parameters.cameraOptionsComponent as? MockCameraOptionsComponent,
+            spec.cameraOptionsComponent as? MockCameraOptionsComponent)
+    }
+
+    func verifyMakeAnimation(maxDuration: TimeInterval,
+                             duration: TimeInterval,
+                             delay: TimeInterval,
+                             expectedScaleFactor: Double) throws {
+        let cameraOptions = CameraOptions.random()
+        let specs = [
+            DefaultViewportTransitionAnimationSpec(
+                duration: duration,
+                delay: delay,
+                cameraOptionsComponent: MockCameraOptionsComponent()),
+            DefaultViewportTransitionAnimationSpec(
+                duration: 1,
+                delay: 0,
+                cameraOptionsComponent: MockCameraOptionsComponent())
+        ]
+        animationSpecProvider.makeAnimationSpecsStub.defaultReturnValue = specs
+        mapboxMap.cameraState = .random()
+
+        let animation = helper.makeAnimation(
+            cameraOptions: cameraOptions,
+            maxDuration: maxDuration)
+
+        XCTAssertEqual(animationSpecProvider.makeAnimationSpecsStub.invocations.map(\.parameters), [cameraOptions])
+
+        // verify that the specs are converted into animations without any scaling
+        XCTAssertEqual(cameraAnimationsManager.makeSimpleCameraAnimatorStub.invocations.count, specs.count)
+        XCTAssertEqual(animationFactory.makeAnimationComponentStub.invocations.count, specs.count)
+
+        for (idx, spec) in specs.enumerated() {
+            try verifyAnimationCreation(spec: spec.scaled(by: expectedScaleFactor), index: idx)
+        }
+
+        XCTAssertEqual(animationFactory.makeAnimationStub.invocations.count, 1)
+        let makeAnimationInvocation = try XCTUnwrap(animationFactory.makeAnimationStub.invocations.first)
+        XCTAssertEqual(makeAnimationInvocation.parameters.count, animationFactory.makeAnimationComponentStub.invocations.count)
+        for (a, b) in zip(makeAnimationInvocation.parameters, animationFactory.makeAnimationComponentStub.invocations.map(\.returnValue)) {
+            XCTAssertIdentical(a, b)
+        }
+        XCTAssertIdentical(animation, makeAnimationInvocation.returnValue)
+    }
+
+    func testMakeAnimationWithLongestDurationLessThanMax() throws {
+        try verifyMakeAnimation(
+            maxDuration: 100,
+            duration: 25,
+            delay: 25,
+            expectedScaleFactor: 1)
+    }
+
+    func testMakeAnimationWithLongestDurationEqualToMax() throws {
+        try verifyMakeAnimation(
+            maxDuration: 100,
+            duration: 50,
+            delay: 50,
+            expectedScaleFactor: 1)
+    }
+
+    func testMakeAnimationWithLongestDurationGreaterThanMax() throws {
+        try verifyMakeAnimation(
+            maxDuration: 100,
+            duration: 100,
+            delay: 100,
+            expectedScaleFactor: 0.5)
+    }
+}

--- a/Tests/MapboxMapsTests/Viewport/Transitions/Default/DefaultViewportTransitionAnimationSpecProviderTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/Transitions/Default/DefaultViewportTransitionAnimationSpecProviderTests.swift
@@ -1,0 +1,125 @@
+@testable import MapboxMaps
+import XCTest
+
+final class DefaultViewportTransitionAnimationSpecProviderTests: XCTestCase {
+
+    var mapboxMap: MockMapboxMap!
+    var lowZoomToHighZoomAnimationSpecProvider: MockDefaultViewportTransitionAnimationSpecProvider!
+    var highZoomToLowZoomAnimationSpecProvider: MockDefaultViewportTransitionAnimationSpecProvider!
+    var provider: DefaultViewportTransitionAnimationSpecProvider!
+
+    override func setUp() {
+        super.setUp()
+        mapboxMap = MockMapboxMap()
+        lowZoomToHighZoomAnimationSpecProvider = MockDefaultViewportTransitionAnimationSpecProvider()
+        highZoomToLowZoomAnimationSpecProvider = MockDefaultViewportTransitionAnimationSpecProvider()
+        provider = DefaultViewportTransitionAnimationSpecProvider(
+            mapboxMap: mapboxMap,
+            lowZoomToHighZoomAnimationSpecProvider: lowZoomToHighZoomAnimationSpecProvider,
+            highZoomToLowZoomAnimationSpecProvider: highZoomToLowZoomAnimationSpecProvider)
+
+        lowZoomToHighZoomAnimationSpecProvider.makeAnimationSpecsStub.defaultReturnValue = .random(
+            withLength: .random(in: 1...10),
+            generator: {
+                DefaultViewportTransitionAnimationSpec(
+                    duration: .random(in: 0...10),
+                    delay: .random(in: 0...10),
+                    cameraOptionsComponent: MockCameraOptionsComponent())
+            })
+        highZoomToLowZoomAnimationSpecProvider.makeAnimationSpecsStub.defaultReturnValue = .random(
+            withLength: .random(in: 1...10),
+            generator: {
+                DefaultViewportTransitionAnimationSpec(
+                    duration: .random(in: 0...10),
+                    delay: .random(in: 0...10),
+                    cameraOptionsComponent: MockCameraOptionsComponent())
+            })
+    }
+
+    override func tearDown() {
+        provider = nil
+        highZoomToLowZoomAnimationSpecProvider = nil
+        lowZoomToHighZoomAnimationSpecProvider = nil
+        mapboxMap = nil
+        super.tearDown()
+    }
+
+    func verifySpecs(_ specs: [DefaultViewportTransitionAnimationSpec],
+                     provider: MockDefaultViewportTransitionAnimationSpecProvider) throws {
+        let returnedSpecs = try XCTUnwrap(provider.makeAnimationSpecsStub.invocations.first?.returnValue)
+        XCTAssertEqual(specs.count, returnedSpecs.count)
+        for (spec, returnedSpec) in zip(specs, returnedSpecs) {
+            XCTAssertEqual(spec.duration, returnedSpec.duration)
+            XCTAssertEqual(spec.delay, returnedSpec.delay)
+            XCTAssertIdentical(
+                spec.cameraOptionsComponent as? MockCameraOptionsComponent,
+                returnedSpec.cameraOptionsComponent as? MockCameraOptionsComponent)
+        }
+    }
+
+    func testMakeAnimationSpecsWithNilTargetZoom() throws {
+        var cameraOptions = CameraOptions.random()
+        cameraOptions.zoom = nil
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(
+            highZoomToLowZoomAnimationSpecProvider.makeAnimationSpecsStub.invocations.map(\.parameters),
+            [cameraOptions])
+        XCTAssertEqual(
+            lowZoomToHighZoomAnimationSpecProvider.makeAnimationSpecsStub.invocations.count,
+            0)
+        try verifySpecs(specs, provider: highZoomToLowZoomAnimationSpecProvider)
+    }
+
+    func testMakeAnimationSpecsWithCurrentZoomGreaterThanTargetZoom() throws {
+        var cameraOptions = CameraOptions.random()
+        cameraOptions.zoom = .random(in: 0...20)
+
+        mapboxMap.cameraState.zoom = cameraOptions.zoom! + 1
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(
+            highZoomToLowZoomAnimationSpecProvider.makeAnimationSpecsStub.invocations.map(\.parameters),
+            [cameraOptions])
+        XCTAssertEqual(
+            lowZoomToHighZoomAnimationSpecProvider.makeAnimationSpecsStub.invocations.count,
+            0)
+        try verifySpecs(specs, provider: highZoomToLowZoomAnimationSpecProvider)
+    }
+
+    func testMakeAnimationSpecsWithCurrentZoomEqualToTargetZoom() throws {
+        var cameraOptions = CameraOptions.random()
+        cameraOptions.zoom = .random(in: 0...20)
+
+        mapboxMap.cameraState.zoom = cameraOptions.zoom!
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(
+            highZoomToLowZoomAnimationSpecProvider.makeAnimationSpecsStub.invocations.map(\.parameters),
+            [cameraOptions])
+        XCTAssertEqual(
+            lowZoomToHighZoomAnimationSpecProvider.makeAnimationSpecsStub.invocations.count,
+            0)
+        try verifySpecs(specs, provider: highZoomToLowZoomAnimationSpecProvider)
+    }
+
+    func testMakeAnimationSpecsWithCurrentZoomLessThanTargetZoom() throws {
+        var cameraOptions = CameraOptions.random()
+        cameraOptions.zoom = .random(in: 1...20)
+
+        mapboxMap.cameraState.zoom = cameraOptions.zoom! - 1
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(
+            highZoomToLowZoomAnimationSpecProvider.makeAnimationSpecsStub.invocations.count,
+            0)
+        XCTAssertEqual(
+            lowZoomToHighZoomAnimationSpecProvider.makeAnimationSpecsStub.invocations.map(\.parameters),
+            [cameraOptions])
+        try verifySpecs(specs, provider: lowZoomToHighZoomAnimationSpecProvider)
+    }
+}

--- a/Tests/MapboxMapsTests/Viewport/Transitions/Default/DefaultViewportTransitionAnimationSpecTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/Transitions/Default/DefaultViewportTransitionAnimationSpecTests.swift
@@ -1,0 +1,28 @@
+@testable import MapboxMaps
+import XCTest
+
+final class DefaultViewportTransitionAnimationSpecTests: XCTestCase {
+
+    func testTotal() {
+        let spec = DefaultViewportTransitionAnimationSpec(
+            duration: .random(in: 0...100),
+            delay: .random(in: 0...100),
+            cameraOptionsComponent: MockCameraOptionsComponent())
+
+        XCTAssertEqual(spec.total, spec.duration + spec.delay)
+    }
+
+    func testScaledBy() {
+        let scaleFactor = Double.random(in: 0...10)
+
+        let spec = DefaultViewportTransitionAnimationSpec(
+            duration: .random(in: 0...100),
+            delay: .random(in: 0...100),
+            cameraOptionsComponent: MockCameraOptionsComponent())
+
+        let scaledSpec = spec.scaled(by: scaleFactor)
+
+        XCTAssertEqual(scaledSpec.duration, spec.duration * scaleFactor)
+        XCTAssertEqual(scaledSpec.delay, spec.delay * scaleFactor)
+    }
+}

--- a/Tests/MapboxMapsTests/Viewport/Transitions/Default/DefaultViewportTransitionAnimationTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/Transitions/Default/DefaultViewportTransitionAnimationTests.swift
@@ -1,0 +1,198 @@
+@testable import MapboxMaps
+import XCTest
+
+final class DefaultViewportTransitionAnimationTests: XCTestCase {
+    var components: [MockDefaultViewportTransitionAnimation]!
+    var animation: DefaultViewportTransitionAnimation!
+
+    override func setUp() {
+        super.setUp()
+        components = Array.random(
+            withLength: .random(in: 1...10),
+            generator: MockDefaultViewportTransitionAnimation.init)
+        animation = DefaultViewportTransitionAnimation(components: components)
+    }
+
+    override func tearDown() {
+        animation = nil
+        components = nil
+        super.tearDown()
+    }
+
+    func testStartAllComponentsSucceed() throws {
+        let completionStub = Stub<Bool, Void>()
+        let completionExpectation = expectation(description: "completion invoked")
+        completionStub.defaultSideEffect = { _ in
+            completionExpectation.fulfill()
+        }
+
+        animation.start(with: completionStub.call(with:))
+
+        for component in components {
+            XCTAssertEqual(component.startStub.invocations.count, 1)
+            let completion = try XCTUnwrap(component.startStub.invocations.first?.parameters)
+            completion(true)
+        }
+
+        wait(for: [completionExpectation], timeout: 0.5)
+
+        XCTAssertEqual(completionStub.invocations.map(\.parameters), [true])
+    }
+
+    func testStartOneComponentFails() throws {
+        let completionStub = Stub<Bool, Void>()
+        let completionExpectation = expectation(description: "completion invoked")
+        completionStub.defaultSideEffect = { _ in
+            completionExpectation.fulfill()
+        }
+
+        animation.start(with: completionStub.call(with:))
+
+        let failingIndex = Int.random(in: 0..<components.count)
+        for (idx, component) in components.enumerated() {
+            XCTAssertEqual(component.startStub.invocations.count, 1)
+            let completion = try XCTUnwrap(component.startStub.invocations.first?.parameters)
+            completion(idx != failingIndex)
+        }
+
+        wait(for: [completionExpectation], timeout: 0.5)
+
+        XCTAssertEqual(completionStub.invocations.map(\.parameters), [false])
+    }
+
+    func testStartWithZeroComponents() throws {
+        animation = DefaultViewportTransitionAnimation(components: [])
+
+        let completionStub = Stub<Bool, Void>()
+        let completionExpectation = expectation(description: "completion invoked")
+        completionStub.defaultSideEffect = { _ in
+            completionExpectation.fulfill()
+        }
+
+        animation.start(with: completionStub.call(with:))
+
+        wait(for: [completionExpectation], timeout: 0.5)
+
+        XCTAssertEqual(completionStub.invocations.map(\.parameters), [true])
+    }
+
+    func testUpdateTargetCamera() {
+        let cameraOptions = CameraOptions.random()
+
+        animation.updateTargetCamera(with: cameraOptions)
+
+        for component in components {
+            XCTAssertEqual(component.updateTargetCameraStub.invocations.map(\.parameters), [cameraOptions])
+        }
+    }
+
+    func testCancel() {
+        animation.cancel()
+
+        for component in components {
+            XCTAssertEqual(component.cancelStub.invocations.count, 1)
+        }
+    }
+}
+
+final class DefaultViewportTransitionAnimationComponentTests: XCTestCase {
+    var animator: MockSimpleCameraAnimator!
+    var delay: TimeInterval!
+    var cameraOptionsComponent: MockCameraOptionsComponent!
+    var mapboxMap: MockMapboxMap!
+    var animationComponent: DefaultViewportTransitionAnimationComponent!
+
+    override func setUp() {
+        super.setUp()
+        animator = MockSimpleCameraAnimator()
+        delay = .random(in: 0...100)
+        cameraOptionsComponent = MockCameraOptionsComponent()
+        mapboxMap = MockMapboxMap()
+        animationComponent = DefaultViewportTransitionAnimationComponent(
+            animator: animator,
+            delay: delay,
+            cameraOptionsComponent: cameraOptionsComponent,
+            mapboxMap: mapboxMap)
+    }
+
+    override func tearDown() {
+        animationComponent = nil
+        mapboxMap = nil
+        cameraOptionsComponent = nil
+        delay = nil
+        animator = nil
+        super.tearDown()
+    }
+
+    func testStartAndCompleteWithPositionStartOrEnd() throws {
+        let completionStub = Stub<Bool, Void>()
+
+        animationComponent.start(with: completionStub.call(with:))
+
+        XCTAssertEqual(animator.addCompletionStub.invocations.count, 1)
+        let animatorCompletion = try XCTUnwrap(animator.addCompletionStub.invocations.first?.parameters)
+        XCTAssertEqual(animator.startAnimationAfterDelayStub.invocations.map(\.parameters), [delay])
+
+        let position: UIViewAnimatingPosition = [.start, .end].randomElement()!
+        animatorCompletion(position)
+
+        XCTAssertEqual(completionStub.invocations.map(\.parameters), [true])
+    }
+
+    func testStartAndCompleteWithPositionCurrent() throws {
+        let completionStub = Stub<Bool, Void>()
+
+        animationComponent.start(with: completionStub.call(with:))
+
+        XCTAssertEqual(animator.addCompletionStub.invocations.count, 1)
+        let animatorCompletion = try XCTUnwrap(animator.addCompletionStub.invocations.first?.parameters)
+        XCTAssertEqual(animator.startAnimationAfterDelayStub.invocations.map(\.parameters), [delay])
+
+        animatorCompletion(.current)
+
+        XCTAssertEqual(completionStub.invocations.map(\.parameters), [false])
+    }
+
+    func testUpdateTargetCameraWhenUpdatedComponentIsNil() {
+        let cameraOptions = CameraOptions.random()
+        cameraOptionsComponent.updatedStub.defaultReturnValue = nil
+
+        animationComponent.updateTargetCamera(with: cameraOptions)
+
+        XCTAssertEqual(cameraOptionsComponent.updatedStub.invocations.map(\.parameters), [cameraOptions])
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 0)
+        XCTAssertEqual(animator.$to.setStub.invocations.count, 0)
+    }
+
+    func testUpdateTargetCameraWhenUpdatedComponentIsNonNilAndAnimatorIsInactive() {
+        let updatedComponent = MockCameraOptionsComponent()
+        cameraOptionsComponent.updatedStub.defaultReturnValue = updatedComponent
+        animator.state = .inactive
+        let cameraOptions = CameraOptions.random()
+
+        animationComponent.updateTargetCamera(with: cameraOptions)
+
+        XCTAssertEqual(cameraOptionsComponent.updatedStub.invocations.map(\.parameters), [cameraOptions])
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.map(\.parameters), [updatedComponent.cameraOptions])
+        XCTAssertEqual(animator.$to.setStub.invocations.count, 0)
+    }
+
+    func testUpdateTargetCameraWhenUpdatedComponentIsNonNilAndAnimatorIsNotInactive() {
+        let updatedComponent = MockCameraOptionsComponent()
+        cameraOptionsComponent.updatedStub.defaultReturnValue = updatedComponent
+        animator.state = [.active, .stopped].randomElement()!
+        let cameraOptions = CameraOptions.random()
+
+        animationComponent.updateTargetCamera(with: cameraOptions)
+
+        XCTAssertEqual(cameraOptionsComponent.updatedStub.invocations.map(\.parameters), [cameraOptions])
+        XCTAssertEqual(mapboxMap.setCameraStub.invocations.count, 0)
+        XCTAssertEqual(animator.$to.setStub.invocations.map(\.parameters), [updatedComponent.cameraOptions])
+    }
+
+    func testCancel() {
+        animationComponent.cancel()
+
+        XCTAssertEqual(animator.cancelStub.invocations.count, 1)
+    }
+}

--- a/Tests/MapboxMapsTests/Viewport/Transitions/Default/Mocks/MockCameraOptionsComponent.swift
+++ b/Tests/MapboxMapsTests/Viewport/Transitions/Default/Mocks/MockCameraOptionsComponent.swift
@@ -1,0 +1,10 @@
+@testable import MapboxMaps
+
+final class MockCameraOptionsComponent: CameraOptionsComponentProtocol {
+    @Stubbed var cameraOptions: CameraOptions = .random()
+
+    let updatedStub = Stub<CameraOptions, CameraOptionsComponentProtocol?>(defaultReturnValue: nil)
+    func updated(with cameraOptions: CameraOptions) -> CameraOptionsComponentProtocol? {
+        updatedStub.call(with: cameraOptions)
+    }
+}

--- a/Tests/MapboxMapsTests/Viewport/Transitions/Default/Mocks/MockDefaultViewportTransitionAnimation.swift
+++ b/Tests/MapboxMapsTests/Viewport/Transitions/Default/Mocks/MockDefaultViewportTransitionAnimation.swift
@@ -1,0 +1,19 @@
+@testable import MapboxMaps
+
+final class MockDefaultViewportTransitionAnimation: DefaultViewportTransitionAnimationProtocol {
+
+    let startStub = Stub<(Bool) -> Void, Void>()
+    func start(with completion: @escaping (Bool) -> Void) {
+        startStub.call(with: completion)
+    }
+
+    let updateTargetCameraStub = Stub<CameraOptions, Void>()
+    func updateTargetCamera(with cameraOptions: CameraOptions) {
+        updateTargetCameraStub.call(with: cameraOptions)
+    }
+
+    let cancelStub = Stub<Void, Void>()
+    func cancel() {
+        cancelStub.call()
+    }
+}

--- a/Tests/MapboxMapsTests/Viewport/Transitions/Default/Mocks/MockDefaultViewportTransitionAnimationFactory.swift
+++ b/Tests/MapboxMapsTests/Viewport/Transitions/Default/Mocks/MockDefaultViewportTransitionAnimationFactory.swift
@@ -1,0 +1,30 @@
+@testable import MapboxMaps
+import XCTest
+
+final class MockDefaultViewportTransitionAnimationFactory: DefaultViewportTransitionAnimationFactoryProtocol {
+    struct MakeAnimationComponentParams {
+        var animator: SimpleCameraAnimatorProtocol
+        var delay: TimeInterval
+        var cameraOptionsComponent: CameraOptionsComponentProtocol
+    }
+    let makeAnimationComponentStub = Stub<
+        MakeAnimationComponentParams,
+        DefaultViewportTransitionAnimationProtocol>(
+            defaultReturnValue: MockDefaultViewportTransitionAnimation())
+    func makeAnimationComponent(animator: SimpleCameraAnimatorProtocol,
+                                delay: TimeInterval,
+                                cameraOptionsComponent: CameraOptionsComponentProtocol) -> DefaultViewportTransitionAnimationProtocol {
+        makeAnimationComponentStub.call(with: .init(
+            animator: animator,
+            delay: delay,
+            cameraOptionsComponent: cameraOptionsComponent))
+    }
+
+    let makeAnimationStub = Stub<
+        [DefaultViewportTransitionAnimationProtocol],
+        DefaultViewportTransitionAnimationProtocol>(
+            defaultReturnValue: MockDefaultViewportTransitionAnimation())
+    func makeAnimation(components: [DefaultViewportTransitionAnimationProtocol]) -> DefaultViewportTransitionAnimationProtocol {
+        makeAnimationStub.call(with: components)
+    }
+}

--- a/Tests/MapboxMapsTests/Viewport/Transitions/Default/Mocks/MockDefaultViewportTransitionAnimationHelper.swift
+++ b/Tests/MapboxMapsTests/Viewport/Transitions/Default/Mocks/MockDefaultViewportTransitionAnimationHelper.swift
@@ -2,18 +2,18 @@
 
 final class MockDefaultViewportTransitionAnimationHelper: DefaultViewportTransitionAnimationHelperProtocol {
 
-    struct AnimateParams {
+    struct MakeAnimationParams {
         var cameraOptions: CameraOptions
         var maxDuration: TimeInterval
-        var completion: (Bool) -> Void
     }
-    let animateStub = Stub<AnimateParams, Cancelable>(defaultReturnValue: MockCancelable())
-    func animate(to cameraOptions: CameraOptions,
-                 maxDuration: TimeInterval,
-                 completion: @escaping (Bool) -> Void) -> Cancelable {
-        animateStub.call(with: .init(
+    let makeAnimationStub = Stub<
+        MakeAnimationParams,
+        DefaultViewportTransitionAnimationProtocol>(
+            defaultReturnValue: MockDefaultViewportTransitionAnimation())
+    func makeAnimation(cameraOptions: CameraOptions,
+                       maxDuration: TimeInterval) -> DefaultViewportTransitionAnimationProtocol {
+        makeAnimationStub.call(with: .init(
             cameraOptions: cameraOptions,
-            maxDuration: maxDuration,
-            completion: completion))
+            maxDuration: maxDuration))
     }
 }

--- a/Tests/MapboxMapsTests/Viewport/Transitions/Default/Mocks/MockDefaultViewportTransitionAnimationSpecProvider.swift
+++ b/Tests/MapboxMapsTests/Viewport/Transitions/Default/Mocks/MockDefaultViewportTransitionAnimationSpecProvider.swift
@@ -1,0 +1,11 @@
+@testable import MapboxMaps
+
+final class MockDefaultViewportTransitionAnimationSpecProvider: DefaultViewportTransitionAnimationSpecProviderProtocol {
+    let makeAnimationSpecsStub = Stub<
+        CameraOptions,
+        [DefaultViewportTransitionAnimationSpec]>(
+            defaultReturnValue: [])
+    func makeAnimationSpecs(cameraOptions: CameraOptions) -> [DefaultViewportTransitionAnimationSpec] {
+        makeAnimationSpecsStub.call(with: cameraOptions)
+    }
+}


### PR DESCRIPTION
This PR updates the DefaultViewportTransition to animate using SimpleCameraAnimator and update the animator's target camera dynamically during the animation. This approach results in arriving at exactly the right location at the end of the transition.

Before:
https://user-images.githubusercontent.com/205658/161695243-fd8c1204-278e-4c48-86fe-46cb8639f5e6.mp4

After:
https://user-images.githubusercontent.com/205658/161695273-eb3b3467-21be-4c0f-9d12-9b0821f7c5e1.mp4

The high-to-low and low-to-high animation spec providers are not yet tested. Those tests will be added in a subsequent PR.

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
