### PR TITLE
Start location services lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+* Start location services lazily. ([#1262](https://github.com/mapbox/mapbox-maps-ios/pull/1262))
+
 ## 10.5.0-beta.1 - April 7, 2022
 
 * Mitigate `OfflineRegionManager.mergeOfflineDatabase(for:completion)` throwing `TypeConversionError.unexpectedType` on a successfull merge. Introduce `OfflineRegionManager.mergeOfflineDatabase(forPath:completion)` as the correct way to merge offline database. ([#1192](https://github.com/mapbox/mapbox-maps-ios/pull/1192))

--- a/Sources/MapboxMaps/Foundation/ObservableValue.swift
+++ b/Sources/MapboxMaps/Foundation/ObservableValue.swift
@@ -1,5 +1,13 @@
 internal final class ObservableValue<Value> where Value: Equatable {
-    private var observers = [Observer]()
+    private var observers = [Observer]() {
+        didSet {
+            if !observers.isEmpty, oldValue.isEmpty {
+                onFirstSubscribe?()
+            } else if observers.isEmpty, !oldValue.isEmpty {
+                onLastUnsubscribe?()
+            }
+        }
+    }
 
     internal private(set) var value: Value?
 
@@ -28,6 +36,10 @@ internal final class ObservableValue<Value> where Value: Equatable {
             self?.observers.removeAll { $0 === observer }
         }
     }
+
+    internal var onFirstSubscribe: (() -> Void)?
+
+    internal var onLastUnsubscribe: (() -> Void)?
 
     private final class Observer {
         private let handler: (Observer, Value) -> Void

--- a/Sources/MapboxMaps/Location/InterpolatedLocationProducer.swift
+++ b/Sources/MapboxMaps/Location/InterpolatedLocationProducer.swift
@@ -28,8 +28,16 @@ internal final class InterpolatedLocationProducer: NSObject, InterpolatedLocatio
         self.locationInterpolator = locationInterpolator
         self.dateProvider = dateProvider
         super.init()
-        locationProducer.add(self)
-        displayLinkCoordinator.add(self)
+        observableInterpolatedLocation.onFirstSubscribe = { [weak self, weak displayLinkCoordinator] in
+            guard let self = self else { return }
+            locationProducer.add(self)
+            displayLinkCoordinator?.add(self)
+        }
+        observableInterpolatedLocation.onLastUnsubscribe = { [weak self, weak displayLinkCoordinator] in
+            guard let self = self else { return }
+            locationProducer.remove(self)
+            displayLinkCoordinator?.remove(self)
+        }
     }
 
     // delivers the latest location synchronously, if available

--- a/Sources/MapboxMaps/Location/ObservableInterpolatedLocation.swift
+++ b/Sources/MapboxMaps/Location/ObservableInterpolatedLocation.swift
@@ -1,4 +1,6 @@
 internal protocol ObservableInterpolatedLocationProtocol: AnyObject {
+    var onFirstSubscribe: (() -> Void)? { get set }
+    var onLastUnsubscribe: (() -> Void)? { get set }
     var value: InterpolatedLocation? { get }
     func notify(with newValue: InterpolatedLocation)
     func observe(with handler: @escaping (InterpolatedLocation) -> Bool) -> Cancelable
@@ -21,5 +23,15 @@ internal final class ObservableInterpolatedLocation: ObservableInterpolatedLocat
 
     internal func observe(with handler: @escaping (InterpolatedLocation) -> Bool) -> Cancelable {
         return observableValue.observe(with: handler)
+    }
+
+    internal var onFirstSubscribe: (() -> Void)? {
+        get { observableValue.onFirstSubscribe }
+        set { observableValue.onFirstSubscribe = newValue }
+    }
+
+    internal var onLastUnsubscribe: (() -> Void)? {
+        get { observableValue.onLastUnsubscribe }
+        set { observableValue.onLastUnsubscribe = newValue }
     }
 }

--- a/Tests/MapboxMapsTests/Integration Tests/Map/MapViewIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Integration Tests/Map/MapViewIntegrationTests.swift
@@ -9,6 +9,7 @@ final class MapViewIntegrationTests: IntegrationTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
+        try guardForMetalDevice()
 
         guard let root = rootViewController?.view else {
             throw XCTSkip("No valid UIWindow or root view controller")
@@ -44,8 +45,6 @@ final class MapViewIntegrationTests: IntegrationTestCase {
     }
 
     func testMapViewIsReleasedAfterCameraTransition() throws {
-        try guardForMetalDevice()
-
         weak var weakMapView: MapView?
         try autoreleasepool {
 
@@ -75,5 +74,17 @@ final class MapViewIntegrationTests: IntegrationTestCase {
             XCTAssertNotNil(weakMapView)
         }
         XCTAssertNil(weakMapView)
+    }
+
+    func testMapViewDoesNotStartLocationServicesAutomatically() {
+        let locationProvider = MockLocationProvider()
+
+        mapView.location.overrideLocationProvider(with: locationProvider)
+
+        XCTAssertTrue(locationProvider.startUpdatingLocationStub.invocations.isEmpty)
+        XCTAssertTrue(locationProvider.startUpdatingHeadingStub.invocations.isEmpty)
+        XCTAssertTrue(locationProvider.requestAlwaysAuthorizationStub.invocations.isEmpty)
+        XCTAssertTrue(locationProvider.requestWhenInUseAuthorizationStub.invocations.isEmpty)
+        XCTAssertTrue(locationProvider.requestTemporaryFullAccuracyAuthorizationStub.invocations.isEmpty)
     }
 }

--- a/Tests/MapboxMapsTests/Location/InterpolatedLocationProducerTests.swift
+++ b/Tests/MapboxMapsTests/Location/InterpolatedLocationProducerTests.swift
@@ -36,10 +36,26 @@ final class InterpolatedLocationProducerTests: XCTestCase {
     }
 
     func testInitialization() {
+        XCTAssertEqual(locationProducer.addStub.invocations.count, 0)
+        XCTAssertEqual(displayLinkCoordinator.addStub.invocations.count, 0)
+    }
+
+    func testOnFirstSubscribe() {
+        observableInterpolatedLocation.onFirstSubscribe?()
+
         XCTAssertEqual(locationProducer.addStub.invocations.count, 1)
         XCTAssertIdentical(locationProducer.addStub.invocations.first?.parameters, interpolatedLocationProducer)
         XCTAssertEqual(displayLinkCoordinator.addStub.invocations.count, 1)
         XCTAssertIdentical(displayLinkCoordinator.addStub.invocations.first?.parameters, interpolatedLocationProducer)
+    }
+
+    func testOnLastUnsubscribe() {
+        observableInterpolatedLocation.onLastUnsubscribe?()
+
+        XCTAssertEqual(locationProducer.removeStub.invocations.count, 1)
+        XCTAssertIdentical(locationProducer.removeStub.invocations.first?.parameters, interpolatedLocationProducer)
+        XCTAssertEqual(displayLinkCoordinator.removeStub.invocations.count, 1)
+        XCTAssertIdentical(displayLinkCoordinator.removeStub.invocations.first?.parameters, interpolatedLocationProducer)
     }
 
     func testLocation() {

--- a/Tests/MapboxMapsTests/Location/Mocks/MockObservableInterpolatedLocation.swift
+++ b/Tests/MapboxMapsTests/Location/Mocks/MockObservableInterpolatedLocation.swift
@@ -12,4 +12,8 @@ final class MockObservableInterpolatedLocation: ObservableInterpolatedLocationPr
     func notify(with newValue: InterpolatedLocation) {
         notifyStub.call(with: newValue)
     }
+
+    var onFirstSubscribe: (() -> Void)?
+
+    var onLastUnsubscribe: (() -> Void)?
 }

--- a/Tests/MapboxMapsTests/Viewport/Helpers/ObservableValueTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/Helpers/ObservableValueTests.swift
@@ -113,4 +113,34 @@ final class ObservableValueTests: XCTestCase {
 
         XCTAssertEqual(handlerStub.invocations.map(\.parameters), [value, value2])
     }
+
+    func testOnFirstSubscribe() {
+        let onFirstSubscribeStub = Stub<Void, Void>()
+        observableValue.onFirstSubscribe = onFirstSubscribeStub.call
+
+        for _ in 0...Int.random(in: 1...10) {
+            _ = observableValue.observe(with: { _ in true })
+        }
+
+        XCTAssertEqual(onFirstSubscribeStub.invocations.count, 1)
+    }
+
+    func testOnLastUnsubscribe() {
+        let onLastUnsubscribeStub = Stub<Void, Void>()
+        observableValue.onLastUnsubscribe = onLastUnsubscribeStub.call
+
+        let cancelables = (0...Int.random(in: 1...10)).map { i in
+            observableValue.observe(with: { _ in i.isMultiple(of: 2) })
+        }
+
+        cancelables.enumerated().forEach { (i, cancelable) in
+            if i.isMultiple(of: 2) {
+                cancelable.cancel()
+            }
+        }
+
+        observableValue.notify(with: 0)
+
+        XCTAssertEqual(onLastUnsubscribeStub.invocations.count, 1)
+    }
 }


### PR DESCRIPTION
#1090 resulted in a regression that caused location services to be started eagerly when creating a MapView rather than waiting until a feature requiring location was actually used.

Fixes #1251

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
