### PR TITLE
Resolve issue where value is declared after observer is notified

### DIFF
--- a/Sources/MapboxMaps/Foundation/ObservableValue.swift
+++ b/Sources/MapboxMaps/Foundation/ObservableValue.swift
@@ -15,10 +15,10 @@ internal final class ObservableValue<Value> where Value: Equatable {
         guard newValue != value else {
             return
         }
+        value = newValue
         observers.forEach { (observer) in
             observer.invokeHandler(with: newValue)
         }
-        value = newValue
     }
 
     internal func observe(with handler: @escaping (Value) -> Bool) -> Cancelable {


### PR DESCRIPTION
Set the value prior to notifying the observer. 

## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
