### PR TITLE
Update update-version.sh to have recommended format for CFBundleShortVersionString

### DIFF
--- a/scripts/release/update-version.sh
+++ b/scripts/release/update-version.sh
@@ -20,7 +20,7 @@ fi
 
 SEM_VERSION=$1
 SEM_VERSION=${SEM_VERSION/#v}
-SHORT_VERSION=${SEM_VERSION%-*}
+SHORT_VERSION=${SEM_VERSION%%-*}
 
 brew_install_if_needed jq
 


### PR DESCRIPTION
> The required format is three period-separated integers, such as 10.14.1. The string can only contain numeric characters (0-9) and periods.

[CFBundleShortVersionString](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring)

As discussed yesterday with @evil159 we found out that the short version does not match the recommended/required format by Apply if our semantic version is as following `x.y.z-beta.1-something`