### PR TITLE
Feature/mapsios 271 puck 3d default scale (#1523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+* Apply mercator scale to 3D puck also when its `modelScale` is not specified. ([#1523](https://github.com/mapbox/mapbox-maps-ios/pull/1523))
+
 ## 10.8.0-beta.1 - August 11, 2022
 
 * Expose image property for compass ornament. ([#1468](https://github.com/mapbox/mapbox-maps-ios/pull/1468))
@@ -15,7 +17,6 @@ Mapbox welcomes participation and contributions from everyone.
 * Add the ability to display heading calibration alert. ([#1509](https://github.com/mapbox/mapbox-maps-ios/pull/1509))
 * Add support for sonar-like pulsing animation around 2D puck. ([#1513](https://github.com/mapbox/mapbox-maps-ios/pull/1513))
 * Support view annotation lookup by an identifier. ([#1512](https://github.com/mapbox/mapbox-maps-ios/pull/1512))
-* Apply mercator scale to 3D puck also when its `modelScale` is not specified. ([#1523](https://github.com/mapbox/mapbox-maps-ios/pull/1523))
 
 ## 10.7.0 - July 28, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Add the ability to display heading calibration alert. ([#1509](https://github.com/mapbox/mapbox-maps-ios/pull/1509))
 * Add support for sonar-like pulsing animation around 2D puck. ([#1513](https://github.com/mapbox/mapbox-maps-ios/pull/1513))
 * Support view annotation lookup by an identifier. ([#1512](https://github.com/mapbox/mapbox-maps-ios/pull/1512))
+* Apply mercator scale to 3D puck also when its `modelScale` is not specified. ([#1523](https://github.com/mapbox/mapbox-maps-ios/pull/1523))
 
 ## 10.7.0 - July 28, 2022
 

--- a/Sources/MapboxMaps/Location/Puck/Puck3D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck3D.swift
@@ -132,7 +132,7 @@ internal final class Puck3D: Puck {
     }
 
     private var modelScale: Value<[Double]>? {
-        switch configuration.modelScale {
+        switch configuration.modelScale ?? .constant([1, 1, 1]) {
         case .constant(let scales):
             let maxZoom = 22.0
             let minZoom = 0.5
@@ -159,7 +159,7 @@ internal final class Puck3D: Puck {
                 }
             )
 
-        default: return configuration.modelScale
+        case .expression: return configuration.modelScale
         }
     }
 }

--- a/Tests/MapboxMapsTests/Location/Puck/Puck3DTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/Puck3DTests.swift
@@ -211,7 +211,7 @@ final class Puck3DTests: XCTestCase {
 
     func testDefaultModelScale() throws {
         let stubbedModelScale = 1.0
-        configuration.modelScale = .constant([stubbedModelScale, stubbedModelScale, stubbedModelScale])
+        configuration.modelScale = .random(.constant([stubbedModelScale, stubbedModelScale, stubbedModelScale]))
 
         recreatePuck()
 


### PR DESCRIPTION
* Apply mercator scale to puck 3D also when its modelScale is not set.
- When a modelScale is not set, assume it is [1,1,1] (real size) and apply mercator scale for it.
