### PR TITLE
Update MapboxCoreMaps and MapboxCommon

### DIFF
--- a/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "17bdf379cdb12df2f616c83c6375ad38ebaa86e4",
-          "version": "21.3.0-rc.2"
+          "revision": "59b81d4f6316a661c322e8c47bc3310f8a1bdd4a",
+          "version": "21.3.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "ab60553776d8d81f3420e2ebf81c2b4fe34a13fa",
-          "version": "10.5.0-rc.1"
+          "revision": "212c3983e6ba2fe5c85ce9e4b9d811ea05755330",
+          "version": "10.5.0"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Expose API to check whether an image exists in `Style`. ([#1297](https://github.com/mapbox/mapbox-maps-ios/pull/1297))
 * Invoke animator completion handlers added after completion or cancellation. ([#1305](https://github.com/mapbox/mapbox-maps-ios/pull/1305))
 * Call `MapboxMap.reduceMemoryUse` when application goes to background. ([#1301](https://github.com/mapbox/mapbox-maps-ios/pull/1301))
+* Update to MapboxCoreMaps 10.5.0 and MapboxCommon 21.3.0. ([#1310](https://github.com/mapbox/mapbox-maps-ios/pull/1310))
 
 ## 10.5.0-rc.1 - April 20, 2022
 

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -21,8 +21,8 @@ Pod::Spec.new do |m|
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
   m.resources = ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json']
 
-  m.dependency 'MapboxCoreMaps', '10.5.0-rc.1'
-  m.dependency 'MapboxCommon', '21.3.0-rc.2'
+  m.dependency 'MapboxCoreMaps', '10.5.0'
+  m.dependency 'MapboxCommon', '21.3.0'
   m.dependency 'MapboxMobileEvents', '1.0.7'
   m.dependency 'Turf', '~> 2.0'
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "17bdf379cdb12df2f616c83c6375ad38ebaa86e4",
-          "version": "21.3.0-rc.2"
+          "revision": "59b81d4f6316a661c322e8c47bc3310f8a1bdd4a",
+          "version": "21.3.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "ab60553776d8d81f3420e2ebf81c2b4fe34a13fa",
-          "version": "10.5.0-rc.1"
+          "revision": "212c3983e6ba2fe5c85ce9e4b9d811ea05755330",
+          "version": "10.5.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
             targets: ["MapboxMaps"]),
     ],
     dependencies: [
-        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.5.0-rc.1")),
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("21.3.0-rc.2")),
+        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.5.0")),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("21.3.0")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", .exact("1.0.7")),
         .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.0.0"),
         .package(name: "CocoaImageHashing", url: "https://github.com/ameingast/cocoaimagehashing", .exact("1.9.0"))

--- a/scripts/release/packager/versions.json
+++ b/scripts/release/packager/versions.json
@@ -1,6 +1,6 @@
 {
-	"MapboxCoreMaps": "10.5.0-rc.1",
-	"MapboxCommon": "21.3.0-rc.2",
+	"MapboxCoreMaps": "10.5.0",
+	"MapboxCommon": "21.3.0",
 	"Turf": "v2.4.0",
 	"MapboxMobileEvents": "v1.0.7"
 }


### PR DESCRIPTION
## Features ✨ and improvements 🏁
* Map projection API moved from Map to Style, in order to allow specifying the map projection in the style. API is no longer experimental.
* Automatic transition between the globe and mercator projection updated to appear visually more subtle.
* Update mapbox-common to v21.3.0.
* Avoid repeated tile loading from network (or repeated tile decompression when the tile is fetched from the cache database) and repeated vector tile data allocation and parsing when loading render tiles referring to the same logical tile
* Switch to use shader to calculate the 'line-trim-offset' property update.
* Layer properties transitions performance improved if the layer is transitioning to the same constant value or if transitioning from/to data-driven property.
* New line layer paint property introduced: '{"line-trim-offset", [trim-start, trim-end]}', to take the line trim-off percentage range based on the whole line range [0.0, 1.0]. The property will only be effective when 'line-gradient' property is set. The line part between [trim-start, trim-end] will be marked as transparent to make a line gradient a vanishing effect. If either 'trim-start' or 'trim-end' offset is out of valid range, the default range [0.0, 0.0] will be set.
* Globe view controls revamped for more intuitive interaction with touch controls.
* OfflineRegion::getStatus() API added to get the completion status and the local size of the existing legacy offline regions.

## Bug fixes 🐞
* The legacy offline region observer instance is not unnecessarily retained inside the engine.
* Fix a bug of querying rendered feature for circle layer with map-pitch-alignment when the pitch is zero.
* Fix a bug where zooming was not possible with terrain enabled and exaggeration 0.
* Fix an issue where internal hsla() function was converted to an invalid rgba expression.
* Fix a bug that 'line-trim-offset' calculation did not property cover 'round' or 'square' line cap in line ends.
* Dispatched in-flight events will not be delivered if 'unsubscribe' is called before an event is delivered.
* Fix an issue where some of the visible tiles could be erroneously culled during transition between globe and mercator projection.
* Fixes issues where camera appears under terrain, or map gets bumpy repositioning after exaggeration change.
* Disable terrain rendering if GPU does not support Vertex Texture Fetch.
* Fixed a bug that occasionally prevents symbols from loading.