### PR TITLE
Avoid triggering assertion for the 3D puck layer when returning `allL…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## 10.9.1 - November 9, 2022
 
 * Bump MapboxCoreMaps to v10.9.1. ([#1703](https://github.com/mapbox/mapbox-maps-ios/pull/1703))
+* Avoid triggering assertion for the 3D puck layer when returning `allLayerIdentifiers`. ([#1705](https://github.com/mapbox/mapbox-maps-ios/pull/1705))
 
 ## 10.9.0 - October 19, 2022
 

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/StyleObjectInfo+3DPuck.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/StyleObjectInfo+3DPuck.swift
@@ -1,0 +1,6 @@
+import Foundation
+@_implementationOnly import MapboxCoreMaps_Private
+
+internal extension StyleObjectInfo {
+    var is3DPuckLayer: Bool { type == "model" && id == Puck3D.layerID }
+}

--- a/Sources/MapboxMaps/Location/Puck/Puck3D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck3D.swift
@@ -1,6 +1,8 @@
 @_implementationOnly import MapboxCommon_Private
 
 internal final class Puck3D: Puck {
+    private static let sourceID = "puck-model-source"
+    internal static let layerID = "puck-model-layer"
 
     internal var isActive = false {
         didSet {
@@ -41,9 +43,6 @@ internal final class Puck3D: Puck {
     private let interpolatedLocationProducer: InterpolatedLocationProducerProtocol
 
     private let cancelables = CancelableContainer()
-
-    private static let sourceID = "puck-model-source"
-    private static let layerID = "puck-model-layer"
 
     internal init(configuration: Puck3DConfiguration,
                   style: StyleProtocol,

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -443,6 +443,8 @@ public final class Style: StyleProtocol {
     /// The ordered list of the current style layers' identifiers and types
     public var allLayerIdentifiers: [LayerInfo] {
         return _styleManager.getStyleLayers().compactMap { info in
+            if info.is3DPuckLayer { return nil }
+
             guard let layerType = LayerType(rawValue: info.type) else {
                 assertionFailure("Failed to create LayerType from \(info.type)")
                 return nil

--- a/Tests/MapboxMapsTests/Foundation/Style/StyleTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Style/StyleTests.swift
@@ -120,6 +120,13 @@ final class StyleTests: XCTestCase {
         })
     }
 
+    func testGetAllLayerIdentifiersDoesNotTriggerAssertFor3DPuckLayer() {
+        styleManager.getStyleLayersStub.defaultReturnValue = [StyleObjectInfo(id: Puck3D.layerID, type: "model")]
+
+        // test should fail in debug configuration because of an assertion being triggered in `allLayerIdentifiers`
+        XCTAssertTrue(style.allLayerIdentifiers.allSatisfy { $0.id != Puck3D.layerID })
+    }
+
     func testStyleCanAddLayer() {
         XCTAssertThrowsError(try style.addLayer(NonEncodableLayer()))
 


### PR DESCRIPTION
…ayerIdentifiers` (#1650)

<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
