### PR TITLE
Fix snapshotted example

### DIFF
--- a/Apps/Examples/Examples/All Examples/SnapshotterExample.swift
+++ b/Apps/Examples/Examples/All Examples/SnapshotterExample.swift
@@ -9,51 +9,73 @@ public class SnapshotterExample: UIViewController, ExampleProtocol {
     public var snapshotter: Snapshotter!
     public var snapshotView: UIImageView!
     private var snapshotting = false
-
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(frame: view.safeAreaLayoutGuide.layoutFrame)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.distribution = .fillEqually
+        stackView.alignment = .fill
+        stackView.spacing = 12.0
+        return stackView
+    }()
     override public func viewDidLoad() {
         super.viewDidLoad()
 
-        // Create a vertical stack view to hold both the map view and the snapshot.
-        let stackView = UIStackView(frame: view.safeAreaLayoutGuide.layoutFrame)
-        stackView.axis = .vertical
-        stackView.distribution = .fill
-        stackView.alignment = .center
-        stackView.spacing = 12.0
-
-        let mapViewRect = CGRect(x: 0, y: 0, width: view.bounds.width/2, height: view.bounds.height / 2)
-
-        let mapInitOptions = MapInitOptions(cameraOptions: CameraOptions(center: CLLocationCoordinate2D(latitude: 50, longitude: 138.482),
-                                                                         zoom: 3.5),
-                                            styleURI: .dark)
-
-        mapView = MapView(frame: mapViewRect, mapInitOptions: mapInitOptions)
+        let mapInitOptions = MapInitOptions(
+            cameraOptions: CameraOptions(center: CLLocationCoordinate2D(latitude: 50, longitude: 138.482), zoom: 3.5),
+            styleURI: .dark
+        )
+        mapView = MapView(frame: view.bounds, mapInitOptions: mapInitOptions)
+        mapView.translatesAutoresizingMaskIntoConstraints = false
         // Add the `MapViewController`'s view to the stack view as a
         // child view controller.
         stackView.addArrangedSubview(mapView)
 
         // Add the image view to the stack view, which will eventually contain the snapshot.
-        let stackViewBounds = CGRect(x: 0,
-                                     y: 0,
-                                     width: view.bounds.size.width,
-                                     height: view.bounds.height / 2)
-        snapshotView = UIImageView(frame: stackViewBounds)
+        snapshotView = UIImageView()
+        snapshotView.translatesAutoresizingMaskIntoConstraints = false
         stackView.addArrangedSubview(snapshotView)
-
-        NSLayoutConstraint.activate([
-            mapView.widthAnchor.constraint(equalToConstant: view.bounds.size.width),
-            snapshotView.widthAnchor.constraint(equalToConstant: stackViewBounds.width),
-            snapshotView.heightAnchor.constraint(equalToConstant: stackViewBounds.height)
-        ])
 
         // Add the stack view to the root view.
         view.addSubview(stackView)
 
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        if #available(iOS 15.0, *) {
+            view.backgroundColor = .systemMint
+        } else {
+            view.backgroundColor = .systemGray
+        }
+        if #available(iOS 13.0, *) {
+            snapshotView.backgroundColor = .systemGray4
+        } else {
+            snapshotView.backgroundColor = .systemGray
+        }
+    }
+
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        if snapshotter == nil {
+            initializeSnapshotter()
+        }
+    }
+
+    private func initializeSnapshotter() {
         // Configure the snapshotter object with its default access
         // token, size, map style, and camera.
+        let size = CGSize(
+            width: view.safeAreaLayoutGuide.layoutFrame.width,
+            height: (view.safeAreaLayoutGuide.layoutFrame.height - stackView.spacing) / 2)
         let options = MapSnapshotOptions(
-            size: stackViewBounds.size,
+            size: size,
             pixelRatio: UIScreen.main.scale,
-            resourceOptions: mapInitOptions.resourceOptions)
+            resourceOptions: ResourceOptionsManager.default.resourceOptions)
 
         snapshotter = Snapshotter(options: options)
         snapshotter.style.uri = .light


### PR DESCRIPTION
This PR makes the map view and it's snapshot to be the same size. Additionally, map view's top layout is changed in order not to be obstructed by the navigation bar.

| Before | After |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/1478430/182338534-84c9f6ee-2631-47d6-80a7-7e5679515a31.png" width = 250/> | <img src="https://user-images.githubusercontent.com/1478430/182338586-cff36dec-ad1a-4b42-8155-56b03db28471.png" width = 250/> |

## Pull request checklist:
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Review and agree to the Contributor License Agreement ([CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement)).
