### PR TITLE
Feature/mapsios 271 puck 3d default scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Add the ability to display heading calibration alert. ([#1509](https://github.com/mapbox/mapbox-maps-ios/pull/1509))
 * Add support for sonar-like pulsing animation around 2D puck. ([#1513](https://github.com/mapbox/mapbox-maps-ios/pull/1513))
 * Support view annotation lookup by an identifier. ([#1512](https://github.com/mapbox/mapbox-maps-ios/pull/1512))
+* Apply mercator scale to 3D puck also when its `modelScale` is not specified. ([#1523](https://github.com/mapbox/mapbox-maps-ios/pull/1523))
 
 ## 10.7.0 - July 28, 2022
 

--- a/Sources/MapboxMaps/Location/Puck/Puck3D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck3D.swift
@@ -132,7 +132,7 @@ internal final class Puck3D: Puck {
     }
 
     private var modelScale: Value<[Double]>? {
-        switch configuration.modelScale {
+        switch configuration.modelScale ?? .constant([1, 1, 1]) {
         case .constant(let scales):
             let maxZoom = 22.0
             let minZoom = 0.5
@@ -159,7 +159,7 @@ internal final class Puck3D: Puck {
                 }
             )
 
-        default: return configuration.modelScale
+        case .expression: return configuration.modelScale
         }
     }
 }

--- a/Tests/MapboxMapsTests/Location/Puck/Puck3DTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/Puck3DTests.swift
@@ -211,7 +211,7 @@ final class Puck3DTests: XCTestCase {
 
     func testDefaultModelScale() throws {
         let stubbedModelScale = 1.0
-        configuration.modelScale = .constant([stubbedModelScale, stubbedModelScale, stubbedModelScale])
+        configuration.modelScale = .random(.constant([stubbedModelScale, stubbedModelScale, stubbedModelScale]))
 
         recreatePuck()
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->
Apply mercator scale when `modelScale` is nil (assuming it will be [1, 1, 1])

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
