### PR TITLE
Release drawables when moving to background

### DIFF
--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -471,6 +471,7 @@ open class MapView: UIView {
     @objc private func appDidEnterBackground() {
         displayLink?.isPaused = true
         mapboxMap.reduceMemoryUse()
+        metalView?.releaseDrawables()
     }
 
     @available(iOS 13.0, *)
@@ -487,6 +488,7 @@ open class MapView: UIView {
 
         displayLink?.isPaused = true
         mapboxMap.reduceMemoryUse()
+        metalView?.releaseDrawables()
     }
 
     @objc private func didReceiveMemoryWarning() {

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -267,6 +267,12 @@ final class MapViewTests: XCTestCase {
         XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [true])
     }
 
+    func testReleaseDrawablesInvokedWhenAppMovingToBackground() {
+        notificationCenter.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+        XCTAssertEqual(metalView.releaseDrawablesStub.invocations.count, 1)
+    }
+
     func testDisplayLinkResumedWhenAppMovingToForeground() {
         notificationCenter.post(name: UIApplication.willEnterForegroundNotification, object: nil)
 
@@ -379,6 +385,16 @@ final class MapViewTestsWithScene: XCTestCase {
         notificationCenter.post(name: UIScene.didEnterBackgroundNotification, object: window.parentScene)
 
         XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [true])
+    }
+
+    func testReleaseDrawablesInvokedWhenSceneMovingToBackground() throws {
+        guard #available(iOS 13.0, *) else {
+            throw XCTSkip("Test requires iOS 13 or higher.")
+        }
+
+        notificationCenter.post(name: UIScene.didEnterBackgroundNotification, object: window.parentScene)
+
+        XCTAssertEqual(metalView.releaseDrawablesStub.invocations.count, 1)
     }
 
     func testMetalViewHasCorrectParameters() {

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMetalView.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMetalView.swift
@@ -6,4 +6,10 @@ final class MockMetalView: MTKView {
         super.draw()
         drawStub.call()
     }
+
+    let releaseDrawablesStub = Stub<Void, Void>()
+    override func releaseDrawables() {
+        super.releaseDrawables()
+        releaseDrawablesStub.call()
+    }
 }


### PR DESCRIPTION
Reduce memory use when moving to background by releasing drawables

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
