### PR TITLE
Update Viewport Example

### DIFF
--- a/Apps/Examples/Examples/All Examples/ViewportExample.swift
+++ b/Apps/Examples/Examples/All Examples/ViewportExample.swift
@@ -36,11 +36,11 @@ final class ViewportExample: UIViewController, ExampleProtocol {
         mapView.mapboxMap.setCamera(to: CameraOptions(center: cupertino, zoom: 14))
 
         mapView.location.options.puckType = .puck2D(.makeDefault(showBearing: true))
-        mapView.location.options.puckBearingSource = .course
+        mapView.location.options.puckBearingSource = .heading
 
         followPuckViewportState = mapView.viewport.makeFollowPuckViewportState(
             options: FollowPuckViewportStateOptions(
-                bearing: .course))
+                bearing: .heading))
 
         overviewViewportState = mapView.viewport.makeOverviewViewportState(
             options: OverviewViewportStateOptions(

--- a/Sources/MapboxMaps/Location/LocationOptions.swift
+++ b/Sources/MapboxMaps/Location/LocationOptions.swift
@@ -33,9 +33,11 @@ public struct LocationOptions: Equatable {
 
 /// Controls how the puck is oriented
 public enum PuckBearingSource: Equatable {
-    /// The puck should set its bearing using `heading: CLHeading`
+    /// The puck should set its bearing using `heading: CLHeading`. Bearing will mimic user's
+    /// spatial orientation.
     case heading
 
-    /// The puck should set its bearing using `course: CLLocationDirection`
+    /// The puck should set its bearing using `course: CLLocationDirection`. Bearing will mimic
+    /// the general direction of travel.
     case course
 }


### PR DESCRIPTION
Change bearing to `.heading` to get expected user bearing/ bearing transition

## Pull request checklist:
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
