### PR TITLE
Smooth reduced accuracy ring radius interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+## 10.9.0-rc.1
+
+* Fix accuracy ring radius jumping when zooming the map in/out with `.reducedAccuracy` location authorization.([#1625](https://github.com/mapbox/mapbox-maps-ios/pull/1625))
+
 ## 10.9.0-beta.2 - September 29, 2022
 
 * Replace MapboxMobileEvents dependency with CoreTelemetry (part of MapboxCommon). ([#1379](https://github.com/mapbox/mapbox-maps-ios/pull/1379))

--- a/Sources/MapboxMaps/Location/Puck/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck2D.swift
@@ -167,11 +167,13 @@ internal final class Puck2D: Puck {
                 [Expression.Operator.linear.rawValue],
                 [Expression.Operator.zoom.rawValue],
                 0,
-                400000,
+                200_000,
                 4,
-                200000,
+                50_000,
+                6,
+                20_000,
                 8,
-                5000]
+                location.horizontalAccuracy]
             newLayerPaintProperties[.accuracyRadiusColor] = StyleColor(configuration.accuracyRingColor).rgbaString
             newLayerPaintProperties[.accuracyRadiusBorderColor] = StyleColor(configuration.accuracyRingBorderColor).rgbaString
         }

--- a/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
@@ -427,7 +427,12 @@ final class Puck2DTests: XCTestCase {
     }
 
     func testActivatingPuckWithReducedAccuracy() throws {
-        let location = updateLocation(with: .reducedAccuracy, heading: .random(in: 0..<360))
+        let accuracy: CLLocationAccuracy = .random(in: 1_000..<20_000)
+        let location = updateLocation(
+            with: .reducedAccuracy,
+            heading: .random(in: 0..<360),
+            horizontalAccuracy: accuracy
+        )
         style.layerExistsStub.defaultReturnValue = false
 
         puck2D.isActive = true
@@ -445,11 +450,13 @@ final class Puck2DTests: XCTestCase {
             ["linear"],
             ["zoom"],
             0,
-            400000,
+            200_000,
             4,
-            200000,
+            50_000,
+            6,
+            20_000,
             8,
-            5000]
+            accuracy]
         expectedProperties["accuracy-radius-color"] = StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)).rgbaString
         expectedProperties["accuracy-radius-border-color"] = StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)).rgbaString
         let actualProperties = try XCTUnwrap(style.addPersistentLayerWithPropertiesStub.invocations.first?.parameters.properties)
@@ -467,7 +474,8 @@ final class Puck2DTests: XCTestCase {
         // there are a bunch of properties that aren't used in "reduced" mode
         // and they should be reset to their default values if the layer already
         // existed
-        let location = updateLocation(with: .reducedAccuracy, heading: nil)
+        let accuracy: CLLocationAccuracy = .random(in: 1_000..<20_000)
+        let location = updateLocation(with: .reducedAccuracy, heading: nil, horizontalAccuracy: accuracy)
 
         var expectedProperties = [String: Any]()
         expectedProperties["location"] = [
@@ -480,11 +488,13 @@ final class Puck2DTests: XCTestCase {
             ["linear"],
             ["zoom"],
             0,
-            400000,
+            200_000,
             4,
-            200000,
+            50_000,
+            6,
+            20_000,
             8,
-            5000]
+            accuracy]
         expectedProperties["accuracy-radius-color"] = StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)).rgbaString
         expectedProperties["accuracy-radius-border-color"] = StyleColor(UIColor(red: 0.537, green: 0.812, blue: 0.941, alpha: 0.3)).rgbaString
         for key in originalKeys where expectedProperties[key] == nil {


### PR DESCRIPTION
This PR adjusts interpolation steps of `reducedAccuracy`'s authorization accuracy ring radius to eliminate sudden changes of the ring radius. Additionally on higher zoom levels(>=8) radius of the accuracy ring is set to reflect the accuracy received from location provider.

### Zoom out
| Before | After |
| ----- | ----- |
| <video src="https://user-images.githubusercontent.com/1478430/194303560-8c61c5de-5a0a-431c-a536-cf32903bd99a.MP4" width = 250/> | <video src="https://user-images.githubusercontent.com/1478430/194303595-7d31dd03-ea58-4a44-bc13-bf2f19a7605d.MP4" width = 250/> |

### Zoom in
| Before | After |
| ----- | ----- |
| <video src="https://user-images.githubusercontent.com/1478430/194303772-b734a454-7570-4b25-b36d-ff63b4c59b16.MP4" width = 250/> | <video src="https://user-images.githubusercontent.com/1478430/194303854-3960a6ff-caf7-4a84-a9d5-4a756947edc0.mp4" width = 250/> |

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
