### PR TITLE
Fix GeoJSONData.url incorrectly converting to string

### DIFF
--- a/Sources/MapboxMaps/Style/StyleSourceManager.swift
+++ b/Sources/MapboxMaps/Style/StyleSourceManager.swift
@@ -167,7 +167,7 @@ internal final class StyleSourceManager: StyleSourceManagerProtocol {
         let item = DispatchWorkItem { [weak self] in
             if self == nil { return } // not capturing self here as toString conversion below can take time
 
-            let json = try! data.toString()
+            let json = try! data.stringValue()
 
             self?.mainQueue.async { [weak self] in
                 do {

--- a/Sources/MapboxMaps/Style/Types/GeoJSONSourceData.swift
+++ b/Sources/MapboxMaps/Style/Types/GeoJSONSourceData.swift
@@ -63,6 +63,15 @@ public enum GeoJSONSourceData: Codable {
             try container.encode("")
         }
     }
+
+    internal func stringValue() throws -> String {
+        switch self {
+        case .url(let uRL):
+            return uRL.absoluteString
+        default:
+            return try self.toString()
+        }
+    }
 }
 
 extension GeoJSONObject {

--- a/Tests/MapboxMapsTests/Foundation/Style/StyleSourceManagerTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Style/StyleSourceManagerTests.swift
@@ -331,4 +331,44 @@ final class StyleSourceManagerTests: XCTestCase {
         XCTAssertEqual(params.properties as? NSDictionary, ["type": "geojson", "data": ""] as? NSDictionary)
         XCTAssertEqual(backgroundQueue.asyncWorkItemStub.invocations.count, 1)
     }
+
+    func testAddGeoJSONSourceWithURL() throws {
+        let id = String.randomASCII(withLength: 10)
+        var source = GeoJSONSource()
+        let url = URL(string: "https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson")!
+        source.data = .url(url)
+        backgroundQueue.asyncWorkItemStub.defaultSideEffect = { $0.parameters.perform() }
+        mainQueue.asyncClosureStub.defaultSideEffect = { $0.parameters.work() }
+
+        try sourceManager.addSource(source, id: id)
+
+        XCTAssertEqual(styleManager.addStyleSourceStub.invocations.count, 1)
+        let params = try XCTUnwrap(styleManager.addStyleSourceStub.invocations.first?.parameters)
+        XCTAssertEqual(params.sourceId, id)
+        XCTAssertEqual(params.properties as? NSDictionary, ["type": "geojson", "data": ""] as? NSDictionary)
+        XCTAssertEqual(backgroundQueue.asyncWorkItemStub.invocations.count, 1)
+        XCTAssertEqual(mainQueue.asyncClosureStub.invocations.count, 1)
+        XCTAssertEqual(styleManager.setStyleSourcePropertyStub.invocations.count, 1)
+        let setSourcePropertyParams = try XCTUnwrap(styleManager.setStyleSourcePropertyStub.invocations.first?.parameters)
+        XCTAssertEqual(setSourcePropertyParams.sourceId, id)
+        XCTAssertEqual(setSourcePropertyParams.property, "data")
+        XCTAssertEqual(setSourcePropertyParams.value as? String, url.absoluteString)
+    }
+
+    func testAddGeoJSONSourceWithEmptyData() throws {
+        let id = String.randomASCII(withLength: 10)
+        var source = GeoJSONSource()
+        source.data = .empty
+        backgroundQueue.asyncWorkItemStub.defaultSideEffect = { $0.parameters.perform() }
+        mainQueue.asyncClosureStub.defaultSideEffect = { $0.parameters.work() }
+
+        try sourceManager.addSource(source, id: id)
+
+        XCTAssertEqual(styleManager.addStyleSourceStub.invocations.count, 1)
+        let params = try XCTUnwrap(styleManager.addStyleSourceStub.invocations.first?.parameters)
+        XCTAssertEqual(params.sourceId, id)
+        XCTAssertEqual(params.properties as? NSDictionary, ["type": "geojson", "data": ""] as? NSDictionary)
+        XCTAssertEqual(backgroundQueue.asyncWorkItemStub.invocations.count, 0)
+        XCTAssertEqual(mainQueue.asyncClosureStub.invocations.count, 0)
+    }
 }


### PR DESCRIPTION
`toString()` conversion converts `GeoJSONData.url` case into JSON-wrapped string e.g.: `""http://example.com""`, while core expects urls to be passed as plain strings.

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
