### PR TITLE
Update CoreMaps to 10.6.0-beta.1

### DIFF
--- a/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/Apps.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "59b81d4f6316a661c322e8c47bc3310f8a1bdd4a",
-          "version": "21.3.0"
+          "revision": "9c029c5de823bf7b25240321da04b60e96240d29",
+          "version": "22.0.0-beta.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "9984e5f6218ce3b5e5ad540218085e6743e133b2",
-          "version": "10.5.1"
+          "revision": "ba379d9c0167bbcfb39e93a7e5337df04c362694",
+          "version": "10.6.0-beta.1"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Call `MapboxMap.reduceMemoryUse` when application goes to background. ([#1301](https://github.com/mapbox/mapbox-maps-ios/pull/1301))
 * Update to MapboxMobileEvents v1.0.8. ([#1324](https://github.com/mapbox/mapbox-maps-ios/pull/1324))
 * Enable explicit drawing behavior for metal view(call `draw()` explicitly instead of `setNeedsDisplay` when view's content need to be redrawn) again.([#1331](https://github.com/mapbox/mapbox-maps-ios/pull/1331))
+* Update to MapboxCoreMaps 10.6.0-beta.1 and MapboxCommon 22.0.0-beta.1. ([#1335](https://github.com/mapbox/mapbox-maps-ios/pull/1335))
 
 ## 10.5.0 - May 5, 2022
 

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -21,8 +21,8 @@ Pod::Spec.new do |m|
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
   m.resources = ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json']
 
-  m.dependency 'MapboxCoreMaps', '10.5.1'
-  m.dependency 'MapboxCommon', '21.3.0'
+  m.dependency 'MapboxCoreMaps', '10.6.0-beta.1'
+  m.dependency 'MapboxCommon', '22.0.0-beta.1'
   m.dependency 'MapboxMobileEvents', '1.0.8'
   m.dependency 'Turf', '~> 2.0'
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "59b81d4f6316a661c322e8c47bc3310f8a1bdd4a",
-          "version": "21.3.0"
+          "revision": "9c029c5de823bf7b25240321da04b60e96240d29",
+          "version": "22.0.0-beta.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "9984e5f6218ce3b5e5ad540218085e6743e133b2",
-          "version": "10.5.1"
+          "revision": "ba379d9c0167bbcfb39e93a7e5337df04c362694",
+          "version": "10.6.0-beta.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
             targets: ["MapboxMaps"]),
     ],
     dependencies: [
-        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.5.1")),
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("21.3.0")),
+        .package(name: "MapboxCoreMaps", url: "https://github.com/mapbox/mapbox-core-maps-ios.git", .exact("10.6.0-beta.1")),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("22.0.0-beta.1")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", .exact("1.0.8")),
         .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.0.0"),
         .package(name: "CocoaImageHashing", url: "https://github.com/ameingast/cocoaimagehashing", .exact("1.9.0"))

--- a/scripts/release/packager/versions.json
+++ b/scripts/release/packager/versions.json
@@ -1,6 +1,6 @@
 {
-	"MapboxCoreMaps": "10.5.1",
-	"MapboxCommon": "21.3.0",
+	"MapboxCoreMaps": "10.6.0-beta.1",
+	"MapboxCommon": "22.0.0-beta.1",
 	"Turf": "v2.4.0",
 	"MapboxMobileEvents": "v1.0.8"
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
* Update CoreMaps to 10.6.0-beta.1
<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Public changelog entries
## Features ✨ and improvements 🏁
* Use a single shared buffer across all globe tiles to increase globe rendering performance
* Increase performance of 'line-trim-offset' rendering by using shader instead of expensive CPU calculations
* The TilesetDescriptorOptions::pixelRatio parameter is now passed to the TileStore and considered for the raster tile pack loading. This enables loading of a raster tilepacks for retina displays.
* Re-introduce partial tile loading feature that decreases map load times

## Bug fixes 🐞
* Fix for momentary appearing of a lower zoom level tile labels during camera movement
* Fix for location indicator not being rendered at the horizon when terrain is enabled
* Fix for loading gltf models with interleaved buffers
* Fix a bug that 'line-trim-offset' calculation did not property cover 'round' or 'square' line cap in line ends

## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
