### PR TITLE
Add API to enable/disable render world copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Remove ornament position deprecation. ([#1676](https://github.com/mapbox/mapbox-maps-ios/pull/1676))
 * Prevent map from being rendered on background. By aligning better with Scene lifecycle API, as well as, respecting scene/application activation status, rendering artifacts should no longer be an issue after app is coming from background.  ([#1675])(https://github.com/mapbox/mapbox-maps-ios/pull/1675))
 * Update MapboxCoreMaps to `v10.10.0-beta.1` and MapboxCommon to `v23.2.0-beta.1`. ([#1680](https://github.com/mapbox/mapbox-maps-ios/pull/1680))
+* Add API to enable/disable render of world copies. ([#1684](https://github.com/mapbox/mapbox-maps-ios/pull/1684))
 
 ## 10.9.0 - October 19, 2022
 

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -185,8 +185,8 @@ public final class MapboxMap: MapboxMapProtocol {
     /// In this case, features that cross 180 and -180 degrees longitude will be cut in two (with one portion on the right edge of the map
     /// and the other on the left edge of the map) at every zoom level.
     ///
-    /// By default, `isRenderWorldCopiesEnabled` is set to `true`.
-    public var isRenderWorldCopiesEnabled: Bool {
+    /// By default, `shouldRenderWorldCopies` is set to `true`.
+    public var shouldRenderWorldCopies: Bool {
         get { __map.getRenderWorldCopies() }
         set { __map.setRenderWorldCopiesForRenderWorldCopies(newValue) }
     }

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -178,6 +178,25 @@ public final class MapboxMap: MapboxMapProtocol {
         __map.setRenderCacheOptionsFor(cacheOptions)
     }
 
+    /// Sets whether multiple copies of the world will be rendered side by side beyond -180 and 180 degrees longitude.
+    ///
+    /// If disabled, when the map is zoomed out far enough that a single representation of the world does not fill the map's entire container,
+    /// there will be blank space beyond 180 and -180 degrees longitude.
+    /// In this case, features that cross 180 and -180 degrees longitude will be cut in two (with one portion on the right edge of the map
+    /// and the other on the left edge of the map) at every zoom level.
+    ///
+    /// By default, renderWorldCopies is set to `true`.
+    ///
+    /// - Parameter isEnabled: The boolean value defining whether rendering world copies is going to be enabled or not.
+    public func setRenderWorldCopies(_ isEnabled: Bool) {
+        __map.setRenderWorldCopiesForRenderWorldCopies(isEnabled)
+    }
+
+    /// Returns whether multiple copies of the world are being rendered side by side beyond -180 and 180 degrees longitude.
+    public func getRenderWorldCopies() -> Bool {
+        __map.getRenderWorldCopies()
+    }
+
     /// Gets the resource options for the map.
     ///
     /// All optional fields of the returned object are initialized with the

--- a/Sources/MapboxMaps/Foundation/MapboxMap.swift
+++ b/Sources/MapboxMaps/Foundation/MapboxMap.swift
@@ -178,23 +178,17 @@ public final class MapboxMap: MapboxMapProtocol {
         __map.setRenderCacheOptionsFor(cacheOptions)
     }
 
-    /// Sets whether multiple copies of the world will be rendered side by side beyond -180 and 180 degrees longitude.
+    /// Defines whether multiple copies of the world will be rendered side by side beyond -180 and 180 degrees longitude.
     ///
     /// If disabled, when the map is zoomed out far enough that a single representation of the world does not fill the map's entire container,
     /// there will be blank space beyond 180 and -180 degrees longitude.
     /// In this case, features that cross 180 and -180 degrees longitude will be cut in two (with one portion on the right edge of the map
     /// and the other on the left edge of the map) at every zoom level.
     ///
-    /// By default, renderWorldCopies is set to `true`.
-    ///
-    /// - Parameter isEnabled: The boolean value defining whether rendering world copies is going to be enabled or not.
-    public func setRenderWorldCopies(_ isEnabled: Bool) {
-        __map.setRenderWorldCopiesForRenderWorldCopies(isEnabled)
-    }
-
-    /// Returns whether multiple copies of the world are being rendered side by side beyond -180 and 180 degrees longitude.
-    public func getRenderWorldCopies() -> Bool {
-        __map.getRenderWorldCopies()
+    /// By default, `isRenderWorldCopiesEnabled` is set to `true`.
+    public var isRenderWorldCopiesEnabled: Bool {
+        get { __map.getRenderWorldCopies() }
+        set { __map.setRenderWorldCopiesForRenderWorldCopies(newValue) }
     }
 
     /// Gets the resource options for the map.

--- a/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
@@ -85,12 +85,12 @@ final class MapboxMapTests: XCTestCase {
     func testGetRenderWorldCopies() {
         let renderWorldCopies = Bool.random()
         mapboxMap.__testingMap.setRenderWorldCopiesForRenderWorldCopies(renderWorldCopies)
-        XCTAssertEqual(mapboxMap.getRenderWorldCopies(), renderWorldCopies)
+        XCTAssertEqual(mapboxMap.isRenderWorldCopiesEnabled, renderWorldCopies)
     }
 
     func testSetRenderWorldCopies() {
         let renderWorldCopies = Bool.random()
-        mapboxMap.setRenderWorldCopies(renderWorldCopies)
+        mapboxMap.isRenderWorldCopiesEnabled = renderWorldCopies
         XCTAssertEqual(mapboxMap.__testingMap.getRenderWorldCopies(), renderWorldCopies)
     }
 

--- a/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
@@ -82,6 +82,18 @@ final class MapboxMapTests: XCTestCase {
         XCTAssertEqual(actualSize, CGSize(expectedSize))
     }
 
+    func testGetRenderWorldCopies() {
+        let renderWorldCopies = Bool.random()
+        mapboxMap.__testingMap.setRenderWorldCopiesForRenderWorldCopies(renderWorldCopies)
+        XCTAssertEqual(mapboxMap.getRenderWorldCopies(), renderWorldCopies)
+    }
+
+    func testSetRenderWorldCopies() {
+        let renderWorldCopies = Bool.random()
+        mapboxMap.setRenderWorldCopies(renderWorldCopies)
+        XCTAssertEqual(mapboxMap.__testingMap.getRenderWorldCopies(), renderWorldCopies)
+    }
+
     func testGetCameraOptions() {
         XCTAssertEqual(mapboxMap.cameraState, CameraState(mapboxMap.__testingMap.getCameraState()))
     }

--- a/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapboxMapTests.swift
@@ -85,12 +85,12 @@ final class MapboxMapTests: XCTestCase {
     func testGetRenderWorldCopies() {
         let renderWorldCopies = Bool.random()
         mapboxMap.__testingMap.setRenderWorldCopiesForRenderWorldCopies(renderWorldCopies)
-        XCTAssertEqual(mapboxMap.isRenderWorldCopiesEnabled, renderWorldCopies)
+        XCTAssertEqual(mapboxMap.shouldRenderWorldCopies, renderWorldCopies)
     }
 
     func testSetRenderWorldCopies() {
         let renderWorldCopies = Bool.random()
-        mapboxMap.isRenderWorldCopiesEnabled = renderWorldCopies
+        mapboxMap.shouldRenderWorldCopies = renderWorldCopies
         XCTAssertEqual(mapboxMap.__testingMap.getRenderWorldCopies(), renderWorldCopies)
     }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

MAPSIOS-436 Add API to enable/disable `RenderWorldCopies` - whether multiple copies of the world will be rendered side by side beyond -180 and 180 degrees longitude.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
