### PR TITLE
Use asynchronous GeoJSON marshaling in annotation managers

### DIFF
--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -154,9 +154,7 @@ public class CircleAnnotationManager: AnnotationManagerInternal {
         // build and update the source data
         let featureCollection = FeatureCollection(features: annotations.map(\.feature))
         do {
-            let data = try JSONEncoder().encode(featureCollection)
-            let jsonObject = try JSONSerialization.jsonObject(with: data) as! [String: Any]
-            try style.setSourceProperty(for: sourceId, property: "data", value: jsonObject)
+            try style.updateGeoJSONSource(withId: sourceId, geoJSON: .featureCollection(featureCollection))
         } catch {
             Log.error(
                 forMessage: "Could not update annotations in CircleAnnotationManager due to error: \(error)",

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -172,9 +172,7 @@ public class PointAnnotationManager: AnnotationManagerInternal {
         // build and update the source data
         let featureCollection = FeatureCollection(features: annotations.map(\.feature))
         do {
-            let data = try JSONEncoder().encode(featureCollection)
-            let jsonObject = try JSONSerialization.jsonObject(with: data) as! [String: Any]
-            try style.setSourceProperty(for: sourceId, property: "data", value: jsonObject)
+            try style.updateGeoJSONSource(withId: sourceId, geoJSON: .featureCollection(featureCollection))
         } catch {
             Log.error(
                 forMessage: "Could not update annotations in PointAnnotationManager due to error: \(error)",

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -154,9 +154,7 @@ public class PolygonAnnotationManager: AnnotationManagerInternal {
         // build and update the source data
         let featureCollection = FeatureCollection(features: annotations.map(\.feature))
         do {
-            let data = try JSONEncoder().encode(featureCollection)
-            let jsonObject = try JSONSerialization.jsonObject(with: data) as! [String: Any]
-            try style.setSourceProperty(for: sourceId, property: "data", value: jsonObject)
+            try style.updateGeoJSONSource(withId: sourceId, geoJSON: .featureCollection(featureCollection))
         } catch {
             Log.error(
                 forMessage: "Could not update annotations in PolygonAnnotationManager due to error: \(error)",

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -154,9 +154,7 @@ public class PolylineAnnotationManager: AnnotationManagerInternal {
         // build and update the source data
         let featureCollection = FeatureCollection(features: annotations.map(\.feature))
         do {
-            let data = try JSONEncoder().encode(featureCollection)
-            let jsonObject = try JSONSerialization.jsonObject(with: data) as! [String: Any]
-            try style.setSourceProperty(for: sourceId, property: "data", value: jsonObject)
+            try style.updateGeoJSONSource(withId: sourceId, geoJSON: .featureCollection(featureCollection))
         } catch {
             Log.error(
                 forMessage: "Could not update annotations in PolylineAnnotationManager due to error: \(error)",

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -16,6 +16,7 @@ internal protocol StyleProtocol: AnyObject {
     func sourceExists(withId id: String) -> Bool
     func setSourceProperty(for sourceId: String, property: String, value: Any) throws
     func setSourceProperties(for sourceId: String, properties: [String: Any]) throws
+    func updateGeoJSONSource(withId id: String, geoJSON: GeoJSONObject) throws
 
     //swiftlint:disable function_parameter_count
     func addImage(_ image: UIImage,

--- a/Tests/MapboxMapsTests/Style/Mocks/MockStyle.swift
+++ b/Tests/MapboxMapsTests/Style/Mocks/MockStyle.swift
@@ -133,4 +133,13 @@ final class MockStyle: StyleProtocol {
     func addImage(_ image: UIImage, id: String, sdf: Bool, contentInsets: UIEdgeInsets) throws {
         addImageWithInsetsStub.call(with: .init(image: image, id: id, sdf: sdf, contentInsets: contentInsets))
     }
+
+    struct UpdateGeoJSONSourceParams {
+        let id: String
+        let geojson: GeoJSONObject
+    }
+    let updateGeoJSONSourceStub = Stub<UpdateGeoJSONSourceParams, Void>()
+    func updateGeoJSONSource(withId id: String, geoJSON: GeoJSONObject) throws {
+        updateGeoJSONSourceStub.call(with: UpdateGeoJSONSourceParams(id: id, geojson: geoJSON))
+    }
 }


### PR DESCRIPTION
This PR updates Circle/Point/Polygon/Polyline annotation managers to use asynchronous GeoJSON update API.
## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
         TBD separately

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
