### PR TITLE
Fix memory leak when viewport is being deallocated while transition is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+* Fix memory leak when viewport is being deallocated while transition is running. ([#1691](https://github.com/mapbox/mapbox-maps-ios/pull/1691))
+
 ## 10.10.0-beta-1 - November 4, 2022
 
 * Animates to camera that fit a list of view annotations. ([#1634](https://github.com/mapbox/mapbox-maps-ios/pull/1634))

--- a/Sources/MapboxMaps/Viewport/ViewportImpl.swift
+++ b/Sources/MapboxMaps/Viewport/ViewportImpl.swift
@@ -37,6 +37,12 @@ internal final class ViewportImpl: ViewportImplProtocol {
 
     private let anyTouchGestureRecognizer: UIGestureRecognizer
 
+    deinit {
+        currentCancelable?.cancel()
+        currentCancelable = nil
+        status = .idle
+    }
+
     // viewport requires a default transition at all times
     internal init(options: ViewportOptions,
                   mainQueue: DispatchQueueProtocol,

--- a/Sources/MapboxMaps/Viewport/ViewportImpl.swift
+++ b/Sources/MapboxMaps/Viewport/ViewportImpl.swift
@@ -39,7 +39,6 @@ internal final class ViewportImpl: ViewportImplProtocol {
 
     deinit {
         currentCancelable?.cancel()
-        currentCancelable = nil
         status = .idle
     }
 

--- a/Tests/MapboxMapsTests/Integration Tests/Map/MapViewIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Integration Tests/Map/MapViewIntegrationTests.swift
@@ -112,12 +112,16 @@ final class MapViewIntegrationTests: IntegrationTestCase {
              XCTAssertNotNil(weakMapView)
          }
 
+        let mainQueueExpectation = expectation(description: "Main queue scheduled event")
         // appending the check to the end of the queue as some delegate notification are scheduled on the main queue
         DispatchQueue.main.async {
+            mainQueueExpectation.fulfill()
             XCTAssertNil(weakState)
             XCTAssertNil(weakViewport)
             XCTAssertNil(weakMapView)
         }
+
+        wait(for: [mainQueueExpectation], timeout: 1)
     }
 
     func testMapViewDoesNotStartLocationServicesAutomatically() {

--- a/Tests/MapboxMapsTests/Integration Tests/Map/MapViewIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Integration Tests/Map/MapViewIntegrationTests.swift
@@ -81,7 +81,7 @@ final class MapViewIntegrationTests: IntegrationTestCase {
         weak var weakViewport: Viewport?
         weak var weakMapView: MapView?
 
-        try autoreleasepool { () -> Void in
+        try autoreleasepool {
             guard let rootView = rootViewController?.view else {
                 throw XCTSkip("No valid UIWindow or root view controller")
             }

--- a/Tests/MapboxMapsTests/Viewport/ViewportImplTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/ViewportImplTests.swift
@@ -63,6 +63,28 @@ final class ViewportImplTests: XCTestCase {
         }
     }
 
+    func testViewportAndStateIsReleasedAfterTransition() {
+        weak var weakState: ViewportState?
+        weak var weakImpl: ViewportImpl? = viewportImpl
+
+        autoreleasepool {
+            let state = MockViewportState()
+            weakState = state
+            viewportImpl.transition(to: state, transition: nil, completion: nil)
+            viewportImpl = nil
+
+            // reset stubs to break their references to the viewport impl
+            mainQueue.asyncClosureStub.reset()
+            defaultTransition.runStub.reset()
+            anyTouchGestureRecognizer.addTargetStub.reset()
+            doubleTapGestureRecognizer.addTargetStub.reset()
+            doubleTouchGestureRecognizer.addTargetStub.reset()
+        }
+
+        XCTAssertNil(weakState)
+        XCTAssertNil(weakImpl)
+    }
+
     func transitionAndNotify(withToState toState: ViewportState, transition: ViewportTransition? = nil, completion: ((Bool) -> Void)?) {
         viewportImpl.transition(to: toState, transition: transition, completion: completion)
         drainMainQueue()

--- a/Tests/MapboxMapsTests/Viewport/ViewportImplTests.swift
+++ b/Tests/MapboxMapsTests/Viewport/ViewportImplTests.swift
@@ -63,28 +63,6 @@ final class ViewportImplTests: XCTestCase {
         }
     }
 
-    func testViewportAndStateIsReleasedAfterTransition() {
-        weak var weakState: ViewportState?
-        weak var weakImpl: ViewportImpl? = viewportImpl
-
-        autoreleasepool {
-            let state = MockViewportState()
-            weakState = state
-            viewportImpl.transition(to: state, transition: nil, completion: nil)
-            viewportImpl = nil
-
-            // reset stubs to break their references to the viewport impl
-            mainQueue.asyncClosureStub.reset()
-            defaultTransition.runStub.reset()
-            anyTouchGestureRecognizer.addTargetStub.reset()
-            doubleTapGestureRecognizer.addTargetStub.reset()
-            doubleTouchGestureRecognizer.addTargetStub.reset()
-        }
-
-        XCTAssertNil(weakState)
-        XCTAssertNil(weakImpl)
-    }
-
     func transitionAndNotify(withToState toState: ViewportState, transition: ViewportTransition? = nil, completion: ((Bool) -> Void)?) {
         viewportImpl.transition(to: toState, transition: transition, completion: completion)
         drainMainQueue()


### PR DESCRIPTION
This PR addresses a memory leak that happens if viewport is deallocated before state transition is finished.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
