### PR TITLE
Reenable Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -560,7 +560,7 @@ jobs:
             xcodebuild build-for-testing \
               -scheme MapboxMaps \
               -configuration << parameters.configuration >> \
-              -destination "platform=iOS Simulator,name=iPhone 13" \
+              -destination "generic/platform=iOS Simulator" \
               -derivedDataPath build \
               -enableCodeCoverage YES \
               -testPlan "MapboxMapsAll" \
@@ -612,7 +612,7 @@ jobs:
             - run:
                 name: Generate code coverage report
                 command: |
-                  xcrun llvm-cov export -arch arm64 -format="lcov" \
+                  xcrun llvm-cov export -arch $(uname -m) -format="lcov" \
                     -instr-profile=$(find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profdata' | head -n 1) \
                     $(find build -name "MapboxMaps.o") > coverage.lcov
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -617,7 +617,7 @@ jobs:
                   chmod +x codecov
                   time ./codecov
             - store_artifacts:
-                path: "coverage-report*"
+                path: coverage.lcov
       - run:
           name: Compress XCResult
           command: zip -r MapboxMapsTests.xcresult.zip MapboxMapsTests.xcresult

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,9 +559,8 @@ jobs:
           command: |
             xcodebuild build-for-testing \
               -scheme MapboxMaps \
-              -sdk iphonesimulator \
               -configuration << parameters.configuration >> \
-              -destination 'generic/platform=iOS Simulator' \
+              -destination "platform=iOS Simulator,name=iPhone 13" \
               -derivedDataPath build \
               -enableCodeCoverage YES \
               -testPlan "MapboxMapsAll" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -597,6 +597,7 @@ jobs:
               -destination 'platform=iOS Simulator,<< parameters.destination >>' \
               -enableCodeCoverage YES \
               -resultBundlePath MapboxMapsTests.xcresult | tee run_log.txt | xcpretty --report junit --output junit.xml
+      - run: brew install gnupg
       - run:
           name: Send code coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,7 @@ workflows:
       - build-unit-tests
       - run-unit-tests:
           xcode: 14.1.0
+          codecoverage: true
           matrix:
             parameters:
               destination: ["OS=15.5,name=iPhone 13", "OS=16.1,name=iPhone 14"]
@@ -581,6 +582,9 @@ jobs:
         type: string
       xcode:
         type: string
+      codecoverage:
+        type: boolean
+        default: false
     macos:
       xcode: << parameters.xcode >>
     resource_class: macos.x86.medium.gen2
@@ -598,22 +602,22 @@ jobs:
               -destination 'platform=iOS Simulator,<< parameters.destination >>' \
               -enableCodeCoverage YES \
               -resultBundlePath MapboxMapsTests.xcresult | tee run_log.txt | xcpretty --report junit --output junit.xml
-      - run: brew install gnupg
-      - run:
-          name: Send code coverage
-          command: |
-            curl https://uploader.codecov.io/verification.gpg | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
-
-            curl -Os https://uploader.codecov.io/latest/macos/codecov
-            curl -Os https://uploader.codecov.io/latest/macos/codecov.SHA256SUM
-            curl -Os https://uploader.codecov.io/latest/macos/codecov.SHA256SUM.sig
-
-            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-
-            shasum -a 256 -c codecov.SHA256SUM
-
-            chmod +x codecov
-            time ./codecov --xc --xp MapboxMapsTests.xcresult
+      - run: find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profdata' -exec cp {} . \;
+      - store_artifacts:
+          path: "*.profdata"
+      - store_artifacts:
+          path: Coverage.profdata
+      - when:
+          condition: << parameters.codecoverage >>
+          steps:
+            - run:
+                name: Send code coverage
+                command: |
+                  curl -Os https://uploader.codecov.io/latest/macos/codecov
+                  chmod +x codecov
+                  time ./codecov --xc --xp MapboxMapsTests.xcresult
+            - store_artifacts:
+                path: "coverage-report*"
       - run:
           name: Compress XCResult
           command: zip -r MapboxMapsTests.xcresult.zip MapboxMapsTests.xcresult

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -585,6 +585,7 @@ jobs:
       xcode: << parameters.xcode >>
     resource_class: macos.x86.medium.gen2
     steps:
+      - checkout
       - attach_workspace:
           at: build
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,11 +601,6 @@ jobs:
               -destination 'platform=iOS Simulator,<< parameters.destination >>' \
               -enableCodeCoverage YES \
               -resultBundlePath MapboxMapsTests.xcresult | tee run_log.txt | xcpretty --report junit --output junit.xml
-      - run: find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profdata' -exec cp {} . \;
-      - store_artifacts:
-          path: "*.profdata"
-      - store_artifacts:
-          path: Coverage.profdata
       - when:
           condition: << parameters.codecoverage >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -613,19 +613,15 @@ jobs:
             - run:
                 name: Generate code coverage report
                 command: |
-                  find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profdata' -exec cp {} . \;
-                  SDK_FILE=$(find build -name "MapboxMaps.o")
-                  xcrun llvm-cov show -instr-profile=Coverage.profdata "$SDK_FILE" > coverage.txt
-                  xcrun llvm-cov export -arch arm64 -format="lcov" -instr-profile=Coverage.profdata "$SDK_FILE" > coverage.lcov
-                  xcrun llvm-cov export -arch arm64 -format="html" -instr-profile=Coverage.profdata "$SDK_FILE" > coverage.html
-                  xcrun llvm-cov export -arch arm64 -format="text" -instr-profile=Coverage.profdata "$SDK_FILE" > coverageExport.txt
-                  xcrun llvm-cov export -arch arm64 -format="json" -instr-profile=Coverage.profdata "$SDK_FILE" > coverage.json
+                  xcrun llvm-cov export -arch arm64 -format="lcov" \
+                    -instr-profile=$(find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profdata' | head -n 1) \
+                    $(find build -name "MapboxMaps.o") > coverage.lcov
             - run:
                 name: Send code coverage
                 command: |
                   curl -Os https://uploader.codecov.io/latest/macos/codecov
                   chmod +x codecov
-                  time ./codecov #--xc --xp MapboxMapsTests.xcresult
+                  time ./codecov
             - store_artifacts:
                 path: "coverage-report*"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -598,6 +598,21 @@ jobs:
               -enableCodeCoverage YES \
               -resultBundlePath MapboxMapsTests.xcresult | tee run_log.txt | xcpretty --report junit --output junit.xml
       - run:
+          name: Send code coverage
+          command: |
+            curl https://uploader.codecov.io/verification.gpg | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+
+            curl -Os https://uploader.codecov.io/latest/macos/codecov
+            curl -Os https://uploader.codecov.io/latest/macos/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/macos/codecov.SHA256SUM.sig
+
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+
+            shasum -a 256 -c codecov.SHA256SUM
+
+            chmod +x codecov
+            ./codecov
+      - run:
           name: Compress XCResult
           command: zip -r MapboxMapsTests.xcresult.zip MapboxMapsTests.xcresult
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,11 +611,21 @@ jobs:
           condition: << parameters.codecoverage >>
           steps:
             - run:
+                name: Generate code coverage report
+                command: |
+                  find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profdata' -exec cp {} . \;
+                  SDK_FILE=$(find build -name "MapboxMaps.o")
+                  xcrun llvm-cov show -instr-profile=Coverage.profdata "$SDK_FILE" > coverage.txt
+                  xcrun llvm-cov export -arch arm64 -format="lcov" -instr-profile=Coverage.profdata "$SDK_FILE" > coverage.lcov
+                  xcrun llvm-cov export -arch arm64 -format="html" -instr-profile=Coverage.profdata "$SDK_FILE" > coverage.html
+                  xcrun llvm-cov export -arch arm64 -format="text" -instr-profile=Coverage.profdata "$SDK_FILE" > coverageExport.txt
+                  xcrun llvm-cov export -arch arm64 -format="json" -instr-profile=Coverage.profdata "$SDK_FILE" > coverage.json
+            - run:
                 name: Send code coverage
                 command: |
                   curl -Os https://uploader.codecov.io/latest/macos/codecov
                   chmod +x codecov
-                  time ./codecov --xc --xp MapboxMapsTests.xcresult
+                  time ./codecov #--xc --xp MapboxMapsTests.xcresult
             - store_artifacts:
                 path: "coverage-report*"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -612,7 +612,7 @@ jobs:
             shasum -a 256 -c codecov.SHA256SUM
 
             chmod +x codecov
-            ./codecov
+            time ./codecov --xc --xp MapboxMapsTests.xcresult
       - run:
           name: Compress XCResult
           command: zip -r MapboxMapsTests.xcresult.zip MapboxMapsTests.xcresult


### PR DESCRIPTION
This pull request enables codecov.io service to track coverage reports and validate coverage changes. It also uses the brand [new uploader](https://github.com/codecov/uploader/tree/main). 
Since we are running tests in the separate job there are no more extra files that helps codecov to find the appropriate profdata (LLVM coverage format). according to my investigations, codecov.io supports `lcov` format along with visual text format but do not support txt format (JSON inside).
The **alternative** was to pass `--xc --xp <path-to-xcresult>`. In that case codecov would collect all the data from XCResult bundle and convert it to the supported format. However, the conversion takes about 3 minutes of CI time so I preferred a bit more manual approach. 

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
MAPSIOS-346