### PR TITLE
Expose distance-from-center and pitch expressions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Fix block retain cycle in `MapboxMap/observeStyleLoad(_:)`. ([#1575](https://github.com/mapbox/mapbox-maps-ios/pull/1575))
 * Fix block retain cycle in `MapboxMap/observeStyleLoad(_:)`, from now on `loadStyleURI` and `loadStyleJSON` completion block will not be invoked when MapboxMap is deallocated. ([#1575](https://github.com/mapbox/mapbox-maps-ios/pull/1575))
 * Remove `DictionaryEncoder` enforce nil encoding for nested level of the dictionary. ([#1565](https://github.com/mapbox/mapbox-maps-ios/pull/1565))
+* Expose `distance-from-center` and `pitch` expressions. ([#1559](https://github.com/mapbox/mapbox-maps-ios/pull/1559))
 
 ## 10.8.1 - September 8, 2022
 

--- a/Sources/MapboxMaps/Style/Generated/Expressions/AllExpressions.swift
+++ b/Sources/MapboxMaps/Style/Generated/Expressions/AllExpressions.swift
@@ -94,6 +94,9 @@ public extension Expression {
         /// Returns the shortest distance in meters between the evaluated feature and the input geometry. The input value can be a valid GeoJSON of type `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, `Feature`, or `FeatureCollection`. Distance values returned may vary in precision due to loss in precision from encoding geometries, particularly below zoom level 13.
         case distance = "distance"
 
+        /// Returns the distance of a `symbol` instance from the center of the map. The distance is measured in pixels divided by the height of the map container. It measures 0 at the center, decreases towards the camera and increase away from the camera. For example, if the height of the map is 1000px, a value of -1 means 1000px away from the center towards the camera, and a value of 1 means a distance of 1000px away from the camera from the center. `["distance-from-center"]` may only be used in the `filter` expression for a `symbol` layer.
+        case distanceFromCenter = "distance-from-center"
+
         /// Returns the input string converted to lowercase. Follows the Unicode Default Case Conversion algorithm and the locale-insensitive case mappings in the Unicode Character Database.
         case downcase = "downcase"
 
@@ -196,6 +199,9 @@ public extension Expression {
 
         /// Returns the mathematical constant pi.
         case pi = "pi"
+
+        /// Returns the current pitch in degrees. `["pitch"]` may only be used in the `filter` expression for a `symbol` layer.
+        case pitch = "pitch"
 
         /// Returns the feature properties object.  Note that in some cases, it may be more efficient to use `["get", "property_name"]` directly.
         case properties = "properties"

--- a/Tests/MapboxMapsTests/Style/ExpressionTests/ExpressionTests.swift
+++ b/Tests/MapboxMapsTests/Style/ExpressionTests/ExpressionTests.swift
@@ -132,4 +132,21 @@ final class ExpressionTests: XCTestCase {
         XCTAssertEqual(coloradoJSON["properties"] as? [String: Int],
                        ["population": 5_773_714])
     }
+
+    func testDistanceFromCenterExpression() {
+        let expression = Expression(.distanceFromCenter) {
+            Expression(.literal) { 1.0 }
+        }
+
+        XCTAssertEqual(expression.description, "[distance-from-center, [literal, 1.0]]")
+    }
+
+    func testPitchExpression() {
+        let expression = Expression(.pitch) {
+            Expression(.literal) { 20.0 }
+        }
+
+        XCTAssertEqual(expression.description, "[pitch, [literal, 20.0]]")
+    }
+
 }


### PR DESCRIPTION
These expressions can be used to filter symbols:
 - **Pitch** 
   - Returns the current pitch in degrees. `["pitch"]` may only be used in the `filter` expression for a `symbol` layer.
 - **Distance-from-center**
   - Returns the distance of a `symbol` instance from the center of the map. The distance is measured in pixels divided by the height of the map container. It measures 0 at the center, decreases towards the camera and increase away from the camera. For example, if the height of the map is 1000px, a value of -1 means 1000px away from the center towards the camera, and a value of 1 means a distance of 1000px away from the camera from the center. `["distance-from-center"]` may only be used in the `filter` expression for a `symbol` layer.


## TODO: 
 - [ ] Test or add an example around this functionality
 - [ ] Update changelog and public API docs
  
## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
