### PR TITLE
Resolve initial view annotation placement issue

### DIFF
--- a/Sources/MapboxMaps/Annotations/ViewAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/ViewAnnotationManager.swift
@@ -149,15 +149,17 @@ public final class ViewAnnotationManager {
         }
 
         view.translatesAutoresizingMaskIntoConstraints = false
+        view.isHidden = true 
 
         let id = id ?? UUID().uuidString
         try mapboxMap.addViewAnnotation(withId: id, options: creationOptions)
         viewsById[id] = view
         idsByView[view] = id
-        expectedHiddenByView[view] = !(creationOptions.visible ?? true)
+        expectedHiddenByView[view] = true
         if let featureId = creationOptions.associatedFeatureId {
             viewsByFeatureIds[featureId] = view
         }
+        containerView.addSubview(view)
     }
 
     /// Remove given `UIView` from the map if it was present.

--- a/Sources/MapboxMaps/Annotations/ViewAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/ViewAnnotationManager.swift
@@ -158,7 +158,6 @@ public final class ViewAnnotationManager {
         if let featureId = creationOptions.associatedFeatureId {
             viewsByFeatureIds[featureId] = view
         }
-        containerView.addSubview(view)
     }
 
     /// Remove given `UIView` from the map if it was present.

--- a/Sources/MapboxMaps/Annotations/ViewAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/ViewAnnotationManager.swift
@@ -149,7 +149,7 @@ public final class ViewAnnotationManager {
         }
 
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.isHidden = true 
+        view.isHidden = true
 
         let id = id ?? UUID().uuidString
         try mapboxMap.addViewAnnotation(withId: id, options: creationOptions)

--- a/Tests/MapboxMapsTests/Annotations/ViewAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/ViewAnnotationManagerTests.swift
@@ -336,7 +336,7 @@ final class ViewAnnotationManagerTests: XCTestCase {
         XCTAssertTrue(observer.framesDidChangeStub.invocations.isEmpty)
     }
 
-    func testViewAnnotationUpdateObserverNotifiedAboutNewlyHiddenViews() {
+    func testViewAnnotationUpdateObserverConfirmsNewlyAddedViewsAreHidden() {
         let annotationView = addTestAnnotationView()
         let observer = MockViewAnnotationUpdateObserver()
         manager.addViewAnnotationUpdateObserver(observer)

--- a/Tests/MapboxMapsTests/Annotations/ViewAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/ViewAnnotationManagerTests.swift
@@ -222,6 +222,9 @@ final class ViewAnnotationManagerTests: XCTestCase {
         let annotationView = addTestAnnotationView()
         let id = mapboxMap.addViewAnnotationStub.invocations.last!.parameters.id
 
+        // Annotation is correctly hidden when first added to map
+        XCTAssertTrue(annotationView.isHidden)
+
         // Position update should also call validation
         triggerPositionUpdate(forId: id)
         XCTAssertEqual(mapboxMap.removeViewAnnotationStub.invocations.count, 0)

--- a/Tests/MapboxMapsTests/Annotations/ViewAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/ViewAnnotationManagerTests.swift
@@ -296,9 +296,9 @@ final class ViewAnnotationManagerTests: XCTestCase {
         let annotationViewB = addTestAnnotationView()
         let annotationViewC = addTestAnnotationView()
 
-        XCTAssertFalse(annotationViewA.isHidden)
-        XCTAssertFalse(annotationViewB.isHidden)
-        XCTAssertFalse(annotationViewC.isHidden)
+        XCTAssertTrue(annotationViewA.isHidden)
+        XCTAssertTrue(annotationViewB.isHidden)
+        XCTAssertTrue(annotationViewC.isHidden)
 
         manager.onViewAnnotationPositionsUpdate(forPositions: [ViewAnnotationPositionDescriptor(
             identifier: "test-id",
@@ -344,7 +344,7 @@ final class ViewAnnotationManagerTests: XCTestCase {
         manager.onViewAnnotationPositionsUpdate(forPositions: [])
 
         XCTAssertTrue(annotationView.isHidden)
-        XCTAssertEqual(observer.visibilityDidChangeStub.invocations.first?.parameters, [annotationView])
+        XCTAssertTrue(observer.visibilityDidChangeStub.invocations.isEmpty)
     }
 
     func testViewAnnotationUpdateObserverNotifiedAboutNewlyVisibleViews() {


### PR DESCRIPTION
Removed the addition of view annotation to the containerView, which caused the view annotation to initially load in the top left corner. 