### PR TITLE
Update dependencies

### DIFF
--- a/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "be5dcb5db023fa37111e2eb195942be1e5cb8db6",
-          "version": "21.3.0-beta.2"
+          "revision": "17bdf379cdb12df2f616c83c6375ad38ebaa86e4",
+          "version": "21.3.0-rc.2"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "9f6442f99356d682e39c24986b864d9caca9b972",
-          "version": "10.5.0-beta.1"
+          "revision": "ab60553776d8d81f3420e2ebf81c2b4fe34a13fa",
+          "version": "10.5.0-rc.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "a7db78a2281ffe79966443ebe5687766d6c024c7",
-          "version": "2.3.0"
+          "revision": "569e0f0e96fda86e1a1dcefaefa68cfa9491ffc1",
+          "version": "2.4.0"
         }
       }
     ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Add support for runtime source properties. ([#1267](https://github.com/mapbox/mapbox-maps-ios/pull/1267))
 * Start location services lazily. ([#1262](https://github.com/mapbox/mapbox-maps-ios/pull/1262))
 * Fix localization crash on iOS 11 and 12. ([#1278](https://github.com/mapbox/mapbox-maps-ios/pull/1278))
+* Update to MapboxCoreMaps 10.5.0-rc.1 and MapboxCommon 21.3.0-rc.2. ([#1281](https://github.com/mapbox/mapbox-maps-ios/pull/1281))
 
 ## 10.5.0-beta.1 - April 7, 2022
 
@@ -28,7 +29,6 @@ Mapbox welcomes participation and contributions from everyone.
 * Update `DefaultViewportTransition` to solve the moving target problem. ([#1245](https://github.com/mapbox/mapbox-maps-ios/pull/1245))
 * Increase deceleration cutoff threshold from 20 to 35 to prevent camera changes
  after animation stops. ([#1244](https://github.com/mapbox/mapbox-maps-ios/pull/1244))
-* Update to MapboxCoreMaps 10.5.0-beta.1 and MapboxCommon 21.3.0-beta.2. ([]())
 * Update to MapboxCoreMaps 10.5.0-beta.1 and MapboxCommon 21.3.0-beta.2. ([#1235](https://github.com/mapbox/mapbox-maps-ios/pull/1235))
 * API for using globe projection has been moved to `Style.setProjection(_:)` and `Style.projection` and is no longer experimental. ([#1235](https://github.com/mapbox/mapbox-maps-ios/pull/1235))
 * Add `OfflineRegion.getStatus(completion:)`. ([#1239](https://github.com/mapbox/mapbox-maps-ios/pull/1239))

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -21,8 +21,8 @@ Pod::Spec.new do |m|
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
   m.resources = ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json']
 
-  m.dependency 'MapboxCoreMaps', '10.5.0-beta.1'
-  m.dependency 'MapboxCommon', '21.3.0-beta.2'
+  m.dependency 'MapboxCoreMaps', '10.5.0-rc.1'
+  m.dependency 'MapboxCommon', '21.3.0-rc.2'
   m.dependency 'MapboxMobileEvents', '1.0.7'
   m.dependency 'Turf', '~> 2.0'
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "be5dcb5db023fa37111e2eb195942be1e5cb8db6",
-          "version": "21.3.0-beta.2"
+          "revision": "17bdf379cdb12df2f616c83c6375ad38ebaa86e4",
+          "version": "21.3.0-rc.2"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "9f6442f99356d682e39c24986b864d9caca9b972",
-          "version": "10.5.0-beta.1"
+          "revision": "ab60553776d8d81f3420e2ebf81c2b4fe34a13fa",
+          "version": "10.5.0-rc.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "a7db78a2281ffe79966443ebe5687766d6c024c7",
-          "version": "2.3.0"
+          "revision": "569e0f0e96fda86e1a1dcefaefa68cfa9491ffc1",
+          "version": "2.4.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
             targets: ["MapboxMaps"]),
     ],
     dependencies: [
-        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.5.0-beta.1")),
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("21.3.0-beta.2")),
+        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.5.0-rc.1")),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("21.3.0-rc.2")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", .exact("1.0.7")),
         .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.0.0"),
         .package(name: "CocoaImageHashing", url: "https://github.com/ameingast/cocoaimagehashing", .exact("1.9.0"))

--- a/scripts/release/packager/versions.json
+++ b/scripts/release/packager/versions.json
@@ -1,6 +1,6 @@
 {
-	"MapboxCoreMaps": "10.5.0-beta.1",
-	"MapboxCommon": "21.3.0-beta.2",
-	"Turf": "v2.3.0",
+	"MapboxCoreMaps": "10.5.0-rc.1",
+	"MapboxCommon": "21.3.0-rc.2",
+	"Turf": "v2.4.0",
 	"MapboxMobileEvents": "v1.0.7"
 }


### PR DESCRIPTION
MapboxCoreMaps: v10.5.0-beta.1 -> v10.5.0-rc.1
MapboxCommon: v21.3.0-beta.2 -> v21.3.0-rc.2
Turf: v2.3.0 -> v2.4.0 (only for development & direct download; SPM & CocoaPods dependency version requirements remain set to any 2.x)

## Features ✨ and improvements 🏁
* Avoid repeated tile loading from network (or repeated tile decompression when the tile is fetched from the cache database) and repeated vector tile data allocation and parsing when loading render tiles referring to the same logical tile.
* Switch to use shader to calculate the 'line-trim-offset' property update.  

## Bug fixes 🐞
* Fix issue where internal hsla() function was converted to an invalid rgba expression
* Fix a bug that 'line-trim-offset' calculation did not property cover 'round' or 'square' line cap in line ends.
