### PR TITLE
Expose accidentally internal properties for resource request payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+* Expose `ResourceRequest` properties publicly. ([#1548](https://github.com/mapbox/mapbox-maps-ios/pull/1548))
+
 ## 10.8.0-rc.1 - August 24, 2022
 
 * Apply mercator scale to 3D puck also when its `modelScale` is not specified. ([#1523](https://github.com/mapbox/mapbox-maps-ios/pull/1523))

--- a/Sources/MapboxMaps/Foundation/Events/Payload/ResourceRequestPayload.swift
+++ b/Sources/MapboxMaps/Foundation/Events/Payload/ResourceRequestPayload.swift
@@ -34,10 +34,10 @@ public struct ResourceRequest: Decodable {
         case network
     }
 
-    let url: String
-    let kind: Kind
-    let priority: Priority
-    let loadingMethod: [LoadingMethod]
+    public let url: String
+    public let kind: Kind
+    public let priority: Priority
+    public let loadingMethod: [LoadingMethod]
 }
 
 public struct ResourceResponse: Decodable {


### PR DESCRIPTION
`ResourceRequest` don't have access modifier specified making them to be `internal`-only. This PR exposes them `public`'ly. 
<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
