### PR TITLE
Update `OrnamentsManager` to dynamically respect language direction.

### DIFF
--- a/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
@@ -45,7 +45,7 @@ public protocol OrnamentOptionsProtocol {
 /// Used to configure position, margin, and visibility for the map's scale bar view.
 public struct ScaleBarViewOptions: OrnamentOptionsProtocol, Equatable {
     /// The default value for this property is `.topLeft`.
-    public var position: OrnamentPosition = .topLeft
+    public var position: OrnamentPosition = .topLeading
     /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
     public var margins: CGPoint = defaultOrnamentsMargin
     /// The default value for this property is `.adaptive`.
@@ -58,7 +58,7 @@ public struct ScaleBarViewOptions: OrnamentOptionsProtocol, Equatable {
 /// Used to configure position, margin, image and visibility for the map's compass view.
 public struct CompassViewOptions: OrnamentOptionsProtocol, Equatable {
     /// The default value for this property is `.topRight`.
-    public var position: OrnamentPosition = .topRight
+    public var position: OrnamentPosition = .topTrailing
     /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
     public var margins: CGPoint = defaultOrnamentsMargin
     /// The default value for this property is nil, default compass image will be drawn.
@@ -70,7 +70,7 @@ public struct CompassViewOptions: OrnamentOptionsProtocol, Equatable {
 /// Used to configure position, margin, and visibility for the map's attribution button.
 public struct AttributionButtonOptions: OrnamentOptionsProtocol, Equatable {
     /// The default value for this property is `.bottomRight`.
-    public var position: OrnamentPosition = .bottomRight
+    public var position: OrnamentPosition = .bottomTrailing
     /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
     public var margins: CGPoint = defaultOrnamentsMargin
     /// The default value for this property is `visible`. Setting this property to `.adaptive`
@@ -84,7 +84,7 @@ public struct AttributionButtonOptions: OrnamentOptionsProtocol, Equatable {
 /// Used to configure position, margin, and visibility for the map's logo view.
 public struct LogoViewOptions: OrnamentOptionsProtocol, Equatable {
     /// The default value for this property is `.bottomLeft`.
-    public var position: OrnamentPosition = .bottomLeft
+    public var position: OrnamentPosition = .bottomLeading
     /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
     public var margins: CGPoint = defaultOrnamentsMargin
     /// The default value for this property is `visible`. Setting this property to `.adaptive`

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -186,7 +186,6 @@ public class OrnamentsManager: NSObject {
     }
 
     private func constraints(with view: UIView, position: OrnamentPosition, margins: CGPoint) -> [NSLayoutConstraint] {
-        
         let layoutGuide = view.superview!.safeAreaLayoutGuide
         switch position {
         case .topLeft:

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -2,10 +2,19 @@ import UIKit
 
 public enum OrnamentPosition: String, Equatable {
     // Clockwise from top left
+    @available(*, deprecated, renamed: "topLeading")
     case topLeft
+    @available(*, deprecated, renamed: "topTrailing")
     case topRight
+    @available(*, deprecated, renamed: "bottomLeading")
     case bottomRight
+    @available(*, deprecated, renamed: "bottomTrailing")
     case bottomLeft
+
+    case topLeading
+    case topTrailing
+    case bottomLeading
+    case bottomTrailing
 }
 
 public enum OrnamentVisibility: String, Equatable {
@@ -177,31 +186,38 @@ public class OrnamentsManager: NSObject {
     }
 
     private func constraints(with view: UIView, position: OrnamentPosition, margins: CGPoint) -> [NSLayoutConstraint] {
-        // handle AutoLayout changes when device character direction changes
-        let currentDeviceLanguage: String! = Locale.current.languageCode
-        let rightToLeft = Locale.LanguageDirection.rightToLeft
-
-        if Locale.characterDirection(forLanguage: currentDeviceLanguage) == rightToLeft {
-            UIView.appearance().semanticContentAttribute = .forceRightToLeft
-            //0 is on the left side
-            _scaleBarView.semanticContentAttribute = .spatial
-        }
-
+        
         let layoutGuide = view.superview!.safeAreaLayoutGuide
         switch position {
         case .topLeft:
             return [
-                view.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: margins.x),
+                view.leftAnchor.constraint(equalTo: layoutGuide.leftAnchor, constant: margins.x),
                 view.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: margins.y)]
         case .topRight:
             return  [
-                view.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -margins.x),
+                view.rightAnchor.constraint(equalTo: layoutGuide.rightAnchor, constant: -margins.x),
                 view.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: margins.y)]
         case .bottomLeft:
             return [
-                view.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: margins.x),
+                view.leftAnchor.constraint(equalTo: layoutGuide.leftAnchor, constant: margins.x),
                 view.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor, constant: -margins.y)]
         case .bottomRight:
+            return [
+                view.rightAnchor.constraint(equalTo: layoutGuide.rightAnchor, constant: -margins.x),
+                view.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor, constant: -margins.y)]
+        case .topLeading:
+            return [
+                view.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: margins.x),
+                view.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: margins.y)]
+        case .topTrailing:
+            return  [
+                view.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -margins.x),
+                view.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: margins.y)]
+        case .bottomLeading:
+            return [
+                view.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: margins.x),
+                view.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor, constant: -margins.y)]
+        case .bottomTrailing:
             return [
                 view.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -margins.x),
                 view.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor, constant: -margins.y)]

--- a/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentsManager.swift
@@ -177,23 +177,33 @@ public class OrnamentsManager: NSObject {
     }
 
     private func constraints(with view: UIView, position: OrnamentPosition, margins: CGPoint) -> [NSLayoutConstraint] {
+        // handle AutoLayout changes when device character direction changes
+        let currentDeviceLanguage: String! = Locale.current.languageCode
+        let rightToLeft = Locale.LanguageDirection.rightToLeft
+
+        if Locale.characterDirection(forLanguage: currentDeviceLanguage) == rightToLeft {
+            UIView.appearance().semanticContentAttribute = .forceRightToLeft
+            //0 is on the left side
+            _scaleBarView.semanticContentAttribute = .spatial
+        }
+
         let layoutGuide = view.superview!.safeAreaLayoutGuide
         switch position {
         case .topLeft:
             return [
-                view.leftAnchor.constraint(equalTo: layoutGuide.leftAnchor, constant: margins.x),
+                view.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: margins.x),
                 view.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: margins.y)]
         case .topRight:
             return  [
-                view.rightAnchor.constraint(equalTo: layoutGuide.rightAnchor, constant: -margins.x),
+                view.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -margins.x),
                 view.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: margins.y)]
         case .bottomLeft:
             return [
-                view.leftAnchor.constraint(equalTo: layoutGuide.leftAnchor, constant: margins.x),
+                view.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: margins.x),
                 view.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor, constant: -margins.y)]
         case .bottomRight:
             return [
-                view.rightAnchor.constraint(equalTo: layoutGuide.rightAnchor, constant: -margins.x),
+                view.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -margins.x),
                 view.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor, constant: -margins.y)]
         }
     }

--- a/Sources/MapboxMaps/Ornaments/ScaleBar/MapboxScaleBarOrnamentView.swift
+++ b/Sources/MapboxMaps/Ornaments/ScaleBar/MapboxScaleBarOrnamentView.swift
@@ -346,7 +346,7 @@ internal class MapboxScaleBarOrnamentView: UIView {
     // MARK: - Convenience Methods
 
     private func usesRightToLeftLayout() -> Bool {
-        return traitCollection.layoutDirection == .rightToLeft
+        return effectiveUserInterfaceLayoutDirection == .rightToLeft
     }
 
     internal func preferredRow() -> Row {

--- a/Sources/MapboxMaps/Ornaments/ScaleBar/MapboxScaleBarOrnamentView.swift
+++ b/Sources/MapboxMaps/Ornaments/ScaleBar/MapboxScaleBarOrnamentView.swift
@@ -231,7 +231,7 @@ internal class MapboxScaleBarOrnamentView: UIView {
         let halfLabelWidth = ceil(lastLabelWidth / 2)
         //
         let scaleBarOffsetForRight = staticContainerView.frame.width - totalBarWidth - halfLabelWidth
-        let barOffset = isOnRight ? scaleBarOffsetForRight : 0.0
+        let barOffset = isRightToLeft || isOnRight ? scaleBarOffsetForRight : 0.0
 
         dynamicContainerView.frame = CGRect(x: barOffset,
                                      y: intrinsicContentSize.height - Constants.barHeight,
@@ -346,7 +346,7 @@ internal class MapboxScaleBarOrnamentView: UIView {
     // MARK: - Convenience Methods
 
     private func usesRightToLeftLayout() -> Bool {
-        return UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft
+        return traitCollection.layoutDirection == .rightToLeft
     }
 
     internal func preferredRow() -> Row {


### PR DESCRIPTION
- Changed `leftAnchor` and `rightAnchor` to `leadingAnchor` and `trailingAnchor` so they would not be ignored by RTL configuration. 
- Updated `constraints(with: positions: margins:)` method to take device language direction into account when placing `scaleBar`, `logoView`, `attributionButton` and `compassView` ornaments. 

- Will need to add tests. 

| Before | After |
| --- | --- |
|![Simulator Screen Shot - iPhone 12 - 2022-07-29 at 23 18 22](https://user-images.githubusercontent.com/44972592/181870538-eb679750-3201-4019-8ac2-00b578b5dfe5.png)| ![Simulator Screen Shot - iPhone 12 - 2022-08-01 at 12 45 02](https://user-images.githubusercontent.com/44972592/182200744-63093e37-271e-4b96-8ee0-63f0a1856007.png)|



## Pull request checklist:
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
