### PR TITLE
Allow to override layoutSubviews in MapView subclasses

### DIFF
--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -538,7 +538,7 @@ open class MapView: UIView {
         commonInit(mapInitOptions: mapInitOptions, overridingStyleURI: ibStyleURI)
     }
 
-    public override func layoutSubviews() {
+    open override func layoutSubviews() {
         super.layoutSubviews()
         mapboxMap.size = bounds.size
     }


### PR DESCRIPTION
Right now one gets `Overriding non-open instance method outside of its defining module` if he tries to override layoutSubviews in a MapView subclass.


## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
