### PR TITLE
Use maps-ios prefix in Log message category.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Update to MapboxCoreMaps 10.5.0-beta.1 and MapboxCommon 21.3.0-beta.2. ([#1235](https://github.com/mapbox/mapbox-maps-ios/pull/1235))
 * API for using globe projection has been moved to `Style.setProjection(_:)` and `Style.projection` and is no longer experimental. ([#1235](https://github.com/mapbox/mapbox-maps-ios/pull/1235)) 
 * Add `OfflineRegion.getStatus(completion:)`. ([#1239](https://github.com/mapbox/mapbox-maps-ios/pull/1239))
+ * Add a prefix `maps-ios` to all Log message's category. ([#1250](https://github.com/mapbox/mapbox-maps-ios/pull/1250)))
 
 ## 10.4.1 - March 28, 2022
 

--- a/Sources/MapboxMaps/Foundation/Logger.swift
+++ b/Sources/MapboxMaps/Foundation/Logger.swift
@@ -1,0 +1,30 @@
+import Foundation
+@_implementationOnly import MapboxCommon_Private.MBXLog_Internal
+
+internal struct Log {
+    private typealias Logger = MapboxCommon_Private.Log
+
+    private static func logCategory(_ additionalCategory: String?) -> String {
+        let logPrefix = "maps-ios"
+        guard let additionalCategory = additionalCategory else {
+            return logPrefix
+        }
+        return "\(logPrefix)/\(additionalCategory)"
+    }
+
+    internal static func debug(forMessage message: String, category: String? = nil) {
+        Logger.debug(forMessage: message, category: logCategory(category))
+    }
+
+    internal static func info(forMessage message: String, category: String? = nil) {
+        Logger.info(forMessage: message, category: logCategory(category))
+    }
+
+    internal static func warning(forMessage message: String, category: String? = nil) {
+        Logger.warning(forMessage: message, category: logCategory(category))
+    }
+
+    internal static func error(forMessage message: String, category: String? = nil) {
+        Logger.error(forMessage: message, category: logCategory(category))
+    }
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->
This pull request adds `maps-ios` prefix to all Log message's category, if there is an additional category passed in (i.e `Puck`, `Annotations`, `Gestures`) then we append this additional category to the said prefix, using `/` as separator.

## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
