### PR TITLE
Avoid triggering assertion for the 3D puck layer when returning `allLayerIdentifiers`

### DIFF
--- a/Sources/MapboxMaps/Foundation/Extensions/Core/StyleObjectInfo+3DPuck.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/StyleObjectInfo+3DPuck.swift
@@ -1,0 +1,6 @@
+import Foundation
+@_implementationOnly import MapboxCoreMaps_Private
+
+internal extension StyleObjectInfo {
+    var is3DPuckLayer: Bool { type == "model" && "id" == Puck3D.layerID }
+}

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/StyleObjectInfo+3DPuck.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/StyleObjectInfo+3DPuck.swift
@@ -2,5 +2,5 @@ import Foundation
 @_implementationOnly import MapboxCoreMaps_Private
 
 internal extension StyleObjectInfo {
-    var is3DPuckLayer: Bool { type == "model" && "id" == Puck3D.layerID }
+    var is3DPuckLayer: Bool { type == "model" && id == Puck3D.layerID }
 }

--- a/Sources/MapboxMaps/Location/Puck/Puck3D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck3D.swift
@@ -1,6 +1,8 @@
 @_implementationOnly import MapboxCommon_Private
 
 internal final class Puck3D: Puck {
+    private static let sourceID = "puck-model-source"
+    internal static let layerID = "puck-model-layer"
 
     internal var isActive = false {
         didSet {
@@ -41,9 +43,6 @@ internal final class Puck3D: Puck {
     private let interpolatedLocationProducer: InterpolatedLocationProducerProtocol
 
     private let cancelables = CancelableContainer()
-
-    private static let sourceID = "puck-model-source"
-    private static let layerID = "puck-model-layer"
 
     internal init(configuration: Puck3DConfiguration,
                   style: StyleProtocol,

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -443,6 +443,8 @@ public final class Style: StyleProtocol {
     /// The ordered list of the current style layers' identifiers and types
     public var allLayerIdentifiers: [LayerInfo] {
         return _styleManager.getStyleLayers().compactMap { info in
+            if info.is3DPuckLayer { return nil }
+
             guard let layerType = LayerType(rawValue: info.type) else {
                 assertionFailure("Failed to create LayerType from \(info.type)")
                 return nil

--- a/Tests/MapboxMapsTests/Foundation/Style/StyleTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Style/StyleTests.swift
@@ -120,6 +120,13 @@ final class StyleTests: XCTestCase {
         })
     }
 
+    func testGetAllLayerIdentifiersDoesNotTriggerAssertFor3DPuckLayer() {
+        styleManager.getStyleLayersStub.defaultReturnValue = [StyleObjectInfo(id: Puck3D.layerID, type: "model")]
+
+        // test fails if there is an assertion triggered here
+        _ = style.allLayerIdentifiers
+    }
+
     func testStyleCanAddLayer() {
         XCTAssertThrowsError(try style.addLayer(NonEncodableLayer()))
 

--- a/Tests/MapboxMapsTests/Foundation/Style/StyleTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Style/StyleTests.swift
@@ -123,8 +123,8 @@ final class StyleTests: XCTestCase {
     func testGetAllLayerIdentifiersDoesNotTriggerAssertFor3DPuckLayer() {
         styleManager.getStyleLayersStub.defaultReturnValue = [StyleObjectInfo(id: Puck3D.layerID, type: "model")]
 
-        // test fails if there is an assertion triggered here
-        _ = style.allLayerIdentifiers
+        // test should fail in debug configuration because of an assertion being triggered in `allLayerIdentifiers`
+        XCTAssertTrue(style.allLayerIdentifiers.allSatisfy { $0.id != Puck3D.layerID })
     }
 
     func testStyleCanAddLayer() {


### PR DESCRIPTION
3D puck uses a special layer, it trips code in `allLayerIdentifiers` getter into triggering an assertion when obtaining layer info. This PR makes the `allLayerIdentifiers` getter to ignore 3D puck layer altogether.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
