### PR TITLE
Add a unit test for `coordinateBounds(for:)`

### DIFF
--- a/Tests/MapboxMapsTests/Foundation/MapboxMapsFoundationTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapboxMapsFoundationTests.swift
@@ -202,8 +202,6 @@ class MapboxMapsFoundationTests: XCTestCase {
         try! mapView.mapboxMap.setCameraBounds(with: CameraBoundsOptions(bounds: bounds))
 
         let convertedBounds = mapView.mapboxMap.coordinateBounds(for: mapView.bounds)
-        print(convertedBounds.southwest)
-        print(convertedBounds.northeast)
 
         XCTAssertEqual(bounds.southwest.latitude, convertedBounds.southwest.latitude, accuracy: 0.1)
         XCTAssertEqual(bounds.southwest.longitude, convertedBounds.southwest.longitude, accuracy: 0.1)

--- a/Tests/MapboxMapsTests/Foundation/MapboxMapsFoundationTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapboxMapsFoundationTests.swift
@@ -194,6 +194,24 @@ class MapboxMapsFoundationTests: XCTestCase {
         XCTAssertEqual(nePoint.y, neRect.y, accuracy: 0.1)
     }
 
+    func testRectToCoordinateBounds() {
+        let southwest = CLLocationCoordinate2D(latitude: 60.673178565817715, longitude: 24.06005859375)
+        let northeast = CLLocationCoordinate2D(latitude: 61.66381021180711, longitude: 25.90576171875)
+
+        let bounds = CoordinateBounds(southwest: southwest, northeast: northeast)
+        try! mapView.mapboxMap.setCameraBounds(with: CameraBoundsOptions(bounds: bounds))
+
+        let convertedBounds = mapView.mapboxMap.coordinateBounds(for: mapView.bounds)
+        print(convertedBounds.southwest)
+        print(convertedBounds.northeast)
+
+        XCTAssertEqual(bounds.southwest.latitude, convertedBounds.southwest.latitude, accuracy: 0.1)
+        XCTAssertEqual(bounds.southwest.longitude, convertedBounds.southwest.longitude, accuracy: 0.1)
+
+        XCTAssertEqual(bounds.northeast.latitude, convertedBounds.northeast.latitude, accuracy: 0.1)
+        XCTAssertEqual(bounds.northeast.longitude, convertedBounds.northeast.longitude, accuracy: 0.1)
+    }
+
     func testImageConversion() {
         guard let original = UIImage(named: "green-star", in: .mapboxMapsTests, compatibleWith: nil) else {
             XCTFail("Could not load test image from bundle")


### PR DESCRIPTION
This PR adds a unit test for `coordinateBounds(for:)` method that converts `CGRect` to `CoordinateBounds`.