### PR TITLE
Use literal in PointAnnotationManager.textFont

### DIFF
--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -317,10 +317,10 @@ public class PointAnnotationManager: AnnotationManagerInternal {
     /// Font stack to use for displaying text.
     public var textFont: [String]? {
         get {
-            return layerProperties["text-font"] as? [String]
+            return (layerProperties["text-font"] as? [Any])?[1] as? [String]
         }
         set {
-            layerProperties["text-font"] = newValue
+            layerProperties["text-font"] = newValue.map { ["literal", $0] }
         }
     }
 


### PR DESCRIPTION
`[String]` is interpreted as an expression unless it is wrapped in a literal expression.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
