### PR TITLE
Move location provider heading orientation update frequency

### DIFF
--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -399,7 +399,8 @@ open class MapView: UIView {
 
         // Initialize/Configure location source and location manager
         locationProducer = dependencyProvider.makeLocationProducer(
-            mayRequestWhenInUseAuthorization: bundle.infoDictionary?["NSLocationWhenInUseUsageDescription"] != nil, userInterfaceOrientationView: self)
+            mayRequestWhenInUseAuthorization: bundle.infoDictionary?["NSLocationWhenInUseUsageDescription"] != nil,
+            userInterfaceOrientationView: self)
         let interpolatedLocationProducer = dependencyProvider.makeInterpolatedLocationProducer(
             locationProducer: locationProducer,
             displayLinkCoordinator: self)
@@ -622,7 +623,6 @@ open class MapView: UIView {
 
         cameraAnimatorsRunnerEnablable.isEnabled = true
 
-        locationProducer.updateHeadingOrientationIfNeeded()
         updateDisplayLinkPreferredFramesPerSecond()
         displayLink.add(to: .current, forMode: .common)
     }

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -440,6 +440,8 @@ open class MapView: UIView {
     }
 
     deinit {
+        displayLink?.invalidate()
+        headingOrientationUpdateTimer?.invalidate()
         cameraAnimatorsRunner.cancelAnimations()
         cameraAnimatorsRunnerEnablable.isEnabled = false
     }
@@ -568,8 +570,6 @@ open class MapView: UIView {
             return
         }
 
-        updateHeadingOrientationIfNeeded()
-
         for participant in displayLinkParticipants.allObjects {
             participant.participate()
         }
@@ -630,7 +630,16 @@ open class MapView: UIView {
 
         updateDisplayLinkPreferredFramesPerSecond()
         displayLink.add(to: .current, forMode: .common)
+
+        headingOrientationUpdateTimer?.invalidate()
+        headingOrientationUpdateTimer = nil
+
+        headingOrientationUpdateTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] timer in
+            self?.updateHeadingOrientationIfNeeded()
+        }
     }
+
+    private var headingOrientationUpdateTimer: Timer?
 
     // MARK: Location
 

--- a/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
+++ b/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
@@ -15,7 +15,7 @@ internal protocol MapViewDependencyProviderProtocol: AnyObject {
                             mapboxMap: MapboxMapProtocol,
                             cameraAnimationsManager: CameraAnimationsManagerProtocol) -> GestureManager
     func makeLocationProducer(mayRequestWhenInUseAuthorization: Bool,
-                                       userInterfaceOrientationView: UIView) -> LocationProducerProtocol
+                              userInterfaceOrientationView: UIView) -> LocationProducerProtocol
     func makeInterpolatedLocationProducer(locationProducer: LocationProducerProtocol,
                                           displayLinkCoordinator: DisplayLinkCoordinator) -> InterpolatedLocationProducerProtocol
     func makeLocationManager(locationProducer: LocationProducerProtocol,

--- a/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
+++ b/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
@@ -228,6 +228,7 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
             interfaceOrientationProvider: interfaceOrientationProvider,
             notificationCenter: notificationCenter,
             userInterfaceOrientationView: userInterfaceOrientationView,
+            device: .current,
             mayRequestWhenInUseAuthorization: mayRequestWhenInUseAuthorization)
     }
 

--- a/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
+++ b/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
@@ -14,7 +14,8 @@ internal protocol MapViewDependencyProviderProtocol: AnyObject {
     func makeGestureManager(view: UIView,
                             mapboxMap: MapboxMapProtocol,
                             cameraAnimationsManager: CameraAnimationsManagerProtocol) -> GestureManager
-    func makeLocationProducer(mayRequestWhenInUseAuthorization: Bool) -> LocationProducerProtocol
+    func makeLocationProducer(mayRequestWhenInUseAuthorization: Bool,
+                                       userInterfaceOrientationView: UIView) -> LocationProducerProtocol
     func makeInterpolatedLocationProducer(locationProducer: LocationProducerProtocol,
                                           displayLinkCoordinator: DisplayLinkCoordinator) -> InterpolatedLocationProducerProtocol
     func makeLocationManager(locationProducer: LocationProducerProtocol,
@@ -40,6 +41,11 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
     internal let cameraAnimatorsRunnerEnablable: MutableEnablableProtocol = Enablable()
     private let gesturesCameraAnimatorsRunnerEnablable = Enablable()
     private let mainQueue: MainQueueProtocol = MainQueueWrapper()
+    private let interfaceOrientationProvider: InterfaceOrientationProvider
+
+    internal init(interfaceOrientationProvider: InterfaceOrientationProvider) {
+        self.interfaceOrientationProvider = interfaceOrientationProvider
+    }
 
     internal func makeMetalView(frame: CGRect, device: MTLDevice?) -> MTKView {
         MTKView(frame: frame, device: device)
@@ -214,10 +220,14 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
             mapboxMap: mapboxMap)
     }
 
-    internal func makeLocationProducer(mayRequestWhenInUseAuthorization: Bool) -> LocationProducerProtocol {
+    internal func makeLocationProducer(mayRequestWhenInUseAuthorization: Bool,
+                                       userInterfaceOrientationView: UIView) -> LocationProducerProtocol {
         let locationProvider = AppleLocationProvider()
         return LocationProducer(
             locationProvider: locationProvider,
+            interfaceOrientationProvider: interfaceOrientationProvider,
+            notificationCenter: notificationCenter,
+            userInterfaceOrientationView: userInterfaceOrientationView,
             mayRequestWhenInUseAuthorization: mayRequestWhenInUseAuthorization)
     }
 

--- a/Sources/MapboxMaps/Location/AppleLocationProvider.swift
+++ b/Sources/MapboxMaps/Location/AppleLocationProvider.swift
@@ -12,9 +12,14 @@ public final class AppleLocationProvider: NSObject {
     }
     private weak var delegate: LocationProviderDelegate?
 
+    public var headingOrientation: CLDeviceOrientation {
+        didSet { locationProvider.headingOrientation = headingOrientation }
+    }
+
     public override init() {
         locationProvider = CLLocationManager()
         privateLocationProviderOptions = LocationOptions()
+        headingOrientation = locationProvider.headingOrientation
         super.init()
         locationProvider.delegate = self
     }
@@ -70,11 +75,6 @@ extension AppleLocationProvider: LocationProvider {
 
     public func stopUpdatingLocation() {
         locationProvider.stopUpdatingLocation()
-    }
-
-    public var headingOrientation: CLDeviceOrientation {
-        get { locationProvider.headingOrientation }
-        set { locationProvider.headingOrientation = newValue }
     }
 
     public func startUpdatingHeading() {

--- a/Sources/MapboxMaps/Location/LocationProducer.swift
+++ b/Sources/MapboxMaps/Location/LocationProducer.swift
@@ -157,8 +157,10 @@ internal final class LocationProducer: LocationProducerProtocol {
         // on user interface orientation change
         // not sure if this is needed at all
         let backupTimerInterval: TimeInterval = 3
-        headingOrientationUpdateBackupTimer = Timer.scheduledTimer(withTimeInterval: backupTimerInterval, repeats: true)
-        { [weak self] _ in
+        headingOrientationUpdateBackupTimer = Timer.scheduledTimer(
+            withTimeInterval: backupTimerInterval,
+            repeats: true
+        ) { [weak self] _ in
             self?.updateHeadingOrientationIfNeeded(showWarning: true)
         }
         headingOrientationUpdateBackupTimer?.tolerance = 0.5

--- a/Sources/MapboxMaps/Location/LocationProducer.swift
+++ b/Sources/MapboxMaps/Location/LocationProducer.swift
@@ -107,6 +107,7 @@ internal final class LocationProducer: LocationProducerProtocol {
 
     private let interfaceOrientationProvider: InterfaceOrientationProvider
     private let notificationCenter: NotificationCenterProtocol
+    private let device: UIDevice
     private var mayRequestWhenInUseAuthorization: Bool
     private var headingOrientationUpdateBackupTimer: Timer?
     private weak var userInterfaceOrientationView: UIView?
@@ -115,6 +116,7 @@ internal final class LocationProducer: LocationProducerProtocol {
                   interfaceOrientationProvider: InterfaceOrientationProvider,
                   notificationCenter: NotificationCenterProtocol,
                   userInterfaceOrientationView: UIView,
+                  device: UIDevice,
                   mayRequestWhenInUseAuthorization: Bool) {
         self.locationProvider = locationProvider
         self.notificationCenter = notificationCenter
@@ -122,6 +124,7 @@ internal final class LocationProducer: LocationProducerProtocol {
         self.latestAccuracyAuthorization = locationProvider.accuracyAuthorization
         self.interfaceOrientationProvider = interfaceOrientationProvider
         self.userInterfaceOrientationView = userInterfaceOrientationView
+        self.device = device
         self.locationProvider.setDelegate(self)
     }
 
@@ -160,7 +163,7 @@ internal final class LocationProducer: LocationProducerProtocol {
         }
         headingOrientationUpdateBackupTimer?.tolerance = 0.5
 
-        UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+        device.beginGeneratingDeviceOrientationNotifications()
         notificationCenter.addObserver(self,
                                        selector: #selector(deviceOrientationDidChange),
                                        name: UIDevice.orientationDidChangeNotification,
@@ -171,7 +174,7 @@ internal final class LocationProducer: LocationProducerProtocol {
         headingOrientationUpdateBackupTimer?.invalidate()
         headingOrientationUpdateBackupTimer = nil
 
-        UIDevice.current.endGeneratingDeviceOrientationNotifications()
+        device.endGeneratingDeviceOrientationNotifications()
         notificationCenter.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
     }
 
@@ -194,7 +197,6 @@ internal final class LocationProducer: LocationProducerProtocol {
         if locationProvider.headingOrientation != headingOrientation {
             locationProvider.headingOrientation = headingOrientation
             if showWarning {
-                assertionFailure("User interface should be updated by the `UIDevice.orientationDidChangeNotification` notification")
                 Log.warning(forMessage: "Unexpected user interface orientation change was detected. Please file an issue at https://github.com/mapbox/mapbox-maps-ios/issues")
             }
         }

--- a/Sources/MapboxMaps/Location/LocationProducer.swift
+++ b/Sources/MapboxMaps/Location/LocationProducer.swift
@@ -152,10 +152,11 @@ internal final class LocationProducer: LocationProducerProtocol {
     private func startUpdatingInterfaceOrientation() {
         // backup timer if there are some cases when `UIDevice.orientationDidChangeNotification` is not fired
         // on user interface orientation change
+        // not sure if this is needed at all
         let backupTimerInterval: TimeInterval = 3
         headingOrientationUpdateBackupTimer = Timer.scheduledTimer(withTimeInterval: backupTimerInterval, repeats: true)
         { [weak self] _ in
-            self?.updateHeadingOrientationIfNeeded()
+            self?.updateHeadingOrientationIfNeeded(showWarning: true)
         }
         headingOrientationUpdateBackupTimer?.tolerance = 0.5
 
@@ -179,6 +180,10 @@ internal final class LocationProducer: LocationProducerProtocol {
     }
 
     internal func updateHeadingOrientationIfNeeded() {
+        updateHeadingOrientationIfNeeded(showWarning: false)
+    }
+
+    private func updateHeadingOrientationIfNeeded(showWarning: Bool) {
         guard let view = userInterfaceOrientationView,
               let headingOrientation = interfaceOrientationProvider.headingOrientation(for: view) else {
             return
@@ -188,6 +193,10 @@ internal final class LocationProducer: LocationProducerProtocol {
         // so we only set it when it changes to avoid unnecessary work.
         if locationProvider.headingOrientation != headingOrientation {
             locationProvider.headingOrientation = headingOrientation
+            if showWarning {
+                assertionFailure("User interface should be updated by the `UIDevice.orientationDidChangeNotification` notification")
+                Log.warning(forMessage: "Unexpected user interface orientation change was detected. Please file an issue at https://github.com/mapbox/mapbox-maps-ios/issues")
+            }
         }
     }
 

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -9,7 +9,6 @@ final class MapViewTests: XCTestCase {
     var displayLink: MockDisplayLink!
     var locationProducer: MockLocationProducer!
     var dependencyProvider: MockMapViewDependencyProvider!
-    var orientationProvider: MockInterfaceOrientationProvider!
     var attributionURLOpener: MockAttributionURLOpener!
     var mapView: MapView!
     var window: UIWindow!
@@ -28,13 +27,11 @@ final class MapViewTests: XCTestCase {
         dependencyProvider.cameraAnimatorsRunnerEnablable = cameraAnimatorsRunnerEnablable
         dependencyProvider.makeDisplayLinkStub.defaultReturnValue = displayLink
         dependencyProvider.makeLocationProducerStub.defaultReturnValue = locationProducer
-        orientationProvider = MockInterfaceOrientationProvider()
         attributionURLOpener = MockAttributionURLOpener()
         mapView = MapView(
             frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)),
             mapInitOptions: MapInitOptions(),
             dependencyProvider: dependencyProvider,
-            orientationProvider: orientationProvider,
             urlOpener: attributionURLOpener)
         window = UIWindow()
         window.addSubview(mapView)
@@ -49,7 +46,6 @@ final class MapViewTests: XCTestCase {
         window = nil
         mapView = nil
         attributionURLOpener = nil
-        orientationProvider = nil
         dependencyProvider = nil
         locationProducer = nil
         displayLink = nil
@@ -99,7 +95,6 @@ final class MapViewTests: XCTestCase {
             frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)),
             mapInitOptions: MapInitOptions(),
             dependencyProvider: dependencyProvider,
-            orientationProvider: orientationProvider,
             urlOpener: attributionURLOpener)
 
         XCTAssertEqual(cameraAnimatorsRunnerEnablable.$isEnabled.setStub.invocations.map(\.parameters), [false])
@@ -125,7 +120,6 @@ final class MapViewTests: XCTestCase {
             frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)),
             mapInitOptions: MapInitOptions(),
             dependencyProvider: dependencyProvider,
-            orientationProvider: orientationProvider,
             urlOpener: attributionURLOpener)
         let runner = try XCTUnwrap(dependencyProvider.makeCameraAnimatorsRunnerStub.invocations.first?.returnValue as? MockCameraAnimatorsRunner)
         runner.cancelAnimationsStub.reset()
@@ -279,23 +273,6 @@ final class MapViewTests: XCTestCase {
         XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [false])
     }
 
-    func testOrientationProviderIsUsed() throws {
-        try invokeDisplayLinkCallback()
-
-        XCTAssertEqual(orientationProvider.interfaceOrientationStub.invocations.count, 1)
-    }
-
-    func testOrientationChangeIsPropagated() throws {
-        let orientations: [UIInterfaceOrientation] = [.portrait, .landscapeLeft, .landscapeRight, .portraitUpsideDown]
-        for orientation in orientations {
-            orientationProvider.interfaceOrientationStub.defaultReturnValue = orientation
-
-            try invokeDisplayLinkCallback()
-
-            XCTAssertEqual(locationProducer.headingOrientation, CLDeviceOrientation(interfaceOrientation: orientation))
-        }
-    }
-
     func testURLOpener() {
         let manager = AttributionDialogManager(dataSource: MockAttributionDataSource(), delegate: MockAttributionDialogManagerDelegate())
         let url = URL(string: "http://example.com")!
@@ -342,7 +319,6 @@ final class MapViewTestsWithScene: XCTestCase {
             frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)),
             mapInitOptions: MapInitOptions(),
             dependencyProvider: dependencyProvider,
-            orientationProvider: orientationProvider,
             urlOpener: attributionURLOpener)
         window = UIWindow()
         window.addSubview(mapView)
@@ -403,7 +379,6 @@ final class MapViewTestsWithScene: XCTestCase {
             frame: CGRect(origin: .zero, size: mapViewSize),
             mapInitOptions: MapInitOptions(),
             dependencyProvider: dependencyProvider,
-            orientationProvider: orientationProvider,
             urlOpener: attributionURLOpener)
 
         let metalView = mapView.getMetalView(for: nil)
@@ -427,7 +402,6 @@ final class MapViewTestsWithScene: XCTestCase {
             frame: CGRect(origin: .zero, size: mapViewSize),
             mapInitOptions: MapInitOptions(),
             dependencyProvider: dependencyProvider,
-            orientationProvider: orientationProvider,
             urlOpener: attributionURLOpener)
 
         let metalView = mapView.getMetalView(for: nil)

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
@@ -73,9 +73,18 @@ final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
         return GestureHandler(gestureRecognizer: UIGestureRecognizer())
     }
 
-    let makeLocationProducerStub = Stub<Bool, MockLocationProducer>(defaultReturnValue: MockLocationProducer())
-    func makeLocationProducer(mayRequestWhenInUseAuthorization: Bool) -> LocationProducerProtocol {
-        return makeLocationProducerStub.call(with: mayRequestWhenInUseAuthorization)
+    struct MakeLocationProducerParameteres {
+        let mayRequestWhenInUseAuthorization: Bool
+        let userInterfaceOrientationView: UIView
+    }
+    let makeLocationProducerStub = Stub<MakeLocationProducerParameteres, MockLocationProducer>(defaultReturnValue: MockLocationProducer())
+    func makeLocationProducer(mayRequestWhenInUseAuthorization: Bool, userInterfaceOrientationView: UIView) -> MapboxMaps.LocationProducerProtocol {
+        return makeLocationProducerStub.call(with:
+                .init(
+                    mayRequestWhenInUseAuthorization: mayRequestWhenInUseAuthorization,
+                    userInterfaceOrientationView: userInterfaceOrientationView
+                )
+        )
     }
 
     func makeInterpolatedLocationProducer(locationProducer: LocationProducerProtocol,

--- a/Tests/MapboxMapsTests/Location/LocationProducerTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationProducerTests.swift
@@ -19,6 +19,7 @@ final class LocationProducerTests: XCTestCase {
         interfaceOrientationProvider = MockInterfaceOrientationProvider()
         notificationCenter = MockNotificationCenter()
         userInterfaceOrientationView = UIView()
+        // swiftlint:disable:next discouraged_direct_init
         device = UIDevice()
         locationProducer = LocationProducer(
             locationProvider: locationProvider,

--- a/Tests/MapboxMapsTests/Location/Mocks/MockLocationProducer.swift
+++ b/Tests/MapboxMapsTests/Location/Mocks/MockLocationProducer.swift
@@ -25,4 +25,10 @@ final class MockLocationProducer: LocationProducerProtocol {
     func remove(_ consumer: LocationConsumer) {
         removeStub.call(with: consumer)
     }
+
+    let updateHeadingOrientationIfNeededStub = Stub<Void, Void>()
+    func updateHeadingOrientationIfNeeded() {
+        updateHeadingOrientationIfNeededStub.call()
+    }
+
 }

--- a/Tests/MapboxMapsTests/Location/Mocks/MockLocationProvider.swift
+++ b/Tests/MapboxMapsTests/Location/Mocks/MockLocationProvider.swift
@@ -11,7 +11,7 @@ final class MockLocationProvider: LocationProvider {
 
     var heading: CLHeading?
 
-    var headingOrientation: CLDeviceOrientation = .unknown
+    @Stubbed var headingOrientation: CLDeviceOrientation = .unknown
 
     let setDelegateStub = Stub<LocationProviderDelegate, Void>()
     func setDelegate(_ delegate: LocationProviderDelegate) {


### PR DESCRIPTION
Location provider's heading orientation seems to be updated unnecessary often(every frame), this PR reduces the frequency of interface orientation polling to 3s to keep it as a back up and introduces `UIDevice.orientationDidChangeNotification` as a primary trigger for heading orientation updates. Additionally, the heading orientation update handling is moved into location producer class.

| Before | After |
| ----- | ----- |
| <video src="https://user-images.githubusercontent.com/1478430/193757167-a43bf437-6caf-4cdc-907c-ec27042f756e.MP4" width = 400/> | <video src="https://user-images.githubusercontent.com/1478430/193757808-4100fe26-0e2f-42af-ba84-f1a267e3442f.MP4" width = 400/> |
| Virtually no difference between the two |

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
