### PR TITLE
Fix latitude being NaN during flyTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Expand scale bar range up to 15000 km/10000 miles. ([#1455](https://github.com/mapbox/mapbox-maps-ios/pull/1455))
 * Add the ability to override scale bar units. ([#1473](https://github.com/mapbox/mapbox-maps-ios/pull/1473))
 * Animate padding changes between 2 camera when used with `FlyToCameraAnimator`. ([#1479](https://github.com/mapbox/mapbox-maps-ios/pull/1479))
+* Fix NaN latitude crash rarely happening in `CameraAnimationsManager.fly(to:duration:completion)`. ([#1485](https://github.com/mapbox/mapbox-maps-ios/pull/1485))
 
 ## 10.7.0-rc.1 - July 14, 2022
 

--- a/Sources/MapboxMaps/Camera/FlyToInterpolator.swift
+++ b/Sources/MapboxMaps/Camera/FlyToInterpolator.swift
@@ -152,14 +152,11 @@ internal struct FlyToInterpolator {
         }
 
         // r₀: Zoom-out factor during ascent.
-        let r0 = (u1 != 0.0) ? r(0) : .greatestFiniteMagnitude
-        let r1 = (u1 != 0.0) ? r(1) : .greatestFiniteMagnitude
+        let r0 = (u1 != 0.0) ? r(0) : .infinity
+        let r1 = (u1 != 0.0) ? r(1) : .infinity
 
         // When u₀ = u₁, the optimal path doesn’t require both ascent and descent.
-        let isClose =
-            (fabs(u1) < 0.000001) ||
-            (r0 == .greatestFiniteMagnitude) ||
-            (r1 == .greatestFiniteMagnitude)
+        let isClose = (fabs(u1) < 0.000001) || r0.isInfinite || r1.isInfinite
 
         /** w(s): Returns the visible span on the ground, measured in pixels with respect to the initial scale.
          * Assumes an angular field of view of 2 arctan ½ ≈ 53°.

--- a/Tests/MapboxMapsTests/Camera/FlyToTests.swift
+++ b/Tests/MapboxMapsTests/Camera/FlyToTests.swift
@@ -130,4 +130,25 @@ internal class FlyToTests: XCTestCase {
             }
         }
     }
+
+    func testFlyToUnprojectLatitudeNaNUseCase() {
+        // given
+        let source = CameraState(
+            center: .init(latitude: 48.19267299999896, longitude: 11.57336700000414),
+            padding: .zero,
+            zoom: 19,
+            bearing: 0,
+            pitch: 0
+        )
+        let dest = CameraOptions(center: .init(latitude: 48.192673, longitude: 11.573367), zoom: 16.5)
+        let flyTo = FlyToInterpolator(
+            from: source,
+            to: dest,
+            cameraBounds: .default,
+            size: CGSize(width: 1920, height: 960)
+        )
+
+        // then
+        XCTAssertNoThrow(flyTo.coordinate(at: 0))
+    }
 }


### PR DESCRIPTION
In some specific cases when using paddings close to the screen size and high zoom flyTo could produce a native exception:

`latitude must not be NaN`

Fix this issue by treating infinite values in algorithm properly.


<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
