### PR TITLE
Prevent map from being rendered on background

### DIFF
--- a/Apps/Examples/Examples/AppDelegate.swift
+++ b/Apps/Examples/Examples/AppDelegate.swift
@@ -26,4 +26,36 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         return true
     }
+
+    @available(iOS 13.0, *)
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        let config = UISceneConfiguration(name: "Default configuration", sessionRole: connectingSceneSession.role)
+        config.delegateClass = SceneDelegate.self
+        config.sceneClass = UIWindowScene.self
+        return config
+    }
+}
+
+@available(iOS 13.0, *)
+final class SceneDelegate: NSObject, UISceneDelegate {
+    var windows: [UIWindow] = []
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+
+        let window = UIWindow(windowScene: windowScene)
+
+        let examplesTableViewController = ExampleTableViewController()
+        let navigationController = UINavigationController(rootViewController: examplesTableViewController)
+
+        let appearance = UINavigationBar.appearance()
+        appearance.prefersLargeTitles = true
+
+        appearance.scrollEdgeAppearance = UINavigationBarAppearance()
+
+        window.rootViewController = navigationController
+        window.makeKeyAndVisible()
+
+        windows.append(window)
+    }
 }

--- a/Apps/Examples/Examples/AppDelegate.swift
+++ b/Apps/Examples/Examples/AppDelegate.swift
@@ -11,9 +11,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
-        let examplesTableViewController = ExampleTableViewController()
-        let navigationController = UINavigationController(rootViewController: examplesTableViewController)
-
         let appearance = UINavigationBar.appearance()
         appearance.prefersLargeTitles = true
 
@@ -21,8 +18,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             appearance.scrollEdgeAppearance = UINavigationBarAppearance()
         }
 
-        window?.rootViewController = navigationController
-        window?.makeKeyAndVisible()
+        if #unavailable(iOS 13.0) {
+            let examplesTableViewController = ExampleTableViewController()
+            let navigationController = UINavigationController(rootViewController: examplesTableViewController)
+            window?.rootViewController = navigationController
+            window?.makeKeyAndVisible()
+        }
 
         return true
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Expose the list of added view annotations. ([#1621](https://github.com/mapbox/mapbox-maps-ios/pull/1621))
 * Fix `loadStyleURI/loadStyleJSON` completion being invoked more than once. ([#1665](https://github.com/mapbox/mapbox-maps-ios/pull/1665))
 * Remove ornament position deprecation. ([#1676](https://github.com/mapbox/mapbox-maps-ios/pull/1676))
+* Prevent map from being rendered on background. ([#1675])(https://github.com/mapbox/mapbox-maps-ios/pull/1675))
 
 ## 10.9.0 - October 19, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Fix `loadStyleURI/loadStyleJSON` completion being invoked more than once. ([#1665](https://github.com/mapbox/mapbox-maps-ios/pull/1665))
 * Remove ornament position deprecation. ([#1676](https://github.com/mapbox/mapbox-maps-ios/pull/1676))
 * Prevent map from being rendered on background. ([#1675])(https://github.com/mapbox/mapbox-maps-ios/pull/1675))
+* Prevent map from being rendered on background. By aligning better with Scene lifecycle API, as well as, respecting scene/application activation status, rendering artifacts should no longer be an issue after app is coming from background.  ([#1675])(https://github.com/mapbox/mapbox-maps-ios/pull/1675))
 
 ## 10.9.0 - October 19, 2022
 

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -623,19 +623,19 @@ open class MapView: UIView {
 
         // this will make sure that display link is only running on an active scene in foreground,
         // preventing metal view drawing on background if the view is added to window not on foreground
-        displayLink.isPaused = window.prefersDisplayLinkPaused || UIApplication.shared.prefersDisplayLinkPaused
+        if shouldDisplayLinkBePaused(window: window) {
+            displayLink.isPaused = true
+        }
 
         displayLink.add(to: .current, forMode: .common)
     }
-}
 
-private extension UIApplication {
-    var prefersDisplayLinkPaused: Bool { UIApplication.shared.applicationState != .active }
-}
+    private func shouldDisplayLinkBePaused(window: UIWindow) -> Bool {
+        if UIApplication.shared.applicationState != .active {
+            return true
+        }
 
-private extension UIWindow {
-    var prefersDisplayLinkPaused: Bool {
-        if #available(iOS 13, *), windowScene?.activationState != .foregroundActive {
+        if #available(iOS 13, *), window.windowScene?.activationState != .foregroundActive {
             return true
         }
 

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -438,7 +438,6 @@ open class MapView: UIView {
 
     private func subscribeToLifecycleNotifications() {
         if #available(iOS 13.0, *) {
-            print("metal: ✨ Setting up as a scene-based app")
             notificationCenter.addObserver(self,
                                            selector: #selector(sceneDidEnterBackground(_:)),
                                            name: UIScene.didEnterBackgroundNotification,
@@ -452,7 +451,6 @@ open class MapView: UIView {
                                            name: UIScene.didActivateNotification,
                                            object: window?.parentScene)
         } else {
-            print("metal: 📱 UIApplication-based app is all we know")
             notificationCenter.addObserver(self,
                                            selector: #selector(appDidBecomeActive),
                                            name: UIApplication.didBecomeActiveNotification,
@@ -470,53 +468,41 @@ open class MapView: UIView {
     }
 
     @objc private func appDidEnterBackground() {
-        print("metal: 🥶 appDidEnterBackground")
         displayLink?.isPaused = true
         reduceMemoryUse()
     }
 
     @objc private func appDidBecomeActive() {
-        print("metal: ⬆️ appDidBecomeActive")
         displayLink?.isPaused = false
     }
 
     @objc private func appWillResignActive() {
-        print("metal: 🔻 appWillResignActive")
         displayLink?.isPaused = true
     }
 
     @available(iOS 13.0, *)
     @objc private func sceneDidActivate(_ notification: Notification) {
-        guard notification.object as? UIScene == window?.parentScene else {
-            fatalError("sceneDidActivate")
-        }
-        print("metal: ⬆️ sceneDidActivate")
+        guard notification.object as? UIScene == window?.parentScene else { return }
+
         displayLink?.isPaused = false
     }
 
     @available(iOS 13, *)
     @objc private func sceneWillDeactivate(_ notification: Notification) {
-        guard notification.object as? UIScene == window?.parentScene else {
-            fatalError("sceneWillDeactivate")
-        }
+        guard notification.object as? UIScene == window?.parentScene else { return }
 
-        print("metal: 🔻 sceneWillDeactivate")
         displayLink?.isPaused = true
     }
 
     @available(iOS 13, *)
     @objc private func sceneDidEnterBackground(_ notification: Notification) {
-        guard notification.object as? UIScene == window?.parentScene else {
-            fatalError("sceneDidEnterBackground")
-        }
+        guard notification.object as? UIScene == window?.parentScene else { return }
 
-        print("metal: 🥶 sceneDidEnterBackground")
         displayLink?.isPaused = true
         reduceMemoryUse()
     }
 
     @objc private func didReceiveMemoryWarning() {
-        print("metal: 📝 didReceiveMemoryWarning")
         reduceMemoryUse()
     }
 
@@ -569,10 +555,7 @@ open class MapView: UIView {
     }
 
     @_spi(Metrics) public var metricsReporter: MapViewMetricsReporter?
-    var timestamp: CFTimeInterval = 0
     private func updateFromDisplayLink(displayLink: CADisplayLink) {
-        print("update from displaylink: \(displayLink.timestamp - timestamp)")
-        timestamp = displayLink.timestamp
         metricsReporter?.beforeDisplayLinkCallback(displayLink: displayLink)
         defer { metricsReporter?.afterDisplayLinkCallback(displayLink: displayLink) }
         if window == nil {
@@ -637,16 +620,16 @@ open class MapView: UIView {
         cameraAnimatorsRunnerEnablable.isEnabled = true
 
         updateDisplayLinkPreferredFramesPerSecond()
+
         // this will make sure that display link is only running on an active scene in foreground,
-        // preventing metal view drawing on background
-        // TODO: check if this works for unattached scheme(if unattached scene sends `UIScene.didActivateNotification` notifications
+        // preventing metal view drawing on background if the view is added to window not on foreground
         if #available(iOS 13, *), let scene = window.windowScene, scene.activationState != .foregroundActive {
             displayLink.isPaused = true
         }
         if UIApplication.shared.applicationState != .active {
             displayLink.isPaused = true
         }
-        
+
         displayLink.add(to: .current, forMode: .common)
     }
 }

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -623,14 +623,23 @@ open class MapView: UIView {
 
         // this will make sure that display link is only running on an active scene in foreground,
         // preventing metal view drawing on background if the view is added to window not on foreground
-        if #available(iOS 13, *), let scene = window.windowScene, scene.activationState != .foregroundActive {
-            displayLink.isPaused = true
-        }
-        if UIApplication.shared.applicationState != .active {
-            displayLink.isPaused = true
-        }
+        displayLink.isPaused = window.prefersDisplayLinkPaused || UIApplication.shared.prefersDisplayLinkPaused
 
         displayLink.add(to: .current, forMode: .common)
+    }
+}
+
+private extension UIApplication {
+    var prefersDisplayLinkPaused: Bool { UIApplication.shared.applicationState != .active }
+}
+
+private extension UIWindow {
+    var prefersDisplayLinkPaused: Bool {
+        if #available(iOS 13, *), windowScene?.activationState != .foregroundActive {
+            return true
+        }
+
+        return false
     }
 }
 

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -437,7 +437,13 @@ open class MapView: UIView {
     }
 
     private func subscribeToLifecycleNotifications() {
-        if #available(iOS 13.0, *), bundle.infoDictionary?["UIApplicationSceneManifest"] != nil {
+        if #available(iOS 13.0, *) {
+            print("metal: scene \(UIApplication.shared.delegate?.responds(to: #selector(UIApplicationDelegate.application(_:configurationForConnecting:options:))))")
+        } else {
+            // Fallback on earlier versions
+        }
+        if #available(iOS 13.0, *) {
+            print("metal: ✨ Setting up as a scene-based app")
             notificationCenter.addObserver(self,
                                            selector: #selector(sceneDidEnterBackground(_:)),
                                            name: UIScene.didEnterBackgroundNotification,
@@ -450,7 +456,8 @@ open class MapView: UIView {
                                            selector: #selector(sceneDidActivate(_:)),
                                            name: UIScene.didActivateNotification,
                                            object: window?.parentScene)
-        } else {
+        }
+            print("metal: 📱 UIApplication-based app is all we know")
             notificationCenter.addObserver(self,
                                            selector: #selector(appDidEnterBackground),
                                            name: UIApplication.didEnterBackgroundNotification,
@@ -463,43 +470,55 @@ open class MapView: UIView {
                                            selector: #selector(appWillResignActive),
                                            name: UIApplication.willResignActiveNotification,
                                            object: nil)
-        }
+//        }
     }
 
     @objc private func appDidEnterBackground() {
+        print("metal: 🥶 appDidEnterBackground")
         reduceMemoryUse()
     }
 
     @objc private func appDidBecomeActive() {
+        print("metal: ⬆️ appDidBecomeActive")
         displayLink?.isPaused = false
     }
 
     @objc private func appWillResignActive() {
+        print("metal: 🔻 appWillResignActive")
         displayLink?.isPaused = true
     }
 
     @available(iOS 13.0, *)
     @objc private func sceneDidActivate(_ notification: Notification) {
-        guard notification.object as? UIScene == window?.parentScene else { return }
-
+        guard notification.object as? UIScene == window?.parentScene else {
+            fatalError("sceneDidActivate")
+        }
+        print("metal: ⬆️ sceneDidActivate")
         displayLink?.isPaused = false
     }
 
     @available(iOS 13, *)
     @objc private func sceneWillDeactivate(_ notification: Notification) {
-        guard notification.object as? UIScene == window?.parentScene else { return }
+        guard notification.object as? UIScene == window?.parentScene else {
+            fatalError("sceneWillDeactivate")
+        }
 
+        print("metal: 🔻 sceneWillDeactivate")
         displayLink?.isPaused = true
     }
 
     @available(iOS 13, *)
     @objc private func sceneDidEnterBackground(_ notification: Notification) {
-        guard notification.object as? UIScene == window?.parentScene else { return }
+        guard notification.object as? UIScene == window?.parentScene else {
+            fatalError("sceneDidEnterBackground")
+        }
 
+        print("metal: 🥶 sceneDidEnterBackground")
         reduceMemoryUse()
     }
 
     @objc private func didReceiveMemoryWarning() {
+        print("metal: 📝 didReceiveMemoryWarning")
         reduceMemoryUse()
     }
 
@@ -552,8 +571,10 @@ open class MapView: UIView {
     }
 
     @_spi(Metrics) public var metricsReporter: MapViewMetricsReporter?
-
+    var timestamp: CFTimeInterval = 0
     private func updateFromDisplayLink(displayLink: CADisplayLink) {
+        print("update from displaylink: \(displayLink.timestamp - timestamp)")
+        timestamp = displayLink.timestamp
         metricsReporter?.beforeDisplayLinkCallback(displayLink: displayLink)
         defer { metricsReporter?.afterDisplayLinkCallback(displayLink: displayLink) }
         if window == nil {
@@ -618,6 +639,16 @@ open class MapView: UIView {
         cameraAnimatorsRunnerEnablable.isEnabled = true
 
         updateDisplayLinkPreferredFramesPerSecond()
+        // this will make sure that display link is only running on an active scene in foreground,
+        // preventing metal view drawing on background
+        // TODO: check if this works for unattached scheme(if unattached scene sends `UIScene.didActivateNotification` notifications
+        if #available(iOS 13, *), let scene = window.windowScene, scene.activationState != .foregroundActive {
+            displayLink.isPaused = true
+        }
+        if UIApplication.shared.applicationState != .active {
+            displayLink.isPaused = true
+        }
+        
         displayLink.add(to: .current, forMode: .common)
     }
 }

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -438,11 +438,6 @@ open class MapView: UIView {
 
     private func subscribeToLifecycleNotifications() {
         if #available(iOS 13.0, *) {
-            print("metal: scene \(UIApplication.shared.delegate?.responds(to: #selector(UIApplicationDelegate.application(_:configurationForConnecting:options:))))")
-        } else {
-            // Fallback on earlier versions
-        }
-        if #available(iOS 13.0, *) {
             print("metal: ✨ Setting up as a scene-based app")
             notificationCenter.addObserver(self,
                                            selector: #selector(sceneDidEnterBackground(_:)),
@@ -456,25 +451,27 @@ open class MapView: UIView {
                                            selector: #selector(sceneDidActivate(_:)),
                                            name: UIScene.didActivateNotification,
                                            object: window?.parentScene)
-        }
+        } else {
             print("metal: 📱 UIApplication-based app is all we know")
-            notificationCenter.addObserver(self,
-                                           selector: #selector(appDidEnterBackground),
-                                           name: UIApplication.didEnterBackgroundNotification,
-                                           object: nil)
             notificationCenter.addObserver(self,
                                            selector: #selector(appDidBecomeActive),
                                            name: UIApplication.didBecomeActiveNotification,
                                            object: nil)
-            notificationCenter.addObserver(self,
-                                           selector: #selector(appWillResignActive),
-                                           name: UIApplication.willResignActiveNotification,
-                                           object: nil)
-//        }
+        }
+
+        notificationCenter.addObserver(self,
+                                       selector: #selector(appDidEnterBackground),
+                                       name: UIApplication.didEnterBackgroundNotification,
+                                       object: nil)
+        notificationCenter.addObserver(self,
+                                       selector: #selector(appWillResignActive),
+                                       name: UIApplication.willResignActiveNotification,
+                                       object: nil)
     }
 
     @objc private func appDidEnterBackground() {
         print("metal: 🥶 appDidEnterBackground")
+        displayLink?.isPaused = true
         reduceMemoryUse()
     }
 
@@ -514,6 +511,7 @@ open class MapView: UIView {
         }
 
         print("metal: 🥶 sceneDidEnterBackground")
+        displayLink?.isPaused = true
         reduceMemoryUse()
     }
 

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -283,27 +283,38 @@ final class MapViewTests: XCTestCase {
         XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [false])
     }
 
-    func testSubscribesToCorrectNotifications() {
+    func testSubscribesToCorrectNotificationsOniOS12() throws {
+        if #available(iOS 13, *) {
+            throw XCTSkip()
+        }
+
         let observers = notificationCenter.addObserverStub.invocations.map(\.parameters.observer)
 
         XCTAssertTrue(observers.allSatisfy { ($0 as AnyObject) === mapView })
 
-        if #available(iOS 13.0, *) {
-            XCTAssertEqual(notificationCenter.addObserverStub.invocations.count, 6)
-            XCTAssertEqual(notificationCenter.addObserverStub.invocations[0].parameters.name, UIScene.didEnterBackgroundNotification)
-            XCTAssertEqual(notificationCenter.addObserverStub.invocations[1].parameters.name, UIScene.willDeactivateNotification)
-            XCTAssertEqual(notificationCenter.addObserverStub.invocations[2].parameters.name, UIScene.didActivateNotification)
-            XCTAssertEqual(notificationCenter.addObserverStub.invocations[3].parameters.name, UIApplication.didEnterBackgroundNotification)
-            XCTAssertEqual(notificationCenter.addObserverStub.invocations[4].parameters.name, UIApplication.willResignActiveNotification)
-            XCTAssertEqual(notificationCenter.addObserverStub.invocations[5].parameters.name, UIApplication.didReceiveMemoryWarningNotification)
-        } else {
-            XCTAssertEqual(notificationCenter.addObserverStub.invocations.count, 4)
+        XCTAssertEqual(notificationCenter.addObserverStub.invocations.count, 4)
 
-            XCTAssertEqual(notificationCenter.addObserverStub.invocations[0].parameters.name, UIApplication.didBecomeActiveNotification)
-            XCTAssertEqual(notificationCenter.addObserverStub.invocations[1].parameters.name, UIApplication.didEnterBackgroundNotification)
-            XCTAssertEqual(notificationCenter.addObserverStub.invocations[2].parameters.name, UIApplication.willResignActiveNotification)
-            XCTAssertEqual(notificationCenter.addObserverStub.invocations[3].parameters.name, UIApplication.didReceiveMemoryWarningNotification)
+        XCTAssertEqual(notificationCenter.addObserverStub.invocations[0].parameters.name, UIApplication.didBecomeActiveNotification)
+        XCTAssertEqual(notificationCenter.addObserverStub.invocations[1].parameters.name, UIApplication.didEnterBackgroundNotification)
+        XCTAssertEqual(notificationCenter.addObserverStub.invocations[2].parameters.name, UIApplication.willResignActiveNotification)
+        XCTAssertEqual(notificationCenter.addObserverStub.invocations[3].parameters.name, UIApplication.didReceiveMemoryWarningNotification)
+
+    }
+    func testSubscribesToCorrectNotifications() throws {
+        guard #available(iOS 13, *) else {
+            throw XCTSkip()
         }
+        let observers = notificationCenter.addObserverStub.invocations.map(\.parameters.observer)
+
+        XCTAssertTrue(observers.allSatisfy { ($0 as AnyObject) === mapView })
+
+        XCTAssertEqual(notificationCenter.addObserverStub.invocations.count, 6)
+        XCTAssertEqual(notificationCenter.addObserverStub.invocations[0].parameters.name, UIScene.didEnterBackgroundNotification)
+        XCTAssertEqual(notificationCenter.addObserverStub.invocations[1].parameters.name, UIScene.willDeactivateNotification)
+        XCTAssertEqual(notificationCenter.addObserverStub.invocations[2].parameters.name, UIScene.didActivateNotification)
+        XCTAssertEqual(notificationCenter.addObserverStub.invocations[3].parameters.name, UIApplication.didEnterBackgroundNotification)
+        XCTAssertEqual(notificationCenter.addObserverStub.invocations[4].parameters.name, UIApplication.willResignActiveNotification)
+        XCTAssertEqual(notificationCenter.addObserverStub.invocations[5].parameters.name, UIApplication.didReceiveMemoryWarningNotification)
     }
 
     func testURLOpener() {

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -261,7 +261,7 @@ final class MapViewTests: XCTestCase {
 
     func testDisplayLinkPausedWhenAppDidEnterBackground() {
         displayLink.$isPaused.setStub.reset()
-        
+
         notificationCenter.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
 
         XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [true])

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -252,12 +252,16 @@ final class MapViewTests: XCTestCase {
     }
 
     func testDisplayLinkPausedWhenAppWillResignActive() {
+        displayLink.$isPaused.setStub.reset()
+
         notificationCenter.post(name: UIApplication.willResignActiveNotification, object: nil)
 
         XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [true])
     }
 
     func testDisplayLinkPausedWhenAppDidEnterBackground() {
+        displayLink.$isPaused.setStub.reset()
+        
         notificationCenter.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
 
         XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [true])
@@ -376,6 +380,7 @@ final class MapViewTestsWithScene: XCTestCase {
         guard #available(iOS 13.0, *) else {
             throw XCTSkip("Test requires iOS 13 or higher.")
         }
+        displayLink.$isPaused.setStub.reset()
 
         notificationCenter.post(name: UIScene.didActivateNotification, object: window.parentScene)
 
@@ -386,6 +391,7 @@ final class MapViewTestsWithScene: XCTestCase {
         guard #available(iOS 13.0, *) else {
             throw XCTSkip("Test requires iOS 13 or higher.")
         }
+        displayLink.$isPaused.setStub.reset()
 
         notificationCenter.post(name: UIScene.willDeactivateNotification, object: window.parentScene)
 
@@ -396,6 +402,7 @@ final class MapViewTestsWithScene: XCTestCase {
         guard #available(iOS 13.0, *) else {
             throw XCTSkip("Test requires iOS 13 or higher.")
         }
+        displayLink.$isPaused.setStub.reset()
 
         notificationCenter.post(name: UIScene.didEnterBackgroundNotification, object: window.parentScene)
 

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -270,7 +270,7 @@ final class MapViewTests: XCTestCase {
     }
 
     func testDisplayLinkResumedWhenAppDidBecomeActiveOnIOS12() throws {
-        guard #unavailable(iOS 13.0) else {
+        if #available(iOS 13.0, *) {
             throw XCTSkip("Test applies only on iOS 12")
         }
 

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -257,16 +257,49 @@ final class MapViewTests: XCTestCase {
         XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [true])
     }
 
+    func testDisplayLinkPausedWhenAppDidEnterBackground() {
+        notificationCenter.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+        XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [true])
+    }
+
     func testReleaseDrawablesInvokedWhenAppDidBecomeActive() {
         notificationCenter.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
 
         XCTAssertEqual(metalView.releaseDrawablesStub.invocations.count, 1)
     }
 
-    func testDisplayLinkResumedWhenAppDidBecomeActive() {
+    func testDisplayLinkResumedWhenAppDidBecomeActiveOnIOS12() throws {
+        guard #unavailable(iOS 13.0) else {
+            throw XCTSkip("Test applies only on iOS 12")
+        }
+
         notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
 
         XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [false])
+    }
+
+    func testSubscribesToCorrectNotifications() {
+        let observers = notificationCenter.addObserverStub.invocations.map(\.parameters.observer)
+
+        XCTAssertTrue(observers.allSatisfy { ($0 as AnyObject) === mapView })
+
+        if #available(iOS 13.0, *) {
+            XCTAssertEqual(notificationCenter.addObserverStub.invocations.count, 6)
+            XCTAssertEqual(notificationCenter.addObserverStub.invocations[0].parameters.name, UIScene.didEnterBackgroundNotification)
+            XCTAssertEqual(notificationCenter.addObserverStub.invocations[1].parameters.name, UIScene.willDeactivateNotification)
+            XCTAssertEqual(notificationCenter.addObserverStub.invocations[2].parameters.name, UIScene.didActivateNotification)
+            XCTAssertEqual(notificationCenter.addObserverStub.invocations[3].parameters.name, UIApplication.didEnterBackgroundNotification)
+            XCTAssertEqual(notificationCenter.addObserverStub.invocations[4].parameters.name, UIApplication.willResignActiveNotification)
+            XCTAssertEqual(notificationCenter.addObserverStub.invocations[5].parameters.name, UIApplication.didReceiveMemoryWarningNotification)
+        } else {
+            XCTAssertEqual(notificationCenter.addObserverStub.invocations.count, 4)
+
+            XCTAssertEqual(notificationCenter.addObserverStub.invocations[0].parameters.name, UIApplication.didBecomeActiveNotification)
+            XCTAssertEqual(notificationCenter.addObserverStub.invocations[1].parameters.name, UIApplication.didEnterBackgroundNotification)
+            XCTAssertEqual(notificationCenter.addObserverStub.invocations[2].parameters.name, UIApplication.willResignActiveNotification)
+            XCTAssertEqual(notificationCenter.addObserverStub.invocations[3].parameters.name, UIApplication.didReceiveMemoryWarningNotification)
+        }
     }
 
     func testURLOpener() {
@@ -355,6 +388,16 @@ final class MapViewTestsWithScene: XCTestCase {
         }
 
         notificationCenter.post(name: UIScene.willDeactivateNotification, object: window.parentScene)
+
+        XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [true])
+    }
+
+    func testDisplayLinkPausedWhenSceneDidEnterBackground() throws {
+        guard #available(iOS 13.0, *) else {
+            throw XCTSkip("Test requires iOS 13 or higher.")
+        }
+
+        notificationCenter.post(name: UIScene.didEnterBackgroundNotification, object: window.parentScene)
 
         XCTAssertEqual(displayLink.$isPaused.setStub.invocations.map(\.parameters), [true])
     }


### PR DESCRIPTION
This PR introduces changes in display link pausing/unpausing in relation to app/scene lifecycle:
* iOS 13 an up display link is paused/unpaused according to scene lifecycle events. Additionally, as a failsafe display link is paused according to app deactivation/background lifecycle events.
* iOS 12 and below display link is paused/unpaused according to app lifecycle events only.
* When map view is being added to a window display link will be paused if the app/window scene is not on foreground(the idea is that the link will be unpaused when app/scene go into foreground).

Also Examples is setup as scene-based app by default on iOS 13 and upwards to make use of more modern API.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
