### PR TITLE
Avoid overwriting hard-coded MBXAccessToken

### DIFF
--- a/scripts/insert_access_token.sh
+++ b/scripts/insert_access_token.sh
@@ -5,11 +5,17 @@ token_file=~/.mapbox
 token_file2=~/mapbox
 token="$(cat $token_file 2>/dev/null || cat $token_file2 2>/dev/null)"
 plist="$TARGET_BUILD_DIR/$INFOPLIST_PATH"
-if [ "$token" ]; then
-  plutil -replace MBXAccessToken -string "$token" "$plist"
-  echo "Token insertion successful"
-elif /usr/libexec/PlistBuddy -c "Print :MBXAccessToken" "$plist"; then
-  echo \'error: Missing Mapbox access token\'
-  echo "error: Get an access token from <https://www.mapbox.com/studio/account/tokens/>, then create a new file at ~/.mapbox that contains the access token."
-  exit 1
+
+# Only overwrite or error if the Info.plist contains the MBXAccessToken key with an empty value
+# This allows overriding ~/.mapbox and ~/mapbox by editing the Info.plist directly and avoids
+# emitting an error if the Info.plist is not configured to need an access token.
+if existing_value="$(/usr/libexec/PlistBuddy -c "Print :MBXAccessToken" "$plist")" && [ -z "$existing_value" ]; then
+  if [ "$token" ]; then
+    plutil -replace MBXAccessToken -string "$token" "$plist"
+    echo "Token insertion successful"
+  else
+    echo \'error: Missing Mapbox access token\'
+    echo "error: Get an access token from <https://www.mapbox.com/studio/account/tokens/>, then create a new file at ~/.mapbox that contains the access token."
+    exit 1
+  fi
 fi


### PR DESCRIPTION
Previously, if you tried to use the Examples app by hard-coding your access token in its Info.plist, you'd [run into trouble](https://github.com/mapbox/mapbox-maps-ios/issues/1176). This change makes it so that the build will not overwrite any non-empty access token in the Info.plist.