### PR TITLE
Expose opacity for location puck

### DIFF
--- a/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
@@ -48,6 +48,21 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
         }
     }
 
+    private var puckOpacity: PuckOpaticy = .opaque {
+        didSet {
+            updatePuckUI()
+        }
+    }
+
+    private enum PuckOpaticy: Double {
+        case opaque = 1
+        case semiTransparent = 0.5
+
+        mutating func toggle() {
+            self = self == .opaque ? .semiTransparent : .opaque
+        }
+    }
+
     private enum PuckVisibility {
         case isVisible
         case isHidden
@@ -198,6 +213,10 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
             self.showsPuck.toggle()
         })
 
+        alert.addAction(UIAlertAction(title: "Toggle Puck opacity", style: .default) { _ in
+            self.puckOpacity.toggle()
+        })
+
         alert.addAction(UIAlertAction(title: "Toggle Puck image", style: .default) { _ in
             self.puckImage.toggle()
         })
@@ -231,7 +250,7 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
         puckConfiguration = Puck2DConfiguration.makeDefault(showBearing: showsBearing.isVisible)
         puckConfiguration.showsAccuracyRing = showsAccuracyRing.isVisible
         puckConfiguration.topImage = puckImage.image
-
+        puckConfiguration.opacity = puckOpacity.rawValue
         switch showsPuck {
         case .isVisible:
             mapView.location.options.puckType = .puck2D(puckConfiguration)

--- a/Apps/Examples/Examples/All Examples/Custom3DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom3DPuckExample.swift
@@ -63,7 +63,7 @@ final class Custom3DPuckExample: UIViewController, ExampleProtocol, LocationCons
             }
         }
 
-        let configuration = Puck3DConfiguration(model: myModel, modelScale: .expression(scalingExpression))
+        let configuration = Puck3DConfiguration(model: myModel, modelScale: .expression(scalingExpression), modelOpacity: .constant(0.5))
         mapView.location.options.puckType = .puck3D(configuration)
         mapView.location.options.puckBearingSource = .course
 

--- a/Sources/MapboxMaps/Location/Puck/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck2D.swift
@@ -7,7 +7,6 @@ internal final class Puck2D: Puck {
     private static let topImageId = "locationIndicatorLayerTopImage"
     private static let bearingImageId = "locationIndicatorLayerBearingImage"
     private static let shadowImageId = "locationIndicatorLayerShadowImage"
-    private static let opacity = "locationIndicatorLayerOpacity"
 
     internal var isActive = false {
         didSet {
@@ -136,9 +135,7 @@ internal final class Puck2D: Puck {
             if configuration.bearingImage != nil {
                 newLayerLayoutProperties[.bearingImage] = Self.bearingImageId
             }
-            if configuration.opacity != nil {
-                newLayerPaintProperties[.locationIndicatorOpacity] = Self.opacity
-            }
+
             newLayerLayoutProperties[.shadowImage] = Self.shadowImageId
             newLayerPaintProperties[.locationTransition] = immediateTransition
             newLayerPaintProperties[.topImageSize] = encodedScale
@@ -146,6 +143,7 @@ internal final class Puck2D: Puck {
             newLayerPaintProperties[.shadowImageSize] = encodedScale
             newLayerPaintProperties[.emphasisCircleRadiusTransition] = immediateTransition
             newLayerPaintProperties[.bearingTransition] = immediateTransition
+            newLayerPaintProperties[.locationIndicatorOpacity] = configuration.opacity
             newLayerPaintProperties[.locationIndicatorOpacityTransition] = immediateTransition
             if configuration.showsAccuracyRing {
                 newLayerPaintProperties[.accuracyRadius] = location.horizontalAccuracy

--- a/Sources/MapboxMaps/Location/Puck/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck2D.swift
@@ -7,6 +7,7 @@ internal final class Puck2D: Puck {
     private static let topImageId = "locationIndicatorLayerTopImage"
     private static let bearingImageId = "locationIndicatorLayerBearingImage"
     private static let shadowImageId = "locationIndicatorLayerShadowImage"
+    private static let opacity = "locationIndicatorLayerOpacity"
 
     internal var isActive = false {
         didSet {
@@ -135,6 +136,9 @@ internal final class Puck2D: Puck {
             if configuration.bearingImage != nil {
                 newLayerLayoutProperties[.bearingImage] = Self.bearingImageId
             }
+            if configuration.opacity != nil {
+                newLayerPaintProperties[.locationIndicatorOpacity] = Self.opacity
+            }
             newLayerLayoutProperties[.shadowImage] = Self.shadowImageId
             newLayerPaintProperties[.locationTransition] = immediateTransition
             newLayerPaintProperties[.topImageSize] = encodedScale
@@ -142,6 +146,7 @@ internal final class Puck2D: Puck {
             newLayerPaintProperties[.shadowImageSize] = encodedScale
             newLayerPaintProperties[.emphasisCircleRadiusTransition] = immediateTransition
             newLayerPaintProperties[.bearingTransition] = immediateTransition
+            newLayerPaintProperties[.locationIndicatorOpacityTransition] = immediateTransition
             if configuration.showsAccuracyRing {
                 newLayerPaintProperties[.accuracyRadius] = location.horizontalAccuracy
                 newLayerPaintProperties[.accuracyRadiusColor] = StyleColor(configuration.accuracyRingColor).rgbaString

--- a/Sources/MapboxMaps/Location/Puck/Puck3D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck3D.swift
@@ -104,6 +104,7 @@ internal final class Puck3D: Puck {
             modelLayer.modelScale = modelScale
             modelLayer.modelType = .constant(.locationIndicator)
             modelLayer.modelRotation = configuration.modelRotation
+            modelLayer.modelOpacity = configuration.modelOpacity
             try! style.addPersistentLayer(modelLayer, layerPosition: nil)
         } else if needsUpdateModelScale {
             try? style.setLayerProperty(

--- a/Sources/MapboxMaps/Location/Puck/PuckType.swift
+++ b/Sources/MapboxMaps/Location/Puck/PuckType.swift
@@ -47,7 +47,7 @@ public struct Puck2DConfiguration: Equatable {
     }
 
     /// The opacity of the entire location indicator.
-    public var opacity: CGFloat?
+    public var opacity: CGFloat
 
     /// Image to use as the top of the location indicator.
     public var topImage: UIImage?
@@ -87,7 +87,7 @@ public struct Puck2DConfiguration: Equatable {
                 scale: Value<Double>? = nil,
                 pulsing: Pulsing? = nil,
                 showsAccuracyRing: Bool = false,
-                opacity: CGFloat? = nil) {
+                opacity: CGFloat = 1) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage
@@ -116,7 +116,7 @@ public struct Puck2DConfiguration: Equatable {
                 showsAccuracyRing: Bool = false,
                 accuracyRingColor: UIColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3),
                 accuracyRingBorderColor: UIColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3),
-                opacity: CGFloat? = nil) {
+                opacity: CGFloat = 1) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage
@@ -148,7 +148,7 @@ public struct Puck3DConfiguration: Equatable {
     /// The rotation of the model in euler angles [lon, lat, z].
     public var modelRotation: Value<[Double]>?
 
-    ///The opacity of the model used as the location puck
+    /// The opacity of the model used as the location puck
     public var modelOpacity: Value<Double>?
 
     /// Initialize a `Puck3DConfiguration` with a model, scale and rotation.
@@ -156,6 +156,7 @@ public struct Puck3DConfiguration: Equatable {
     ///   - model: The `gltf` model to use for the puck.
     ///   - modelScale: The amount to scale the model by.
     ///   - modelRotation: The rotation of the model in euler angles `[lon, lat, z]`.
+    ///   - modelOpacity: The opacity of the model used as the location puck
     public init(model: Model, modelScale: Value<[Double]>? = nil, modelRotation: Value<[Double]>? = nil, modelOpacity: Value<Double>? = nil) {
         self.model = model
         self.modelScale = modelScale

--- a/Sources/MapboxMaps/Location/Puck/PuckType.swift
+++ b/Sources/MapboxMaps/Location/Puck/PuckType.swift
@@ -47,7 +47,7 @@ public struct Puck2DConfiguration: Equatable {
     }
 
     /// The opacity of the entire location indicator.
-    public var opacity: Value<Double>?
+    public var opacity: CGFloat?
 
     /// Image to use as the top of the location indicator.
     public var topImage: UIImage?
@@ -87,7 +87,7 @@ public struct Puck2DConfiguration: Equatable {
                 scale: Value<Double>? = nil,
                 pulsing: Pulsing? = nil,
                 showsAccuracyRing: Bool = false,
-                opacity: Value<Double>? = nil) {
+                opacity: CGFloat? = nil) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage
@@ -116,7 +116,7 @@ public struct Puck2DConfiguration: Equatable {
                 showsAccuracyRing: Bool = false,
                 accuracyRingColor: UIColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3),
                 accuracyRingBorderColor: UIColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3),
-                opacity: Value<Double>? = nil) {
+                opacity: CGFloat? = nil) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage

--- a/Sources/MapboxMaps/Location/Puck/PuckType.swift
+++ b/Sources/MapboxMaps/Location/Puck/PuckType.swift
@@ -46,6 +46,9 @@ public struct Puck2DConfiguration: Equatable {
         }
     }
 
+    /// The opacity of the entire location indicator.
+    public var opacity: Value<Double>?
+
     /// Image to use as the top of the location indicator.
     public var topImage: UIImage?
 
@@ -70,30 +73,33 @@ public struct Puck2DConfiguration: Equatable {
     /// The color of the accuracy ring border.
     public var accuracyRingBorderColor: UIColor
 
-    /// Initialize a `Puck2D` object with a top image, bearing image, shadow image, scale, and accuracy ring visibility.
+    /// Initialize a `Puck2D` object with a top image, bearing image, shadow image, scale, opacity and accuracy ring visibility.
     /// - Parameters:
     ///   - topImage: The image to use as the top layer for the location indicator.
     ///   - bearingImage: The image used as the middle of the location indicator.
     ///   - shadowImage: The image that acts as a background of the location indicator.
-    ///   - scale: The size of the images, as a scale factor applied to the size of the specified image..
+    ///   - scale: The size of the images, as a scale factor applied to the size of the specified image.
     ///   - showsAccuracyRing: Indicates whether the location accurary ring should be shown.
+    ///   - opacity: The opacity of the entire location indicator.
     public init(topImage: UIImage? = nil,
                 bearingImage: UIImage? = nil,
                 shadowImage: UIImage? = nil,
                 scale: Value<Double>? = nil,
                 pulsing: Pulsing? = nil,
-                showsAccuracyRing: Bool = false) {
+                showsAccuracyRing: Bool = false,
+                opacity: Value<Double>? = nil) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage
         self.scale = scale
         self.pulsing = pulsing
         self.showsAccuracyRing = showsAccuracyRing
+        self.opacity = opacity
         self.accuracyRingColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)
         self.accuracyRingBorderColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)
     }
 
-    /// Initialize a `Puck2D` object with a top image, bearing image, shadow image, scale, and accuracy ring visibility.
+    /// Initialize a `Puck2D` object with a top image, bearing image, shadow image, scale, opacity and accuracy ring visibility.
     /// - Parameters:
     ///   - topImage: The image to use as the top layer for the location indicator.
     ///   - bearingImage: The image used as the middle of the location indicator.
@@ -102,13 +108,15 @@ public struct Puck2DConfiguration: Equatable {
     ///   - showsAccuracyRing: Indicates whether the location accurary ring should be shown.
     ///   - accuracyRingColor:The color of the accuracy ring.
     ///   - accuracyRingBorderColor: The color of the accuracy ring border.
+    ///   - opacity: The opacity of the entire location indicator.
     public init(topImage: UIImage? = nil,
                 bearingImage: UIImage? = nil,
                 shadowImage: UIImage? = nil,
                 scale: Value<Double>? = nil,
                 showsAccuracyRing: Bool = false,
                 accuracyRingColor: UIColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3),
-                accuracyRingBorderColor: UIColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)) {
+                accuracyRingBorderColor: UIColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3),
+                opacity: Value<Double>? = nil) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage
@@ -116,6 +124,7 @@ public struct Puck2DConfiguration: Equatable {
         self.showsAccuracyRing = showsAccuracyRing
         self.accuracyRingColor = accuracyRingColor
         self.accuracyRingBorderColor = accuracyRingBorderColor
+        self.opacity = opacity
     }
 
     /// Create a Puck2DConfiguration instance with or without an arrow bearing image. Default without the arrow bearing image.
@@ -139,15 +148,19 @@ public struct Puck3DConfiguration: Equatable {
     /// The rotation of the model in euler angles [lon, lat, z].
     public var modelRotation: Value<[Double]>?
 
+    ///The opacity of the model used as the location puck
+    public var modelOpacity: Value<Double>?
+
     /// Initialize a `Puck3DConfiguration` with a model, scale and rotation.
     /// - Parameters:
     ///   - model: The `gltf` model to use for the puck.
     ///   - modelScale: The amount to scale the model by.
     ///   - modelRotation: The rotation of the model in euler angles `[lon, lat, z]`.
-    public init(model: Model, modelScale: Value<[Double]>? = nil, modelRotation: Value<[Double]>? = nil) {
+    public init(model: Model, modelScale: Value<[Double]>? = nil, modelRotation: Value<[Double]>? = nil, modelOpacity: Value<Double>? = nil) {
         self.model = model
         self.modelScale = modelScale
         self.modelRotation = modelRotation
+        self.modelOpacity = modelOpacity
     }
 }
 

--- a/Sources/MapboxMaps/Location/Puck/PuckType.swift
+++ b/Sources/MapboxMaps/Location/Puck/PuckType.swift
@@ -47,7 +47,7 @@ public struct Puck2DConfiguration: Equatable {
     }
 
     /// The opacity of the entire location indicator.
-    public var opacity: CGFloat
+    public var opacity: Double
 
     /// Image to use as the top of the location indicator.
     public var topImage: UIImage?
@@ -87,7 +87,7 @@ public struct Puck2DConfiguration: Equatable {
                 scale: Value<Double>? = nil,
                 pulsing: Pulsing? = nil,
                 showsAccuracyRing: Bool = false,
-                opacity: CGFloat = 1) {
+                opacity: Double = 1) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage
@@ -116,7 +116,7 @@ public struct Puck2DConfiguration: Equatable {
                 showsAccuracyRing: Bool = false,
                 accuracyRingColor: UIColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3),
                 accuracyRingBorderColor: UIColor = UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3),
-                opacity: CGFloat = 1) {
+                opacity: Double = 1) {
         self.topImage = topImage
         self.bearingImage = bearingImage
         self.shadowImage = shadowImage

--- a/Sources/MapboxMaps/Style/Generated/Layers/LocationIndicatorLayer.swift
+++ b/Sources/MapboxMaps/Style/Generated/Layers/LocationIndicatorLayer.swift
@@ -78,6 +78,12 @@ public struct LocationIndicatorLayer: Layer {
     /// Transition options for `location`.
     public var locationTransition: StyleTransition?
 
+    /// The opacity of the entire location indicator layer.
+    public var locationIndicatorOpacity: Value<Double>?
+
+    /// Transition options for `locationIndicatorOpacity`.
+    public var locationIndicatorOpacityTransition: StyleTransition?
+
     /// The amount of the perspective compensation, between 0 and 1. A value of 1 produces a location indicator of constant width across the screen. A value of 0 makes it scale naturally according to the viewing projection.
     public var perspectiveCompensation: Value<Double>?
 
@@ -127,6 +133,8 @@ public struct LocationIndicatorLayer: Layer {
         try paintContainer.encodeIfPresent(imagePitchDisplacement, forKey: .imagePitchDisplacement)
         try paintContainer.encodeIfPresent(location, forKey: .location)
         try paintContainer.encodeIfPresent(locationTransition, forKey: .locationTransition)
+        try paintContainer.encodeIfPresent(locationIndicatorOpacity, forKey: .locationIndicatorOpacity)
+        try paintContainer.encodeIfPresent(locationIndicatorOpacityTransition, forKey: .locationIndicatorOpacityTransition)
         try paintContainer.encodeIfPresent(perspectiveCompensation, forKey: .perspectiveCompensation)
         try paintContainer.encodeIfPresent(shadowImageSize, forKey: .shadowImageSize)
         try paintContainer.encodeIfPresent(shadowImageSizeTransition, forKey: .shadowImageSizeTransition)
@@ -168,6 +176,8 @@ public struct LocationIndicatorLayer: Layer {
             imagePitchDisplacement = try paintContainer.decodeIfPresent(Value<Double>.self, forKey: .imagePitchDisplacement)
             location = try paintContainer.decodeIfPresent(Value<[Double]>.self, forKey: .location)
             locationTransition = try paintContainer.decodeIfPresent(StyleTransition.self, forKey: .locationTransition)
+            locationIndicatorOpacity = try paintContainer.decodeIfPresent(Value<Double>.self, forKey: .locationIndicatorOpacity)
+            locationIndicatorOpacityTransition = try paintContainer.decodeIfPresent(StyleTransition.self, forKey: .locationIndicatorOpacityTransition)
             perspectiveCompensation = try paintContainer.decodeIfPresent(Value<Double>.self, forKey: .perspectiveCompensation)
             shadowImageSize = try paintContainer.decodeIfPresent(Value<Double>.self, forKey: .shadowImageSize)
             shadowImageSizeTransition = try paintContainer.decodeIfPresent(StyleTransition.self, forKey: .shadowImageSizeTransition)
@@ -220,6 +230,8 @@ public struct LocationIndicatorLayer: Layer {
         case imagePitchDisplacement = "image-pitch-displacement"
         case location = "location"
         case locationTransition = "location-transition"
+        case locationIndicatorOpacity = "location-indicator-opacity"
+        case locationIndicatorOpacityTransition = "location-indicator-opacity-transition"
         case perspectiveCompensation = "perspective-compensation"
         case shadowImageSize = "shadow-image-size"
         case shadowImageSizeTransition = "shadow-image-size-transition"

--- a/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
@@ -16,7 +16,8 @@ final class Puck2DTests: XCTestCase {
             topImage: UIImage(),
             bearingImage: UIImage(),
             shadowImage: UIImage(),
-            scale: .constant(.random(in: 1..<10)))
+            scale: .constant(.random(in: 1..<10)),
+            opacity: .random(in: 0.0...1.0))
         style = MockStyle()
         interpolatedLocationProducer = MockInterpolatedLocationProducer()
         mapboxMap = MockMapboxMap()
@@ -242,6 +243,8 @@ final class Puck2DTests: XCTestCase {
         expectedPaintLayerProperties[.emphasisCircleRadiusTransition] = ["duration": 0, "delay": 0]
         expectedPaintLayerProperties[.bearingTransition] = ["duration": 0, "delay": 0]
         expectedPaintLayerProperties[.bearing] = 0
+        expectedPaintLayerProperties[.locationIndicatorOpacity] = configuration.opacity
+        expectedPaintLayerProperties[.locationIndicatorOpacityTransition] = ["duration": 0, "delay": 0]
 
         var expectedProperties = expectedLayoutLayerProperties
             .mapKeys(\.rawValue)
@@ -306,6 +309,19 @@ final class Puck2DTests: XCTestCase {
 
     func testActivatingPuckWithNilScale() throws {
         configuration.scale = nil
+        recreatePuck()
+        let location = updateLocation(with: .fullAccuracy, heading: nil)
+        style.layerExistsStub.defaultReturnValue = false
+
+        puck2D.isActive = true
+
+        let expectedProperties = makeExpectedLayerProperties(with: location)
+        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.properties)
+        XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
+    }
+
+    func testActivatingPuckWithNilOpacity() throws {
+        configuration.opacity = nil
         recreatePuck()
         let location = updateLocation(with: .fullAccuracy, heading: nil)
         style.layerExistsStub.defaultReturnValue = false

--- a/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
@@ -320,19 +320,6 @@ final class Puck2DTests: XCTestCase {
         XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
     }
 
-    func testActivatingPuckWithNilOpacity() throws {
-        configuration.opacity = nil
-        recreatePuck()
-        let location = updateLocation(with: .fullAccuracy, heading: nil)
-        style.layerExistsStub.defaultReturnValue = false
-
-        puck2D.isActive = true
-
-        let expectedProperties = makeExpectedLayerProperties(with: location)
-        let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.properties)
-        XCTAssertEqual(actualProperties as NSDictionary, expectedProperties as NSDictionary)
-    }
-
     func testActivatingPuckWithShowsAccuracyRingTrue() throws {
         configuration.showsAccuracyRing = true
         recreatePuck()

--- a/Tests/MapboxMapsTests/Location/Puck/Puck3DTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/Puck3DTests.swift
@@ -209,6 +209,18 @@ final class Puck3DTests: XCTestCase {
         XCTAssertEqual(actualLayer.modelRotation, configuration.modelRotation)
     }
 
+    func testModelOpacity() throws {
+        configuration.modelOpacity = .constant(.random(in: 0.0...1.0))
+        recreatePuck()
+        interpolatedLocationProducer.location = .random()
+        style.layerExistsStub.defaultReturnValue = false
+
+        puck3D.isActive = true
+
+        let actualLayer = try XCTUnwrap(style.addPersistentLayerStub.invocations.first?.parameters.layer as? ModelLayer)
+        XCTAssertEqual(actualLayer.modelOpacity, configuration.modelOpacity)
+    }
+
     func testDefaultModelScale() throws {
         let stubbedModelScale = 1.0
         configuration.modelScale = .random(.constant([stubbedModelScale, stubbedModelScale, stubbedModelScale]))

--- a/Tests/MapboxMapsTests/Location/Puck/PuckTypeTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/PuckTypeTests.swift
@@ -138,7 +138,7 @@ internal class PuckTypeTests: XCTestCase {
         let showsAccuracyRing: Bool = .random()
         let accuracyRingColor: UIColor = .random()
         let accuracyRingBorderColor: UIColor = .random()
-        let opacity: CGFloat? = .random(in: 0.0...1.0)
+        let opacity: CGFloat = .random(in: 0.0...1.0)
 
         let config = Puck2DConfiguration(
             topImage: topImage,

--- a/Tests/MapboxMapsTests/Location/Puck/PuckTypeTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/PuckTypeTests.swift
@@ -73,7 +73,7 @@ internal class PuckTypeTests: XCTestCase {
         XCTAssertFalse(config.showsAccuracyRing)
         XCTAssertEqual(config.accuracyRingColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
         XCTAssertEqual(config.accuracyRingBorderColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
-        XCTAssertNil(config.opacity)
+        XCTAssertEqual(config.opacity, 1)
     }
 
     func testPuck2DConfigurationInitializerWithNonDefaultValues() {
@@ -82,7 +82,7 @@ internal class PuckTypeTests: XCTestCase {
         let shadowImage: UIImage? = .random(UIImage())
         let scale: Value<Double>? = .random(.constant(.random(in: 0...10)))
         let showsAccuracyRing: Bool = .random()
-        let opacity: CGFloat? = .random(in: 0.0...1.0)
+        let opacity: CGFloat = .random(in: 0.0...1.0)
 
         let config = Puck2DConfiguration(
             topImage: topImage,
@@ -115,7 +115,7 @@ internal class PuckTypeTests: XCTestCase {
         XCTAssertFalse(config.showsAccuracyRing)
         XCTAssertEqual(config.accuracyRingColor, .black)
         XCTAssertEqual(config.accuracyRingBorderColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
-        XCTAssertNil(config.opacity)
+        XCTAssertEqual(config.opacity, 1)
 
         let config2 = Puck2DConfiguration(
             accuracyRingBorderColor: .black)
@@ -127,7 +127,7 @@ internal class PuckTypeTests: XCTestCase {
         XCTAssertFalse(config2.showsAccuracyRing)
         XCTAssertEqual(config2.accuracyRingColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
         XCTAssertEqual(config2.accuracyRingBorderColor, .black)
-        XCTAssertNil(config.opacity)
+        XCTAssertEqual(config.opacity, 1)
     }
 
     func testPuck2DConfigurationExtendedInitializerWithNonDefaultValues() {

--- a/Tests/MapboxMapsTests/Location/Puck/PuckTypeTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/PuckTypeTests.swift
@@ -73,6 +73,7 @@ internal class PuckTypeTests: XCTestCase {
         XCTAssertFalse(config.showsAccuracyRing)
         XCTAssertEqual(config.accuracyRingColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
         XCTAssertEqual(config.accuracyRingBorderColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
+        XCTAssertNil(config.opacity)
     }
 
     func testPuck2DConfigurationInitializerWithNonDefaultValues() {
@@ -81,13 +82,15 @@ internal class PuckTypeTests: XCTestCase {
         let shadowImage: UIImage? = .random(UIImage())
         let scale: Value<Double>? = .random(.constant(.random(in: 0...10)))
         let showsAccuracyRing: Bool = .random()
+        let opacity: CGFloat? = .random(in: 0.0...1.0)
 
         let config = Puck2DConfiguration(
             topImage: topImage,
             bearingImage: bearingImage,
             shadowImage: shadowImage,
             scale: scale,
-            showsAccuracyRing: showsAccuracyRing)
+            showsAccuracyRing: showsAccuracyRing,
+            opacity: opacity)
 
         XCTAssertTrue(config.topImage === topImage)
         XCTAssertTrue(config.bearingImage === bearingImage)
@@ -96,6 +99,7 @@ internal class PuckTypeTests: XCTestCase {
         XCTAssertEqual(config.showsAccuracyRing, showsAccuracyRing)
         XCTAssertEqual(config.accuracyRingColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
         XCTAssertEqual(config.accuracyRingBorderColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
+        XCTAssertEqual(config.opacity, opacity)
     }
 
     func testPuck2DConfigurationExtendedInitializerWithDefaultValues() {
@@ -111,6 +115,7 @@ internal class PuckTypeTests: XCTestCase {
         XCTAssertFalse(config.showsAccuracyRing)
         XCTAssertEqual(config.accuracyRingColor, .black)
         XCTAssertEqual(config.accuracyRingBorderColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
+        XCTAssertNil(config.opacity)
 
         let config2 = Puck2DConfiguration(
             accuracyRingBorderColor: .black)
@@ -122,6 +127,7 @@ internal class PuckTypeTests: XCTestCase {
         XCTAssertFalse(config2.showsAccuracyRing)
         XCTAssertEqual(config2.accuracyRingColor, UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3))
         XCTAssertEqual(config2.accuracyRingBorderColor, .black)
+        XCTAssertNil(config.opacity)
     }
 
     func testPuck2DConfigurationExtendedInitializerWithNonDefaultValues() {
@@ -132,6 +138,7 @@ internal class PuckTypeTests: XCTestCase {
         let showsAccuracyRing: Bool = .random()
         let accuracyRingColor: UIColor = .random()
         let accuracyRingBorderColor: UIColor = .random()
+        let opacity: CGFloat? = .random(in: 0.0...1.0)
 
         let config = Puck2DConfiguration(
             topImage: topImage,
@@ -140,7 +147,8 @@ internal class PuckTypeTests: XCTestCase {
             scale: scale,
             showsAccuracyRing: showsAccuracyRing,
             accuracyRingColor: accuracyRingColor,
-            accuracyRingBorderColor: accuracyRingBorderColor)
+            accuracyRingBorderColor: accuracyRingBorderColor,
+            opacity: opacity)
 
         XCTAssertTrue(config.topImage === topImage)
         XCTAssertTrue(config.bearingImage === bearingImage)
@@ -149,6 +157,7 @@ internal class PuckTypeTests: XCTestCase {
         XCTAssertEqual(config.showsAccuracyRing, showsAccuracyRing)
         XCTAssertEqual(config.accuracyRingColor, accuracyRingColor)
         XCTAssertEqual(config.accuracyRingBorderColor, accuracyRingBorderColor)
+        XCTAssertEqual(config.opacity, opacity)
     }
 
     func testPuck2DPulsingConfigurationInitializerWithDefaultValues() {

--- a/scripts/api-compatibility-check/breakage_allowlist.txt
+++ b/scripts/api-compatibility-check/breakage_allowlist.txt
@@ -27,3 +27,7 @@ Var FollowPuckViewportStateOptions.animationDuration has been removed
 
 // Added a new parameter with a default value to Puck2DConfiguration constructor(non-source breaking change)
 Constructor Puck2DConfiguration.init(topImage:bearingImage:shadowImage:scale:showsAccuracyRing:) has been removed
+
+// Added a new parameter with a default value to Puck2DConfiguration and Puck3DConfiguration constructor(non-source breaking change)
+Constructor Puck2DConfiguration.init(topImage:bearingImage:shadowImage:scale:showsAccuracyRing:accuracyRingColor:accuracyRingBorderColor:) has been removed
+Constructor Puck3DConfiguration.init(model:modelScale:modelRotation:) has been removed


### PR DESCRIPTION
Expose new location indicator opacity. This new variable allows to set an opacity to the location puck. The new feature can be seen in the Puck3D and Puck 2D examples.

  | Puck3D | Puck2D |
  | ----- | ----- |
  | <video src="https://user-images.githubusercontent.com/44972592/191314825-4cfb4d90-2ff2-473a-9cf9-a3809c395a0b.mp4"> | <video src="https://user-images.githubusercontent.com/44972592/191314889-792f486c-3467-4d09-95bc-a22c0f46ffa5.mp4"> |

## Pull request checklist:
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
