### PR TITLE
[compass] expose compass image property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 
 ## main
+* Expose image property for compass ornament. ([#1466](https://github.com/mapbox/mapbox-maps-ios/pull/1466))
 
 * Expand scale bar range up to 15000 km/10000 miles. ([#1455](https://github.com/mapbox/mapbox-maps-ios/pull/1455))
 * Add the ability to override scale bar units. ([#1473](https://github.com/mapbox/mapbox-maps-ios/pull/1473))

--- a/Sources/MapboxMaps/Ornaments/Compass/MapboxCompassOrnamentView.swift
+++ b/Sources/MapboxMaps/Ornaments/Compass/MapboxCompassOrnamentView.swift
@@ -50,18 +50,24 @@ internal class MapboxCompassOrnamentView: UIButton {
                                               value: "Rotates the map to face due north",
                                               comment: "Accessibility hint")
 
-        if let image = createCompassImage() {
-            containerView.image = image
-            NSLayoutConstraint.activate([
-                widthAnchor.constraint(equalToConstant: image.size.width),
-                heightAnchor.constraint(equalToConstant: image.size.height),
-                containerView.widthAnchor.constraint(equalToConstant: image.size.width),
-                containerView.heightAnchor.constraint(equalToConstant: image.size.height)
-            ])
-        }
         containerView.translatesAutoresizingMaskIntoConstraints = false
+        if let image = createCompassImage() {
+            updateImage(image: image)
+        }
         addSubview(containerView)
         addTarget(self, action: #selector(didTap), for: .touchUpInside)
+    }
+
+    func updateImage(image: UIImage?) {
+        guard let image = image else { return }
+
+        containerView.image = image
+        NSLayoutConstraint.activate([
+            widthAnchor.constraint(equalToConstant: image.size.width),
+            heightAnchor.constraint(equalToConstant: image.size.height),
+            containerView.widthAnchor.constraint(equalToConstant: image.size.width),
+            containerView.heightAnchor.constraint(equalToConstant: image.size.height)
+        ])
     }
 
     required internal init?(coder: NSCoder) {

--- a/Sources/MapboxMaps/Ornaments/Compass/MapboxCompassOrnamentView.swift
+++ b/Sources/MapboxMaps/Ornaments/Compass/MapboxCompassOrnamentView.swift
@@ -9,6 +9,7 @@ internal class MapboxCompassOrnamentView: UIButton {
     }
 
     internal var containerView = UIImageView()
+    internal var containerViewConstraints = [NSLayoutConstraint]()
     internal var visibility: OrnamentVisibility = .adaptive {
         didSet {
             animateVisibilityUpdate()
@@ -60,14 +61,15 @@ internal class MapboxCompassOrnamentView: UIButton {
 
     func updateImage(image: UIImage?) {
         guard let image = image else { return }
-
+        NSLayoutConstraint.deactivate(containerViewConstraints)
         containerView.image = image
-        NSLayoutConstraint.activate([
+        containerViewConstraints = [
             widthAnchor.constraint(equalToConstant: image.size.width),
             heightAnchor.constraint(equalToConstant: image.size.height),
             containerView.widthAnchor.constraint(equalToConstant: image.size.width),
             containerView.heightAnchor.constraint(equalToConstant: image.size.height)
-        ])
+        ]
+        NSLayoutConstraint.activate(containerViewConstraints)
     }
 
     required internal init?(coder: NSCoder) {

--- a/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
@@ -55,12 +55,14 @@ public struct ScaleBarViewOptions: OrnamentOptionsProtocol, Equatable {
     public var useMetricUnits: Bool = Locale.current.usesMetricSystem
 }
 
-/// Used to configure position, margin, and visibility for the map's compass view.
+/// Used to configure position, margin, image and visibility for the map's compass view.
 public struct CompassViewOptions: OrnamentOptionsProtocol, Equatable {
     /// The default value for this property is `.topRight`.
     public var position: OrnamentPosition = .topRight
     /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
     public var margins: CGPoint = defaultOrnamentsMargin
+    /// The default value for this property is nil, default compass image will be drawn.
+    public var image: UIImage?
     /// The default value for this property is `.adaptive`.
     public var visibility: OrnamentVisibility = .adaptive
 }

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -162,6 +162,9 @@ public class OrnamentsManager: NSObject {
                                                        margins: options.attributionButton.margins)
         constraints.append(contentsOf: attributionButtonConstraints)
 
+        // Update the image of compass
+        _compassView.updateImage(image: options.compass.image)
+
         // Activate new constraints
         NSLayoutConstraint.activate(constraints)
 

--- a/Tests/MapboxMapsTests/Ornaments/Compass/MapboxCompassOrnamentViewTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/Compass/MapboxCompassOrnamentViewTests.swift
@@ -95,4 +95,29 @@ class MapboxCompassOrnamentViewTests: XCTestCase {
         // Then
         XCTAssertFalse(compass.containerView.isHidden)
     }
+
+    func testCustomCompassImage() {
+        // Given
+        let compass = MapboxCompassOrnamentView()
+        // When
+        let originalImage = compass.containerView.image
+        // Then
+        XCTAssertNotNil(originalImage)
+
+        // Given
+        let expectedImage = emptyImage(with: CGSize(width: 25, height: 25))
+        // When
+        compass.updateImage(image: expectedImage)
+        // Then
+        XCTAssertTrue(compass.containerView.image!.isEqual(expectedImage))
+        // And
+        XCTAssertFalse(compass.containerView.image!.isEqual(originalImage))
+    }
+
+    private func emptyImage(with size: CGSize) -> UIImage? {
+        UIGraphicsBeginImageContext(size)
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image
+    }
 }


### PR DESCRIPTION
This PR allows to provide a custom image for the map compass. 

```swift
mapView.ornaments.options.compass.image = UIImage(named: "foobar")
```

https://user-images.githubusercontent.com/2151639/179181387-ecf81e2c-f91f-4e4a-b1cf-e0ec9a327502.mp4



## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
