### PR TITLE
Flush telemetry on MapView deinit

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/MapboxMaps.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/MapboxMaps.xcscheme
@@ -68,7 +68,7 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "NO"
+            buildForRunning = "YES"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "YES">

--- a/Apps/Examples/Examples.xcodeproj/xcshareddata/xcschemes/Examples.xcscheme
+++ b/Apps/Examples/Examples.xcodeproj/xcshareddata/xcschemes/Examples.xcscheme
@@ -55,6 +55,16 @@
                ReferencedContainer = "container:Examples.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "MapboxMapsTests"
+               BuildableName = "MapboxMapsTests"
+               BlueprintName = "MapboxMapsTests"
+               ReferencedContainer = "container:../..">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ XCODE_BUILD_SIM_SDK = set -o pipefail && xcodebuild \
 	-sdk iphonesimulator \
 	-configuration $(CONFIGURATION) \
 	-jobs $(JOBS) \
+	ENABLE_TESTABILITY=YES \
 	COMPILER_INDEX_STORE_ENABLE=NO
 
 .PHONY: build-sdk-for-simulator
@@ -101,7 +102,6 @@ build-sdk-for-testing-simulator:
 		-destination 'platform=iOS Simulator,OS=latest,name=iPhone 11' \
 		-enableCodeCoverage YES \
 		build-for-testing \
-		ENABLE_TESTABILITY=YES \
 		ONLY_ACTIVE_ARCH=YES
 
 .PHONY: test-sdk-without-building-simulator
@@ -154,6 +154,7 @@ build-sdk-for-device:
 		build \
 		ONLY_ACTIVE_ARCH=NO \
 		COMPILER_INDEX_STORE_ENABLE=NO \
+		ENABLE_TESTABILITY=YES \
 		$(CODE_SIGNING)
 
 $(XCODE_PROJECT_FILE): project.yml

--- a/Sources/MapboxMaps/Foundation/Events/EventsManager.swift
+++ b/Sources/MapboxMaps/Foundation/Events/EventsManager.swift
@@ -14,7 +14,17 @@ extension UserDefaults {
     }
 }
 
-internal final class EventsManager {
+internal protocol EventsManagerProtocol {
+    static func shared(withAccessToken accessToken: String) -> EventsManagerProtocol
+
+    func sendMapLoadEvent()
+
+    func sendTurnstile()
+
+    func flush()
+}
+
+internal final class EventsManager: EventsManagerProtocol {
     private enum Constants {
         static let MGLAPIClientUserAgentBase = "mapbox-maps-ios"
         static let SDKVersion = Bundle.mapboxMapsMetadata.version
@@ -27,7 +37,7 @@ internal final class EventsManager {
     // calls to MMEEventsManager.shared().flush() when handling memory warnings.
     private static var shared: EventsManager?
 
-    internal static func shared(withAccessToken accessToken: String) -> EventsManager {
+    internal static func shared(withAccessToken accessToken: String) -> EventsManagerProtocol {
         let result = shared ?? EventsManager(accessToken: accessToken)
         shared = result
         return result
@@ -39,8 +49,10 @@ internal final class EventsManager {
 
     private let metricsEnabledObservation: NSKeyValueObservation
 
-    private init(accessToken: String) {
-        let eventsServerOptions = EventsServerOptions(token: accessToken, userAgentFragment: Constants.MGLAPIClientUserAgentBase, deferredDeliveryServiceOptions: nil)
+    internal init(accessToken: String) {
+        let eventsServerOptions = EventsServerOptions(token: accessToken,
+                                                      userAgentFragment: Constants.MGLAPIClientUserAgentBase,
+                                                      deferredDeliveryServiceOptions: nil)
         eventsService = EventsService.getOrCreate(for: eventsServerOptions)
         telemetryService = TelemetryService.getOrCreate(for: eventsServerOptions)
 

--- a/Sources/MapboxMaps/Foundation/Events/EventsManager.swift
+++ b/Sources/MapboxMaps/Foundation/Events/EventsManager.swift
@@ -134,12 +134,16 @@ internal final class EventsManager {
 
     internal func sendMapLoadEvent() {
         let attributes = self.getMapLoadEventAttributes()
-        let mapLoadEvent = MapboxCommon_Private.Event(priority: .queued, attributes: attributes, deferredOptions: nil)
+        let mapLoadEvent = MapboxCommon_Private.Event(priority: .queued,
+                                                      attributes: attributes,
+                                                      deferredOptions: nil)
         eventsService.sendEvent(for: mapLoadEvent)
     }
 
     internal func sendTurnstile() {
-        let turnstileEvent = TurnstileEvent(skuId: UserSKUIdentifier.mapsMAUS, sdkIdentifier: Constants.MGLAPIClientUserAgentBase, sdkVersion: Constants.SDKVersion)
+        let turnstileEvent = TurnstileEvent(skuId: UserSKUIdentifier.mapsMAUS,
+                                            sdkIdentifier: Constants.MGLAPIClientUserAgentBase,
+                                            sdkVersion: Constants.SDKVersion)
         eventsService.sendTurnstileEvent(for: turnstileEvent)
     }
 

--- a/Sources/MapboxMaps/Foundation/Events/EventsManager.swift
+++ b/Sources/MapboxMaps/Foundation/Events/EventsManager.swift
@@ -134,7 +134,7 @@ internal final class EventsManager {
 
     internal func sendMapLoadEvent() {
         let attributes = self.getMapLoadEventAttributes()
-        let mapLoadEvent = MapboxCommon_Private.Event(priority: .immediate, attributes: attributes, deferredOptions: nil)
+        let mapLoadEvent = MapboxCommon_Private.Event(priority: .queued, attributes: attributes, deferredOptions: nil)
         eventsService.sendEvent(for: mapLoadEvent)
     }
 

--- a/Sources/MapboxMaps/Foundation/Events/EventsManager.swift
+++ b/Sources/MapboxMaps/Foundation/Events/EventsManager.swift
@@ -142,4 +142,10 @@ internal final class EventsManager {
         let turnstileEvent = TurnstileEvent(skuId: UserSKUIdentifier.mapsMAUS, sdkIdentifier: Constants.MGLAPIClientUserAgentBase, sdkVersion: Constants.SDKVersion)
         eventsService.sendTurnstileEvent(for: turnstileEvent)
     }
+
+    /// Flush events from internal telemetry and events services
+    internal func flush() {
+        telemetryService.flush()
+        eventsService.flush()
+    }
 }

--- a/Sources/MapboxMaps/Foundation/Events/EventsManager.swift
+++ b/Sources/MapboxMaps/Foundation/Events/EventsManager.swift
@@ -14,7 +14,7 @@ extension UserDefaults {
     }
 }
 
-internal protocol EventsManagerProtocol {
+internal protocol EventsManagerProtocol: AnyObject {
     func sendMapLoadEvent()
 
     func sendTurnstile()

--- a/Sources/MapboxMaps/Foundation/MapView+Attribution.swift
+++ b/Sources/MapboxMaps/Foundation/MapView+Attribution.swift
@@ -37,7 +37,7 @@ extension MapView: AttributionDialogManagerDelegate {
         var queryItems = [referrerQueryItem]
 
         let sdkVersion = Bundle.mapboxMapsMetadata.version
-        var accessToken = resourceOptions?.accessToken ?? "unknown"
+        var accessToken = resourceOptions.accessToken
         accessToken = accessToken.isEmpty ? "unknown" : accessToken
 
         if let styleURIString = mapboxMap.style.uri?.rawValue,

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -78,7 +78,7 @@ open class MapView: UIView {
     private let viewAnnotationContainerView = SubviewInteractionOnlyView()
 
     /// Resource options for this map view
-    internal private(set) var resourceOptions: ResourceOptions!
+    internal let resourceOptions: ResourceOptions!
 
     private var needsDisplayRefresh: Bool = false
     private var displayLink: DisplayLinkProtocol?
@@ -172,6 +172,8 @@ open class MapView: UIView {
 
     internal let attributionUrlOpener: AttributionURLOpener
 
+    internal let eventsManager: EventsManagerProtocol
+
     /// Initialize a MapView
     /// - Parameters:
     ///   - frame: frame for the MapView.
@@ -186,11 +188,13 @@ open class MapView: UIView {
             orientationProvider = UIApplicationInterfaceOrientationProvider()
         }
 
-        self.dependencyProvider = MapViewDependencyProvider(interfaceOrientationProvider: orientationProvider)
-        self.attributionUrlOpener = DefaultAttributionURLOpener()
+        dependencyProvider = MapViewDependencyProvider(interfaceOrientationProvider: orientationProvider)
+        attributionUrlOpener = DefaultAttributionURLOpener()
         notificationCenter = dependencyProvider.notificationCenter
         bundle = dependencyProvider.bundle
         cameraAnimatorsRunnerEnablable = dependencyProvider.cameraAnimatorsRunnerEnablable
+        resourceOptions = mapInitOptions.resourceOptions
+        eventsManager = dependencyProvider.makeEventsManager(accessToken: resourceOptions.accessToken)
         super.init(frame: frame)
         commonInit(mapInitOptions: mapInitOptions, overridingStyleURI: nil)
     }
@@ -207,11 +211,13 @@ open class MapView: UIView {
                 mapInitOptions: MapInitOptions = MapInitOptions(),
                 orientationProvider: InterfaceOrientationProvider,
                 urlOpener: AttributionURLOpener) {
-        self.dependencyProvider = MapViewDependencyProvider(interfaceOrientationProvider: orientationProvider)
-        self.attributionUrlOpener = urlOpener
+        dependencyProvider = MapViewDependencyProvider(interfaceOrientationProvider: orientationProvider)
+        attributionUrlOpener = urlOpener
         notificationCenter = dependencyProvider.notificationCenter
         bundle = dependencyProvider.bundle
         cameraAnimatorsRunnerEnablable = dependencyProvider.cameraAnimatorsRunnerEnablable
+        resourceOptions = mapInitOptions.resourceOptions
+        eventsManager = dependencyProvider.makeEventsManager(accessToken: resourceOptions.accessToken)
         super.init(frame: frame)
         commonInit(mapInitOptions: mapInitOptions, overridingStyleURI: nil)
     }
@@ -226,13 +232,15 @@ open class MapView: UIView {
     public init(frame: CGRect,
                 mapInitOptions: MapInitOptions = MapInitOptions(),
                 urlOpener: AttributionURLOpener) {
-        self.dependencyProvider = MapViewDependencyProvider(
+        dependencyProvider = MapViewDependencyProvider(
             interfaceOrientationProvider: DefaultInterfaceOrientationProvider()
         )
-        self.attributionUrlOpener = urlOpener
+        attributionUrlOpener = urlOpener
         notificationCenter = dependencyProvider.notificationCenter
         bundle = dependencyProvider.bundle
         cameraAnimatorsRunnerEnablable = dependencyProvider.cameraAnimatorsRunnerEnablable
+        resourceOptions = mapInitOptions.resourceOptions
+        eventsManager = dependencyProvider.makeEventsManager(accessToken: resourceOptions.accessToken)
         super.init(frame: frame)
         commonInit(mapInitOptions: mapInitOptions, overridingStyleURI: nil)
     }
@@ -250,7 +258,9 @@ open class MapView: UIView {
         notificationCenter = dependencyProvider.notificationCenter
         bundle = dependencyProvider.bundle
         cameraAnimatorsRunnerEnablable = dependencyProvider.cameraAnimatorsRunnerEnablable
-        self.attributionUrlOpener = DefaultAttributionURLOpener()
+        attributionUrlOpener = DefaultAttributionURLOpener()
+        resourceOptions = ResourceOptionsManager.default.resourceOptions
+        eventsManager = dependencyProvider.makeEventsManager(accessToken: resourceOptions.accessToken)
         super.init(coder: coder)
     }
 
@@ -259,10 +269,12 @@ open class MapView: UIView {
                   dependencyProvider: MapViewDependencyProviderProtocol,
                   urlOpener: AttributionURLOpener) {
         self.dependencyProvider = dependencyProvider
-        self.attributionUrlOpener = urlOpener
+        attributionUrlOpener = urlOpener
         notificationCenter = dependencyProvider.notificationCenter
         bundle = dependencyProvider.bundle
         cameraAnimatorsRunnerEnablable = dependencyProvider.cameraAnimatorsRunnerEnablable
+        resourceOptions = mapInitOptions.resourceOptions
+        eventsManager = dependencyProvider.makeEventsManager(accessToken: resourceOptions.accessToken)
         super.init(frame: frame)
         commonInit(mapInitOptions: mapInitOptions, overridingStyleURI: nil)
     }
@@ -276,8 +288,6 @@ open class MapView: UIView {
 
     private func commonInit(mapInitOptions: MapInitOptions, overridingStyleURI: URL?) {
         checkForMetalSupport()
-
-        self.resourceOptions = mapInitOptions.resourceOptions
 
         let resolvedMapInitOptions: MapInitOptions
         if mapInitOptions.mapOptions.size == nil {
@@ -357,7 +367,6 @@ open class MapView: UIView {
     }
 
     internal func sendInitialTelemetryEvents() {
-        let eventsManager = EventsManager.shared(withAccessToken: resourceOptions.accessToken)
         eventsManager.sendTurnstile()
         eventsManager.sendMapLoadEvent()
     }
@@ -440,8 +449,6 @@ open class MapView: UIView {
         displayLink?.invalidate()
         cameraAnimatorsRunner.cancelAnimations()
         cameraAnimatorsRunnerEnablable.isEnabled = false
-
-        let eventsManager = EventsManager.shared(withAccessToken: resourceOptions.accessToken)
         eventsManager.flush()
     }
 

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -449,7 +449,6 @@ open class MapView: UIView {
         displayLink?.invalidate()
         cameraAnimatorsRunner.cancelAnimations()
         cameraAnimatorsRunnerEnablable.isEnabled = false
-        eventsManager.flush()
     }
 
     private func subscribeToLifecycleNotifications() {

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -78,7 +78,7 @@ open class MapView: UIView {
     private let viewAnnotationContainerView = SubviewInteractionOnlyView()
 
     /// Resource options for this map view
-    internal let resourceOptions: ResourceOptions!
+    internal let resourceOptions: ResourceOptions
 
     private var needsDisplayRefresh: Bool = false
     private var displayLink: DisplayLinkProtocol?

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -440,6 +440,9 @@ open class MapView: UIView {
         displayLink?.invalidate()
         cameraAnimatorsRunner.cancelAnimations()
         cameraAnimatorsRunnerEnablable.isEnabled = false
+
+        let eventsManager = EventsManager.shared(withAccessToken: resourceOptions.accessToken)
+        eventsManager.flush()
     }
 
     private func subscribeToLifecycleNotifications() {

--- a/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
+++ b/Sources/MapboxMaps/Foundation/MapViewDependencyProvider.swift
@@ -33,6 +33,8 @@ internal protocol MapViewDependencyProviderProtocol: AnyObject {
                                         mapFeatureQueryable: MapFeatureQueryable,
                                         style: StyleProtocol,
                                         displayLinkCoordinator: DisplayLinkCoordinator) -> AnnotationOrchestratorImplProtocol
+
+    func makeEventsManager(accessToken: String) -> EventsManagerProtocol
 }
 
 // swiftlint:disable:next type_body_length
@@ -344,5 +346,9 @@ internal final class MapViewDependencyProvider: MapViewDependencyProviderProtoco
             anyTouchGestureRecognizer: anyTouchGestureRecognizer,
             doubleTapGestureRecognizer: doubleTapGestureRecognizer,
             doubleTouchGestureRecognizer: doubleTouchGestureRecognizer)
+    }
+
+    func makeEventsManager(accessToken: String) -> EventsManagerProtocol {
+        return EventsManager(accessToken: accessToken)
     }
 }

--- a/Sources/MapboxMaps/Snapshot/Snapshotter.swift
+++ b/Sources/MapboxMaps/Snapshot/Snapshotter.swift
@@ -57,7 +57,8 @@ public class Snapshotter {
         mapSnapshotter = MapSnapshotter(options: MapboxCoreMaps.MapSnapshotOptions(options))
         style = Style(with: mapSnapshotter)
         observable = MapboxObservable(observable: mapSnapshotter)
-        EventsManager.shared(withAccessToken: options.resourceOptions.accessToken).sendTurnstile()
+
+        sendTurnstileEvent(accessToken: options.resourceOptions.accessToken)
     }
 
     /// Enables injecting mocks when unit testing
@@ -68,7 +69,13 @@ public class Snapshotter {
         self.mapSnapshotter = mapSnapshotter
         style = Style(with: mapSnapshotter)
         observable = mapboxObservableProvider(mapSnapshotter)
-        EventsManager.shared(withAccessToken: options.resourceOptions.accessToken).sendTurnstile()
+
+        sendTurnstileEvent(accessToken: options.resourceOptions.accessToken)
+    }
+
+    internal func sendTurnstileEvent(accessToken: String) {
+        let eventsManager = EventsManager(accessToken: accessToken)
+        eventsManager.sendTurnstile()
     }
 
     /// The size of the snapshot

--- a/Tests/MapboxMapsTests/Foundation/Events/EventsManagerTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Events/EventsManagerTests.swift
@@ -4,11 +4,11 @@ import XCTest
 
 final class EventsManagerTests: XCTestCase {
 
-    var eventsManager: EventsManager!
+    var eventsManager: EventsManagerProtocol!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        eventsManager = try EventsManager.shared(withAccessToken: mapboxAccessToken())
+        eventsManager = try EventsManager(accessToken: mapboxAccessToken())
     }
 
     override func tearDown() {

--- a/Tests/MapboxMapsTests/Foundation/Events/Mocks/EventsManagerMock.swift
+++ b/Tests/MapboxMapsTests/Foundation/Events/Mocks/EventsManagerMock.swift
@@ -1,17 +1,12 @@
 import Foundation
 @testable import MapboxMaps
 
-class EventsManagerStub: EventsManagerProtocol {
+class EventsManagerMock: EventsManagerProtocol {
 
     @Stubbed var accessToken: String
 
     init(accessToken: String = "tests") {
         self.accessToken = accessToken
-    }
-
-    static let sharedWithAccessTokenStub = Stub<String, EventsManagerProtocol>(defaultReturnValue: EventsManagerStub())
-    static func shared(withAccessToken accessToken: String) -> MapboxMaps.EventsManagerProtocol {
-        return EventsManagerStub(accessToken: accessToken)
     }
 
     let sendMapLoadEventStub = Stub<Void, Void>()

--- a/Tests/MapboxMapsTests/Foundation/Events/Mocks/EventsManagerStub.swift
+++ b/Tests/MapboxMapsTests/Foundation/Events/Mocks/EventsManagerStub.swift
@@ -1,0 +1,36 @@
+import Foundation
+@testable import MapboxMaps
+
+class EventsManagerStub: EventsManagerProtocol {
+
+    @Stubbed var accessToken: String
+
+    init(accessToken: String = "tests") {
+        self.accessToken = accessToken
+    }
+
+    static let sharedWithAccessTokenStub = Stub<String, EventsManagerProtocol>(defaultReturnValue: EventsManagerStub())
+    static func shared(withAccessToken accessToken: String) -> MapboxMaps.EventsManagerProtocol {
+        return EventsManagerStub(accessToken: accessToken)
+    }
+
+    let sendMapLoadEventStub = Stub<Void, Void>()
+    func sendMapLoadEvent() {
+        sendMapLoadEventStub.call()
+    }
+
+    let sendTurnstileStub = Stub<Void, Void>()
+    func sendTurnstile() {
+        sendTurnstileStub.call()
+    }
+
+    let flushStub = Stub<Void, Void>()
+    func flush() {
+        flushStub.call()
+    }
+
+    deinit {
+        flush()
+    }
+
+}

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -333,17 +333,17 @@ final class MapViewTests: XCTestCase {
     }
 
     func testEventsFlushingOnDeinit() throws {
-        dependencyProvider.makeEventsManagerStub.returnValueQueue.append(EventsManagerStub())
+        dependencyProvider.makeEventsManagerStub.returnValueQueue.append(EventsManagerMock())
 
         autoreleasepool {
             mapView = buildMapView()
         }
 
-        let flushStub = try XCTUnwrap(mapView.eventsManager as? EventsManagerStub).flushStub
+        let flushStub = try XCTUnwrap(mapView.eventsManager as? EventsManagerMock).flushStub
 
         XCTAssertTrue(flushStub.invocations.isEmpty)
 
-        resetStubs()
+        resetAllStubs()
         mapView = nil
 
         XCTAssertEqual(flushStub.invocations.count, 1)

--- a/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/MapViewTests.swift
@@ -333,20 +333,18 @@ final class MapViewTests: XCTestCase {
     }
 
     func testEventsFlushingOnDeinit() throws {
-        var eventsManager: EventsManagerStub! = EventsManagerStub(accessToken: "token")
-        let flushStub = eventsManager.flushStub
+        dependencyProvider.makeEventsManagerStub.returnValueQueue.append(EventsManagerStub())
 
-        dependencyProvider.makeEventsManagerStub.execute(withDefault: eventsManager) {
-            autoreleasepool {
-                mapView = buildMapView()
-            }
+        autoreleasepool {
+            mapView = buildMapView()
         }
+
+        let flushStub = try XCTUnwrap(mapView.eventsManager as? EventsManagerStub).flushStub
 
         XCTAssertTrue(flushStub.invocations.isEmpty)
 
         resetStubs()
         mapView = nil
-        eventsManager = nil
 
         XCTAssertEqual(flushStub.invocations.count, 1)
     }

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
@@ -153,7 +153,7 @@ final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
     }
 
     // MARK: - Events Manager
-    let makeEventsManagerStub = Stub<String, EventsManagerProtocol>(defaultReturnValue: EventsManagerStub())
+    let makeEventsManagerStub = Stub<String, EventsManagerProtocol>(defaultReturnValue: EventsManagerMock())
     func makeEventsManager(accessToken: String) -> EventsManagerProtocol {
         makeEventsManagerStub.call(with: accessToken)
     }

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
@@ -10,6 +10,7 @@ final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
 
     @Stubbed var cameraAnimatorsRunnerEnablable: MutableEnablableProtocol = Enablable()
 
+    // MARK: - Metal view
     struct MakeMetalViewParams {
         var frame: CGRect
         var device: MTLDevice?
@@ -20,6 +21,7 @@ final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
         return makeMetalViewStub.call(with: MakeMetalViewParams(frame: frame, device: device))!
     }
 
+    // MARK: - DispayLink
     struct MakeDisplayLinkParams {
         var window: UIWindow
         var target: Any
@@ -37,6 +39,7 @@ final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
                 selector: selector))
     }
 
+    // MARK: - Camera Animators
     let makeCameraAnimatorsRunnerStub = Stub<MapboxMapProtocol, CameraAnimatorsRunnerProtocol>(
         defaultReturnValue: MockCameraAnimatorsRunner())
     func makeCameraAnimatorsRunner(mapboxMap: MapboxMapProtocol) -> CameraAnimatorsRunnerProtocol {
@@ -49,6 +52,7 @@ final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
         MockCameraAnimationsManager()
     }
 
+    // MARK: - Gestures
     func makeGestureManager(
         view: UIView,
         mapboxMap: MapboxMapProtocol,
@@ -73,6 +77,7 @@ final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
         return GestureHandler(gestureRecognizer: UIGestureRecognizer())
     }
 
+    // MARK: - Location
     struct MakeLocationProducerParameteres {
         let mayRequestWhenInUseAuthorization: Bool
         let userInterfaceOrientationView: UIView
@@ -103,6 +108,7 @@ final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
             puckManager: MockPuckManager())
     }
 
+    // MARK: - Viewport
     struct MakeViewportImplParams {
         var mapboxMap: MapboxMapProtocol
         var cameraAnimationsManager: CameraAnimationsManagerProtocol
@@ -124,6 +130,7 @@ final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
             doubleTouchGestureRecognizer: doubleTouchGestureRecognizer))
     }
 
+    // MARK: - Annotations
     struct MakeAnnotationOrchestratorImplParams {
         let view: UIView
         let mapboxMap: MapboxMapProtocol

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMapViewDependencyProvider.swift
@@ -144,4 +144,10 @@ final class MockMapViewDependencyProvider: MapViewDependencyProviderProtocol {
             style: style,
             displayLinkCoordinator: displayLinkCoordinator))
     }
+
+    // MARK: - Events Manager
+    let makeEventsManagerStub = Stub<String, EventsManagerProtocol>(defaultReturnValue: EventsManagerStub())
+    func makeEventsManager(accessToken: String) -> EventsManagerProtocol {
+        makeEventsManagerStub.call(with: accessToken)
+    }
 }

--- a/Tests/MapboxMapsTests/Helpers/Stub.swift
+++ b/Tests/MapboxMapsTests/Helpers/Stub.swift
@@ -34,11 +34,22 @@ final class Stub<ParametersType, ReturnType> {
     func reset() {
         invocations.removeAll()
     }
+
+    /// Temporary replace `defaultReturnValue` with custom value
+    /// - Parameters:
+    ///   - customDefaultReturnValue: New temporary default value
+    ///   - closure: Context to execute with a new defalut value
+    func execute(withDefault customDefaultReturnValue: ReturnType, closure: () -> Void) {
+        let original = defaultReturnValue
+        defaultReturnValue = customDefaultReturnValue
+        closure()
+        defaultReturnValue = original
+    }
 }
 
 extension Stub where ReturnType == Void {
-    convenience init() {
-        self.init(defaultReturnValue: ())
+    convenience init(file: String = #file, line: Int = #line) {
+        self.init(file: file, line: line, defaultReturnValue: ())
     }
 }
 

--- a/Tests/MapboxMapsTests/Helpers/Stub.swift
+++ b/Tests/MapboxMapsTests/Helpers/Stub.swift
@@ -1,4 +1,4 @@
-import MapboxMaps
+import Foundation
 
 final class Stub<ParametersType, ReturnType> {
 

--- a/Tests/MapboxMapsTests/Helpers/Stub.swift
+++ b/Tests/MapboxMapsTests/Helpers/Stub.swift
@@ -45,17 +45,6 @@ final class Stub<ParametersType, ReturnType> {
     func reset() {
         invocations.removeAll()
     }
-
-    /// Temporary replace `defaultReturnValue` with custom value
-    /// - Parameters:
-    ///   - customDefaultReturnValue: New temporary default value
-    ///   - closure: Context to execute with a new defalut value
-    func execute(withDefault customDefaultReturnValue: ReturnType, closure: () -> Void) {
-        let original = defaultReturnValue
-        defaultReturnValue = customDefaultReturnValue
-        closure()
-        defaultReturnValue = original
-    }
 }
 
 extension Stub where ReturnType == Void {

--- a/Tests/MapboxMapsTests/Helpers/Stub.swift
+++ b/Tests/MapboxMapsTests/Helpers/Stub.swift
@@ -1,8 +1,14 @@
+import MapboxMaps
+
 final class Stub<ParametersType, ReturnType> {
 
-    struct Invocation {
+    struct Invocation: CustomStringConvertible {
         var parameters: ParametersType
         var returnValue: ReturnType
+
+        var description: String {
+            "Invocation<\(ParametersType.self), \(ReturnType.self)>"
+        }
     }
 
     typealias SideEffect = (Invocation) -> Void
@@ -17,7 +23,12 @@ final class Stub<ParametersType, ReturnType> {
 
     var sideEffectQueue = [SideEffect]()
 
-    init(defaultReturnValue: ReturnType) {
+    let file: String
+    let line: Int
+
+    init(file: String = #file, line: Int = #line, defaultReturnValue: ReturnType) {
+        self.file = file
+        self.line = line
         self.defaultReturnValue = defaultReturnValue
     }
 
@@ -66,31 +77,28 @@ extension Stub.Invocation: Equatable where ParametersType: Equatable, ReturnType
     }
 }
 
-@propertyWrapper
-final class Stubbed<T> {
-    let getStub: Stub<Void, T>
-    let setStub = Stub<T, Void>()
+extension Stub: CustomStringConvertible {
+    var description: String {
+        let filePath = NSURL(fileURLWithPath: file).lastPathComponent ?? file
 
-    var projectedValue: Stubbed<T> {
-        return self
-    }
+        var result = "Stub<\(ParametersType.self), \(ReturnType.self)> created at \(filePath):\(line)"
+        result += "\n  Default return value is \(defaultReturnValue)"
 
-    init(wrappedValue: T) {
-        getStub = Stub(defaultReturnValue: wrappedValue)
-    }
-
-    var wrappedValue: T {
-        get {
-            getStub.call()
+        if let defaultSideEffect = defaultSideEffect {
+            result += "\n  Has a default side-effect \(String(describing: defaultSideEffect))"
+        } else {
+            result += "\n  Has no default side-effect"
         }
-        set {
-            setStub.call(with: newValue)
-            getStub.defaultReturnValue = newValue
-        }
-    }
 
-    func reset() {
-        getStub.reset()
-        setStub.reset()
+        if invocations.isEmpty {
+            result += "\n  Has no stored invocations"
+        } else {
+            result += "\n  Has \(invocations.count) stored invocations"
+            for invocation in invocations {
+                result += "\n    \(invocation)"
+            }
+        }
+
+        return result
     }
 }

--- a/Tests/MapboxMapsTests/Helpers/StubProtocol.swift
+++ b/Tests/MapboxMapsTests/Helpers/StubProtocol.swift
@@ -1,8 +1,10 @@
-//
-//  File.swift
-//  
-//
-//  Created by odnairy on 10.11.22.
-//
+/// Simple Stub description to enable non-generic casting
+/// Can be useful for debugging purposes in conjunction with `Mirror`
+protocol StubProtocol {
+    func reset()
 
-import Foundation
+    var file: String { get }
+    var line: Int { get }
+}
+
+extension Stub: StubProtocol { }

--- a/Tests/MapboxMapsTests/Helpers/StubProtocol.swift
+++ b/Tests/MapboxMapsTests/Helpers/StubProtocol.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by odnairy on 10.11.22.
+//
+
+import Foundation

--- a/Tests/MapboxMapsTests/Helpers/Stubbed.swift
+++ b/Tests/MapboxMapsTests/Helpers/Stubbed.swift
@@ -1,5 +1,5 @@
 @propertyWrapper
-final class Stubbed<T> {
+final class Stubbed<T>: StubProtocol {
     let getStub: Stub<Void, T>
     let setStub = Stub<T, Void>()
 
@@ -7,7 +7,12 @@ final class Stubbed<T> {
         return self
     }
 
-    init(wrappedValue: T) {
+    let file: String
+    let line: Int
+
+    init(file: String = #file, line: Int = #line,wrappedValue: T) {
+        self.file = file
+        self.line = line
         getStub = Stub(defaultReturnValue: wrappedValue)
     }
 

--- a/Tests/MapboxMapsTests/Helpers/Stubbed.swift
+++ b/Tests/MapboxMapsTests/Helpers/Stubbed.swift
@@ -10,7 +10,7 @@ final class Stubbed<T>: StubProtocol {
     let file: String
     let line: Int
 
-    init(file: String = #file, line: Int = #line,wrappedValue: T) {
+    init(file: String = #file, line: Int = #line, wrappedValue: T) {
         self.file = file
         self.line = line
         getStub = Stub(defaultReturnValue: wrappedValue)

--- a/Tests/MapboxMapsTests/Helpers/Stubbed.swift
+++ b/Tests/MapboxMapsTests/Helpers/Stubbed.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by odnairy on 10.11.22.
+//
+
+import Foundation

--- a/Tests/MapboxMapsTests/Helpers/Stubbed.swift
+++ b/Tests/MapboxMapsTests/Helpers/Stubbed.swift
@@ -1,8 +1,28 @@
-//
-//  File.swift
-//  
-//
-//  Created by odnairy on 10.11.22.
-//
+@propertyWrapper
+final class Stubbed<T> {
+    let getStub: Stub<Void, T>
+    let setStub = Stub<T, Void>()
 
-import Foundation
+    var projectedValue: Stubbed<T> {
+        return self
+    }
+
+    init(wrappedValue: T) {
+        getStub = Stub(defaultReturnValue: wrappedValue)
+    }
+
+    var wrappedValue: T {
+        get {
+            getStub.call()
+        }
+        set {
+            setStub.call(with: newValue)
+            getStub.defaultReturnValue = newValue
+        }
+    }
+
+    func reset() {
+        getStub.reset()
+        setStub.reset()
+    }
+}

--- a/Tests/MapboxMapsTests/Helpers/XCTestCase+ResetStubs.swift
+++ b/Tests/MapboxMapsTests/Helpers/XCTestCase+ResetStubs.swift
@@ -1,8 +1,28 @@
-//
-//  File.swift
-//  
-//
-//  Created by odnairy on 10.11.22.
-//
+import XCTest
 
-import Foundation
+extension XCTestCase {
+    /// Reset all stubs in inner properties
+    ///
+    /// Interates through reflection of current `XCTestCase` and lookup
+    /// for `StubProtocol` properties. Then call `reset()` for each of them.
+    func resetStubs() {
+        Mirror(reflecting: self).children
+            .flatMap { (label, value) in
+                // If value is Optional, carefully unwrap it to get a Wrapped type
+                let innerValue = (value as? OptionalProtocol)?.anyValue ?? value
+                assert(!(innerValue is OptionalProtocol))
+                return Mirror(reflecting: innerValue).children
+            }
+            .compactMap { $0.value as? StubProtocol }
+            .forEach { $0.reset() }
+    }
+}
+
+/// Protocol to enable non-typed access to detect Optionals
+protocol OptionalProtocol {
+    var anyValue: Any? { get }
+}
+
+extension Optional: OptionalProtocol {
+    var anyValue: Any? { return self }
+}

--- a/Tests/MapboxMapsTests/Helpers/XCTestCase+ResetStubs.swift
+++ b/Tests/MapboxMapsTests/Helpers/XCTestCase+ResetStubs.swift
@@ -7,7 +7,7 @@ extension XCTestCase {
     /// for `StubProtocol` properties. Then call `reset()` for each of them.
     func resetStubs() {
         Mirror(reflecting: self).children
-            .flatMap { (label, value) in
+            .flatMap { (_, value) in
                 // If value is Optional, carefully unwrap it to get a Wrapped type
                 let innerValue = (value as? OptionalProtocol)?.anyValue ?? value
                 assert(!(innerValue is OptionalProtocol))

--- a/Tests/MapboxMapsTests/Helpers/XCTestCase+ResetStubs.swift
+++ b/Tests/MapboxMapsTests/Helpers/XCTestCase+ResetStubs.swift
@@ -5,7 +5,7 @@ extension XCTestCase {
     ///
     /// Interates through reflection of current `XCTestCase` and lookup
     /// for `StubProtocol` properties. Then call `reset()` for each of them.
-    func resetStubs() {
+    func resetAllStubs() {
         Mirror(reflecting: self).children
             .flatMap { (_, value) -> Mirror.Children in
                 // If value is Optional, carefully unwrap it to get a Wrapped type

--- a/Tests/MapboxMapsTests/Helpers/XCTestCase+ResetStubs.swift
+++ b/Tests/MapboxMapsTests/Helpers/XCTestCase+ResetStubs.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by odnairy on 10.11.22.
+//
+
+import Foundation

--- a/Tests/MapboxMapsTests/Helpers/XCTestCase+ResetStubs.swift
+++ b/Tests/MapboxMapsTests/Helpers/XCTestCase+ResetStubs.swift
@@ -7,7 +7,7 @@ extension XCTestCase {
     /// for `StubProtocol` properties. Then call `reset()` for each of them.
     func resetStubs() {
         Mirror(reflecting: self).children
-            .flatMap { (_, value) in
+            .flatMap { (_, value) -> Mirror.Children in
                 // If value is Optional, carefully unwrap it to get a Wrapped type
                 let innerValue = (value as? OptionalProtocol)?.anyValue ?? value
                 assert(!(innerValue is OptionalProtocol))


### PR DESCRIPTION
1. Flush telemetry on MapView deinit
2. Enqueue map load event
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: CORESDK-1463