### PR TITLE
Add the ability to override scale bar units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## main
 
 * Expand scale bar range up to 15000 km/10000 miles. ([#1455](https://github.com/mapbox/mapbox-maps-ios/pull/1455))
+* Add the ability to override scale bar units. ([#1473](https://github.com/mapbox/mapbox-maps-ios/pull/1473))
 
 ## 10.7.0-rc.1 - July 14, 2022
 

--- a/Sources/MapboxMaps/Ornaments/DistanceFormatter.swift
+++ b/Sources/MapboxMaps/Ornaments/DistanceFormatter.swift
@@ -11,20 +11,27 @@ internal class DistanceFormatter: MeasurementFormatter {
     ///
     /// - parameter distance: The distance, measured in meters.
     /// - returns: A localized formatted distance string including units.
-    internal func string(fromDistance distance: CLLocationDistance) -> String {
+    internal func string(fromDistance distance: CLLocationDistance, useMetricSystem: Bool? = nil) -> String {
 
         numberFormatter.roundingIncrement = 0.25
 
         var measurement = Measurement(value: distance, unit: UnitLength.meters)
 
-        if !locale.usesMetricSystem {
+        let shouldUseMetricSystem: Bool
+        if let useMetricSystem = useMetricSystem {
+            shouldUseMetricSystem = useMetricSystem
+        } else {
+            shouldUseMetricSystem = locale.usesMetricSystem
+        }
+
+        if !shouldUseMetricSystem {
             unitOptions = .providedUnit
             measurement.convert(to: .miles)
             if measurement.value <= 0.2 {
                 measurement.convert(to: .feet)
             }
         } else {
-            unitOptions = .naturalScale
+            unitOptions = [.providedUnit, .naturalScale]
         }
         return string(from: measurement)
     }

--- a/Sources/MapboxMaps/Ornaments/DistanceFormatter.swift
+++ b/Sources/MapboxMaps/Ornaments/DistanceFormatter.swift
@@ -19,14 +19,14 @@ internal class DistanceFormatter: MeasurementFormatter {
 
         let shouldUseMetricSystem = useMetricSystem ?? locale.usesMetricSystem
 
-        if !shouldUseMetricSystem {
+        if shouldUseMetricSystem {
+            unitOptions = [.providedUnit, .naturalScale]
+        } else {
             unitOptions = .providedUnit
             measurement.convert(to: .miles)
             if measurement.value <= 0.2 {
                 measurement.convert(to: .feet)
             }
-        } else {
-            unitOptions = [.providedUnit, .naturalScale]
         }
         return string(from: measurement)
     }

--- a/Sources/MapboxMaps/Ornaments/DistanceFormatter.swift
+++ b/Sources/MapboxMaps/Ornaments/DistanceFormatter.swift
@@ -17,12 +17,7 @@ internal class DistanceFormatter: MeasurementFormatter {
 
         var measurement = Measurement(value: distance, unit: UnitLength.meters)
 
-        let shouldUseMetricSystem: Bool
-        if let useMetricSystem = useMetricSystem {
-            shouldUseMetricSystem = useMetricSystem
-        } else {
-            shouldUseMetricSystem = locale.usesMetricSystem
-        }
+        let shouldUseMetricSystem = useMetricSystem ?? locale.usesMetricSystem
 
         if !shouldUseMetricSystem {
             unitOptions = .providedUnit

--- a/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
@@ -50,6 +50,9 @@ public struct ScaleBarViewOptions: OrnamentOptionsProtocol, Equatable {
     public var margins: CGPoint = defaultOrnamentsMargin
     /// The default value for this property is `.adaptive`.
     public var visibility: OrnamentVisibility = .adaptive
+    /// Specifies the whether the scale bar uses the metric system.
+    /// True if the scale bar is using metric units, false if the scale bar is using imperial units.
+    public var useMetricUnits: Bool = Locale.current.usesMetricSystem
 }
 
 /// Used to configure position, margin, and visibility for the map's compass view.

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -170,6 +170,7 @@ public class OrnamentsManager: NSObject {
         _compassView.visibility = options.compass.visibility
         _compassView.isHidden = options.compass.visibility == .hidden
         _attributionButton.isHidden = options.attributionButton.visibility == .hidden
+        _scaleBarView.useMetricUnits = options.scaleBar.useMetricUnits
     }
 
     private func constraints(with view: UIView, position: OrnamentPosition, margins: CGPoint) -> [NSLayoutConstraint] {

--- a/Tests/MapboxMapsTests/Ornaments/DistanceFormatterTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/DistanceFormatterTests.swift
@@ -60,10 +60,9 @@ class DistanceFormatterTests: XCTestCase {
         let formattedString = sut.string(fromDistance: 1337, useMetricSystem: false)
 
         XCTAssert(sut.locale.usesMetricSystem, "Selected locale does not use Metric system")
-        if #available(iOS 15, *) {
-            XCTAssertEqual(formattedString, "0.75 mi", "Miles distance is not formatted correctly!")
-        } else {
-            XCTAssertEqual(formattedString, "0.75 mi.", "Miles distance is not formatted correctly!")
-        }
+        XCTAssertEqual(
+            formattedString.trimmingCharacters(in: CharacterSet(charactersIn: ".")),
+            "0.75 mi",
+            "Miles distance is not formatted correctly!")
     }
 }

--- a/Tests/MapboxMapsTests/Ornaments/DistanceFormatterTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/DistanceFormatterTests.swift
@@ -60,6 +60,10 @@ class DistanceFormatterTests: XCTestCase {
         let formattedString = sut.string(fromDistance: 1337, useMetricSystem: false)
 
         XCTAssert(sut.locale.usesMetricSystem, "Selected locale does not use Metric system")
-        XCTAssertEqual(formattedString, "0.75 mi", "Miles distance is not formatted correctly!")
+        if #available(iOS 15, *) {
+            XCTAssertEqual(formattedString, "0.75 mi", "Miles distance is not formatted correctly!")
+        } else {
+            XCTAssertEqual(formattedString, "0.75 mi.", "Miles distance is not formatted correctly!")
+        }
     }
 }

--- a/Tests/MapboxMapsTests/Ornaments/DistanceFormatterTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/DistanceFormatterTests.swift
@@ -42,4 +42,24 @@ class DistanceFormatterTests: XCTestCase {
         XCTAssert(!sut.locale.usesMetricSystem, "Selected locale does not use Imperial system")
         XCTAssertEqual(formattedString, "0.75 mi", "Miles distance is not formatted correctly!")
     }
+
+    func testMetricOverride() {
+        let sut = DistanceFormatter()
+        sut.locale = Locale(identifier: "EN_US")
+
+        let formattedString = sut.string(fromDistance: 1337, useMetricSystem: true)
+
+        XCTAssertFalse(sut.locale.usesMetricSystem, "Selected locale does not use Metric system")
+        XCTAssertEqual(formattedString, "1.25 km", "Kilometers distance is not formatted correctly!")
+    }
+
+    func testImperialOverride() {
+        let sut = DistanceFormatter()
+        sut.locale = Locale(identifier: "EN_CA")
+
+        let formattedString = sut.string(fromDistance: 1337, useMetricSystem: false)
+
+        XCTAssert(sut.locale.usesMetricSystem, "Selected locale does not use Metric system")
+        XCTAssertEqual(formattedString, "0.75 mi", "Miles distance is not formatted correctly!")
+    }
 }

--- a/Tests/MapboxMapsTests/Ornaments/ScaleBar/MapboxScaleBarOrnamentViewTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/ScaleBar/MapboxScaleBarOrnamentViewTests.swift
@@ -5,10 +5,10 @@ class MapboxScaleBarOrnamentViewTests: XCTestCase {
 
     func testImperialScaleBar() {
         let scaleBar = MockMapboxScaleBarOrnamentView()
-        scaleBar._isMetricLocale = false
+        scaleBar.useMetricUnits = false
 
         for row in ScaleBarTestValues.imperialValues {
-            scaleBar.metersPerPoint =  row.metersPerPoint
+            scaleBar.metersPerPoint = row.metersPerPoint
 
             let numberOfBars = scaleBar.preferredRow().numberOfBars
             XCTAssertEqual(Int(numberOfBars), row.numberOfBars, "The number of scale bars should be \(row.numberOfBars) when there are \(scaleBar.metersPerPoint) feet per point.")
@@ -17,6 +17,7 @@ class MapboxScaleBarOrnamentViewTests: XCTestCase {
 
     func testMetricScaleBar() {
         let scaleBar = MockMapboxScaleBarOrnamentView()
+        scaleBar.useMetricUnits = true
 
         for row in ScaleBarTestValues.metricValues {
             scaleBar.metersPerPoint = row.metersPerPoint
@@ -28,7 +29,7 @@ class MapboxScaleBarOrnamentViewTests: XCTestCase {
 
     func testImperialVisibleBars() {
             let scaleBar = MockMapboxScaleBarOrnamentView()
-            scaleBar._isMetricLocale = false
+            scaleBar.useMetricUnits = false
 
             for row in ScaleBarTestValues.imperialValues {
                 scaleBar.metersPerPoint = row.metersPerPoint
@@ -43,6 +44,7 @@ class MapboxScaleBarOrnamentViewTests: XCTestCase {
 
         func testMetricVisibleBars() {
             let scaleBar = MockMapboxScaleBarOrnamentView()
+            scaleBar.useMetricUnits = true
 
             for row in ScaleBarTestValues.metricValues {
                 scaleBar.metersPerPoint = row.metersPerPoint
@@ -60,12 +62,6 @@ class MapboxScaleBarOrnamentViewTests: XCTestCase {
 final class MockMapboxScaleBarOrnamentView: MapboxScaleBarOrnamentView {
     override var maximumWidth: CGFloat {
         return 200
-    }
-
-    internal var _isMetricLocale: Bool = true
-
-    override var isMetricLocale: Bool {
-        return _isMetricLocale
     }
 }
 


### PR DESCRIPTION
This PR adds a public configuration option to allow overriding scale bar distance units. The default value is taken from the current locale.

#### New public API:
`ScaleBarViewOptions.useMetricUnits`

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
