### PR TITLE
Finish tracking mode example when its view appears

### DIFF
--- a/Apps/Examples/Examples/All Examples/TrackingModeExample.swift
+++ b/Apps/Examples/Examples/All Examples/TrackingModeExample.swift
@@ -37,8 +37,13 @@ public class TrackingModeExample: UIViewController, ExampleProtocol {
             // Note that the location manager holds weak references to consumers, which should be retained
             self.mapView.location.addLocationConsumer(newConsumer: self.cameraLocationConsumer)
 
-            self.finish() // Needed for internal testing purposes.
         }
+    }
+
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // The below line is used for internal testing purposes only.
+        finish()
     }
 
     @objc func showHideBearingImage() {


### PR DESCRIPTION
This fixes failing tests for TrackingModeExample - it marks the test as completed when the map loads, but that never happens as the system location permission dialog makes the examples app to become inactive which, in turn, prevents the map from being loaded.

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
