### PR TITLE
Add cast shadow option to 3d puck config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+## main
+
+* Add experimental `Puck3DConfiguration.modelCastShadows` option to control shadow casting for the 3D puck. ([#1435](https://github.com/mapbox/mapbox-maps-ios/pull/1435))
+
 ## 10.7.0-beta.1 - June 29, 2022
 
 * Introduce `FillExtrusionLayer.fillExtrusionAmbientOcclusionIntensity` and `FillExtrusionLayer.fillExtrusionAmbientOcclusionRadius` properties for FillExtrusionLayer. ([1410](https://github.com/mapbox/mapbox-maps-ios/pull/1410))

--- a/Sources/MapboxMaps/Location/Puck/Puck3D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck3D.swift
@@ -104,6 +104,7 @@ internal final class Puck3D: Puck {
             modelLayer.modelScale = modelScale
             modelLayer.modelType = .constant(.locationIndicator)
             modelLayer.modelRotation = configuration.modelRotation
+            modelLayer.modelCastShadows = configuration.modelCastShadows
             try! style.addPersistentLayer(modelLayer, layerPosition: nil)
         } else if needsUpdateModelScale {
             try? style.setLayerProperty(

--- a/Sources/MapboxMaps/Location/Puck/PuckType.swift
+++ b/Sources/MapboxMaps/Location/Puck/PuckType.swift
@@ -99,6 +99,9 @@ public struct Puck3DConfiguration: Equatable {
     /// The rotation of the model in euler angles [lon, lat, z].
     public var modelRotation: Value<[Double]>?
 
+    /// Enable/disable shadow casting for the puck
+    @_spi(Experimental) public var modelCastShadows: Value<Bool>?
+
     /// Initialize a `Puck3DConfiguration` with a model, scale and rotation.
     /// - Parameters:
     ///   - model: The `gltf` model to use for the puck.
@@ -108,6 +111,22 @@ public struct Puck3DConfiguration: Equatable {
         self.model = model
         self.modelScale = modelScale
         self.modelRotation = modelRotation
+    }
+
+    /// Initialize a `Puck3DConfiguration` with a model, scale, rotation and an parameter to control shadow casting.
+    /// - Parameters:
+    ///   - model: The `gltf` model to use for the puck.
+    ///   - modelScale: The amount to scale the model by.
+    ///   - modelRotation: The rotation of the model in euler angles `[lon, lat, z]`.
+    ///   - modelCastShadows: Enable/disable shadow casting for the puck
+    @_spi(Experimental) public init(model: Model,
+                                    modelScale: Value<[Double]>? = nil,
+                                    modelRotation: Value<[Double]>? = nil,
+                                    modelCastShadows: Value<Bool>? = nil) {
+        self.model = model
+        self.modelScale = modelScale
+        self.modelRotation = modelRotation
+        self.modelCastShadows = modelCastShadows
     }
 }
 

--- a/Sources/MapboxMaps/Style/Generated/Layers/ModelLayer.swift
+++ b/Sources/MapboxMaps/Style/Generated/Layers/ModelLayer.swift
@@ -19,6 +19,9 @@ import Foundation
     /// Model to render.
     public var modelId: Value<String>?
 
+    /// Enable/Disable shadow casting for this layer
+    public var modelCastShadows: Value<Bool>?
+
     /// The tint color of the model layer. model-color-mix-intensity (defaults to 0) defines tint(mix) intensity - this means that, this color is not used unless model-color-mix-intensity gets value greater than 0.
     public var modelColor: Value<StyleColor>?
 
@@ -75,6 +78,7 @@ import Foundation
         try container.encodeIfPresent(maxZoom, forKey: .maxZoom)
 
         var paintContainer = container.nestedContainer(keyedBy: PaintCodingKeys.self, forKey: .paint)
+        try paintContainer.encodeIfPresent(modelCastShadows, forKey: .modelCastShadows)
         try paintContainer.encodeIfPresent(modelColor, forKey: .modelColor)
         try paintContainer.encodeIfPresent(modelColorTransition, forKey: .modelColorTransition)
         try paintContainer.encodeIfPresent(modelColorMixIntensity, forKey: .modelColorMixIntensity)
@@ -105,6 +109,7 @@ import Foundation
         maxZoom = try container.decodeIfPresent(Double.self, forKey: .maxZoom)
 
         if let paintContainer = try? container.nestedContainer(keyedBy: PaintCodingKeys.self, forKey: .paint) {
+            modelCastShadows = try paintContainer.decodeIfPresent(Value<Bool>.self, forKey: .modelCastShadows)
             modelColor = try paintContainer.decodeIfPresent(Value<StyleColor>.self, forKey: .modelColor)
             modelColorTransition = try paintContainer.decodeIfPresent(StyleTransition.self, forKey: .modelColorTransition)
             modelColorMixIntensity = try paintContainer.decodeIfPresent(Value<Double>.self, forKey: .modelColorMixIntensity)
@@ -144,6 +149,7 @@ import Foundation
     }
 
     enum PaintCodingKeys: String, CodingKey {
+        case modelCastShadows = "model-cast-shadows"
         case modelColor = "model-color"
         case modelColorTransition = "model-color-transition"
         case modelColorMixIntensity = "model-color-mix-intensity"

--- a/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/ModelLayerIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/IntegrationTests/Layers/ModelLayerIntegrationTests.swift
@@ -29,6 +29,7 @@ final class ModelLayerIntegrationTests: MapViewIntegrationTestCase {
             layer.visibility = .constant(.visible)
             layer.modelId = Value<String>.testConstantValue()
 
+            layer.modelCastShadows = Value<Bool>.testConstantValue()
             layer.modelColor = Value<StyleColor>.testConstantValue()
             layer.modelColorTransition = StyleTransition(duration: 10.0, delay: 10.0)
             layer.modelColorMixIntensity = Value<Double>.testConstantValue()

--- a/Tests/MapboxMapsTests/Style/Generated/Layers/ModelLayerTests.swift
+++ b/Tests/MapboxMapsTests/Style/Generated/Layers/ModelLayerTests.swift
@@ -82,6 +82,7 @@ final class ModelLayerTests: XCTestCase {
 
     func testEncodingAndDecodingOfPaintProperties() {
        var layer = ModelLayer(id: "test-id")
+       layer.modelCastShadows = Value<Bool>.testConstantValue()
        layer.modelColor = Value<StyleColor>.testConstantValue()
        layer.modelColorTransition = StyleTransition(duration: 10.0, delay: 10.0)
        layer.modelColorMixIntensity = Value<Double>.testConstantValue()
@@ -111,6 +112,7 @@ final class ModelLayerTests: XCTestCase {
        do {
            let decodedLayer = try JSONDecoder().decode(ModelLayer.self, from: validData)
            XCTAssert(decodedLayer.visibility == .constant(.visible))
+           XCTAssert(layer.modelCastShadows == Value<Bool>.testConstantValue())
            XCTAssert(layer.modelColor == Value<StyleColor>.testConstantValue())
            XCTAssert(layer.modelColorMixIntensity == Value<Double>.testConstantValue())
            XCTAssert(layer.modelOpacity == Value<Double>.testConstantValue())


### PR DESCRIPTION
This PR adds an experimental option to control shadow casting on the 3D model puck - `Puck3DConfiguration.modelCastShadows`. 

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
