### PR TITLE
Run MetricsV2 tests when CIRCLECI_TAG is set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,28 +412,22 @@ jobs:
       - run:
           name: Run Workflow
           command: |
-            if [[ $CIRCLE_BRANCH == main ]]; then
-              curl -X POST "https://circleci.com/api/v2/project/github/mapbox/mapbox-maps-ios-internal/pipeline" \
+            RUN_TESTS=false
+
+            if [[ $CIRCLE_BRANCH == "main" || -n $CIRCLE_TAG ]]; then
+              RUN_TESTS=true
+            fi
+
+            curl -X POST "https://circleci.com/api/v2/project/github/mapbox/mapbox-maps-ios-internal/pipeline" \
                   -H 'Content-Type: application/json' \
                   -H "Circle-Token: $CIRCLECI_API_TOKEN_MAPBOX_MAPS_IOS_INTERNAL" \
                   -d $'{
                 "branch": "main",
                 "parameters": {
                   "maps-ios-checkout-reference": "<< pipeline.git.revision >>",
-                  "run-tests": true
+                  "run-tests": '$RUN_TESTS'
                 }
               }'
-            else
-              curl -X POST "https://circleci.com/api/v2/project/github/mapbox/mapbox-maps-ios-internal/pipeline" \
-                -H 'Content-Type: application/json' \
-                -H "Circle-Token: $CIRCLECI_API_TOKEN_MAPBOX_MAPS_IOS_INTERNAL" \
-                -d $'{
-              "branch": "main",
-              "parameters": {
-                "maps-ios-checkout-reference": "<< pipeline.git.revision >>"
-              }
-            }'
-            fi
 
   trigger-metrics-collection:
     <<: *base-job


### PR DESCRIPTION
That pull requests address a request to trigger metrics request when a new git tag is created. This would allow us to collect per-release metrics along with per-merge ones.
There is also a small refactoring that address the duplication in triggering script.
MAPSIOS-421

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
