### PR TITLE
Change default bearing source for Custom2DPuckExample

### DIFF
--- a/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
@@ -30,7 +30,7 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
         }
     }
 
-    private var bearingSource: PuckBearingSource = .course {
+    private var bearingSource: PuckBearingSource = .heading {
         didSet {
             mapView.location.options.puckBearingSource = bearingSource
         }
@@ -165,7 +165,7 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
 
         // Granularly configure the location puck with a `Puck2DConfiguration`
         mapView.location.options.puckType = .puck2D(puckConfiguration)
-        mapView.location.options.puckBearingSource = .course
+        mapView.location.options.puckBearingSource = .heading
 
         // Center map over the user's current location
         mapView.mapboxMap.onNext(event: .mapLoaded, handler: { [weak self] _ in


### PR DESCRIPTION
As examples app more likely to be used in a work environment(stationary) `.heading` bearing source makes for a more illustrative example.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
