### PR TITLE
Bugfix/mapsios 328 better handling set style result observers

### DIFF
--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -79,16 +79,22 @@ public final class MapboxMap: MapboxMapProtocol {
     // MARK: - Style loading
 
     private func observeStyleLoad(_ completion: @escaping (Result<Style, Error>) -> Void) {
-        onNext(event: .styleLoaded) { [style] _ in
+        let cancellable = CompositeCancelable()
+
+        cancellable.add(onNext(event: .styleLoaded) { [style] _ in
             if !style.isLoaded {
                 Log.warning(forMessage: "style.isLoaded == false, was this an empty style?", category: "Style")
             }
             completion(.success(style))
-        }
+            cancellable.cancel()
+        })
 
-        onNext(event: .mapLoadingError) { event in
+        cancellable.add(onEvery(event: .mapLoadingError) { event in
+            guard case .style = event.payload.error else { return }
+
             completion(.failure(event.payload.error))
-        }
+            cancellable.cancel()
+        })
     }
 
     /// Loads a `style` from a StyleURI, calling a completion closure when the

--- a/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
@@ -248,29 +248,25 @@ final class MapboxMapTests: XCTestCase {
         mapboxObservable.onTypedNextStub.defaultSideEffect = { invocation in
             guard invocation.parameters.eventName == "style-loaded" else { return }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                let event = MapboxCoreMaps.Event(type: "style-loaded", data: NSNull())
-                invocation.parameters.handler(MapEvent<NoPayload>(event: event))
-                styleLoadEventOccurred.fulfill()
-            }
+            let event = MapboxCoreMaps.Event(type: "style-loaded", data: NSNull())
+            invocation.parameters.handler(MapEvent<NoPayload>(event: event))
+            styleLoadEventOccurred.fulfill()
         }
         mapboxObservable.onTypedEveryStub.defaultSideEffect = { invocation in
             guard invocation.parameters.eventName == "map-loading-error" else { return }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                let event = MapboxCoreMaps.Event(
-                    type: "source",
-                    data: ["type": "source", "message": "Cannot load source", "source-id": "dummy-source-id"])
-                invocation.parameters.handler(MapEvent<MapLoadingErrorPayload>(event: event))
-                mapLoadingErrorEventOccurred.fulfill()
-            }
+            let event = MapboxCoreMaps.Event(
+                type: "source",
+                data: ["type": "source", "message": "Cannot load source", "source-id": "dummy-source-id"])
+            invocation.parameters.handler(MapEvent<MapLoadingErrorPayload>(event: event))
+            mapLoadingErrorEventOccurred.fulfill()
         }
 
         mapboxMap.loadStyleURI(.dark) { _ in
             completionIsCalledOnce.fulfill()
         }
 
-        waitForExpectations(timeout: 2)
+        waitForExpectations(timeout: 0.3)
     }
 
     @available(*, deprecated)

--- a/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
@@ -238,6 +238,40 @@ final class MapboxMapTests: XCTestCase {
         XCTAssertEqual(mapboxObservable.unsubscribeStub.invocations.first?.parameters.events, events)
     }
 
+    func testLoadStyleHandlerIsInvokedExactlyOnce() throws {
+        let styleLoadEventOccurred = expectation(description: "style-loaded event occurred")
+        let mapLoadingErrorEventOccurred = expectation(description: "map-loading-error event occurred")
+        let completionIsCalledOnce = expectation(description: "loadStyle completion should be called once")
+        completionIsCalledOnce.assertForOverFulfill = true
+
+        let mapboxObservable = try XCTUnwrap(mapboxObservableProviderStub.invocations.first?.returnValue as? MockMapboxObservable)
+        mapboxObservable.onTypedNextStub.defaultSideEffect = { invocation in
+            switch invocation.parameters.eventName {
+            case "style-loaded":
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    let event = MapboxCoreMaps.Event(type: "style-loaded", data: NSNull())
+                    invocation.parameters.handler(MapEvent<NoPayload>(event: event))
+                    styleLoadEventOccurred.fulfill()
+                }
+            case "map-loading-error":
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                    let event = MapboxCoreMaps.Event(
+                        type: "source",
+                        data: ["type": "source", "message": "Cannot load source", "source-id": "dummy-source-id"])
+                    invocation.parameters.handler(MapEvent<MapLoadingErrorPayload>(event: event))
+                    mapLoadingErrorEventOccurred.fulfill()
+                }
+            default: break
+            }
+        }
+
+        mapboxMap.loadStyleURI(.dark) { result in
+            completionIsCalledOnce.fulfill()
+        }
+
+        waitForExpectations(timeout: 2)
+    }
+
     @available(*, deprecated)
     func testOnNext() throws {
         let handlerStub = Stub<Event, Void>()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

Fixed MAPSIOS-328
Previously when call to `MapboxMap/loadStyleURI(_:completion:)` and `MapboxMap/loadStyleJSON(_:completion:)`, we will observer 2 events `styleLoaded`and `mapLoadingError`; so even when the given style is successfully loaded, but there is some other error i.e source cannot be loaded, then `mapLoadingError`will fire with error type set to source, we will, however, observe this event and because we have not cancelled our observations when the first event related to our style occured, the completion blocked will be invoked more than once.
This PR fixes this problem by cancelling both observation when first even is received.
## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
