### PR TITLE
Metal view explicit drawing v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Expose API to check whether an image exists in `Style`. ([#1297](https://github.com/mapbox/mapbox-maps-ios/pull/1297))
 * Call `MapboxMap.reduceMemoryUse` when application goes to background. ([#1301](https://github.com/mapbox/mapbox-maps-ios/pull/1301))
 * Update to MapboxMobileEvents v1.0.8. ([#1324](https://github.com/mapbox/mapbox-maps-ios/pull/1324))
+* Enable explicit drawing behavior for metal view(call `draw()` explicitly instead of `setNeedsDisplay` when view's content need to be redrawn) again.([#1331](https://github.com/mapbox/mapbox-maps-ios/pull/1331))
 
 ## 10.5.0 - May 5, 2022
 

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -626,6 +626,10 @@ open class MapView: UIView {
 
 extension MapView: DelegatingMapClientDelegate {
     internal func scheduleRepaint() {
+        guard let metalView = metalView, !metalView.bounds.isEmpty else {
+            return
+        }
+
         needsDisplayRefresh = true
     }
 

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -638,12 +638,8 @@ extension MapView: DelegatingMapClientDelegate {
     }
 
     internal func getMetalView(for metalDevice: MTLDevice?) -> MTKView? {
-        let minSize = CGSize(width: 1, height: 1)
-        let finalSize = CGSize(
-            width: max(minSize.width, bounds.width),
-            height: max(minSize.height, bounds.height))
-
-        let metalView = dependencyProvider.makeMetalView(frame: CGRect(origin: .zero, size: finalSize), device: metalDevice)
+        let minSize = CGRect(x: 0, y: 0, width: 1, height: 1)
+        let metalView = dependencyProvider.makeMetalView(frame: minSize.union(bounds), device: metalDevice)
 
         metalView.translatesAutoresizingMaskIntoConstraints = false
         metalView.autoResizeDrawable = true

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -634,7 +634,12 @@ extension MapView: DelegatingMapClientDelegate {
     }
 
     internal func getMetalView(for metalDevice: MTLDevice?) -> MTKView? {
-        let metalView = dependencyProvider.makeMetalView(frame: bounds, device: metalDevice)
+        let minSize = CGSize(width: 1, height: 1)
+        let finalSize = CGSize(
+            width: max(minSize.width, bounds.width),
+            height: max(minSize.height, bounds.height))
+
+        let metalView = dependencyProvider.makeMetalView(frame: CGRect(origin: .zero, size: finalSize), device: metalDevice)
 
         metalView.translatesAutoresizingMaskIntoConstraints = false
         metalView.autoResizeDrawable = true
@@ -651,13 +656,13 @@ extension MapView: DelegatingMapClientDelegate {
         let sameHeightConstraint = metalView.heightAnchor.constraint(equalTo: heightAnchor)
         sameHeightConstraint.priority = .defaultHigh
 
-        let minHeightConstraint = metalView.heightAnchor.constraint(greaterThanOrEqualToConstant: 1)
+        let minHeightConstraint = metalView.heightAnchor.constraint(greaterThanOrEqualToConstant: minSize.height)
         minHeightConstraint.priority = .required
 
         let sameWidthConstraint = metalView.widthAnchor.constraint(equalTo: widthAnchor)
         sameWidthConstraint.priority = .defaultHigh
 
-        let minWidthConstraint = metalView.widthAnchor.constraint(greaterThanOrEqualToConstant: 1)
+        let minWidthConstraint = metalView.widthAnchor.constraint(greaterThanOrEqualToConstant: minSize.width)
         minWidthConstraint.priority = .required
 
         NSLayoutConstraint.activate([

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -82,7 +82,6 @@ open class MapView: UIView {
     internal private(set) var resourceOptions: ResourceOptions!
 
     private var needsDisplayRefresh: Bool = false
-    private var displayCallback: (() -> Void)?
     private var displayLink: DisplayLinkProtocol?
 
     /// Holding onto this value that comes from `MapOptions` since there is a race condition between
@@ -552,7 +551,7 @@ open class MapView: UIView {
 
         if needsDisplayRefresh {
             needsDisplayRefresh = false
-            displayCallback?()
+            metalView?.draw()
         }
     }
 
@@ -636,9 +635,6 @@ extension MapView: DelegatingMapClientDelegate {
 
     internal func getMetalView(for metalDevice: MTLDevice?) -> MTKView? {
         let metalView = dependencyProvider.makeMetalView(frame: bounds, device: metalDevice)
-        displayCallback = {
-            metalView.setNeedsDisplay()
-        }
 
         metalView.translatesAutoresizingMaskIntoConstraints = false
         metalView.autoResizeDrawable = true
@@ -647,7 +643,7 @@ extension MapView: DelegatingMapClientDelegate {
         metalView.isOpaque = isOpaque
         metalView.layer.isOpaque = isOpaque
         metalView.isPaused = true
-        metalView.enableSetNeedsDisplay = true
+        metalView.enableSetNeedsDisplay = false
         metalView.presentsWithTransaction = false
 
         insertSubview(metalView, at: 0)

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -380,4 +380,42 @@ final class MapViewTestsWithScene: XCTestCase {
 
         XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [true])
     }
+
+    func testMetalViewHasCorrectParameters() {
+        let mapViewSize = CGSize(width: 100, height: 100)
+        mapView = MapView(
+            frame: CGRect(origin: .zero, size: mapViewSize),
+            mapInitOptions: MapInitOptions(),
+            dependencyProvider: dependencyProvider,
+            orientationProvider: orientationProvider,
+            urlOpener: attributionURLOpener)
+
+        let metalView = mapView.getMetalView(for: nil)
+
+        XCTAssertEqual(metalView?.translatesAutoresizingMaskIntoConstraints, false)
+        XCTAssertEqual(metalView?.autoResizeDrawable, true)
+        XCTAssertEqual(metalView?.contentScaleFactor, window.screen.scale)
+        XCTAssertEqual(metalView?.contentMode, .center)
+        XCTAssertEqual(metalView?.isOpaque, true)
+        XCTAssertEqual(metalView?.layer.isOpaque, true)
+        XCTAssertEqual(metalView?.isPaused, true)
+        XCTAssertEqual(metalView?.enableSetNeedsDisplay, false)
+        XCTAssertEqual(metalView?.presentsWithTransaction, false)
+        XCTAssertEqual(metalView?.bounds.size, mapViewSize)
+    }
+
+    func testMetalViewHasMinimumSize() {
+        let mapViewSize = CGSize.zero
+        let minimumMetalViewSize = CGSize(width: 1, height: 1)
+        mapView = MapView(
+            frame: CGRect(origin: .zero, size: mapViewSize),
+            mapInitOptions: MapInitOptions(),
+            dependencyProvider: dependencyProvider,
+            orientationProvider: orientationProvider,
+            urlOpener: attributionURLOpener)
+
+        let metalView = mapView.getMetalView(for: nil)
+
+        XCTAssertEqual(metalView?.bounds.size, minimumMetalViewSize)
+    }
 }

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -40,8 +40,8 @@ final class MapViewTests: XCTestCase {
         window.addSubview(mapView)
 
         metalView = try XCTUnwrap(dependencyProvider.makeMetalViewStub.invocations.first?.returnValue)
-        // reset is required here to ignore the setNeedsDisplay() invocation during initialization
-        metalView.setNeedsDisplayStub.reset()
+        // reset is required here to ignore the draw() invocation during initialization
+        metalView.drawStub.reset()
     }
 
     override func tearDown() {
@@ -203,7 +203,7 @@ final class MapViewTests: XCTestCase {
 
         try invokeDisplayLinkCallback()
 
-        XCTAssertEqual(metalView.setNeedsDisplayStub.invocations.count, 1)
+        XCTAssertEqual(metalView.drawStub.invocations.count, 1)
     }
 
     func testMetalViewDoesFitMapView() {
@@ -342,8 +342,8 @@ final class MapViewTestsWithScene: XCTestCase {
         window.addSubview(mapView)
 
         metalView = try XCTUnwrap(dependencyProvider.makeMetalViewStub.invocations.first?.returnValue)
-        // reset is required here to ignore the setNeedsDisplay() invocation during initialization
-        metalView.setNeedsDisplayStub.reset()
+        // reset is required here to ignore the draw() invocation during initialization
+        metalView.drawStub.reset()
     }
 
     override func tearDown() {

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMetalView.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMetalView.swift
@@ -1,9 +1,9 @@
 import MetalKit
 
 final class MockMetalView: MTKView {
-    let setNeedsDisplayStub = Stub<Void, Void>()
-    override func setNeedsDisplay() {
-        super.setNeedsDisplay()
-        setNeedsDisplayStub.call()
+    let drawStub = Stub<Void, Void>()
+    override func draw() {
+        super.draw()
+        drawStub.call()
     }
 }


### PR DESCRIPTION
This is a [second](https://github.com/mapbox/mapbox-maps-ios/pull/1157) attempt at enabling the "explicit drawing" mode for our internal `MTKView`. 
Previously it was [reverted](https://github.com/mapbox/mapbox-maps-ios/pull/1216) due to the crashes it caused.

The reason for crashing(metal view having zero size) has already been addressed [here](https://github.com/mapbox/mapbox-maps-ios-internal/issues/998). However, the metal view still has zero size before the first layout pass that resizes it to the minimum size.

This PR makes sure that the metal view is initialised with minimal width and height.
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
