### PR TITLE
Remove unused images when updating point annotations

### DIFF
--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -33,7 +33,7 @@ public class CircleAnnotationManager: AnnotationManagerInternal {
     // MARK: - Setup / Lifecycle
 
     /// Dependency required to add sources/layers to the map
-    private let style: Style
+    private let style: StyleProtocol
 
     /// Storage for common layer properties
     private var layerProperties: [String: Any] = [:] {
@@ -54,7 +54,7 @@ public class CircleAnnotationManager: AnnotationManagerInternal {
     private var isDestroyed = false
 
     internal init(id: String,
-                  style: Style,
+                  style: StyleProtocol,
                   layerPosition: LayerPosition?,
                   displayLinkCoordinator: DisplayLinkCoordinator) {
         self.id = id

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -464,6 +464,17 @@ public class PointAnnotationManager: AnnotationManagerInternal {
         }
     }
 
+    /// Text leading value for multi-line text.
+    @available(*, deprecated, message: "text-line-height property is now data driven, use `PointAnnotation.textLineHeight` instead.")
+    public var textLineHeight: Double? {
+        get {
+            return layerProperties["text-line-height"] as? Double
+        }
+        set {
+            layerProperties["text-line-height"] = newValue
+        }
+    }
+
     internal func handleQueriedFeatureIds(_ queriedFeatureIds: [String]) {
         // Find if any `queriedFeatureIds` match an annotation's `id`
         let tappedAnnotations = annotations.filter { queriedFeatureIds.contains($0.id) }

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -111,6 +111,8 @@ public class PointAnnotationManager: AnnotationManagerInternal {
                 forMessage: "Failed to remove source for PointAnnotationManager with id \(id) due to error: \(error)",
                 category: "Annotations")
         }
+        removeImages(from: style, images: addedImages)
+
         displayLinkCoordinator?.remove(displayLinkParticipant)
     }
 

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -33,7 +33,7 @@ public class PolygonAnnotationManager: AnnotationManagerInternal {
     // MARK: - Setup / Lifecycle
 
     /// Dependency required to add sources/layers to the map
-    private let style: Style
+    private let style: StyleProtocol
 
     /// Storage for common layer properties
     private var layerProperties: [String: Any] = [:] {
@@ -54,7 +54,7 @@ public class PolygonAnnotationManager: AnnotationManagerInternal {
     private var isDestroyed = false
 
     internal init(id: String,
-                  style: Style,
+                  style: StyleProtocol,
                   layerPosition: LayerPosition?,
                   displayLinkCoordinator: DisplayLinkCoordinator) {
         self.id = id

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -33,7 +33,7 @@ public class PolylineAnnotationManager: AnnotationManagerInternal {
     // MARK: - Setup / Lifecycle
 
     /// Dependency required to add sources/layers to the map
-    private let style: Style
+    private let style: StyleProtocol
 
     /// Storage for common layer properties
     private var layerProperties: [String: Any] = [:] {
@@ -54,7 +54,7 @@ public class PolylineAnnotationManager: AnnotationManagerInternal {
     private var isDestroyed = false
 
     internal init(id: String,
-                  style: Style,
+                  style: StyleProtocol,
                   layerPosition: LayerPosition?,
                   displayLinkCoordinator: DisplayLinkCoordinator) {
         self.id = id

--- a/Sources/MapboxMaps/Annotations/PointAnnotation+ImageHandling.swift
+++ b/Sources/MapboxMaps/Annotations/PointAnnotation+ImageHandling.swift
@@ -13,11 +13,10 @@ extension PointAnnotation {
     }
 }
 
-extension PointAnnotationManager {
+internal extension PointAnnotationManager {
 
-    func addImageToStyleIfNeeded(style: Style) {
-        let pointAnnotationImages = Set(annotations.compactMap(\.image))
-        for pointAnnotationImage in pointAnnotationImages {
+    func addImagesToStyleIfNeeded(style: StyleProtocol, images: Set<PointAnnotation.Image>) {
+        for pointAnnotationImage in images {
             // If the image is not found, add it to the style
             if !style.imageExists(withId: pointAnnotationImage.name) {
                 do {
@@ -27,6 +26,18 @@ extension PointAnnotationManager {
                         forMessage: "Could not add image to style in PointAnnotationManager due to error: \(error)",
                         category: "Annnotations")
                 }
+            }
+        }
+    }
+
+    func removeImages(from style: StyleProtocol, images: Set<String>) {
+        for image in images {
+            do {
+                try style.removeImage(withId: image)
+            } catch {
+                Log.warning(
+                    forMessage: "Could not remove image from style in PointAnnotationManager due to error: \(error)",
+                    category: "Annnotations")
             }
         }
     }

--- a/Sources/MapboxMaps/Annotations/PointAnnotation+ImageHandling.swift
+++ b/Sources/MapboxMaps/Annotations/PointAnnotation+ImageHandling.swift
@@ -16,16 +16,14 @@ extension PointAnnotation {
 internal extension PointAnnotationManager {
 
     func addImagesToStyleIfNeeded(style: StyleProtocol, images: Set<PointAnnotation.Image>) {
-        for pointAnnotationImage in images {
-            // If the image is not found, add it to the style
-            if !style.imageExists(withId: pointAnnotationImage.name) {
-                do {
-                    try style.addImage(pointAnnotationImage.image, id: pointAnnotationImage.name)
-                } catch {
-                    Log.warning(
-                        forMessage: "Could not add image to style in PointAnnotationManager due to error: \(error)",
-                        category: "Annnotations")
-                }
+        // If the image is not found, add it to the style
+        for pointAnnotationImage in images where !style.imageExists(withId: pointAnnotationImage.name) {
+            do {
+                try style.addImage(pointAnnotationImage.image, id: pointAnnotationImage.name)
+            } catch {
+                Log.warning(
+                    forMessage: "Could not add image to style in PointAnnotationManager due to error: \(error)",
+                    category: "Annnotations")
             }
         }
     }

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -35,7 +35,6 @@ internal extension StyleProtocol {
     }
 }
 
-
 // swiftlint:disable type_body_length
 
 /// Style provides access to the APIs used to dynamically modify the map's style. Use it

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -14,6 +14,7 @@ internal protocol StyleProtocol: AnyObject {
     func addSource(_ source: Source, id: String) throws
     func removeSource(withId id: String) throws
     func sourceExists(withId id: String) -> Bool
+    func setSourceProperty(for sourceId: String, property: String, value: Any) throws
     func setSourceProperties(for sourceId: String, properties: [String: Any]) throws
 
     //swiftlint:disable function_parameter_count
@@ -23,8 +24,17 @@ internal protocol StyleProtocol: AnyObject {
                   stretchX: [ImageStretches],
                   stretchY: [ImageStretches],
                   content: ImageContent?) throws
+    func addImage(_ image: UIImage, id: String, sdf: Bool, contentInsets: UIEdgeInsets) throws
     func removeImage(withId id: String) throws
+    func imageExists(withId id: String) -> Bool
 }
+
+internal extension StyleProtocol {
+    func addImage(_ image: UIImage, id: String, sdf: Bool = false, contentInsets: UIEdgeInsets = .zero) throws {
+        try addImage(image, id: id, sdf: sdf, contentInsets: contentInsets)
+    }
+}
+
 
 // swiftlint:disable type_body_length
 

--- a/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationManagerTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+@testable import MapboxMaps
+import XCTest
+
+final class PointAnnotationManagerTests: XCTestCase {
+    var manager: PointAnnotationManager!
+    var style: MockStyle!
+    var displayLinkCoordinator: DisplayLinkCoordinator!
+
+    override func setUp() {
+        super.setUp()
+
+        style = MockStyle()
+        displayLinkCoordinator = MockDisplayLinkCoordinator()
+        manager = PointAnnotationManager(id: UUID().uuidString,
+                                         style: style,
+                                         layerPosition: nil,
+                                         displayLinkCoordinator: displayLinkCoordinator)
+    }
+
+    override func tearDown() {
+        style = nil
+        displayLinkCoordinator = nil
+        manager = nil
+
+        super.tearDown()
+    }
+
+    func testNewImagesAddedToStyle() {
+        // given
+        let annotations = (0..<10)
+            .map { _ in PointAnnotation.Image(image: UIImage(), name: UUID().uuidString) }
+            .map(PointAnnotation.init)
+
+        // when
+        manager.annotations = annotations
+        manager.syncSourceAndLayerIfNeeded()
+
+        // then
+        XCTAssertEqual(style.addImageWithInsetsStub.invocations.count, annotations.count)
+        XCTAssertEqual(
+            Set(style.addImageWithInsetsStub.invocations.map(\.parameters.id)),
+            Set(annotations.compactMap(\.image?.name))
+        )
+        XCTAssertEqual(
+            Set(style.addImageWithInsetsStub.invocations.map(\.parameters.image)),
+            Set(annotations.compactMap(\.image?.image))
+        )
+        XCTAssertEqual(style.removeImageStub.invocations.count, 0)
+    }
+
+    func testUnusedImagesRemovedFromStyle() {
+        // given
+        let unusedAnnotations = 3
+        let annotations = (0..<10)
+            .map { _ in PointAnnotation.Image(image: UIImage(), name: UUID().uuidString) }
+            .map(PointAnnotation.init)
+        manager.annotations = annotations
+        manager.syncSourceAndLayerIfNeeded()
+
+        // when
+        manager.annotations = annotations.suffix(annotations.count - unusedAnnotations)
+        manager.syncSourceAndLayerIfNeeded()
+
+        // then
+        XCTAssertEqual(style.addImageWithInsetsStub.invocations.count, annotations.count + annotations.count - unusedAnnotations)
+        XCTAssertEqual(
+            Set(style.addImageWithInsetsStub.invocations.map(\.parameters.id)),
+            Set(annotations.compactMap(\.image?.name))
+        )
+        XCTAssertEqual(
+            Set(style.addImageWithInsetsStub.invocations.map(\.parameters.image)),
+            Set(annotations.compactMap(\.image?.image))
+        )
+        XCTAssertEqual(style.removeImageStub.invocations.count, unusedAnnotations)
+        XCTAssertEqual(
+            Set(style.removeImageStub.invocations.map(\.parameters)),
+            Set(annotations.prefix(unusedAnnotations).compactMap(\.image?.name))
+        )
+    }
+
+    func testAllImagesRemovedFromStyle() {
+        // given
+        let annotations = (0..<10)
+            .map { _ in PointAnnotation.Image(image: UIImage(), name: UUID().uuidString) }
+            .map(PointAnnotation.init)
+        manager.annotations = annotations
+        manager.syncSourceAndLayerIfNeeded()
+
+        // when
+        manager.annotations = []
+        manager.syncSourceAndLayerIfNeeded()
+
+        // then
+        XCTAssertEqual(style.addImageWithInsetsStub.invocations.count, annotations.count)
+        XCTAssertEqual(
+            Set(style.addImageWithInsetsStub.invocations.map(\.parameters.id)),
+            Set(annotations.compactMap(\.image?.name))
+        )
+        XCTAssertEqual(
+            Set(style.addImageWithInsetsStub.invocations.map(\.parameters.image)),
+            Set(annotations.compactMap(\.image?.image))
+        )
+        XCTAssertEqual(style.removeImageStub.invocations.count, annotations.count)
+        XCTAssertEqual(
+            Set(style.removeImageStub.invocations.map(\.parameters)),
+            Set(annotations.compactMap(\.image?.name))
+        )
+    }
+}
+
+private extension PointAnnotation {
+    init(image: Image) {
+        self.init(coordinate: .random())
+        self.image = image
+    }
+}

--- a/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationManagerTests.swift
@@ -79,7 +79,7 @@ final class PointAnnotationManagerTests: XCTestCase {
         )
     }
 
-    func testAllImagesRemovedFromStyle() {
+    func testAllImagesRemovedFromStyleOnUpdate() {
         // given
         let annotations = (0..<10)
             .map { _ in PointAnnotation.Image(image: UIImage(), name: UUID().uuidString) }
@@ -106,6 +106,26 @@ final class PointAnnotationManagerTests: XCTestCase {
             Set(style.removeImageStub.invocations.map(\.parameters)),
             Set(annotations.compactMap(\.image?.name))
         )
+    }
+
+    func testAllImagesRemovedFromStyleOnDestroy() {
+        // given
+        let annotations = (0..<10)
+            .map { _ in PointAnnotation.Image(image: UIImage(), name: UUID().uuidString) }
+            .map(PointAnnotation.init)
+        manager.annotations = annotations
+        manager.syncSourceAndLayerIfNeeded()
+
+        // when
+        manager.destroy()
+
+        // then
+        XCTAssertEqual(style.removeImageStub.invocations.count, annotations.count)
+        XCTAssertEqual(
+            Set(style.removeImageStub.invocations.map(\.parameters)),
+            Set(annotations.compactMap(\.image?.name))
+        )
+
     }
 }
 

--- a/Tests/MapboxMapsTests/Style/Mocks/MockStyle.swift
+++ b/Tests/MapboxMapsTests/Style/Mocks/MockStyle.swift
@@ -123,7 +123,6 @@ final class MockStyle: StyleProtocol {
         removeImageStub.call(with: id)
     }
 
-
     struct AddImageWithInsetsParams {
         let image: UIImage
         let id: String

--- a/Tests/MapboxMapsTests/Style/Mocks/MockStyle.swift
+++ b/Tests/MapboxMapsTests/Style/Mocks/MockStyle.swift
@@ -1,6 +1,23 @@
 @testable import MapboxMaps
 
 final class MockStyle: StyleProtocol {
+
+    struct SetSourcePropertyParams {
+        let sourceId: String
+        let property: String
+        let value: Any
+    }
+
+    let setSourcePropertyStub = Stub<SetSourcePropertyParams, Void>()
+    func setSourceProperty(for sourceId: String, property: String, value: Any) throws {
+        setSourcePropertyStub.call(with: .init(sourceId: sourceId, property: property, value: value))
+    }
+
+    let imageExistsStub = Stub<String, Bool>(defaultReturnValue: false)
+    func imageExists(withId id: String) -> Bool {
+        return imageExistsStub.call(with: id)
+    }
+
     struct AddPersistentLayerParams {
         var layer: Layer
         var layerPosition: LayerPosition?
@@ -104,5 +121,17 @@ final class MockStyle: StyleProtocol {
     let removeImageStub = Stub<String, Void>()
     func removeImage(withId id: String) throws {
         removeImageStub.call(with: id)
+    }
+
+
+    struct AddImageWithInsetsParams {
+        let image: UIImage
+        let id: String
+        let sdf: Bool
+        let contentInsets: UIEdgeInsets
+    }
+    let addImageWithInsetsStub = Stub<AddImageWithInsetsParams, Void>()
+    func addImage(_ image: UIImage, id: String, sdf: Bool, contentInsets: UIEdgeInsets) throws {
+        addImageWithInsetsStub.call(with: .init(image: image, id: id, sdf: sdf, contentInsets: contentInsets))
     }
 }


### PR DESCRIPTION
`PointAnnotationManager` can add images from point annotations to style, but doesn't remove them when annotations are updated or when the manager is destroyed. This PR makes point annotation manager to remove unused images when updating annotations, as well as to remove all annotation images when the manager gets destroyed.


|| Memory consumption when annotations being added(1st event) and removed(2nd event) |
| ----- | ----- |
| **Before** | <img src="https://user-images.githubusercontent.com/1478430/190641508-183f3faf-9381-4dce-b42a-42daf1a86a68.png" width = 1000/> |
| **After** | <img src="https://user-images.githubusercontent.com/1478430/190641577-39dbd0d6-4611-4352-a6eb-b6e0724b84a9.png" width = 1000/> |



## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
