### PR TITLE
Fix flaky gesture manager test

### DIFF
--- a/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureManagerTests.swift
@@ -186,6 +186,7 @@ final class GestureManagerTests: XCTestCase {
     func testGestureEnded() throws {
         let gestureType = GestureType.allCases.randomElement()!
         let willAnimate = Bool.random()
+        gestureManager.gestureBegan(for: gestureType)
         gestureManager.gestureEnded(for: gestureType, willAnimate: willAnimate)
 
         XCTAssertEqual(delegate.gestureDidEndStub.invocations.count, 1, "GestureEnded should have been invoked once. It was called \(delegate.gestureDidEndStub.invocations.count) times.")


### PR DESCRIPTION
This fixes test gesture ended gesture manager test failing if gesture type happens to be `pinch`.