### PR TITLE
Expose memory budget API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Fix localization crash on iOS 11 and 12. ([#1278](https://github.com/mapbox/mapbox-maps-ios/pull/1278))
 * Increase tap target to conform to Apple Human Interface guidelines. ([#1283](https://github.com/mapbox/mapbox-maps-ios/pull/1283))
 * Update to MapboxCoreMaps 10.5.0-rc.1 and MapboxCommon 21.3.0-rc.2. ([#1281](https://github.com/mapbox/mapbox-maps-ios/pull/1281))
+* Expose API to set memory budget for `MapboxMap`. ([#1288](https://github.com/mapbox/mapbox-maps-ios/pull/1288))
 
 ## 10.5.0-beta.1 - April 7, 2022
 

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -150,6 +150,21 @@ public final class MapboxMap: MapboxMapProtocol {
         __map.reduceMemoryUse()
     }
 
+    /// The memory budget hint to be used by the map. The budget can be given in
+    /// tile units or in megabytes. A Map will do its best to keep the memory
+    /// allocations for non-essential resources within the budget.
+    ///
+    /// The memory budget distribution and resource
+    /// eviction logic is subject to change. Current implementation sets a memory budget
+    /// hint per data source.
+    ///
+    /// If nil is set, the memory budget in tile units will be dynamically calculated based on
+    /// the current viewport size.
+    /// - Parameter memoryBudget: The memory budget hint to be used by the Map.
+    @_spi(Experimental) public func setMemoryBudget(_ memoryBudget: MapMemoryBudget?) {
+        __map.__setMemoryBudgetFor(memoryBudget)
+    }
+
     /// Gets the resource options for the map.
     ///
     /// All optional fields of the returned object are initialized with the


### PR DESCRIPTION
This PR exposes high-level API to set the memory budget on the `MapboxMap` public interface. 

<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
        Tests can't be written currently since there's no way to mock the `MBMMap`
 - [x] Add documentation comments for any added or updated public APIs.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
