### PR TITLE
Improve reduced accuracy authorization location indicator behavior while zooming

### DIFF
--- a/Sources/MapboxMaps/Location/Puck/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck2D.swift
@@ -347,8 +347,8 @@ private extension Puck2DConfiguration.Pulsing.Radius {
     }
 }
 
-private extension ClosedRange where Bound == Double {
-    var magnitude: Double {
+internal extension ClosedRange where Bound: AdditiveArithmetic {
+    var magnitude: Bound {
         return upperBound - lowerBound
     }
 }

--- a/Sources/MapboxMaps/Location/Puck/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck2D.swift
@@ -162,6 +162,20 @@ internal final class Puck2D: Puck {
         case .reducedAccuracy:
             fallthrough
         @unknown default:
+            // in order to:
+            // 1) ensure that user location indicator is always(at any zoom level) is shown even for reduced accuracy authorization
+            // 2) ensure that there are no unexpected sudden changes in location indicator radius when zoomin in/out
+            // here we calculate a suitable zoom level to transition from `accuracyRadius` to `emphasisCircle`
+            // and setup the transition using expressions.
+            // The zoom level is not hardcoded to enable a seamless and smooth transition between two circles.
+            //
+            // When the current zoom level is below the "cutoff" point - user location indicator is shown as a circle
+            // covering the area of possible user location.
+            // When the current zoom level is from "cutoff" point to "cutoff" point + 1 - user location indicator radius
+            // transitions from the actual accuracy radius to the minimum circle raduis, while crossfading with the emphasis
+            // circle with set radius.
+            // When the current zoom level is above the "cutoff" point - user location indicator is shown as a circle
+            // with static radius.
             let zoomCutoffRange: ClosedRange<Double> = 4.0...7.5
             let accuracyRange: ClosedRange<CLLocationDistance> = 1000...20_000
             let cutoffZoomLevel = zoomCutoffRange.upperBound - (zoomCutoffRange.magnitude * (location.horizontalAccuracy - accuracyRange.lowerBound) / accuracyRange.magnitude)

--- a/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
@@ -852,9 +852,3 @@ final class Puck2DTests: XCTestCase {
         XCTAssertEqual(expectedRadius, radius)
     }
 }
-
-private extension ClosedRange where Bound == Double {
-    var magnitude: Double {
-        return upperBound - lowerBound
-    }
-}


### PR DESCRIPTION
This PR further improves accuracy ring radius interpolation started in https://github.com/mapbox/mapbox-maps-ios/pull/1625

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
