### PR TITLE
Support annotation view lookup by id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Fix NaN latitude crash rarely happening in `CameraAnimationsManager.fly(to:duration:completion)`. ([#1485](https://github.com/mapbox/mapbox-maps-ios/pull/1485))
 * Fix `Style.updateLayer(withId:type:update)` so resetting a layer's properties should work. ([#1476](https://github.com/mapbox/mapbox-maps-ios/pull/1476))
 * Add support for sonar-like pulsing animation around 2D puck. ([#1513](https://github.com/mapbox/mapbox-maps-ios/pull/1513))
+* Support view annotation lookup by an identifier. ([#1512](https://github.com/mapbox/mapbox-maps-ios/pull/1512))
 
 ## 10.7.0 - July 28, 2022
 

--- a/Sources/MapboxMaps/Annotations/ViewAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/ViewAnnotationManager.swift
@@ -91,6 +91,35 @@ public final class ViewAnnotationManager {
     ///
     /// - Parameters:
     ///   - view: `UIView` to be added to the map
+    ///   - options: ``ViewAnnotationOptions`` to control the layout and visibility of the annotation
+    ///
+    /// - Throws:
+    ///   -  ``ViewAnnotationManagerError/viewIsAlreadyAdded`` if the supplied view is already added as an annotation
+    ///   -  ``ViewAnnotationManagerError/geometryFieldMissing`` if options did not include geometry
+    ///   -  ``ViewAnnotationManagerError/associatedFeatureIdIsAlreadyInUse`` if the
+    ///   supplied ``ViewAnnotationOptions/associatedFeatureId`` is already used by another annotation view
+    ///   - ``MapError``: errors during insertion
+    public func add(_ view: UIView, options: ViewAnnotationOptions) throws {
+        try add(view, id: nil, options: options)
+    }
+
+    /// Add a `UIView` instance which will be displayed as an annotation.
+    /// View dimensions will be taken as width / height from the bounds of the view
+    /// unless they are not specified explicitly with ``ViewAnnotationOptions/width`` and ``ViewAnnotationOptions/height``.
+    ///
+    /// Annotation `options` must include Geometry where we want to bind our view annotation.
+    ///
+    /// Width and height could be specified explicitly but better idea will be not specifying them
+    /// as they will be calculated automatically based on view layout.
+    ///
+    /// > Important: The annotation view to be added should have `UIView.transform` property set to `.identity`.
+    /// Providing a transformed view can result in annotation views being misplaced, overlapped and other layout artifacts.
+    ///
+    /// - Note: Use ``ViewAnnotationManager/update(_:options:)`` for changing the visibilty of the view, instead
+    /// of `UIView.isHidden` so that it is removed from the layout calculation.
+    ///
+    /// - Parameters:
+    ///   - view: `UIView` to be added to the map
     ///   - id: The unique string for the `view`.
     ///   - options: ``ViewAnnotationOptions`` to control the layout and visibility of the annotation
     ///
@@ -100,7 +129,7 @@ public final class ViewAnnotationManager {
     ///   -  ``ViewAnnotationManagerError/associatedFeatureIdIsAlreadyInUse`` if the
     ///   supplied ``ViewAnnotationOptions/associatedFeatureId`` is already used by another annotation view
     ///   - ``MapError``: errors during insertion
-    public func add(_ view: UIView, id: String? = nil, options: ViewAnnotationOptions) throws {
+    public func add(_ view: UIView, id: String?, options: ViewAnnotationOptions) throws {
         guard idsByView[view] == nil && id.flatMap(view(forId:)) == nil else {
             throw ViewAnnotationManagerError.viewIsAlreadyAdded
         }

--- a/Tests/MapboxMapsTests/Annotations/ViewAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/ViewAnnotationManagerTests.swift
@@ -106,6 +106,13 @@ final class ViewAnnotationManagerTests: XCTestCase {
         XCTAssertTrue(mapboxMap.removeViewAnnotationStub.invocations.isEmpty)
     }
 
+    func testGetViewByID() {
+        let testView = addTestAnnotationView(id: "test-id")
+
+        XCTAssertEqual(manager.view(forId: "test-id"), testView)
+        XCTAssertNotEqual(manager.view(forId: "other-id"), testView)
+    }
+
     func testAssociatedFeatureIdIsAlreadyInUse() {
         let testView = UIView()
         let geometry = Point(CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0))


### PR DESCRIPTION
- Allow adding annotation view with a custom id, that can be used later to look it up.

<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
