### PR TITLE
Feature/improve tests resource options manager

### DIFF
--- a/Sources/MapboxMaps/Foundation/ResourceOptionsManager.swift
+++ b/Sources/MapboxMaps/Foundation/ResourceOptionsManager.swift
@@ -100,7 +100,7 @@ public class ResourceOptionsManager {
         _resourceOptions.accessToken = token
     }
 
-    internal func defaultAccessToken() -> String {
+    private func defaultAccessToken() -> String {
         // Check User defaults
         #if DEBUG
         if let accessToken = UserDefaults.standard.string(forKey: "MBXAccessToken") {

--- a/Sources/MapboxMaps/Foundation/ResourceOptionsManager.swift
+++ b/Sources/MapboxMaps/Foundation/ResourceOptionsManager.swift
@@ -54,7 +54,6 @@ public class ResourceOptionsManager {
     }
 
     private var _resourceOptions: ResourceOptions!
-    private var tileStore: TileStore?
     private var bundle: Bundle
 
     /// Initializes a `ResourceOptionsManager` with an optional access token.
@@ -99,8 +98,6 @@ public class ResourceOptionsManager {
 
         _resourceOptions = resourceOptions
         _resourceOptions.accessToken = token
-
-        tileStore = resourceOptions.tileStore
     }
 
     internal func defaultAccessToken() -> String {

--- a/Tests/MapboxMapsTests/Foundation/ResourceOptionsManagerTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/ResourceOptionsManagerTests.swift
@@ -55,4 +55,17 @@ class ResourceOptionsManagerTests: XCTestCase {
 
         XCTAssertEqual(token, ResourceOptionsManager.default.resourceOptions.accessToken, "Token should have been reset")
     }
+
+    func testResourceOptionsManagerCanInitializeWithAccessToken() {
+        let sut = ResourceOptionsManager(accessToken: "dummy-mapbox-access-token")
+        XCTAssertEqual(sut.resourceOptions.accessToken, "dummy-mapbox-access-token")
+    }
+
+    func testResourceOptionsManagerCanUpdateResourceOptions() {
+        let sut = ResourceOptionsManager(accessToken: "dummy-mapbox-access-token")
+        let newResourceOptions = ResourceOptions(accessToken: "new-dummy-mapbox-access-token")
+        sut.resourceOptions = newResourceOptions
+
+        XCTAssertEqual(sut.resourceOptions, newResourceOptions)
+    }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->
This pull request removes redundant `tileStore` of `ResourceOptionsManager` and adds unit test cases to verify that `ResourceOptionsManager` can be initialized with a custom token and can update its associated `ResourceOptions`.
## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
