### PR TITLE
Fix language support and label localization 

### DIFF
--- a/Apps/Examples/Examples/All Examples/LocalizationExample.swift
+++ b/Apps/Examples/Examples/All Examples/LocalizationExample.swift
@@ -47,10 +47,14 @@ public class LocalizationExample: UIViewController, ExampleProtocol {
                                       message: "Please select a language to localize to.",
                                       preferredStyle: .actionSheet)
 
-        alert.addAction(UIAlertAction(title: "Device Settings", style: .default, handler: { [weak self] _ in
-            try! self?.mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: Locale.preferredLanguages[0]))
+        alert.addAction(UIAlertAction(title: "Device Locale", style: .default, handler: { [weak self] _ in
+            do {
+                try self?.mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: Locale.preferredLanguages[0]))
+            } catch {
+                print(error)
+            }
         }))
-        
+
         alert.addAction(UIAlertAction(title: "Spanish", style: .default, handler: { [weak self] _ in
             try! self?.mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "es"))
         }))

--- a/Apps/Examples/Examples/All Examples/LocalizationExample.swift
+++ b/Apps/Examples/Examples/All Examples/LocalizationExample.swift
@@ -49,7 +49,7 @@ public class LocalizationExample: UIViewController, ExampleProtocol {
 
         alert.addAction(UIAlertAction(title: "Device Locale", style: .default, handler: { [weak self] _ in
             do {
-                try self?.mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: Locale.preferredLanguages[0]))
+                try self?.mapView.mapboxMap.style.localizeLabels(into: Locale.current)
             } catch {
                 print(error)
             }

--- a/Apps/Examples/Examples/All Examples/LocalizationExample.swift
+++ b/Apps/Examples/Examples/All Examples/LocalizationExample.swift
@@ -47,6 +47,10 @@ public class LocalizationExample: UIViewController, ExampleProtocol {
                                       message: "Please select a language to localize to.",
                                       preferredStyle: .actionSheet)
 
+        alert.addAction(UIAlertAction(title: "Device Settings", style: .default, handler: { [weak self] _ in
+            try! self?.mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: Locale.preferredLanguages[0]))
+        }))
+        
         alert.addAction(UIAlertAction(title: "Spanish", style: .default, handler: { [weak self] _ in
             try! self?.mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "es"))
         }))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## 10.10.0-beta-1 - November 4, 2022
 
+* Fix label localization to properly handle Simplified and Traditional Chinese. ([#1687](https://github.com/mapbox/mapbox-maps-ios/pull/1687))
 * Animates to camera that fit a list of view annotations. ([#1634](https://github.com/mapbox/mapbox-maps-ios/pull/1634))
 * Prevent view annotation being shown erroneously after options update.([#1627](https://github.com/mapbox/mapbox-maps-ios/pull/1627))
 * Add an example animating a view annotation along a route line. ([#1639](https://github.com/mapbox/mapbox-maps-ios/pull/1639))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ Mapbox welcomes participation and contributions from everyone.
 ## main
 
 * Fix memory leak when viewport is being deallocated while transition is running. ([#1691](https://github.com/mapbox/mapbox-maps-ios/pull/1691))
+* Fix label localization to properly handle Simplified and Traditional Chinese. ([#1687](https://github.com/mapbox/mapbox-maps-ios/pull/1687))
 
 ## 10.10.0-beta-1 - November 4, 2022
 
-* Fix label localization to properly handle Simplified and Traditional Chinese. ([#1687](https://github.com/mapbox/mapbox-maps-ios/pull/1687))
 * Animates to camera that fit a list of view annotations. ([#1634](https://github.com/mapbox/mapbox-maps-ios/pull/1634))
 * Prevent view annotation being shown erroneously after options update.([#1627](https://github.com/mapbox/mapbox-maps-ios/pull/1627))
 * Add an example animating a view annotation along a route line. ([#1639](https://github.com/mapbox/mapbox-maps-ios/pull/1639))

--- a/Sources/MapboxMaps/Style/Style+Localization.swift
+++ b/Sources/MapboxMaps/Style/Style+Localization.swift
@@ -31,40 +31,36 @@ extension Style {
         }
     }
 
-    /**
-     Returns the BCP 47 language tag supported by Mapbox Streets source v8 that is most preferred according to the given preferences.
-     */
+    /// Returns the BCP 47 language tag supported by Mapbox Streets source v8 that is most preferred according to the given preferences.
+    /// Docs for language, region, and script codes: https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html
     internal func preferredMapboxStreetsLocalization(among preferences: [String]) -> String? {
         let supportedLocaleIdentifiersv8 = ["ar", "en", "es", "fr", "de", "it", "pt", "ru", "zh-Hans", "zh-Hant", "ja", "ko", "vi"].map(Locale.init(identifier:))
-        
+
         let preferredLocales = preferences.map(Locale.init(identifier:))
+
         let acceptsEnglish = preferredLocales.contains { $0.languageCode == "en" }
         var availableLocales = supportedLocaleIdentifiersv8
         if !acceptsEnglish {
             availableLocales.removeAll { $0.languageCode == "en" }
         }
-        
+
         let mostSpecificLanguage = Bundle.preferredLocalizations(from: availableLocales.map { $0.identifier },
                                                                  forPreferences: preferences)
             .max { $0.count > $1.count }
-        
+
         // `Bundle.preferredLocalizations(from:forPreferences:)` is just returning the first localization it could find.
         if let mostSpecificLanguage = mostSpecificLanguage, !preferredLocales.contains(where: { $0.languageCode == Locale(identifier: mostSpecificLanguage).languageCode }) {
             return nil
         }
-        
         return mostSpecificLanguage
     }
-    
-    /// Filters through source to determine supported locale styles.
-    /// This is needed for v7 support
+
+    /// Returns the shortened language identifier string representing a supported Mapbox Streets Localization
+    /// List of supported language identifiers: https://docs.mapbox.com/data/tilesets/reference/mapbox-streets-v8/#common-fields
     internal func getLocaleValue(locale: Locale) -> String? {
-        let preferences: [String]
-        preferences = [locale.identifier]
+        let preferences = [locale.identifier]
         var localeValue: String?
 
-        // Docs for language, region, and script codes  https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html
-        // List of supported language identifiers: https://docs.mapbox.com/data/tilesets/reference/mapbox-streets-v8/#common-fields
         // Lists those supported by either v7 or v8
         let supportedLocaleIdentifiers = ["ar", "en", "es", "fr", "de", "it", "pt", "ru", "zh-Hans", "zh-Hant", "ja", "ko", "vi", "zh"]
 
@@ -95,7 +91,7 @@ extension Style {
                 }
             }
         }
-        
+
         localeValue = preferredMapboxStreetsLocalization(among: preferences) ?? nil
 
         return localeValue

--- a/Sources/MapboxMaps/Style/Style+Localization.swift
+++ b/Sources/MapboxMaps/Style/Style+Localization.swift
@@ -31,13 +31,41 @@ extension Style {
         }
     }
 
+    /**
+     Returns the BCP 47 language tag supported by Mapbox Streets source v8 that is most preferred according to the given preferences.
+     */
+    internal func preferredMapboxStreetsLocalization(among preferences: [String]) -> String? {
+        let supportedLocaleIdentifiersv8 = ["ar", "en", "es", "fr", "de", "it", "pt", "ru", "zh-Hans", "zh-Hant", "ja", "ko", "vi"].map(Locale.init(identifier:))
+        
+        let preferredLocales = preferences.map(Locale.init(identifier:))
+        let acceptsEnglish = preferredLocales.contains { $0.languageCode == "en" }
+        var availableLocales = supportedLocaleIdentifiersv8
+        if !acceptsEnglish {
+            availableLocales.removeAll { $0.languageCode == "en" }
+        }
+        
+        let mostSpecificLanguage = Bundle.preferredLocalizations(from: availableLocales.map { $0.identifier },
+                                                                 forPreferences: preferences)
+            .max { $0.count > $1.count }
+        
+        // `Bundle.preferredLocalizations(from:forPreferences:)` is just returning the first localization it could find.
+        if let mostSpecificLanguage = mostSpecificLanguage, !preferredLocales.contains(where: { $0.languageCode == Locale(identifier: mostSpecificLanguage).languageCode }) {
+            return nil
+        }
+        
+        return mostSpecificLanguage
+    }
+    
     /// Filters through source to determine supported locale styles.
     /// This is needed for v7 support
     internal func getLocaleValue(locale: Locale) -> String? {
-        var localeValue: String
+        let preferences: [String]
+        preferences = [locale.identifier]
+        var localeValue: String?
 
         // Docs for language, region, and script codes  https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html
         // List of supported language identifiers: https://docs.mapbox.com/data/tilesets/reference/mapbox-streets-v8/#common-fields
+        // Lists those supported by either v7 or v8
         let supportedLocaleIdentifiers = ["ar", "en", "es", "fr", "de", "it", "pt", "ru", "zh-Hans", "zh-Hant", "ja", "ko", "vi", "zh"]
 
         // Do nothing if we do not support the locale
@@ -45,30 +73,30 @@ extension Style {
             return nil
         }
 
+        // Check for streets v7
         let vectorSources = allSourceIdentifiers.filter { source in
             return source.type == .vector
         }
-
-        for sourceInfo in vectorSources where locale.identifier.starts(with: "zh") {
+        for sourceInfo in vectorSources {
             // Force unwrapping since `allSourceIdentifiers` is getting a fresh list of valid sources
             let vectorSource = try! source(withId: sourceInfo.id, type: VectorSource.self)
 
             if vectorSource.url?.contains("mapbox.mapbox-streets-v7") == true {
                 // v7 styles do not support value of "name_zh-Hant"
                 if locale.identifier == "zh-Hant" {
-                    localeValue = "zh"
+                    return "zh"
+                }
+                // v7 styles do not support Italian or Vietnamese
+                if locale.identifier == "it" || locale.identifier == "vi" {
+                    return nil
+                } else {
+                    localeValue = supportedLocaleIdentifiers.contains(locale.identifier) ? locale.identifier : locale.languageCode!
+                    return localeValue
                 }
             }
         }
-
-        // Return Traditional Chinese when specified (including Locales for Taiwan and Hong Kong)
-        if locale.identifier.starts(with: "zh-Hant") {
-            localeValue = "zh-Hant"
-        } else if locale.identifier.starts(with: "zh") {
-            localeValue = "zh-Hans"
-        } else {
-            localeValue = supportedLocaleIdentifiers.contains(locale.identifier) ? locale.identifier : locale.languageCode!
-        }
+        
+        localeValue = preferredMapboxStreetsLocalization(among: preferences) ?? nil
 
         return localeValue
     }

--- a/Sources/MapboxMaps/Style/Style+Localization.swift
+++ b/Sources/MapboxMaps/Style/Style+Localization.swift
@@ -38,13 +38,7 @@ extension Style {
 
         let preferredLocales = preferences.map(Locale.init(identifier:))
 
-        let acceptsEnglish = preferredLocales.contains { $0.languageCode == "en" }
-        var availableLocales = supportedLocaleIdentifiersv8
-        if !acceptsEnglish {
-            availableLocales.removeAll { $0.languageCode == "en" }
-        }
-
-        let mostSpecificLanguage = Bundle.preferredLocalizations(from: availableLocales.map { $0.identifier },
+        let mostSpecificLanguage = Bundle.preferredLocalizations(from: supportedLocaleIdentifiersv8.map { $0.identifier },
                                                                  forPreferences: preferences)
             .max { $0.count > $1.count }
 
@@ -58,14 +52,13 @@ extension Style {
     /// Returns the shortened language identifier string representing a supported Mapbox Streets Localization
     /// List of supported language identifiers: https://docs.mapbox.com/data/tilesets/reference/mapbox-streets-v8/#common-fields
     internal func getLocaleValue(locale: Locale) -> String? {
-        let preferences = [locale.identifier]
         var localeValue: String?
 
         // Lists those supported by either v7 or v8
         let supportedLocaleIdentifiers = ["ar", "en", "es", "fr", "de", "it", "pt", "ru", "zh-Hans", "zh-Hant", "ja", "ko", "vi", "zh"]
 
         // Do nothing if we do not support the locale
-        if !supportedLocaleIdentifiers.contains(locale.languageCode!) {
+        guard supportedLocaleIdentifiers.contains(locale.languageCode!) else {
             return nil
         }
 
@@ -92,7 +85,7 @@ extension Style {
             }
         }
 
-        localeValue = preferredMapboxStreetsLocalization(among: preferences) ?? nil
+        localeValue = preferredMapboxStreetsLocalization(among: [locale.identifier]) ?? nil
 
         return localeValue
     }

--- a/Sources/MapboxMaps/Style/Style+Localization.swift
+++ b/Sources/MapboxMaps/Style/Style+Localization.swift
@@ -73,7 +73,7 @@ extension Style {
                 guard supportedLanguageCodesv7.contains(locale.languageCode!) else {
                     return nil
                 }
-                
+
                 // Streets v7 only supports "zh" and "zh-Hans"
                 if locale.identifier.contains("zh-Hant") {
                     return "zh"

--- a/Sources/MapboxMaps/Style/Style+Localization.swift
+++ b/Sources/MapboxMaps/Style/Style+Localization.swift
@@ -34,8 +34,11 @@ extension Style {
     /// Filters through source to determine supported locale styles.
     /// This is needed for v7 support
     internal func getLocaleValue(locale: Locale) -> String? {
+        var localeValue: String
+
         // Docs for language, region, and script codes  https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html
-        let supportedLocaleIdentifiers = ["ar", "de", "en", "es", "fr", "it", "ja", "ko", "pt", "ru", "vi", "zh", "zh-Hans", "zh-Hant", "zh-Hant-TW"]
+        // List of supported language identifiers: https://docs.mapbox.com/data/tilesets/reference/mapbox-streets-v8/#common-fields
+        let supportedLocaleIdentifiers = ["ar", "en", "es", "fr", "de", "it", "pt", "ru", "zh-Hans", "zh-Hant", "ja", "ko", "vi", "zh"]
 
         // Do nothing if we do not support the locale
         if !supportedLocaleIdentifiers.contains(locale.languageCode!) {
@@ -51,21 +54,23 @@ extension Style {
             let vectorSource = try! source(withId: sourceInfo.id, type: VectorSource.self)
 
             if vectorSource.url?.contains("mapbox.mapbox-streets-v7") == true {
-                // v7 styles does not support value of "name_zh-Hant"
+                // v7 styles do not support value of "name_zh-Hant"
                 if locale.identifier == "zh-Hant" {
-                    return "zh"
-                }
-            } else if vectorSource.url?.contains("mapbox.mapbox-streets-v8") == true {
-                // Return traditional chinese if the Locale is Taiwan
-                if locale.identifier == "zh-Hant-TW" {
-                    return "zh-Hant"
-                } else {
-                    return "zh-Hans"
+                    localeValue = "zh"
                 }
             }
         }
 
-        return supportedLocaleIdentifiers.contains(locale.identifier) ? locale.identifier : locale.languageCode!
+        // Return Traditional Chinese when specified (including Locales for Taiwan and Hong Kong)
+        if locale.identifier.starts(with: "zh-Hant") {
+            localeValue = "zh-Hant"
+        } else if locale.identifier.starts(with: "zh") {
+            localeValue = "zh-Hans"
+        } else {
+            localeValue = supportedLocaleIdentifiers.contains(locale.identifier) ? locale.identifier : locale.languageCode!
+        }
+
+        return localeValue
     }
 
     /// Converts the `SymbolLayer.textField` into the new locale

--- a/Sources/MapboxMaps/Style/Style+Localization.swift
+++ b/Sources/MapboxMaps/Style/Style+Localization.swift
@@ -71,12 +71,13 @@ extension Style {
             let vectorSource = try! source(withId: sourceInfo.id, type: VectorSource.self)
 
             if vectorSource.url?.contains("mapbox.mapbox-streets-v7") == true {
-                // v7 styles do not support value of "name_zh-Hant"
-                if locale.identifier == "zh-Hant" {
+                // Streets v7 only supports "zh" and "zh-Hans"
+                if locale.identifier.contains("zh-Hant") {
                     return "zh"
-                }
-                // v7 styles do not support Italian or Vietnamese
-                if locale.identifier == "it" || locale.identifier == "vi" {
+                } else if locale.identifier.contains("zh-Hans") {
+                    return "zh-Hans"
+                // Streets v7 does not support Italian or Vietnamese
+                } else if locale.identifier.contains("it") || locale.identifier.contains("vi") {
                     return nil
                 } else {
                     localeValue = supportedLocaleIdentifiers.contains(locale.identifier) ? locale.identifier : locale.languageCode!

--- a/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
@@ -25,10 +25,16 @@ final class StyleLocalizationTests: MapViewIntegrationTestCase {
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hans-CN")), "zh-Hans", "Extraneous region codes should be removed.")
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hant-TW")), "zh-Hant")
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hant-HK")), "zh-Hant", "Extraneous region codes should be removed.")
+        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hans-SG")), "zh-Hans")
+        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-CN")), "zh-Hans")
+        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-SG")), "zh-Hans")
+        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-TW")), "zh-Hant")
+        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-HK")), "zh-Hant")
     }
-    
+
     // Test iOS 16 Locale Components
     func testLocaleComponents() {
+        let style = mapView.mapboxMap.style
         if #available(iOS 16, *) {
             let fullLocaleHK = Locale(languageCode: "zh", script: "Hant", languageRegion: "HK")
             XCTAssertEqual(style.getLocaleValue(locale: fullLocaleHK), "zh-Hant")
@@ -38,6 +44,16 @@ final class StyleLocalizationTests: MapViewIntegrationTestCase {
             XCTAssertEqual(style.getLocaleValue(locale: partialLocaleHK2), "zh-Hant")
             let onlyZHLanguage = Locale(languageCode: "zh")
             XCTAssertEqual(style.getLocaleValue(locale: onlyZHLanguage), "zh-Hans")
+            let fullLocaleTW = Locale(languageCode: "zh", script: "Hant", languageRegion: "TW")
+            XCTAssertEqual(style.getLocaleValue(locale: fullLocaleTW), "zh-Hant")
+            let partialLocaleTW2 = Locale(languageCode: "zh", languageRegion: "TW")
+            XCTAssertEqual(style.getLocaleValue(locale: partialLocaleTW2), "zh-Hant")
+            let fullLocaleCN = Locale(languageCode: "zh", script: "Hans", languageRegion: "CN")
+            XCTAssertEqual(style.getLocaleValue(locale: fullLocaleCN), "zh-Hans")
+            let partialLocaleCN = Locale(languageCode: "zh", script: "Hans")
+            XCTAssertEqual(style.getLocaleValue(locale: partialLocaleCN), "zh-Hans")
+            let partialLocaleCN2 = Locale(languageCode: "zh", languageRegion: "CN")
+            XCTAssertEqual(style.getLocaleValue(locale: partialLocaleCN2), "zh-Hans")
         }
     }
 

--- a/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
@@ -17,18 +17,27 @@ final class StyleLocalizationTests: MapViewIntegrationTestCase {
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "pt")), "pt")
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "ru")), "ru")
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "vi")), "vi")
+        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "en-US")), "en", "Extraneous region codes should be removed.")
+        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "en-Latn")), "en", "Extraneous script codes should be removed.")
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh")), "zh-Hans")
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hans")), "zh-Hans")
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hant")), "zh-Hant")
-        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hans-CN")), "zh-Hans")
+        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hans-CN")), "zh-Hans", "Extraneous region codes should be removed.")
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hant-TW")), "zh-Hant")
-        // XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hant-HK")), "zh-Hant")
+        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hant-HK")), "zh-Hant", "Extraneous region codes should be removed.")
+    }
+    
+    // Test iOS 16 Locale Components
+    func testLocaleComponents() {
         if #available(iOS 16, *) {
-            let HongKongLocale = Locale(languageCode: "zh", script: "Hant", languageRegion: "HK")
-            XCTAssertEqual(style.getLocaleValue(locale: HongKongLocale), "zh-Hant")
-        } else {
-            let HongKongLocale = Locale(identifier: "zh-Hant-HK")
-            XCTAssertEqual(style.getLocaleValue(locale: HongKongLocale), "zh-Hant")
+            let fullLocaleHK = Locale(languageCode: "zh", script: "Hant", languageRegion: "HK")
+            XCTAssertEqual(style.getLocaleValue(locale: fullLocaleHK), "zh-Hant")
+            let partialLocaleHK = Locale(languageCode: "zh", script: "Hant")
+            XCTAssertEqual(style.getLocaleValue(locale: partialLocaleHK), "zh-Hant")
+            let partialLocaleHK2 = Locale(languageCode: "zh", languageRegion: "HK")
+            XCTAssertEqual(style.getLocaleValue(locale: partialLocaleHK2), "zh-Hant")
+            let onlyZHLanguage = Locale(languageCode: "zh")
+            XCTAssertEqual(style.getLocaleValue(locale: onlyZHLanguage), "zh-Hans")
         }
     }
 
@@ -41,6 +50,7 @@ final class StyleLocalizationTests: MapViewIntegrationTestCase {
         let style = mapView.mapboxMap.style
 
         XCTAssertThrowsError(try style.localizeLabels(into: Locale(identifier: "tlh")))
+        XCTAssertThrowsError(try style.localizeLabels(into: Locale(identifier: "frm")), "Exact string needs to match, not just prefix")
     }
 
     func testOnlyLocalizesFirstLocalization() throws {

--- a/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
@@ -32,31 +32,6 @@ final class StyleLocalizationTests: MapViewIntegrationTestCase {
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-HK")), "zh-Hant")
     }
 
-    // Test iOS 16 Locale Components
-    func testLocaleComponents() {
-        let style = mapView.mapboxMap.style
-        if #available(iOS 16, *) {
-            let fullLocaleHK = Locale(languageCode: "zh", script: "Hant", languageRegion: "HK")
-            XCTAssertEqual(style.getLocaleValue(locale: fullLocaleHK), "zh-Hant")
-            let partialLocaleHK = Locale(languageCode: "zh", script: "Hant")
-            XCTAssertEqual(style.getLocaleValue(locale: partialLocaleHK), "zh-Hant")
-            let partialLocaleHK2 = Locale(languageCode: "zh", languageRegion: "HK")
-            XCTAssertEqual(style.getLocaleValue(locale: partialLocaleHK2), "zh-Hant")
-            let onlyZHLanguage = Locale(languageCode: "zh")
-            XCTAssertEqual(style.getLocaleValue(locale: onlyZHLanguage), "zh-Hans")
-            let fullLocaleTW = Locale(languageCode: "zh", script: "Hant", languageRegion: "TW")
-            XCTAssertEqual(style.getLocaleValue(locale: fullLocaleTW), "zh-Hant")
-            let partialLocaleTW2 = Locale(languageCode: "zh", languageRegion: "TW")
-            XCTAssertEqual(style.getLocaleValue(locale: partialLocaleTW2), "zh-Hant")
-            let fullLocaleCN = Locale(languageCode: "zh", script: "Hans", languageRegion: "CN")
-            XCTAssertEqual(style.getLocaleValue(locale: fullLocaleCN), "zh-Hans")
-            let partialLocaleCN = Locale(languageCode: "zh", script: "Hans")
-            XCTAssertEqual(style.getLocaleValue(locale: partialLocaleCN), "zh-Hans")
-            let partialLocaleCN2 = Locale(languageCode: "zh", languageRegion: "CN")
-            XCTAssertEqual(style.getLocaleValue(locale: partialLocaleCN2), "zh-Hans")
-        }
-    }
-
     func testGetLocaleValueDoesNotExist() {
         let style = mapView.mapboxMap.style
         XCTAssertNil(style.getLocaleValue(locale: Locale(identifier: "FAKE")))

--- a/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
@@ -44,20 +44,42 @@ final class StyleLocalizationTests: MapViewIntegrationTestCase {
         XCTAssertThrowsError(try style.localizeLabels(into: Locale(identifier: "frm")), "Exact string needs to match, not just prefix")
     }
 
-    func testpreferredMapboxStreetsLocalization() {
+    func testPreferredMapboxStreetsv7Localization() {
         let style = mapView.mapboxMap.style
+        let supportedLanguageCodesv7 = ["ar", "en", "es", "fr", "de", "pt", "ru", "ja", "ko", "zh", "zh_Hans"]
 
-        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["de"]), "de")
-        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["en", "de"]), "en")
-        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "de", "en"]), "de")
-        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "de", "zh-Hans"]), "de")
-        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "zh-Hans"]), "zh-Hans")
-        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "zh"]), "zh-Hans")
-        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "zh", "zh-Hant"]), "zh-Hans")
-        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["vi", "ko"]), "vi")
-        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["ar", "en", "es", "fr", "de", "it", "pt", "ru", "zh-Hans", "zh-Hant", "ja", "ko", "vi"]), "ar")
-        XCTAssertNil(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "ffzh"]))
-        XCTAssertNil(style.preferredMapboxStreetsLocalization(among: [""]))
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["de"], from: supportedLanguageCodesv7), "de")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["en", "de"], from: supportedLanguageCodesv7), "en")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "de", "en"], from: supportedLanguageCodesv7), "de")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "de", "zh-Hans"], from: supportedLanguageCodesv7), "de")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "zh-Hans"], from: supportedLanguageCodesv7), "zh-Hans")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "zh"], from: supportedLanguageCodesv7), "zh")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "zh", "zh-Hant"], from: supportedLanguageCodesv7), "zh")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "zh-Hant", "zh-Hans"], from: supportedLanguageCodesv7), "zh-Hans")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["ar", "en", "es", "fr", "de", "it", "pt", "ru", "zh-Hans", "zh-Hant", "ja", "ko", "vi"], from: supportedLanguageCodesv7), "ar")
+        XCTAssertNil(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "ffzh"], from: supportedLanguageCodesv7))
+        XCTAssertNil(style.preferredMapboxStreetsLocalization(among: [""], from: supportedLanguageCodesv7))
+        XCTAssertNil(style.preferredMapboxStreetsLocalization(among: ["vi", "it"], from: supportedLanguageCodesv7))
+        XCTAssertNil(style.preferredMapboxStreetsLocalization(among: ["it"], from: supportedLanguageCodesv7))
+        XCTAssertNil(style.preferredMapboxStreetsLocalization(among: ["vi"], from: supportedLanguageCodesv7))
+    }
+
+    func testPreferredMapboxStreetsv8Localization() {
+        let style = mapView.mapboxMap.style
+        let supportedLanguageCodesv8 = ["ar", "en", "es", "fr", "de", "it", "pt", "ru", "zh_Hans", "zh_Hant", "ja", "ko", "vi"]
+
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["de"], from: supportedLanguageCodesv8), "de")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["en", "de"], from: supportedLanguageCodesv8), "en")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "de", "en"], from: supportedLanguageCodesv8), "de")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "de", "zh-Hans"], from: supportedLanguageCodesv8), "de")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "zh-Hans"], from: supportedLanguageCodesv8), "zh-Hans")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "zh"], from: supportedLanguageCodesv8), "zh-Hans")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "zh", "zh-Hant"], from: supportedLanguageCodesv8), "zh-Hans")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "zh-hant", "zh-Hans"], from: supportedLanguageCodesv8), "zh-Hant")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["vi", "ko"], from: supportedLanguageCodesv8), "vi")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["ar", "en", "es", "fr", "de", "it", "pt", "ru", "zh-Hans", "zh-Hant", "ja", "ko", "vi"], from: supportedLanguageCodesv8), "ar")
+        XCTAssertNil(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "ffzh"], from: supportedLanguageCodesv8))
+        XCTAssertNil(style.preferredMapboxStreetsLocalization(among: [""], from: supportedLanguageCodesv8))
     }
 
     func testOnlyLocalizesFirstLocalization() throws {

--- a/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
@@ -17,10 +17,19 @@ final class StyleLocalizationTests: MapViewIntegrationTestCase {
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "pt")), "pt")
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "ru")), "ru")
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "vi")), "vi")
-        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh")), "zh")
+        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh")), "zh-Hans")
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hans")), "zh-Hans")
         XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hant")), "zh-Hant")
-        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hant-TW")), "zh-Hant-TW")
+        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hans-CN")), "zh-Hans")
+        XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hant-TW")), "zh-Hant")
+        // XCTAssertEqual(style.getLocaleValue(locale: Locale(identifier: "zh-Hant-HK")), "zh-Hant")
+        if #available(iOS 16, *) {
+            let HongKongLocale = Locale(languageCode: "zh", script: "Hant", languageRegion: "HK")
+            XCTAssertEqual(style.getLocaleValue(locale: HongKongLocale), "zh-Hant")
+        } else {
+            let HongKongLocale = Locale(identifier: "zh-Hant-HK")
+            XCTAssertEqual(style.getLocaleValue(locale: HongKongLocale), "zh-Hant")
+        }
     }
 
     func testGetLocaleValueDoesNotExist() {

--- a/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
+++ b/Tests/MapboxMapsTests/Style/Style+LocalizationTests.swift
@@ -44,6 +44,22 @@ final class StyleLocalizationTests: MapViewIntegrationTestCase {
         XCTAssertThrowsError(try style.localizeLabels(into: Locale(identifier: "frm")), "Exact string needs to match, not just prefix")
     }
 
+    func testpreferredMapboxStreetsLocalization() {
+        let style = mapView.mapboxMap.style
+
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["de"]), "de")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["en", "de"]), "en")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "de", "en"]), "de")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "de", "zh-Hans"]), "de")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "zh-Hans"]), "zh-Hans")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "zh"]), "zh-Hans")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "zh", "zh-Hant"]), "zh-Hans")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["vi", "ko"]), "vi")
+        XCTAssertEqual(style.preferredMapboxStreetsLocalization(among: ["ar", "en", "es", "fr", "de", "it", "pt", "ru", "zh-Hans", "zh-Hant", "ja", "ko", "vi"]), "ar")
+        XCTAssertNil(style.preferredMapboxStreetsLocalization(among: ["rett", "der", "ffzh"]))
+        XCTAssertNil(style.preferredMapboxStreetsLocalization(among: [""]))
+    }
+
     func testOnlyLocalizesFirstLocalization() throws {
         var source = GeoJSONSource()
         source.data = .feature(Feature(geometry: Point(CLLocationCoordinate2D(latitude: 0, longitude: 0))))

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -367,6 +367,33 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
 
         try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh-Hans-CN"))
         assert(placeLabelProperty: "name_zh-Hans")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh_Hant-TW"))
+        assert(placeLabelProperty: "name_zh")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh_Hant-HK"))
+        assert(placeLabelProperty: "name_zh")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh_Hans-CN"))
+        assert(placeLabelProperty: "name_zh-Hans")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh_Hant_TW"))
+        assert(placeLabelProperty: "name_zh")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh_Hant_HK"))
+        assert(placeLabelProperty: "name_zh")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh_Hans_CN"))
+        assert(placeLabelProperty: "name_zh-Hans")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh-Hant-TW"))
+        assert(placeLabelProperty: "name_zh")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh-Hant-HK"))
+        assert(placeLabelProperty: "name_zh")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh-Hans-CN"))
+        assert(placeLabelProperty: "name_zh-Hans")
     }
 
     func testLocalizeLabelsv8() {
@@ -484,6 +511,33 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
         assert(placeLabelProperty: "name_zh-Hant")
 
         try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh-Hans-CN"))
+        assert(placeLabelProperty: "name_zh-Hans")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh_Hant_TW"))
+        assert(placeLabelProperty: "name_zh-Hant")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh_Hant_HK"))
+        assert(placeLabelProperty: "name_zh-Hant")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh_Hans_CN"))
+        assert(placeLabelProperty: "name_zh-Hans")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh_Hant-TW"))
+        assert(placeLabelProperty: "name_zh-Hant")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh_Hant-HK"))
+        assert(placeLabelProperty: "name_zh-Hant")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh_Hans-CN"))
+        assert(placeLabelProperty: "name_zh-Hans")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh-Hant_TW"))
+        assert(placeLabelProperty: "name_zh-Hant")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh-Hant_HK"))
+        assert(placeLabelProperty: "name_zh-Hant")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh-Hans_CN"))
         assert(placeLabelProperty: "name_zh-Hans")
 
         XCTAssertThrowsError(try mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "jkls")), "Locale string needs to match exactly")

--- a/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Style/StyleIntegrationTests.swift
@@ -253,6 +253,242 @@ internal class StyleIntegrationTests: MapViewIntegrationTestCase {
         XCTAssertEqual(result, convertedString)
     }
 
+    func testLocalizeLabelsv7() {
+        let resourceOptions = ResourceOptions(accessToken: "")
+        let mapInitOptions = MapInitOptions(resourceOptions: resourceOptions)
+        let mapView = MapView(frame: UIScreen.main.bounds, mapInitOptions: mapInitOptions)
+
+        let styleJSONObject: [String: Any] = [
+            "version": 7,
+            "center": [
+                -122.385563, 37.763330
+            ],
+            "zoom": 15,
+            "sources": [
+                "composite": [
+                    "url": "mapbox://mapbox.mapbox-streets-v7,mapbox.mapbox-terrain-v2",
+                    "type": "vector",
+                ]
+            ],
+            "layers": [
+                [
+                    "id": "place-labels",
+                    "type": "symbol",
+                    "source": "composite",
+                    "source-layer": "place",
+                    "layout": [
+                        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+                    ],
+                ],
+            ],
+        ]
+
+        let styleJSON: String = ValueConverter.toJson(forValue: styleJSONObject)
+        XCTAssertFalse(styleJSON.isEmpty, "ValueConverter should create valid JSON string.")
+
+        let mapLoadingErrorExpectation = expectation(description: "Map loading error expectation")
+        mapLoadingErrorExpectation.assertForOverFulfill = false
+
+        mapView.mapboxMap.onNext(event: .mapLoadingError, handler: { _ in
+            mapLoadingErrorExpectation.fulfill()
+        })
+
+        mapView.mapboxMap.loadStyleJSON(styleJSON)
+
+        wait(for: [mapLoadingErrorExpectation], timeout: 10.0)
+
+        let style = mapView.mapboxMap.style
+        XCTAssertEqual(style.allSourceIdentifiers.count, 1)
+        XCTAssertEqual(style.allLayerIdentifiers.count, 1)
+
+        func textFieldExpression(layerIdentifier: String) -> Exp? {
+            let expressionArray = style.layerProperty(for: layerIdentifier, property: "text-field").value
+
+            var expressionData: Data?
+            XCTAssertNoThrow(expressionData = try JSONSerialization.data(withJSONObject: expressionArray, options: []))
+            guard expressionData != nil else { return nil }
+
+            var expression: Exp?
+            XCTAssertNoThrow(expression = try JSONDecoder().decode(Exp.self, from: expressionData!))
+            return expression
+        }
+
+        XCTAssertEqual(textFieldExpression(layerIdentifier: "place-labels"),
+                       Exp(.format) {
+                        Exp(.coalesce) { Exp(.get) { "name_en" }; Exp(.get) { "name" } }
+                        FormatOptions()
+                       },
+                       "Place labels should be in English by default.")
+
+        func assert(placeLabelProperty: String) {
+            XCTAssertEqual(textFieldExpression(layerIdentifier: "place-labels"),
+                           Exp(.format) {
+                            Exp(.coalesce) { Exp(.get) { placeLabelProperty }; Exp(.get) { "name" } }
+                            FormatOptions()
+                           },
+                           "Place labels should be localized after localization.")
+        }
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "ar"))
+        assert(placeLabelProperty: "name_ar")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "en"))
+        assert(placeLabelProperty: "name_en")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "es"))
+        assert(placeLabelProperty: "name_es")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "fr"))
+        assert(placeLabelProperty: "name_fr")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "de"))
+        assert(placeLabelProperty: "name_de")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "pt"))
+        assert(placeLabelProperty: "name_pt")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "ru"))
+        assert(placeLabelProperty: "name_ru")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "ja"))
+        assert(placeLabelProperty: "name_ja")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "ko"))
+        assert(placeLabelProperty: "name_ko")
+
+        XCTAssertThrowsError(try mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "vi")), "Vietnamese not availabe in Streets v7")
+
+        XCTAssertThrowsError(try mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "it")), "Italian not availabe in Streets v7")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh-Hant-TW"))
+        assert(placeLabelProperty: "name_zh")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh-Hant-HK"))
+        assert(placeLabelProperty: "name_zh")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh-Hans-CN"))
+        assert(placeLabelProperty: "name_zh-Hans")
+    }
+
+    func testLocalizeLabelsv8() {
+        let resourceOptions = ResourceOptions(accessToken: "")
+        let mapInitOptions = MapInitOptions(resourceOptions: resourceOptions)
+        let mapView = MapView(frame: UIScreen.main.bounds, mapInitOptions: mapInitOptions)
+
+        let styleJSONObject: [String: Any] = [
+            "version": 8,
+            "center": [
+                -122.385563, 37.763330
+            ],
+            "zoom": 15,
+            "sources": [
+                "composite": [
+                    "url": "mapbox://mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2",
+                    "type": "vector",
+                ]
+            ],
+            "layers": [
+                [
+                    "id": "place-labels",
+                    "type": "symbol",
+                    "source": "composite",
+                    "source-layer": "place",
+                    "layout": [
+                        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+                    ],
+                ],
+            ],
+        ]
+
+        let styleJSON: String = ValueConverter.toJson(forValue: styleJSONObject)
+        XCTAssertFalse(styleJSON.isEmpty, "ValueConverter should create valid JSON string.")
+
+        let mapLoadingErrorExpectation = expectation(description: "Map loading error expectation")
+        mapLoadingErrorExpectation.assertForOverFulfill = false
+
+        mapView.mapboxMap.onNext(event: .mapLoadingError, handler: { _ in
+            mapLoadingErrorExpectation.fulfill()
+        })
+
+        mapView.mapboxMap.loadStyleJSON(styleJSON)
+
+        wait(for: [mapLoadingErrorExpectation], timeout: 10.0)
+
+        let style = mapView.mapboxMap.style
+        XCTAssertEqual(style.allSourceIdentifiers.count, 1)
+        XCTAssertEqual(style.allLayerIdentifiers.count, 1)
+
+        func textFieldExpression(layerIdentifier: String) -> Exp? {
+            let expressionArray = style.layerProperty(for: layerIdentifier, property: "text-field").value
+
+            var expressionData: Data?
+            XCTAssertNoThrow(expressionData = try JSONSerialization.data(withJSONObject: expressionArray, options: []))
+            guard expressionData != nil else { return nil }
+
+            var expression: Exp?
+            XCTAssertNoThrow(expression = try JSONDecoder().decode(Exp.self, from: expressionData!))
+            return expression
+        }
+
+        XCTAssertEqual(textFieldExpression(layerIdentifier: "place-labels"),
+                       Exp(.format) {
+                        Exp(.coalesce) { Exp(.get) { "name_en" }; Exp(.get) { "name" } }
+                        FormatOptions()
+                       },
+                       "Place labels should be in English by default.")
+
+        func assert(placeLabelProperty: String) {
+            XCTAssertEqual(textFieldExpression(layerIdentifier: "place-labels"),
+                           Exp(.format) {
+                            Exp(.coalesce) { Exp(.get) { placeLabelProperty }; Exp(.get) { "name" } }
+                            FormatOptions()
+                           },
+                           "Place labels should be localized after localization.")
+        }
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "ar"))
+        assert(placeLabelProperty: "name_ar")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "en"))
+        assert(placeLabelProperty: "name_en")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "es"))
+        assert(placeLabelProperty: "name_es")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "fr"))
+        assert(placeLabelProperty: "name_fr")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "de"))
+        assert(placeLabelProperty: "name_de")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "pt"))
+        assert(placeLabelProperty: "name_pt")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "ru"))
+        assert(placeLabelProperty: "name_ru")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "ja"))
+        assert(placeLabelProperty: "name_ja")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "ko"))
+        assert(placeLabelProperty: "name_ko")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "vi"))
+        assert(placeLabelProperty: "name_vi")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "it"))
+        assert(placeLabelProperty: "name_it")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh-Hant-TW"))
+        assert(placeLabelProperty: "name_zh-Hant")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh-Hant-HK"))
+        assert(placeLabelProperty: "name_zh-Hant")
+
+        try! mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "zh-Hans-CN"))
+        assert(placeLabelProperty: "name_zh-Hans")
+
+        XCTAssertThrowsError(try mapView.mapboxMap.style.localizeLabels(into: Locale(identifier: "jkls")), "Locale string needs to match exactly")
+    }
+
     func testTerrain() throws {
         let sourceId = String.randomASCII(withLength: .random(in: 1...20))
         let exaggeration = Double.random(in: 0...1000)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
This PR addresses #652, properly localizing labels into the preferred script based on Locale. To do so, this PR follows -- with some modifications to avoid breaking changes -- the approach from the Navigation SDK (see [here](https://github.com/mapbox/mapbox-navigation-ios/blob/28d13ff313cb44c47f69c6e386ec6f3dd855e63e/Sources/MapboxNavigation/VectorSource.swift#L27)). This approach provides more robust support for a Locale's preferred language and script option, by checking the preference against the set of language + scripts supported by Mapbox Streets [v8](https://docs.mapbox.com/data/tilesets/reference/mapbox-streets-v8/#common-fields) or [v7](https://docs.mapbox.com/data/tilesets/reference/legacy/mapbox-streets-v7/#name-fields). Additionally, test coverage is expanded to cover more Locales and the localization example modified to include a "Device Locale" option. 

https://user-images.githubusercontent.com/7976026/199850097-fc746fba-6d91-4d4a-a23e-2eca6fec3b11.mp4


<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [x] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
