### PR TITLE
Fix localization crash on iOS 11 and 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 * Add support for runtime source properties. ([#1267](https://github.com/mapbox/mapbox-maps-ios/pull/1267))
 * Start location services lazily. ([#1262](https://github.com/mapbox/mapbox-maps-ios/pull/1262))
+* Fix localization crash on iOS 11 and 12. ([#1278](https://github.com/mapbox/mapbox-maps-ios/pull/1278))
 
 ## 10.5.0-beta.1 - April 7, 2022
 

--- a/Sources/MapboxMaps/Style/Style+Localization.swift
+++ b/Sources/MapboxMaps/Style/Style+Localization.swift
@@ -83,8 +83,8 @@ extension Style {
         let expressionAbbr = try NSRegularExpression(pattern: "\\[\"get\",\\s*\"abbr\"\\]",
                                                      options: .caseInsensitive)
 
-        if var stringExpression = String(data: try JSONEncoder().encode(symbolLayer.textField), encoding: .utf8),
-           stringExpression != "null" {
+        if case .expression(let textField) = symbolLayer.textField,
+           var stringExpression = String(data: try JSONEncoder().encode(textField), encoding: .utf8) {
             stringExpression.updateOnceExpression(replacement: replacement, regex: expressionCoalesce)
             stringExpression.updateExpression(replacement: replacement, regex: expressionAbbr)
 

--- a/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
@@ -81,4 +81,21 @@ final class StyleLocalizationTests: MapViewIntegrationTestCase {
             }
         ))
     }
+
+    func testSkipsSymbolLayersWhereTextFieldIsNil() throws {
+        var source = GeoJSONSource()
+        source.data = .feature(Feature(geometry: Point(CLLocationCoordinate2D(latitude: 0, longitude: 0))))
+        try style.addSource(source, id: "a")
+
+        var symbolLayer = SymbolLayer(id: "a")
+        symbolLayer.source = "a"
+
+        try style.addLayer(symbolLayer)
+
+        try style.localizeLabels(into: Locale(identifier: "de"))
+
+        let updatedLayer = try style.layer(withId: "a", type: SymbolLayer.self)
+
+        XCTAssertNil(updatedLayer.textField)
+    }
 }


### PR DESCRIPTION
* Style.localizeLabels(into:forLayerIds:) crashed on iOS 11 and 12 if
  any of the symbol layers had text-field set to nil.

Fixes #954

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
