### PR TITLE
Align globe examples with gl js

### DIFF
--- a/Apps/Examples/Examples/All Examples/GlobeExample.swift
+++ b/Apps/Examples/Examples/All Examples/GlobeExample.swift
@@ -1,0 +1,26 @@
+import Foundation
+import UIKit
+@_spi(Experimental) import MapboxMaps
+
+@objc(GlobeExample)
+class GlobeExample: UIViewController, ExampleProtocol {
+    internal var mapView: MapView!
+    internal var currentProjection = StyleProjection(name: .globe)
+    internal var currentAtmosphere = Atmosphere()
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+
+        mapView = MapView(frame: view.bounds, mapInitOptions: .init(styleURI: .satelliteStreets))
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        mapView.mapboxMap.setCamera(to: .init(center: CLLocationCoordinate2D(latitude: 50, longitude: 30), zoom: 0.45))
+
+        mapView.mapboxMap.onNext(event: .styleLoaded) { _ in
+            try! self.mapView.mapboxMap.style.setProjection(self.currentProjection)
+            try! self.mapView.mapboxMap.style.setAtmosphere(self.currentAtmosphere)
+            self.finish()
+        }
+
+        view.addSubview(mapView)
+    }
+}

--- a/Apps/Examples/Examples/All Examples/GlobeFlyToExample.swift
+++ b/Apps/Examples/Examples/All Examples/GlobeFlyToExample.swift
@@ -1,0 +1,97 @@
+import Foundation
+import UIKit
+@_spi(Experimental) import MapboxMaps
+import CoreLocation
+
+class GlobeFlyToExample: UIViewController, ExampleProtocol {
+    internal var mapView: MapView!
+    internal var currentProjection = StyleProjection(name: .globe)
+    internal var isAtStart = true
+    var instuctionLabel = UILabel(frame: CGRect.zero)
+
+    private var CAMERA_START = CameraOptions(
+        center: CLLocationCoordinate2D(latitude: 36, longitude: 80),
+        zoom: 1.0,
+        bearing: 0,
+        pitch: 0)
+
+    private var CAMERA_END = CameraOptions(
+        center: CLLocationCoordinate2D(latitude: 46.58842, longitude: 8.11862),
+        zoom: 12.5,
+        bearing: 130.0,
+        pitch: 75.0)
+
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+
+        mapView = MapView(frame: view.bounds, mapInitOptions: .init(styleURI: .satelliteStreets))
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        mapView.mapboxMap.setCamera(to: .init(center: CLLocationCoordinate2D(latitude: 40, longitude: -78), zoom: 1.0))
+
+        mapView.mapboxMap.onNext(event: .styleLoaded) { _ in
+            try! self.mapView.mapboxMap.style.setProjection(self.currentProjection)
+//            try! self.mapView.mapboxMap.style.setAtmosphere(properties: ["color": "rgb(220, 159, 159)",
+//                                                                         "highColor": "rgb(220, 159, 159)",
+//                                                                         "horizonBlend": 0.4])
+            self.addTerrain()
+            self.finish()
+        }
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(animateCameraOnClick))
+        mapView.addGestureRecognizer(tap)
+
+        instuctionLabel.text = "Tap anywhere on the map"
+        instuctionLabel.textColor = UIColor.black
+
+        instuctionLabel.textAlignment = .center
+        instuctionLabel.layer.backgroundColor = UIColor.gray.cgColor
+        instuctionLabel.layer.cornerRadius = 20.0
+        instuctionLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(mapView)
+        view.addSubview(instuctionLabel)
+        installConstraints()
+    }
+
+    func installConstraints() {
+        let safeView = view.safeAreaLayoutGuide
+
+        NSLayoutConstraint.activate([
+            instuctionLabel.topAnchor.constraint(equalTo: safeView.bottomAnchor, constant: -70),
+            instuctionLabel.bottomAnchor.constraint(equalTo: safeView.bottomAnchor, constant: -30),
+            instuctionLabel.leadingAnchor.constraint(equalTo: safeView.leadingAnchor, constant: 70),
+            instuctionLabel.trailingAnchor.constraint(equalTo: safeView.trailingAnchor, constant: -70)
+        ])
+
+    }
+
+    func addTerrain() {
+        var demSource = RasterDemSource()
+        demSource.url = "mapbox://mapbox.mapbox-terrain-dem-v1"
+        // Setting the `tileSize` to 514 provides better performance and adds padding around the outside
+        // of the tiles.
+        demSource.tileSize = 514
+        demSource.maxzoom = 14.0
+        try! mapView.mapboxMap.style.addSource(demSource, id: "mapbox-dem")
+
+        var terrain = Terrain(sourceId: "mapbox-dem")
+        terrain.exaggeration = .constant(1.5)
+
+        try! mapView.mapboxMap.style.setTerrain(terrain)
+    }
+
+    @objc func animateCameraOnClick() {
+        instuctionLabel.isHidden = true
+        var target = CameraOptions()
+        if isAtStart {
+            target = CAMERA_END
+        } else {
+            target = CAMERA_START
+        }
+        isAtStart = !isAtStart
+        mapView.camera.fly(to: target, duration: 12) { _ in
+        }
+
+    }
+}

--- a/Apps/Examples/Examples/All Examples/HeatmapLayerGlobeExample.swift
+++ b/Apps/Examples/Examples/All Examples/HeatmapLayerGlobeExample.swift
@@ -1,0 +1,229 @@
+import UIKit
+@_spi(Experimental) import MapboxMaps
+
+@objc(HeatmapLayerGlobeExample)
+public class HeatmapLayerGlobeExample: UIViewController, ExampleProtocol {
+
+    internal var mapView: MapView!
+    internal var currentProjection = StyleProjection(name: .globe)
+    internal var currentAtmosphere = Atmosphere()
+    internal let earthquakeSourceId: String = "earthquakes"
+    internal let earthquakeLayerId: String = "earthquake-viz"
+    internal let heatmapLayerId = "earthquakes-heat"
+    internal let heatmapLayerSource = "earthquakes"
+    internal let circleLayerId = "earthquakes-circle"
+    internal let earthquakeURL = URL(string: "https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson")!
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Center the map over the United States.
+        let centerCoordinate = CLLocationCoordinate2D(latitude: 50,
+                                                      longitude: -120)
+        let options = MapInitOptions(cameraOptions: CameraOptions(center: centerCoordinate, zoom: 1.0), styleURI: .dark)
+        // Set up map view
+        mapView = MapView(frame: view.bounds, mapInitOptions: options)
+        mapView.ornaments.options.scaleBar.visibility = .hidden
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(mapView)
+
+        mapView.mapboxMap.onNext(event: .mapLoaded) { [weak self] _ in
+            guard let self = self else { return }
+            try! self.mapView.mapboxMap.style.setProjection(self.currentProjection)
+            try! self.mapView.mapboxMap.style.setAtmosphere(self.currentAtmosphere)
+            self.addRuntimeLayers()
+            self.finish()
+        }
+    }
+
+    func addRuntimeLayers() {
+        createEarthquakeSource()
+        createHeatmapLayer()
+        createCircleLayer()
+    }
+
+    func createEarthquakeSource() {
+        var earthquakeSource = GeoJSONSource()
+        earthquakeSource.data = .url(self.earthquakeURL)
+        earthquakeSource.generateId = true
+
+        do {
+            try mapView.mapboxMap.style.addSource(earthquakeSource, id: self.earthquakeSourceId)
+        } catch {
+            print("Ran into an error adding a source: \(error)")
+        }
+    }
+
+    func createHeatmapLayer() {
+
+        // Add earthquake-viz layer
+        var heatmapLayer = HeatmapLayer(id: self.heatmapLayerId)
+        heatmapLayer.source = self.earthquakeSourceId
+        heatmapLayer.maxZoom = 9.0
+        heatmapLayer.sourceLayer  = self.heatmapLayerSource
+
+
+        heatmapLayer.heatmapColor = .expression(
+            Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.heatmapDensity)
+                0
+                "rgba(33.0, 102.0, 172.0, 0.0)"
+                0.2
+                "rgb(102.0, 169.0, 207.0)"
+                0.4
+                "rgb(209.0, 229.0, 240.0)"
+                0.6
+                "rgb(253.0, 219.0, 199.0)"
+                0.8
+                "rgb(239.0, 138.0, 98.0)"
+                1
+                "rgb(178.0, 24.0, 43.0)"
+            }
+        )
+        // Increase the heatmap weight based on frequency and property magnitude
+        heatmapLayer.heatmapWeight = .expression(
+            Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.get) {"mag"}
+                0
+                0
+                6
+                1
+            }
+        )
+        // Increase the heatmap color weight weight by zoom level
+        // heatmap-intensity is a multiplier on top of heatmap-weight
+        heatmapLayer.heatmapIntensity = .expression(
+            Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.zoom)
+                0
+                1
+                9
+                3
+            }
+        )
+        // Adjust the heatmap radius by zoom level
+        heatmapLayer.heatmapRadius = .expression(
+            Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.zoom)
+                0
+                2
+                9
+                20
+            }
+        )
+
+        // Transition from heatmap to circle layer by zoom level
+        heatmapLayer.heatmapOpacity = .expression(
+            Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.zoom)
+                7
+                1
+                9
+                0
+            }
+        )
+
+        do {
+            try mapView.mapboxMap.style.addLayer(heatmapLayer, layerPosition: .above("waterway-label"))
+        } catch {
+            print("Ran into an error adding a layer: \(error)")
+        }
+    }
+
+    public func createCircleLayer() {
+
+        var circleLayerSource = GeoJSONSource()
+        circleLayerSource.data = .url(self.earthquakeURL)
+        circleLayerSource.generateId = true
+
+        do {
+            try mapView.mapboxMap.style.addSource(circleLayerSource, id: self.earthquakeSourceId)
+        } catch {
+            print("Ran into an error adding a source: \(error)")
+        }
+
+        // Add earthquake-viz layer
+        var circleLayer = CircleLayer(id: self.circleLayerId)
+        circleLayer.source = self.earthquakeSourceId
+
+        circleLayer.circleRadius = .expression(
+            Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.zoom)
+                Exp(.literal) {
+                    7
+                }
+                Exp(.interpolate) {
+                    Exp(.linear)
+                    Exp(.get) {"mag"}
+                    1
+                    1
+                    6
+                    4
+                }
+                Exp(.literal) {
+                    16
+                }
+                Exp(.interpolate) {
+                    Exp(.linear)
+                    Exp(.get) {"mag"}
+                    1
+                    5
+                    6
+                    50
+                }
+            }
+        )
+        circleLayer.circleRadiusTransition = StyleTransition(duration: 0.5, delay: 0)
+        circleLayer.circleStrokeColor = .constant(StyleColor(.black))
+        circleLayer.circleStrokeWidth = .constant(1)
+
+        // The feature-state dependent circle-color expression will render
+        // the color according to its magnitude when
+        // a feature's hover state is set to true
+        circleLayer.circleColor = .expression(
+            Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.get) { "mag" }
+                1
+                "rgba(33.0, 102.0, 172.0, 0.0)"
+                1
+                "rgb(102.0, 169.0, 207.0)"
+                3
+                "rgb(209.0, 229.0, 240.0)"
+                4
+                "rgb(253.0, 219.0, 199.0)"
+                5
+                "rgb(239.0, 138.0, 98.0)"
+                6
+                "rgb(178.0, 24.0, 43.0)"
+            }
+        )
+
+        circleLayer.circleOpacity = .expression(
+            Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.zoom)
+                7
+                0
+                8
+                1
+            }
+        )
+
+        circleLayer.circleStrokeColor = .constant(.init(UIColor.white))
+        circleLayer.circleStrokeWidth = .constant(0.1)
+
+        do {
+            try mapView.mapboxMap.style.addLayer(circleLayer, layerPosition: .below(self.heatmapLayerId))
+        } catch {
+            print("Ran into an error adding a layer: \(error)")
+        }
+    }
+
+}

--- a/Apps/Examples/Examples/All Examples/SpinningGlobeExample.swift
+++ b/Apps/Examples/Examples/All Examples/SpinningGlobeExample.swift
@@ -1,0 +1,86 @@
+import Foundation
+import UIKit
+@_spi(Experimental) import MapboxMaps
+import CoreLocation
+
+class SpinningGlobeExample: UIViewController, GestureManagerDelegate, ExampleProtocol{
+
+    var userInteracting = false
+    var spinEnabled = true
+    var currentProjection = StyleProjection(name: .globe)
+    var currentAtmosphere = Atmosphere()
+    var mapView: MapView!
+    var runningAnimation: Cancelable!
+
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+
+        mapView = MapView(frame: view.bounds, mapInitOptions: .init(styleURI: .satellite))
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        mapView.mapboxMap.setCamera(to: .init(center: CLLocationCoordinate2D(latitude: 40, longitude: -90), zoom: 1.0))
+
+        mapView.mapboxMap.onNext(event: .styleLoaded) { _ in
+            try! mapView.mapboxMap.style.setProjection(self.currentProjection)
+            try! self.mapView.mapboxMap.style.setAtmosphere(self.currentAtmosphere)
+            //        try! mapView.mapboxMap.style.setAtmosphere(properties: ["color": "rgb(220, 159, 159)",
+            //                                                                "highColor": "rgb(220, 159, 159)",
+            //                                                                "horizonBlend": 0.4])
+            self.spinGlobe()
+            self.finish()
+        }
+
+        mapView.gestures.delegate = self
+
+        view.addSubview(mapView)
+    }
+
+    func spinGlobe() {
+        // At low zooms, complete a revolution every two minutes.
+        let secPerRevolution = 120.0
+        // Above zoom level 5, do not rotate.
+        let maxSpinZoom = 5.0
+        // Rotate at intermediate speeds between zoom levels 3 and 5.
+        let slowSpinZoom = 3.0
+
+        let zoom = mapView.cameraState.zoom
+        if (spinEnabled && !userInteracting && zoom < maxSpinZoom) {
+            var distancePerSecond = 360.0 / secPerRevolution
+            if (zoom > slowSpinZoom) {
+                // Slow spinning at higher zooms
+                let zoomDif = (maxSpinZoom - zoom) / (maxSpinZoom - slowSpinZoom)
+                distancePerSecond *= zoomDif
+            }
+            let center = mapView.cameraState.center
+            let targetCenter = CLLocationCoordinate2D(latitude: center.latitude, longitude: center.longitude - distancePerSecond)
+
+            // Smoothly animate the map over one second.
+            // When this animation is complete, call it again
+            mapView.camera.ease(to: .init(center: targetCenter), duration: 1.0, curve: .linear) { _ in
+
+                self.spinGlobe()
+            }
+        }
+
+    }
+
+    func gestureManager(_ gestureManager: GestureManager, didBegin gestureType: GestureType) {
+        // do nothing
+    }
+
+    func gestureManager(_ gestureManager: GestureManager, didEnd gestureType: GestureType, willAnimate: Bool) {
+        if gestureType == .doubleTouchToZoomOut || gestureType == .pinch || gestureType == .doubleTapToZoomIn {
+            if mapView.cameraState.zoom < 5 {
+                if userInteracting == true {
+                    self.spinGlobe()
+                }
+            } else {
+                print("dont spin")
+            }
+        }
+    }
+
+    func gestureManager(_ gestureManager: GestureManager, didEndAnimatingFor gestureType: GestureType) {
+        // do nothing
+    }
+}

--- a/Apps/Examples/Examples/Models/Examples.swift
+++ b/Apps/Examples/Examples/Models/Examples.swift
@@ -53,6 +53,9 @@ struct Examples {
             "title": "Accessibility",
             "examples": accessibilityExamples
         ],
+        [   "title": "Globe and Atmosphere",
+            "examples": globeAndAtmosphere
+        ],
         [
             "title": "Experimental",
             "examples": experimentalExamples
@@ -301,11 +304,24 @@ struct Examples {
                 type: VoiceOverAccessibilityExample.self),
     ]
 
+    // Examples that display maps using the globe projection
+    static let globeAndAtmosphere = [
+        Example(title: "Display Globe View",
+                description: "Create a map using the globe projection.",
+                type: GlobeExample.self),
+        Example(title: "Globe projection Fly-to camera animation",
+                description: "Display camera animations using the globe projection.",
+                type: GlobeFlyToExample.self),
+        Example(title: "Create a rotating globe",
+                description: "Display your map as an interactive, rotating globe.",
+                type: SpinningGlobeExample.self),
+        Example(title: "Globe projection heatmap",
+                description: "Display your heatmap using the globe projection.",
+                type: HeatmapLayerGlobeExample.self)
+    ]
+
     // Examples that uses experimental APIs
     static let experimentalExamples = [
-        Example(title: "Globe View",
-                description: "Display map on a globe.",
-                type: GlobeViewExample.self),
         Example(title: "Viewport",
                 description: "Viewport camera showcase",
                 type: ViewportExample.self),


### PR DESCRIPTION
Moved projection and atmosphere configuration to .styleLoaded block and added heatmap globe example to match Android
- currently blocked by https://github.com/mapbox/mapbox-maps-ios/pull/1405

## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
