### PR TITLE
Prevent view annotation being shown erroneously after options update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 * Fix behavior with initial view annotation placement.([#1604](https://github.com/mapbox/mapbox-maps-ios/pull/1604)
 * Fix behavior where selected view annotation is not moved to correct z-order.([#1607](https://github.com/mapbox/mapbox-maps-ios/pull/1607)
+* Prevent view annotation being shown erroneously after options update.([#1627](https://github.com/mapbox/mapbox-maps-ios/pull/1627))
 
 ## 10.9.0-beta.2 - September 29, 2022
 

--- a/Sources/MapboxMaps/Annotations/ViewAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/ViewAnnotationManager.swift
@@ -220,7 +220,7 @@ public final class ViewAnnotationManager {
         let currentFeatureId = try? mapboxMap.options(forViewAnnotationWithId: id).associatedFeatureId
         try mapboxMap.updateViewAnnotation(withId: id, options: options)
 
-        if let visible = options.visible, visible == false {
+        if options.visible == false {
             expectedHiddenByView[view] = true
             view.isHidden = true
         }

--- a/Sources/MapboxMaps/Annotations/ViewAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/ViewAnnotationManager.swift
@@ -219,9 +219,12 @@ public final class ViewAnnotationManager {
         }
         let currentFeatureId = try? mapboxMap.options(forViewAnnotationWithId: id).associatedFeatureId
         try mapboxMap.updateViewAnnotation(withId: id, options: options)
-        let isHidden = !(options.visible ?? true)
-        expectedHiddenByView[view] = isHidden
-        viewsById[id]?.isHidden = isHidden
+
+        if let visible = options.visible, visible == false {
+            expectedHiddenByView[view] = true
+            view.isHidden = true
+        }
+
         if let id = currentFeatureId, let updatedId = options.associatedFeatureId, id != updatedId {
             viewsByFeatureIds[id] = nil
         }

--- a/Tests/MapboxMapsTests/Annotations/ViewAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/ViewAnnotationManagerTests.swift
@@ -333,6 +333,17 @@ final class ViewAnnotationManagerTests: XCTestCase {
         XCTAssertTrue(annotationViewC.isHidden)
     }
 
+    func testViewAnnotationUpdateDoesNotUnhideHiddenViews() throws {
+        let annotationView = addTestAnnotationView()
+        let id = try XCTUnwrap(mapboxMap.addViewAnnotationStub.invocations.last?.parameters.id)
+
+        manager.onViewAnnotationPositionsUpdate(forPositions: [])
+
+        try manager.update(annotationView, options: ViewAnnotationOptions())
+
+        XCTAssertTrue(annotationView.isHidden)
+    }
+
     func testViewAnnotationUpdateObserverNotifiedAboutUpdatedFrames() throws {
         let annotationView = addTestAnnotationView()
         let id = try XCTUnwrap(mapboxMap.addViewAnnotationStub.invocations.last?.parameters.id)


### PR DESCRIPTION
Updating options for an off-screen annotation with `visibility` set to `true` unhides the corresponding view which may result in it being displayed on top of the map. This PR addresses this issue by preventing updated view annotation to be un-hidden during the update. 
With this change view annotation are only shown as a result of view annotation position update event.


## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
