### PR TITLE
Invoke animator completion handlers added after completion or cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## main
 
 * Expose API to check whether an image exists in `Style`. ([#1297](https://github.com/mapbox/mapbox-maps-ios/pull/1297))
+* Invoke animator completion handlers added after completion or cancellation. ([#1305])(https://github.com/mapbox/mapbox-maps-ios/pull/1305))
 
 ## 10.5.0-rc.1 - April 20, 2022
 

--- a/Sources/MapboxMaps/Camera/CameraAnimator.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimator.swift
@@ -18,7 +18,9 @@ internal protocol CameraAnimatorProtocol: CameraAnimator {
     /// Implementations must use a weak reference.
     var delegate: CameraAnimatorDelegate? { get set }
 
-    /// Adds a completion block to the animator.
+    /// Adds a completion block to the animator. If the animator is already complete,
+    /// implementations should invoke the completion block asynchronously with the
+    /// same `UIViewAnimatingPosition` value as when it completed.
     func addCompletion(_ completion: @escaping AnimationCompletion)
 
     /// Starts the animation. Does nothing if the animator has already completed.

--- a/Sources/MapboxMaps/Camera/CameraAnimatorsFactory.swift
+++ b/Sources/MapboxMaps/Camera/CameraAnimatorsFactory.swift
@@ -37,15 +37,18 @@ internal final class CameraAnimatorsFactory: CameraAnimatorsFactoryProtocol {
 
     private let cameraViewContainerView: UIView
     private let mapboxMap: MapboxMapProtocol
+    private let mainQueue: MainQueueProtocol
     private let dateProvider: DateProvider
     private let cameraOptionsInterpolator: CameraOptionsInterpolatorProtocol
 
     internal init(cameraViewContainerView: UIView,
                   mapboxMap: MapboxMapProtocol,
+                  mainQueue: MainQueueProtocol,
                   dateProvider: DateProvider,
                   cameraOptionsInterpolator: CameraOptionsInterpolatorProtocol) {
         self.cameraViewContainerView = cameraViewContainerView
         self.mapboxMap = mapboxMap
+        self.mainQueue = mainQueue
         self.dateProvider = dateProvider
         self.cameraOptionsInterpolator = cameraOptionsInterpolator
     }
@@ -58,6 +61,7 @@ internal final class CameraAnimatorsFactory: CameraAnimatorsFactoryProtocol {
             owner: animationOwner,
             duration: duration,
             mapboxMap: mapboxMap,
+            mainQueue: mainQueue,
             dateProvider: dateProvider)
     }
 
@@ -124,6 +128,7 @@ internal final class CameraAnimatorsFactory: CameraAnimatorsFactoryProtocol {
             propertyAnimator: propertyAnimator,
             owner: animationOwner,
             mapboxMap: mapboxMap,
+            mainQueue: mainQueue,
             cameraView: cameraView)
         cameraAnimator.addAnimations(animations)
         return cameraAnimator
@@ -140,6 +145,7 @@ internal final class CameraAnimatorsFactory: CameraAnimatorsFactoryProtocol {
             decelerationFactor: decelerationFactor,
             owner: animationOwner,
             locationChangeHandler: locationChangeHandler,
+            mainQueue: mainQueue,
             dateProvider: dateProvider)
     }
 
@@ -155,6 +161,7 @@ internal final class CameraAnimatorsFactory: CameraAnimatorsFactoryProtocol {
             curve: curve,
             owner: owner,
             mapboxMap: mapboxMap,
+            mainQueue: mainQueue,
             cameraOptionsInterpolator: cameraOptionsInterpolator,
             dateProvider: dateProvider)
     }

--- a/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
+++ b/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
@@ -37,6 +37,7 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
 
     internal let cameraAnimatorsRunnerEnablable: MutableEnablableProtocol = Enablable()
     private let gesturesCameraAnimatorsRunnerEnablable = Enablable()
+    private let mainQueue = MainQueue()
 
     internal func makeMetalView(frame: CGRect, device: MTLDevice?) -> MTKView {
         MTKView(frame: frame, device: device)
@@ -78,6 +79,7 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
             factory: CameraAnimatorsFactory(
                 cameraViewContainerView: cameraViewContainerView,
                 mapboxMap: mapboxMap,
+                mainQueue: mainQueue,
                 dateProvider: DefaultDateProvider(),
                 cameraOptionsInterpolator: cameraOptionsInterpolator),
             runner: cameraAnimatorsRunner)
@@ -279,7 +281,7 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
             animationHelper: animationHelper)
         return ViewportImpl(
             options: .init(),
-            mainQueue: MainQueue(),
+            mainQueue: mainQueue,
             defaultTransition: defaultViewportTransition,
             anyTouchGestureRecognizer: anyTouchGestureRecognizer,
             doubleTapGestureRecognizer: doubleTapGestureRecognizer,

--- a/Tests/MapboxMapsTests/Camera/BasicCameraAnimatorImplIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Camera/BasicCameraAnimatorImplIntegrationTests.swift
@@ -6,6 +6,7 @@ final class BasicCameraAnimatorImplIntegrationTests: XCTestCase {
     var window: UIWindow!
     var cameraView: CameraView!
     var mapboxMap: MockMapboxMap!
+    var mainQueue: MockMainQueue!
     var animator: BasicCameraAnimatorImpl!
     // swiftlint:disable:next weak_delegate
     var delegate: MockBasicCameraAnimatorDelegate!
@@ -17,10 +18,12 @@ final class BasicCameraAnimatorImplIntegrationTests: XCTestCase {
         window.addSubview(cameraView)
         window.makeKeyAndVisible()
         mapboxMap = MockMapboxMap()
+        mainQueue = MockMainQueue()
         animator = BasicCameraAnimatorImpl(
             propertyAnimator: UIViewPropertyAnimator(),
             owner: .unspecified,
             mapboxMap: mapboxMap,
+            mainQueue: mainQueue,
             cameraView: cameraView)
         delegate = MockBasicCameraAnimatorDelegate()
         animator.delegate = delegate
@@ -37,6 +40,7 @@ final class BasicCameraAnimatorImplIntegrationTests: XCTestCase {
     override func tearDown() {
         delegate = nil
         animator = nil
+        mainQueue = nil
         mapboxMap = nil
         cameraView = nil
         window = nil


### PR DESCRIPTION
* Completion handlers added after an animator has already completed will
  now be invoked asynchronously on the main queue.
* Fixes a crash that could occur when trying to add a completion handler
  to a BasicCameraAnimator that was created while animations were
  disabled.

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
