### PR TITLE
Add benchmark baselines and support to parse them

### DIFF
--- a/baselines/performance/MapboxMaps.json
+++ b/baselines/performance/MapboxMaps.json
@@ -1,0 +1,138 @@
+[
+  {
+    "testName": "testNavDayMunichTtrcCold",
+    "metrics": {
+      "HighWaterMarkForHeapAllocations": "691000",
+      "HighWaterMarkForVMAllocations": "125000",
+      "PersistentHeapAllocations": "58.3",
+      "PersistentVMAllocations": "10700",
+      "RunTime": "0.619",
+      "SystemTime": "0.118",
+      "TemporaryHeapAllocations": "186000",
+      "Time": "0.757",
+      "TotalHeapAllocations": "176000",
+      "TransientHeapAllocations": "365000",
+      "TransientVMAllocations": "222000",
+      "UserTime": "0.501"
+    }
+  },
+  {
+    "testName": "testNavDayMunichTtrcWarm",
+    "metrics": {
+      "HighWaterMarkForHeapAllocations": "45700",
+      "HighWaterMarkForVMAllocations": "178000",
+      "PersistentHeapAllocations": "707",
+      "PersistentVMAllocations": "9990",
+      "RunTime": "2.65",
+      "SystemTime": "0.581",
+      "TemporaryHeapAllocations": "685000",
+      "Time": "6.29",
+      "TotalHeapAllocations": "645000",
+      "TransientHeapAllocations": "883000",
+      "TransientVMAllocations": "747000",
+      "UserTime": "2.07"
+    }
+  },
+  {
+    "testName": "testNavDayMunichZoom",
+    "metrics": {
+      "HighWaterMarkForHeapAllocations": "72400",
+      "HighWaterMarkForVMAllocations": "135000",
+      "PersistentHeapAllocations": "159",
+      "PersistentVMAllocations": "8860",
+      "RunTime": "21.4",
+      "SystemTime": "3.02",
+      "TemporaryHeapAllocations": "3840000",
+      "Time": "48.4",
+      "TotalHeapAllocations": "3650000",
+      "TransientHeapAllocations": "8980000",
+      "TransientVMAllocations": "2110000",
+      "UserTime": "18.4"
+    }
+  },
+  {
+    "testName": "testNavDayMunichZoomTilepack",
+    "metrics": {
+      "HighWaterMarkForHeapAllocations": "59600",
+      "HighWaterMarkForVMAllocations": "202000",
+      "PersistentHeapAllocations": "111",
+      "PersistentVMAllocations": "11100",
+      "RunTime": "25.8",
+      "SystemTime": "3.58",
+      "TemporaryHeapAllocations": "6010000",
+      "Time": "54.2",
+      "TotalHeapAllocations": "5760000",
+      "TransientHeapAllocations": "12800000",
+      "TransientVMAllocations": "4250000",
+      "UserTime": "22.2"
+    }
+  },
+  {
+    "testName": "testStreetsMunichTtrcCold",
+    "metrics": {
+      "HighWaterMarkForHeapAllocations": "16300",
+      "HighWaterMarkForVMAllocations": "51700",
+      "PersistentHeapAllocations": "38.4",
+      "PersistentVMAllocations": "7780",
+      "RunTime": "0.452",
+      "SystemTime": "0.0821",
+      "TemporaryHeapAllocations": "140000",
+      "Time": "0.582",
+      "TotalHeapAllocations": "131000",
+      "TransientHeapAllocations": "351000",
+      "TransientVMAllocations": "132000",
+      "UserTime": "0.37"
+    }
+  },
+  {
+    "testName": "testStreetsMunichTtrcWarm",
+    "metrics": {
+      "HighWaterMarkForHeapAllocations": "12700",
+      "HighWaterMarkForVMAllocations": "105000",
+      "PersistentHeapAllocations": "20",
+      "PersistentVMAllocations": "9980",
+      "RunTime": "2.56",
+      "SystemTime": "0.569",
+      "TemporaryHeapAllocations": "641000",
+      "Time": "6.51",
+      "TotalHeapAllocations": "602000",
+      "TransientHeapAllocations": "887000",
+      "TransientVMAllocations": "655000",
+      "UserTime": "1.99"
+    }
+  },
+  {
+    "testName": "WarmCacheBenchmark",
+    "metrics": {
+      "HighWaterMarkForHeapAllocations": "11200",
+      "HighWaterMarkForVMAllocations": "39400",
+      "PersistentHeapAllocations": "17400",
+      "PersistentVMAllocations": "32700",
+      "RunTime": "0.14",
+      "SystemTime": "0.0184",
+      "TemporaryHeapAllocations": "415000",
+      "Time": "0.0829",
+      "TotalHeapAllocations": "51200",
+      "TransientHeapAllocations": "105000",
+      "TransientVMAllocations": "56100",
+      "UserTime": "0.122"
+    }
+  },
+  {
+    "testName": "SDKInitializationTime",
+    "metrics": {
+      "HighWaterMarkForHeapAllocations": "201",
+      "HighWaterMarkForVMAllocations": "22200",
+      "PersistentHeapAllocations": "955",
+      "PersistentVMAllocations": "22100",
+      "RunTime": "0.0105",
+      "SystemTime": "0.00426",
+      "TemporaryHeapAllocations": "679",
+      "Time": "0.01",
+      "TotalHeapAllocations": "861",
+      "TransientHeapAllocations": "1500",
+      "TransientVMAllocations": "310",
+      "UserTime": "0.00622"
+    }
+  }
+]

--- a/scripts/xcparty/Sources/xcparty/MetricsCommand.swift
+++ b/scripts/xcparty/Sources/xcparty/MetricsCommand.swift
@@ -24,6 +24,28 @@ struct MetricsCommand: ParsableCommand {
     })
     var outputPath: String?
 
+    struct BaselineList: Decodable {
+        struct Record: Decodable {
+            let testName: String
+            let metrics: [String: String]
+        }
+
+        let records: [Record]
+
+        func record(forTestName testName: String) -> BaselineList.Record? {
+            records.first(where: { $0.testName == testName })
+        }
+    }
+
+    @Option(name: [.short, .long], help: "Path to baselines JSON file", transform: { path in
+        let path = (path as NSString).expandingTildeInPath
+        let baselineData = try Data(contentsOf: URL(fileURLWithPath: path))
+        let decoder = JSONDecoder()
+        let baselines = try decoder.decode(Array<BaselineList.Record>.self, from: baselineData)
+        return BaselineList(records: baselines)
+    })
+    var baseline: BaselineList
+
     func run() throws {
         let resultFile = XCResultFile(url: pathToXCResult)
         let metricTests = try parseMetrics(resultFile: resultFile)
@@ -51,76 +73,85 @@ struct MetricsCommand: ParsableCommand {
         }
     }
 
-    struct PerfomanceTest {
+    struct PerformanceTest {
         let testName: String
         let metrics: [ActionTestPerformanceMetricSummary]
         let actionRecord: ActionRecord
 
-        static func metrics(from test: ActionTestMetadata, in resultFile: XCResultFile, for actionRecord: ActionRecord) -> PerfomanceTest? {
+        static func metrics(from test: ActionTestMetadata, in resultFile: XCResultFile, for actionRecord: ActionRecord) -> PerformanceTest? {
             guard
                 let testSummaryRef = test.summaryRef,
                 let actionTestSummary = resultFile.getActionTestSummary(id: testSummaryRef.id)
             else { return nil }
 
-            return PerfomanceTest(testName: refineTestFunctionName(test.name),
+            return PerformanceTest(testName: refineTestFunctionName(test.name),
                                   metrics: actionTestSummary.performanceMetrics,
                                   actionRecord: actionRecord)
         }
     }
 
-    func parseMetrics(resultFile: XCResultFile) throws -> [PerfomanceTest] {
+    func parseMetrics(resultFile: XCResultFile) throws -> [PerformanceTest] {
         let invocation = resultFile.getInvocationRecord()!
-        let actionRecord = invocation.actions[0]
-        let testPlanRunSummariesId = actionRecord.actionResult.testsRef!.id
 
-        let testPlanRunSummaries = resultFile.getTestPlanRunSummaries(id: testPlanRunSummariesId)!
+        return invocation.actions.flatMap { actionOnConcreteDevice -> [PerformanceTest] in
+            let testPlanRunSummariesId = actionOnConcreteDevice.actionResult.testsRef!.id
 
-        let testTargetResults = testPlanRunSummaries.summaries[0] // name : "Test Scheme Action"
-            .testableSummaries[0] // projectRelativePath: MobileMetrics.xcodeproj, targetName: MobileMetricsTests
-            .tests[0] // name : "All tests"
-            .subtestGroups[0]
+            let testPlanRunSummaries = resultFile.getTestPlanRunSummaries(id: testPlanRunSummariesId)!
 
-        let testMetrics = testTargetResults.subtestGroups.flatMap { testSuit in
-            testSuit.subtests.compactMap({ PerfomanceTest.metrics(from: $0, in: resultFile, for: actionRecord) })
+            let testTargetResults = testPlanRunSummaries.summaries[0] // name : "Test Scheme Action"
+                .testableSummaries[0] // projectRelativePath: MobileMetrics.xcodeproj, targetName: MobileMetricsTests
+                .tests[0] // name : "All tests"
+                .subtestGroups[0]
+
+            return testTargetResults.subtestGroups.flatMap { testSuit in
+                testSuit.subtests.compactMap({ PerformanceTest.metrics(from: $0, in: resultFile, for: actionOnConcreteDevice) })
+            }
         }
-
-        return testMetrics
     }
 
-    func generateOutputContent(tests: [PerfomanceTest]) throws -> String {
+    static var decimalValueFormatter: NumberFormatter = {
         let valueFormatter = NumberFormatter()
         valueFormatter.numberStyle = .decimal
         valueFormatter.usesGroupingSeparator = false
         valueFormatter.locale = Locale(identifier: "en_US_POSIX")
 
+        return valueFormatter
+    }()
+
+    func generateOutputContent(tests: [PerformanceTest]) throws -> String {
         return try tests
-            .map { test in
-                return [
-                    "name": "ios-maps-v2",
-                    "version": 3,
-                    "created": ISO8601DateFormatter.string(from: Date(), timeZone: .current, formatOptions: [.withInternetDateTime]),
-                    "counters": test.metrics.reduce(into: [:]) { partialResult, metric in
-                        let value = metric.measurements.reduce(0.0, +) / Double(metric.measurements.count)
-                        let metricName = metric.displayName.replacingOccurrences(of: " ", with: "")
-                        partialResult[metricName] = valueFormatter.string(from: value as NSNumber)
-                        partialResult[metricName+"_units"] = metric.unitOfMeasurement
-                    },
-                    "attributes": [
-                        "test_name": refineTestFunctionName(test.testName)
-                    ],
-                    "metadata": deviceMetadata(actionRecord: test.actionRecord),
-                    "build": buildMetadata()
-                ]
-            }
-            .map { json -> String in
-                var options: JSONSerialization.WritingOptions = [.sortedKeys, .withoutEscapingSlashes]
-                if humanReadable {
-                    options.insert([.prettyPrinted])
-                }
-                let data = try JSONSerialization.data(withJSONObject: json, options: options)
-                return String(data: data, encoding: .utf8) ?? ""
-            }
+            .map(generateTestReport)
+            .map(convertToString)
             .joined(separator: "\n")
+    }
+
+    func generateTestReport(test: PerformanceTest) -> [String: Any] {
+        let testName = refineTestFunctionName(test.testName)
+        let baseline = baseline.record(forTestName: testName)
+
+        let counters = test.metrics.reduce(into: [:]) { partialResult, metric in
+            let value = metric.measurements.reduce(0.0, +) / Double(metric.measurements.count)
+            let metricName = metric.displayName.replacingOccurrences(of: " ", with: "")
+
+            partialResult[metricName] = MetricsCommand.decimalValueFormatter.string(from: value as NSNumber)
+            partialResult[metricName+"_units"] = metric.unitOfMeasurement
+
+            if let baselineMetric = baseline?.metrics[metricName] {
+                partialResult[metricName + "_baseline"] = baselineMetric
+            }
+        }
+
+        return [
+            "name": "ios-maps-v2",
+            "version": 3,
+            "created": ISO8601DateFormatter.string(from: Date(), timeZone: .current, formatOptions: [.withInternetDateTime]),
+            "counters": counters,
+            "attributes": [
+                "test_name": testName
+            ],
+            "metadata": deviceMetadata(actionRecord: test.actionRecord),
+            "build": buildMetadata()
+        ]
     }
 
     func deviceMetadata(actionRecord: ActionRecord) -> [String: Any] {
@@ -204,7 +235,10 @@ struct MetricsCommand: ParsableCommand {
         ]
     }
 
+    static var cachedBuildMetadata: [String: Any]!
+
     func buildMetadata() -> [String: Any] {
+        guard MetricsCommand.cachedBuildMetadata == nil else { return MetricsCommand.cachedBuildMetadata }
 
         let repositoryURL = URL(fileURLWithPath: repositoryPath,
             isDirectory: true,
@@ -216,7 +250,7 @@ struct MetricsCommand: ParsableCommand {
             return shell("git -C '\(repoFullPath)' \(command)")
         }
 
-        var baseMetadata: [String: Any] = [
+        var buildMetadata: [String: Any] = [
             "sha": git("rev-parse HEAD"),
             "author": git("log -1 --pretty=format:'%an'"),
             "branch": git("rev-parse --abbrev-ref HEAD"),
@@ -225,10 +259,21 @@ struct MetricsCommand: ParsableCommand {
             "timestamp": Int(git("log -1 --format=%at"))!
         ]
         if let ciBuildNumber = ProcessInfo.processInfo.environment["CIRCLE_BUILD_NUM"] {
-            baseMetadata["ci_ref"] = ciBuildNumber
+            buildMetadata["ci_ref"] = ciBuildNumber
         }
 
-        return baseMetadata
+        MetricsCommand.cachedBuildMetadata = buildMetadata
+
+        return buildMetadata
+    }
+
+    func convertToString(input: [String: Any]) throws -> String {
+        var options: JSONSerialization.WritingOptions = [.sortedKeys, .withoutEscapingSlashes]
+        if humanReadable {
+            options.insert([.prettyPrinted])
+        }
+        let data = try JSONSerialization.data(withJSONObject: input, options: options)
+        return String(data: data, encoding: .utf8) ?? ""
     }
 
     func outputContent(_ content: String) throws {
@@ -240,27 +285,4 @@ struct MetricsCommand: ParsableCommand {
             print(content)
         }
     }
-}
-
-func refineTestFunctionName(_ name: String) -> String {
-    return name
-        .replacingOccurrences(of: "test_sla_", with: "")
-        .replacingOccurrences(of: "()", with: "")
-}
-
-func shell(_ command: String) -> String {
-    let task = Process()
-    let pipe = Pipe()
-
-    task.standardOutput = pipe
-    task.standardError = pipe
-    task.arguments = ["-c", command]
-    task.launchPath = "/bin/zsh"
-    task.launch()
-    task.waitUntilExit()
-
-    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-    let output = String(data: data, encoding: .utf8)!
-
-    return output.trimmingCharacters(in: .whitespacesAndNewlines)
 }

--- a/scripts/xcparty/Sources/xcparty/Utilities.swift
+++ b/scripts/xcparty/Sources/xcparty/Utilities.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+func refineTestFunctionName(_ name: String) -> String {
+    return name
+        .replacingOccurrences(of: "test_sla_", with: "")
+        .replacingOccurrences(of: "()", with: "")
+}
+
+func shell(_ command: String) -> String {
+    let task = Process()
+    let pipe = Pipe()
+
+    task.standardOutput = pipe
+    task.standardError = pipe
+    task.arguments = ["-c", command]
+    task.launchPath = "/bin/zsh"
+    task.launch()
+    task.waitUntilExit()
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(data: data, encoding: .utf8)!
+
+    return output.trimmingCharacters(in: .whitespacesAndNewlines)
+}


### PR DESCRIPTION
This PR also includes following changes:
* Includes baselines to the report
* Support parsing over multiple device repors in the single XCResult
* Cache metadata from git repository to speed up metrics report building
* Some refactoring to break too long methods
* Minor renamings for miss-spelled words

<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
