### PR TITLE
Fix toString conversion on iOS 12

### DIFF
--- a/Sources/MapboxMaps/Foundation/Extensions/Encodable+ToJSON.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Encodable+ToJSON.swift
@@ -25,7 +25,7 @@ internal extension Encodable {
         if #available(iOS 13.0, *) {
             data = try JSONEncoder().encode(self)
         } else {
-            // JSONEncoder doesn't support fragments on older iOS versions
+            // JSONEncoder doesn't support fragments on older iOS versions https://github.com/apple/swift-corelibs-foundation/issues/4402
             data = try JSONSerialization.data(withJSONObject: self.toJSON(), options: .fragmentsAllowed)
         }
 

--- a/Sources/MapboxMaps/Foundation/Extensions/Encodable+ToJSON.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Encodable+ToJSON.swift
@@ -21,7 +21,13 @@ internal extension Encodable {
     /// - Throws: Errors occurring during conversion.
     /// - Returns: A string with JSON representing the object.
     func toString(encoding: String.Encoding = .utf8) throws -> String {
-        let data = try JSONEncoder().encode(self)
+        let data: Data
+        if #available(iOS 13.0, *) {
+            data = try JSONEncoder().encode(self)
+        } else {
+            // JSONEncoder doesn't support fragments on older iOS versions
+            data = try JSONSerialization.data(withJSONObject: self.toJSON(), options: .fragmentsAllowed)
+        }
 
         guard let result = String(data: data, encoding: encoding) else {
             throw TypeConversionError.unsuccessfulConversion


### PR DESCRIPTION
`JSONEncoder` doesn't support encoding top-level fragments on iOS 12([bug report](https://github.com/apple/swift-corelibs-foundation/issues/4402)). This PR makes `toString()` to use `JSONSerialization`(which supports top-level fragments) on iOS 12 instead.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
        Not testable

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
