### PR TITLE
[MAPSIOS-337] fix style localizeLabel for zh locale

### DIFF
--- a/Sources/MapboxMaps/Style/Style+Localization.swift
+++ b/Sources/MapboxMaps/Style/Style+Localization.swift
@@ -60,6 +60,8 @@ extension Style {
                     // Return traditional chinese if the Locale is Taiwan
                     if locale.identifier == "zh-Hant-TW" {
                         return "zh-Hant"
+                    } else {
+                        return "zh-Hans"
                     }
                 }
             }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

Streets source does not support generic `zh` locale in v8. instead, it supports `zh-Hans` and `zh-Hant` fields. 
When providing `zh` locale to `Style.localizeLabel`, it doesn't fallback to any language, resulting in non-localized labels.

In android, we fallback to `zh-Hans` for this specific case. This pr uses same fallback strategy.

| Before | After |
| ----- | ----- |
| <video src="https://user-images.githubusercontent.com/11589497/192527360-9fe8ac86-6930-40c1-8537-568250ef1951.mp4" width = 250/> | <video src="https://user-images.githubusercontent.com/11589497/192527387-321cc6f9-0424-435c-af3a-a68594aa5be7.mp4" width = 250/> |




## Pull request checklist:
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [x] If this PR is a `v10.9` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
