### PR TITLE
Fix for Style/updateLayer fail if nested properties dictionary contains nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 * Expose `ResourceRequest` properties publicly. ([#1548](https://github.com/mapbox/mapbox-maps-ios/pull/1548))
 * Fix block retain cycle in `MapboxMap/observeStyleLoad(_:)`, from now on `loadStyleURI` and `loadStyleJSON` completion block will not be invoked when MapboxMap is deallocated. ([#1575](https://github.com/mapbox/mapbox-maps-ios/pull/1575))
+* Remove `DictionaryEncoder` enforce nil encoding for nested level of the dictionary. ([#1565](https://github.com/mapbox/mapbox-maps-ios/pull/1565))
+
 ## 10.8.1 - September 8, 2022
 
 * Downgrade MME to 1.0.8. ([#1572](https://github.com/mapbox/mapbox-maps-ios/pull/1572))

--- a/Sources/MapboxMaps/Foundation/DictionaryCoding/DictionaryEncoder.swift
+++ b/Sources/MapboxMaps/Foundation/DictionaryCoding/DictionaryEncoder.swift
@@ -7,11 +7,14 @@ private protocol EncoderContainer {
 
 internal final class DictionaryEncoder {
     var userInfo: [CodingUserInfoKey: Any] = [:]
+    /// If `true`, nil values at top level will always be encoded as null.
     var shouldEncodeNilValues = false
     init() {}
 
     func encode<T>(_ value: T) throws -> [String: Any] where T: Encodable {
-        let encoder = Encoder(userInfo: userInfo, shouldEncodeNilValues: shouldEncodeNilValues)
+        let encoder = Encoder(
+            userInfo: userInfo,
+            shouldEncodeNilValues: shouldEncodeNilValues)
         guard let dictionary = try encoder.encode(value) as? [String: Any] else {
             throw Error.unexpectedType
         }
@@ -27,8 +30,7 @@ internal final class DictionaryEncoder {
     private static func encode<T: Encodable>(
         _ value: T,
         codingPath: [CodingKey],
-        userInfo: [CodingUserInfoKey: Any],
-        shouldEncodeNilValues: Bool
+        userInfo: [CodingUserInfoKey: Any]
     ) throws -> Any {
 
         switch value {
@@ -44,7 +46,7 @@ internal final class DictionaryEncoder {
             let encoder = Encoder(
                 codingPath: codingPath,
                 userInfo: userInfo,
-                shouldEncodeNilValues: shouldEncodeNilValues)
+                shouldEncodeNilValues: false)
             return try encoder.encode(value)
         }
     }
@@ -205,8 +207,7 @@ private extension DictionaryEncoder {
             let result = try DictionaryEncoder.encode(
                 value,
                 codingPath: codingPath.appending(key: key),
-                userInfo: userInfo,
-                shouldEncodeNilValues: shouldEncodeNilValues)
+                userInfo: userInfo)
             storage[key.stringValue] = .value(result)
         }
 
@@ -394,8 +395,7 @@ private extension DictionaryEncoder {
                 .value(try DictionaryEncoder.encode(
                     value,
                     codingPath: codingPath.appending(index: count),
-                    userInfo: userInfo,
-                    shouldEncodeNilValues: shouldEncodeNilValues)
+                    userInfo: userInfo)
                 ))
         }
 
@@ -510,8 +510,7 @@ private extension DictionaryEncoder {
             storage = try DictionaryEncoder.encode(
                 value,
                 codingPath: codingPath,
-                userInfo: userInfo,
-                shouldEncodeNilValues: shouldEncodeNilValues)
+                userInfo: userInfo)
         }
     }
 }

--- a/Tests/MapboxMapsTests/Foundation/DictionaryEncoderTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/DictionaryEncoderTests.swift
@@ -113,6 +113,29 @@ final class DictionaryEncoderTests: XCTestCase {
         let encoded = try sut.encode(value)
         XCTAssertTrue(encoded.isEmpty)
     }
+
+    func testEncodeNilNestedLevel() throws {
+        struct TopLevel: Encodable {
+            let everything: Everything?
+        }
+
+        let sut = DictionaryEncoder()
+        sut.shouldEncodeNilValues = true
+
+        let everything = Everything(
+            string: nil,
+            int: nil, int8: nil, int16: nil, int32: nil, int64: nil,
+            uint: nil, uint8: nil, uint16: nil, uint32: nil, uint64: nil,
+            float: nil, double: nil,
+            bool: nil,
+            date: nil,
+            data: nil,
+            url: nil
+        )
+
+        let encoded = try sut.encode(TopLevel(everything: everything))
+        XCTAssertTrue(try XCTUnwrap(encoded["everything"] as? [String: Any]).isEmpty)
+    }
 }
 
 // MARK: Supported Types.
@@ -153,27 +176,5 @@ private struct Everything: Encodable {
         case date
         case data
         case url
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: Keys.self)
-
-        try container.encodeIfPresent(string, forKey: .string)
-        try container.encodeIfPresent(int, forKey: .int)
-        try container.encodeIfPresent(int8, forKey: .int8)
-        try container.encodeIfPresent(int16, forKey: .int16)
-        try container.encodeIfPresent(int32, forKey: .int32)
-        try container.encodeIfPresent(int64, forKey: .int64)
-        try container.encodeIfPresent(uint, forKey: .uint)
-        try container.encodeIfPresent(uint8, forKey: .uint8)
-        try container.encodeIfPresent(uint16, forKey: .uint16)
-        try container.encodeIfPresent(uint32, forKey: .uint32)
-        try container.encodeIfPresent(uint64, forKey: .uint64)
-        try container.encodeIfPresent(float, forKey: .float)
-        try container.encodeIfPresent(double, forKey: .double)
-        try container.encodeIfPresent(bool, forKey: .bool)
-        try container.encodeIfPresent(date, forKey: .date)
-        try container.encodeIfPresent(data, forKey: .data)
-        try container.encodeIfPresent(url, forKey: .url)
     }
 }


### PR DESCRIPTION
- Error happens due to layer's properties contains nil values for nested keys, for these keys, default values will not be applied so they would appear as nil when updating a layer. 
This fixes the problem by only applying nil encoding for the root properties of the dictionary. Please note that the best solution is for GL-Native to support null value to reset a property https://mapbox.atlassian.net/browse/MAPSNAT-528, but since this bug has high priority and is expected to be addressed in early September so I came up with this solution, until GL-Native decides to support us, we will remove this workaround.

<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
