### PR TITLE
Rename hasImage to imageExists for consistency

### DIFF
--- a/Sources/MapboxMaps/Annotations/PointAnnotation+ImageHandling.swift
+++ b/Sources/MapboxMaps/Annotations/PointAnnotation+ImageHandling.swift
@@ -19,7 +19,7 @@ extension PointAnnotationManager {
         let pointAnnotationImages = Set(annotations.compactMap(\.image))
         for pointAnnotationImage in pointAnnotationImages {
             // If the image is not found, add it to the style
-            if !style.hasImage(withId: pointAnnotationImage.name) {
+            if !style.imageExists(withId: pointAnnotationImage.name) {
                 do {
                     try style.addImage(pointAnnotationImage.image, id: pointAnnotationImage.name)
                 } catch {

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -782,7 +782,7 @@ public final class Style: StyleProtocol {
     /// - Parameter id: The identifier of the image.
     ///
     /// - Returns: `true` if the given image exists, `false` otherwise.
-    public func hasImage(withId id: String) -> Bool {
+    public func imageExists(withId id: String) -> Bool {
         return styleManager.hasStyleImage(forImageId: id)
     }
 


### PR DESCRIPTION
`Style` already has `layerExists(withId:)` and `sourceExists(withId:)`, the method to check for image existence should follow the same naming pattern. 