### PR TITLE
Move style layer using decicated MapboxCoreMaps API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Update to MapboxCoreMaps 10.6.0-rc.1 and MapboxCommon 22.0.0-rc.2. ([#1368](https://github.com/mapbox/mapbox-maps-ios/pull/1368))
 * Add mercator scale factor to 3D puck, so that the 3D puck size won't increase as latitude increases. ([#1347](https://github.com/mapbox/mapbox-maps-ios/pull/1347))
 
+* Use MapboxCoreMaps API to move a Layer instead of manually removing the layer then adding it back. ([#1367](https://github.com/mapbox/mapbox-maps-ios/pull/1367))
 ## 10.6.0-beta.2 - May 25, 2022
 
 * Introduce ModelLayer experimental API to render 3D models on the map. ([#1348](https://github.com/mapbox/mapbox-maps-ios/pull/1348))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+* Use MapboxCoreMaps API to move a Layer instead of manually removing the layer then adding it back. ([#1367](https://github.com/mapbox/mapbox-maps-ios/pull/1367))
+
 ## 10.6.0-rc.1 - June 2, 2022
 
 * Update to MapboxCoreMaps 10.6.0-rc.1 and MapboxCommon 22.0.0-rc.2. ([#1368](https://github.com/mapbox/mapbox-maps-ios/pull/1368))
 * Add mercator scale factor to 3D puck, so that the 3D puck size won't increase as latitude increases. ([#1347](https://github.com/mapbox/mapbox-maps-ios/pull/1347))
 
-* Use MapboxCoreMaps API to move a Layer instead of manually removing the layer then adding it back. ([#1367](https://github.com/mapbox/mapbox-maps-ios/pull/1367))
 ## 10.6.0-beta.2 - May 25, 2022
 
 * Introduce ModelLayer experimental API to render 3D models on the map. ([#1348](https://github.com/mapbox/mapbox-maps-ios/pull/1348))

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -85,14 +85,8 @@ public final class Style: StyleProtocol {
      - Throws: `StyleError` on failure, or `NSError` with a _domain of "com.mapbox.bindgen"
      */
     public func moveLayer(withId id: String, to position: LayerPosition) throws {
-        let properties = try layerProperties(for: id)
-        let isPersistent = try isPersistentLayer(id: id)
-        try removeLayer(withId: id)
-
-        if isPersistent {
-            try addPersistentLayer(with: properties, layerPosition: position)
-        } else {
-            try addLayer(with: properties, layerPosition: position)
+        try handleExpected {
+            _styleManager.moveStyleLayer(forLayerId: id, layerPosition: position.corePosition)
         }
     }
 

--- a/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
+++ b/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
@@ -57,6 +57,10 @@ internal protocol StyleManagerProtocol {
     func isStyleLayerPersistent(forLayerId layerId: String) -> Expected<NSNumber, NSString>
 
     func removeStyleLayer(forLayerId layerId: String) -> Expected<NSNull, NSString>
+    func moveStyleLayer(
+        forLayerId layerId: String,
+        layerPosition: MapboxCoreMaps.LayerPosition?
+    ) -> Expected<NSNull, NSString>
 
     func setStyleLayerPropertyForLayerId(
         _ layerId: String,

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockStyleManager.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockStyleManager.swift
@@ -206,6 +206,17 @@ final class MockStyleManager: StyleManagerProtocol {
         removeStyleLayerStub.call(with: layerId)
     }
 
+    struct MoveStyleLayerParameters {
+        let layerId: String
+        let layerPosition: MapboxCoreMaps.LayerPosition?
+    }
+    let moveStyleLayerStub = Stub<MoveStyleLayerParameters, Expected<NSNull, NSString>>(
+        defaultReturnValue: .init(value: NSNull())
+    )
+    func moveStyleLayer(forLayerId layerId: String, layerPosition: MapboxCoreMaps.LayerPosition?) -> Expected<NSNull, NSString> {
+        moveStyleLayerStub.call(with: MoveStyleLayerParameters(layerId: layerId, layerPosition: layerPosition))
+    }
+
     struct SetStyleLayerPropertyParameters {
         let layerId: String
         let property: String

--- a/Tests/MapboxMapsTests/Foundation/StyleTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/StyleTests.swift
@@ -168,6 +168,17 @@ final class StyleTests: XCTestCase {
         XCTAssertThrowsError(try sut.addPersistentLayer(with: ["foo": "bar"], layerPosition: .at(0)))
     }
 
+    func testStyleCanMoveLayer() {
+        let mockStyleManager = MockStyleManager()
+        let sut = Style(with: mockStyleManager)
+
+        mockStyleManager.moveStyleLayerStub.defaultReturnValue = .init(value: NSNull())
+        XCTAssertNoThrow(try sut.moveLayer(withId: "foo", to: .default))
+
+        mockStyleManager.moveStyleLayerStub.defaultReturnValue = .init(error: "Cannot move layer")
+        XCTAssertThrowsError(try sut.moveLayer(withId: "foo", to: .default))
+    }
+
     func testStyleGetLayerCanFail() {
         let mockStyleManager = MockStyleManager()
         let sut = Style(with: mockStyleManager)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->
MAPSIOS-12 Use dedicated API to move a style layer instead of removing/adding layer like currently.
## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).