### PR TITLE
Test default viewport transition animation configs

### DIFF
--- a/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
+++ b/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
@@ -262,8 +262,7 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
                                    doubleTouchGestureRecognizer: UIGestureRecognizer) -> ViewportImplProtocol {
         let lowZoomToHighZoomAnimationSpecProvider = LowZoomToHighZoomAnimationSpecProvider(
             mapboxMap: mapboxMap)
-        let highZoomToLowZoomAnimationSpecProvider = HighZoomToLowZoomAnimationSpecProvider(
-            mapboxMap: mapboxMap)
+        let highZoomToLowZoomAnimationSpecProvider = HighZoomToLowZoomAnimationSpecProvider()
         let animationSpecProvider = DefaultViewportTransitionAnimationSpecProvider(
             mapboxMap: mapboxMap,
             lowZoomToHighZoomAnimationSpecProvider: lowZoomToHighZoomAnimationSpecProvider,

--- a/Sources/MapboxMaps/Snapshot/Snapshotter.swift
+++ b/Sources/MapboxMaps/Snapshot/Snapshotter.swift
@@ -93,12 +93,12 @@ public class Snapshotter {
 
         mapSnapshotter.start { (expected) in
             if expected.isError() {
-                completion(.failure(.snapshotFailed(reason: expected.error as? String)))
+                completion(.failure(.snapshotFailed(reason: expected.error as String)))
                 return
             }
 
             guard expected.isValue(), let snapshot = expected.value else {
-                completion(.failure(.snapshotFailed(reason: expected.error as? String)))
+                completion(.failure(.snapshotFailed(reason: expected.error as String)))
                 return
             }
 

--- a/Sources/MapboxMaps/Viewport/Transitions/Default/HighZoomToLowZoomAnimationSpecProvider.swift
+++ b/Sources/MapboxMaps/Viewport/Transitions/Default/HighZoomToLowZoomAnimationSpecProvider.swift
@@ -1,11 +1,6 @@
 import Foundation
 
 internal final class HighZoomToLowZoomAnimationSpecProvider: DefaultViewportTransitionAnimationSpecProviderProtocol {
-    private let mapboxMap: MapboxMapProtocol
-
-    internal init(mapboxMap: MapboxMapProtocol) {
-        self.mapboxMap = mapboxMap
-    }
 
     internal func makeAnimationSpecs(cameraOptions: CameraOptions) -> [DefaultViewportTransitionAnimationSpec] {
         var animationSpecs = [DefaultViewportTransitionAnimationSpec]()

--- a/Sources/MapboxMaps/Viewport/Transitions/Default/LowZoomToHighZoomAnimationSpecProvider.swift
+++ b/Sources/MapboxMaps/Viewport/Transitions/Default/LowZoomToHighZoomAnimationSpecProvider.swift
@@ -30,8 +30,7 @@ internal final class LowZoomToHighZoomAnimationSpecProvider: DefaultViewportTran
         var zoomDelay: TimeInterval = 0
         var zoomDuration: TimeInterval = 0
         if let zoom = cameraOptions.zoom {
-            let currentMapCameraZoom = cameraState.zoom
-            let zoomDelta = abs(zoom - currentMapCameraZoom)
+            let zoomDelta = abs(zoom - cameraState.zoom)
             // zoom level / s
             let zoomAnimationRate = 2.2
             zoomDelay = centerDuration / 2

--- a/Sources/MapboxMaps/Viewport/Viewport.swift
+++ b/Sources/MapboxMaps/Viewport/Viewport.swift
@@ -141,8 +141,7 @@
     public func makeDefaultViewportTransition(options: DefaultViewportTransitionOptions = .init()) -> DefaultViewportTransition {
         let lowZoomToHighZoomAnimationSpecProvider = LowZoomToHighZoomAnimationSpecProvider(
             mapboxMap: mapboxMap)
-        let highZoomToLowZoomAnimationSpecProvider = HighZoomToLowZoomAnimationSpecProvider(
-            mapboxMap: mapboxMap)
+        let highZoomToLowZoomAnimationSpecProvider = HighZoomToLowZoomAnimationSpecProvider()
         let animationSpecProvider = DefaultViewportTransitionAnimationSpecProvider(
             mapboxMap: mapboxMap,
             lowZoomToHighZoomAnimationSpecProvider: lowZoomToHighZoomAnimationSpecProvider,

--- a/Tests/MapboxMapsTests/Viewport/Transitions/Default/HighZoomToLowZoomAnimationSpecProviderTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/Transitions/Default/HighZoomToLowZoomAnimationSpecProviderTests.swift
@@ -1,0 +1,56 @@
+@testable import MapboxMaps
+import XCTest
+
+final class HighZoomToLowZoomAnimationSpecProviderTests: XCTestCase {
+
+    var provider: HighZoomToLowZoomAnimationSpecProvider!
+
+    override func setUp() {
+        super.setUp()
+        provider = HighZoomToLowZoomAnimationSpecProvider()
+    }
+
+    override func tearDown() {
+        provider = nil
+        super.tearDown()
+    }
+
+    func testMakeAnimationSpecs() {
+        let cameraOptions = CameraOptions.random()
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        guard specs.count == 5 else {
+            XCTFail("Expected 5 specs")
+            return
+        }
+
+        XCTAssertEqual(specs[0].duration, 1)
+        XCTAssertEqual(specs[0].delay, 0.8)
+        XCTAssertEqual(specs[0].cameraOptionsComponent.cameraOptions, CameraOptions(center: cameraOptions.center))
+
+        XCTAssertEqual(specs[1].duration, 1.8)
+        XCTAssertEqual(specs[1].delay, 0)
+        XCTAssertEqual(specs[1].cameraOptionsComponent.cameraOptions, CameraOptions(zoom: cameraOptions.zoom))
+
+        XCTAssertEqual(specs[2].duration, 1.2)
+        XCTAssertEqual(specs[2].delay, 0.6)
+        XCTAssertEqual(specs[2].cameraOptionsComponent.cameraOptions, CameraOptions(bearing: cameraOptions.bearing))
+
+        XCTAssertEqual(specs[3].duration, 1)
+        XCTAssertEqual(specs[3].delay, 0)
+        XCTAssertEqual(specs[3].cameraOptionsComponent.cameraOptions, CameraOptions(pitch: cameraOptions.pitch))
+
+        XCTAssertEqual(specs[4].duration, 1.2)
+        XCTAssertEqual(specs[4].delay, 0)
+        XCTAssertEqual(specs[4].cameraOptionsComponent.cameraOptions, CameraOptions(padding: cameraOptions.padding))
+    }
+
+    func testMakeAnimationSpecsWithEmptyCameraOptions() {
+        let cameraOptions = CameraOptions()
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertTrue(specs.isEmpty)
+    }
+}

--- a/Tests/MapboxMapsTests/Viewport/Transitions/Default/LowZoomToHighZoomAnimationSpecProviderTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/Transitions/Default/LowZoomToHighZoomAnimationSpecProviderTests.swift
@@ -1,0 +1,317 @@
+@testable import MapboxMaps
+import XCTest
+
+final class LowZoomToHighZoomAnimationSpecProviderTests: XCTestCase {
+
+    var mapboxMap: MockMapboxMap!
+    var provider: LowZoomToHighZoomAnimationSpecProvider!
+
+    override func setUp() {
+        super.setUp()
+        mapboxMap = MockMapboxMap()
+        provider = LowZoomToHighZoomAnimationSpecProvider(mapboxMap: mapboxMap)
+    }
+
+    override func tearDown() {
+        provider = nil
+        mapboxMap = nil
+        super.tearDown()
+    }
+
+    func testMakeAnimationSpecsCenterLongDistance() {
+        let cameraOptions = CameraOptions(center: .random())
+        // center duration is calculated based on 500 screen points per second
+        // or 3 seconds, whichever is smaller. This configuration simultes a
+        // 2000 point distance, so it should be clamped to 3 seconds.
+        mapboxMap.pointStub.returnValueQueue = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 2000, y: 0)]
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(
+            mapboxMap.pointStub.invocations.map(\.parameters),
+            [mapboxMap.cameraState.center, cameraOptions.center!])
+        XCTAssertEqual(specs.count, 1)
+        XCTAssertEqual(specs.first?.duration, 3)
+        XCTAssertEqual(specs.first?.delay, 0)
+        XCTAssertEqual(specs.first?.cameraOptionsComponent.cameraOptions, cameraOptions)
+    }
+
+    func testMakeAnimationSpecsCenterShortDistance() {
+        let cameraOptions = CameraOptions(center: .random())
+        // center duration is calculated based on 500 screen points per second
+        // or 3 seconds, whichever is smaller. This configuration simultes a
+        // 500 point distance, so it should take 1 second.
+        mapboxMap.pointStub.returnValueQueue = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 500, y: 0)]
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(
+            mapboxMap.pointStub.invocations.map(\.parameters),
+            [mapboxMap.cameraState.center, cameraOptions.center!])
+        XCTAssertEqual(specs.count, 1)
+        XCTAssertEqual(specs.first?.duration, 1)
+        XCTAssertEqual(specs.first?.delay, 0)
+        XCTAssertEqual(specs.first?.cameraOptionsComponent.cameraOptions, cameraOptions)
+    }
+
+    func testMakeAnimationSpecsZoomLargeDifference() {
+        let cameraOptions = CameraOptions(zoom: .random(in: 10...22))
+        // zoom duration is calculated based on 2.2 zoom levels per second or 3
+        // seconds, whichever is smaller. This configuration simulates a 10
+        // level difference, so it should be clamped to 3 seconds.
+        mapboxMap.cameraState.zoom = cameraOptions.zoom! - 10
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 1)
+        XCTAssertEqual(specs.first?.duration, 3)
+        XCTAssertEqual(specs.first?.delay, 0)
+        XCTAssertEqual(specs.first?.cameraOptionsComponent.cameraOptions, cameraOptions)
+    }
+
+    func testMakeAnimationSpecsZoomSmallDifference() throws {
+        let cameraOptions = CameraOptions(zoom: .random(in: 2.2...22))
+        // zoom duration is calculated based on 2.2 zoom levels per second or 3
+        // seconds, whichever is smaller. This configuration simulates a 2.2
+        // level difference, so it should take 1 second.
+        mapboxMap.cameraState.zoom = cameraOptions.zoom! - 2.2
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 1)
+        let spec = try XCTUnwrap(specs.first)
+        XCTAssertEqual(spec.duration, 1, accuracy: 1e-6)
+        XCTAssertEqual(spec.delay, 0)
+        XCTAssertEqual(spec.cameraOptionsComponent.cameraOptions, cameraOptions)
+    }
+
+    func testMakeAnimationSpecsZoomWithDelay() {
+        let cameraOptions = CameraOptions(center: .random(), zoom: .random(in: 10...22))
+        // zoom delay is calculated as half of the center duration. In this
+        // case, the center duration will be 3 seconds, so the zoom delay should
+        // be 1.5 seconds.
+        mapboxMap.pointStub.returnValueQueue = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 2000, y: 0)]
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 2)
+        XCTAssertEqual(specs.last?.delay, 1.5)
+    }
+
+    func testMakeAnimationSpecsBearingWithoutZoom() {
+        let cameraOptions = CameraOptions(bearing: .random(in: 0...360))
+        // If there's no zoom animation, bearing is not delayed
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 1)
+        XCTAssertEqual(specs.first?.duration, 1.8)
+        XCTAssertEqual(specs.first?.delay, 0)
+        XCTAssertEqual(specs.first?.cameraOptionsComponent.cameraOptions, cameraOptions)
+    }
+
+    func testMakeAnimationSpecsBearingWithShortZoomAnimation() {
+        mapboxMap.cameraState.zoom = 0
+        let cameraOptions = CameraOptions(zoom: 2.2, bearing: .random(in: 0...360))
+        // If there is a zoom animation, bearing is configured to end at the
+        // same time as it unless the zoom animation ends in less time than the
+        // total bearing animation. In this scenario, the zoom animation is too
+        // short (1 second), so the bearing animation is not delayed.
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 2)
+        XCTAssertEqual(specs.last?.duration, 1.8)
+        XCTAssertEqual(specs.last?.delay, 0)
+    }
+
+    func testMakeAnimationSpecsBearingWithLongZoomAnimation() throws {
+        mapboxMap.cameraState.zoom = 0
+        let cameraOptions = CameraOptions(zoom: 6.6, bearing: .random(in: 0...360))
+        // If there is a zoom animation, bearing is configured to end at the
+        // same time as it unless the zoom animation ends in less time than the
+        // total bearing animation. In this scenario, the zoom animation is
+        // longer (3 s) than the bearing animation, so the bearing animation is
+        // delayed by 3 - 1.8 = 1.2 s.
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 2)
+        let spec = try XCTUnwrap(specs.last)
+        XCTAssertEqual(spec.duration, 1.8)
+        XCTAssertEqual(spec.delay, 1.2, accuracy: 1e-6)
+    }
+
+    func testMakeAnimationSpecsBearingWithShortButDelayedZoomAnimation() throws {
+        // zoom delay is calculated as half of the center duration. In this
+        // case, the center duration will be 3 seconds, so the zoom delay should
+        // be 1.5 seconds.
+        mapboxMap.pointStub.returnValueQueue = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 2000, y: 0)]
+        mapboxMap.cameraState.zoom = 0
+        let cameraOptions = CameraOptions(
+            center: .random(),
+            zoom: 2.2,
+            bearing: .random(in: 0...360))
+        // If there is a zoom animation, bearing is configured to end at the
+        // same time as it unless the zoom animation ends in less time than the
+        // total bearing animation. In this scenario, the zoom animation is
+        // shorter (1 s) than the bearing animation, but due to its 1.5 second
+        // delay, it ends at 2.5 s from when the animations begin, so the
+        // bearing animation is delayed by 2.5 - 1.8 = 0.7 s.
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 3)
+        let spec = try XCTUnwrap(specs.last)
+        XCTAssertEqual(spec.duration, 1.8)
+        XCTAssertEqual(spec.delay, 0.7, accuracy: 1e-6)
+    }
+
+    func testMakeAnimationSpecsPitchWithoutZoom() {
+        let cameraOptions = CameraOptions(pitch: .random(in: 0...85))
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 1)
+        XCTAssertEqual(specs.first?.duration, 1.2)
+        XCTAssertEqual(specs.first?.delay, 0)
+        XCTAssertEqual(specs.first?.cameraOptionsComponent.cameraOptions, cameraOptions)
+    }
+
+    func testMakeAnimationSpecsPitchWithShortZoomAnimation() {
+        mapboxMap.cameraState.zoom = 0
+        let cameraOptions = CameraOptions(zoom: 2.2, pitch: .random(in: 0...85))
+        // If there is a zoom animation, pitch is configured to end 0.1 s after
+        // it unless the zoom animation ends in less time than the total pitch
+        // animation minus 0.1 s. In this scenario, the zoom animation is too
+        // short (1 second), so the pitch animation is not delayed.
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 2)
+        XCTAssertEqual(specs.last?.duration, 1.2)
+        XCTAssertEqual(specs.last?.delay, 0)
+    }
+
+    func testMakeAnimationSpecsPitchWithLongZoomAnimation() throws {
+        mapboxMap.cameraState.zoom = 0
+        let cameraOptions = CameraOptions(zoom: 6.6, pitch: .random(in: 0...85))
+        // If there is a zoom animation, pitch is configured to end 0.1 s after
+        // it unless the zoom animation ends in less time than the total pitch
+        // animation minus 0.1 s. In this scenario, the zoom animation is
+        // longer (3 s) than the pitch animation, so the pitch animation is
+        // delayed by 3 - 1.2 + 0.1 = 1.9 s.
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 2)
+        let spec = try XCTUnwrap(specs.last)
+        XCTAssertEqual(spec.duration, 1.2)
+        XCTAssertEqual(spec.delay, 1.9, accuracy: 1e-6)
+    }
+
+    func testMakeAnimationSpecsPitchWithShortButDelayedZoomAnimation() throws {
+        // zoom delay is calculated as half of the center duration. In this
+        // case, the center duration will be 3 seconds, so the zoom delay should
+        // be 1.5 seconds.
+        mapboxMap.pointStub.returnValueQueue = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 2000, y: 0)]
+        mapboxMap.cameraState.zoom = 0
+        let cameraOptions = CameraOptions(
+            center: .random(),
+            zoom: 2.2,
+            pitch: .random(in: 0...85))
+        // If there is a zoom animation, pitch is configured to end 0.1 s after
+        // it unless the zoom animation ends in less time than the total pitch
+        // animation minus 0.1 s. In this scenario, the zoom animation is
+        // shorter (1 s) than the pitch animation, but due to its 1.5 second
+        // delay, it ends at 2.5 s from when the animations begin, so the
+        // pitch animation is delayed by 2.5 - 1.2 + 0.1 = 1.4 s.
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 3)
+        let spec = try XCTUnwrap(specs.last)
+        XCTAssertEqual(spec.duration, 1.2)
+        XCTAssertEqual(spec.delay, 1.4, accuracy: 1e-6)
+    }
+
+    func testMakeAnimationSpecsPaddingWithoutZoom() {
+        let cameraOptions = CameraOptions(padding: .random())
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 1)
+        XCTAssertEqual(specs.first?.duration, 1.2)
+        XCTAssertEqual(specs.first?.delay, 0)
+        XCTAssertEqual(specs.first?.cameraOptionsComponent.cameraOptions, cameraOptions)
+    }
+
+    func testMakeAnimationSpecsPaddingWithShortZoomAnimation() {
+        mapboxMap.cameraState.zoom = 0
+        let cameraOptions = CameraOptions(padding: .random(), zoom: 2.2)
+        // If there is a zoom animation, padding is configured to end 0.1 s
+        // after it unless the zoom animation ends in less time than the total
+        // padding animation minus 0.1 s. In this scenario, the zoom animation
+        // is too short (1 second), so the padding animation is not delayed.
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 2)
+        XCTAssertEqual(specs.last?.duration, 1.2)
+        XCTAssertEqual(specs.last?.delay, 0)
+    }
+
+    func testMakeAnimationSpecsPaddingWithLongZoomAnimation() throws {
+        mapboxMap.cameraState.zoom = 0
+        let cameraOptions = CameraOptions(padding: .random(), zoom: 6.6)
+        // If there is a zoom animation, padding is configured to end 0.1 s
+        // after it unless the zoom animation ends in less time than the total
+        // padding animation minus 0.1 s. In this scenario, the zoom animation
+        // is longer (3 s) than the padding animation, so the padding animation
+        // is delayed by 3 - 1.2 + 0.1 = 1.9 s.
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 2)
+        let spec = try XCTUnwrap(specs.last)
+        XCTAssertEqual(spec.duration, 1.2)
+        XCTAssertEqual(spec.delay, 1.9, accuracy: 1e-6)
+    }
+
+    func testMakeAnimationSpecsPaddingWithShortButDelayedZoomAnimation() throws {
+        // zoom delay is calculated as half of the center duration. In this
+        // case, the center duration will be 3 seconds, so the zoom delay should
+        // be 1.5 seconds.
+        mapboxMap.pointStub.returnValueQueue = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 2000, y: 0)]
+        mapboxMap.cameraState.zoom = 0
+        let cameraOptions = CameraOptions(
+            center: .random(),
+            padding: .random(),
+            zoom: 2.2)
+        // If there is a zoom animation, padding is configured to end 0.1 s
+        // after it unless the zoom animation ends in less time than the total
+        // padding animation minus 0.1 s. In this scenario, the zoom animation
+        // is shorter (1 s) than the padding animation, but due to its 1.5
+        // second delay, it ends at 2.5 s from when the animations begin, so the
+        // padding animation is delayed by 2.5 - 1.2 + 0.1 = 1.4 s.
+
+        let specs = provider.makeAnimationSpecs(cameraOptions: cameraOptions)
+
+        XCTAssertEqual(specs.count, 3)
+        let spec = try XCTUnwrap(specs.last)
+        XCTAssertEqual(spec.duration, 1.2)
+        XCTAssertEqual(spec.delay, 1.4, accuracy: 1e-6)
+    }
+}


### PR DESCRIPTION
Adds unit tests for `LowZoomToHighZoomAnimationSpecProvider` and `HighZoomToLowZoomAnimationSpecProvider`.

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
