### PR TITLE
Fix view annotation losing its feature association after update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Introduce `GestureOptions.simultaneousRotateAndPinchZoomEnabled` and deprecate `GestureOptions.pinchRotateEnabled` in favor of `GestureOptions.rotateEnabled`. ([1429](https://github.com/mapbox/mapbox-maps-ios/pull/1429))
 * Add experimental `Puck3DConfiguration.modelCastShadows` option to control shadow casting for the 3D puck. ([#1435](https://github.com/mapbox/mapbox-maps-ios/pull/1435))
 * Expose public initializer for `TilesetDescriptorOptionsForTilesets`. ([1431](https://github.com/mapbox/mapbox-maps-ios/pull/1431))
+* Fix view annotation losing its feature association after update. ([1446](https://github.com/mapbox/mapbox-maps-ios/pull/1446))
 
 ## 10.7.0-beta.1 - June 29, 2022
 

--- a/Sources/MapboxMaps/Annotations/ViewAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/ViewAnnotationManager.swift
@@ -193,7 +193,7 @@ public final class ViewAnnotationManager {
         let isHidden = !(options.visible ?? true)
         expectedHiddenByView[view] = isHidden
         viewsById[id]?.isHidden = isHidden
-        if let id = currentFeatureId, id != options.associatedFeatureId {
+        if let id = currentFeatureId, let updatedId = options.associatedFeatureId, id != updatedId {
             viewsByFeatureIds[id] = nil
         }
         if let featureId = options.associatedFeatureId {

--- a/Tests/MapboxMapsTests/Annotations/ViewAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/ViewAnnotationManagerTests.swift
@@ -137,6 +137,25 @@ final class ViewAnnotationManagerTests: XCTestCase {
         XCTAssertEqual(optionsB, manager.options(forFeatureId: testIdB))
     }
 
+    func testAssociatedFeatureIdUpdateDoesNotDissociate() throws {
+        let testIdA = "testIdA"
+        let testView = UIView()
+        let optionsA = ViewAnnotationOptions(geometry: Point(.random()),
+                                             width: 0,
+                                             height: 0,
+                                             associatedFeatureId: testIdA)
+        let updateOptions = ViewAnnotationOptions(geometry: optionsA.geometry,
+                                                  width: 100,
+                                                  height: 100,
+                                                  associatedFeatureId: nil)
+        try manager.add(testView, options: optionsA)
+        mapboxMap.optionsForViewAnnotationWithIdStub.defaultReturnValue = optionsA
+
+        try manager.update(testView, options: updateOptions)
+
+        XCTAssertEqual(testView, manager.view(forFeatureId: testIdA))
+    }
+
     func testUpdate() {
         let annotationView = addTestAnnotationView()
         XCTAssertEqual(mapboxMap.updateViewAnnotationStub.invocations.count, 0)


### PR DESCRIPTION
This PR addresses the issue when a view annotation loses its feature id association when updating other(non-`associatedFeatureId`) properties.

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
