### PR TITLE
Resolve issue with simultaneous recognition of tap gesture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## main
 
 * Fix memory leak when viewport is being deallocated while transition is running. ([#1691](https://github.com/mapbox/mapbox-maps-ios/pull/1691))
+* Fix issue with simultaneous recognition of tap gesture. ([#1712](https://github.com/mapbox/mapbox-maps-ios/pull/1712))
 
 ## 10.10.0-beta-1 - November 4, 2022
 

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/SingleTapGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/SingleTapGestureHandler.swift
@@ -12,6 +12,7 @@ internal final class SingleTapGestureHandler: GestureHandler {
         self.cameraAnimationsManager = cameraAnimationsManager
         super.init(gestureRecognizer: gestureRecognizer)
         gestureRecognizer.addTarget(self, action: #selector(handleGesture(_:)))
+        gestureRecognizer.delegate = self
     }
 
     @objc private func handleGesture(_ gestureRecognizer: UITapGestureRecognizer) {
@@ -23,5 +24,11 @@ internal final class SingleTapGestureHandler: GestureHandler {
         default:
             break
         }
+    }
+}
+
+extension SingleTapGestureHandler: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return gestureRecognizer is UITapGestureRecognizer
     }
 }

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/SingleTapGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/SingleTapGestureHandler.swift
@@ -29,6 +29,7 @@ internal final class SingleTapGestureHandler: GestureHandler {
 
 extension SingleTapGestureHandler: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return gestureRecognizer is UITapGestureRecognizer
+        return self.gestureRecognizer === gestureRecognizer &&
+        otherGestureRecognizer is UITapGestureRecognizer
     }
 }

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/SingleTapGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/SingleTapGestureHandlerTests.swift
@@ -28,12 +28,6 @@ final class SingleTapGestureHandlerTests: XCTestCase {
         super.tearDown()
     }
 
-    func sendActions(with state: UIGestureRecognizer.State, numberOfTouches: Int) {
-        gestureRecognizer.getStateStub.defaultReturnValue = state
-        gestureRecognizer.getNumberOfTouchesStub.defaultReturnValue = numberOfTouches
-        gestureRecognizer.sendActions()
-    }
-
     func testInitialization() {
         XCTAssertTrue(gestureRecognizer === gestureHandler.gestureRecognizer)
         XCTAssertEqual(gestureRecognizer.numberOfTapsRequired, 1)

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/SingleTapGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/SingleTapGestureHandlerTests.swift
@@ -28,6 +28,12 @@ final class SingleTapGestureHandlerTests: XCTestCase {
         super.tearDown()
     }
 
+    func sendActions(with state: UIGestureRecognizer.State, numberOfTouches: Int) {
+        gestureRecognizer.getStateStub.defaultReturnValue = state
+        gestureRecognizer.getNumberOfTouchesStub.defaultReturnValue = numberOfTouches
+        gestureRecognizer.sendActions()
+    }
+
     func testInitialization() {
         XCTAssertTrue(gestureRecognizer === gestureHandler.gestureRecognizer)
         XCTAssertEqual(gestureRecognizer.numberOfTapsRequired, 1)
@@ -43,5 +49,27 @@ final class SingleTapGestureHandlerTests: XCTestCase {
         XCTAssertEqual(delegate.gestureEndedStub.invocations.count, 1)
         XCTAssertEqual(delegate.gestureEndedStub.invocations.first?.parameters.gestureType, .singleTap)
         XCTAssertEqual(delegate.gestureEndedStub.invocations.first?.parameters.willAnimate, false)
+    }
+
+    func testSingleTapRecognizesSimultaneouslyWithTapGesture() {
+        let shouldRecognizeSimultaneously = gestureHandler.gestureRecognizer(
+            gestureRecognizer,
+            shouldRecognizeSimultaneouslyWith: UITapGestureRecognizer()
+        )
+
+        XCTAssertTrue(shouldRecognizeSimultaneously)
+    }
+
+    func testSingleTapShouldNotRecognizeSimultaneouslyWithNonTapGesture() {
+        let recognizers = [UIPanGestureRecognizer(), UILongPressGestureRecognizer(), UISwipeGestureRecognizer(), UIScreenEdgePanGestureRecognizer(), UIPinchGestureRecognizer()]
+
+        for recognizer in recognizers {
+            let shouldRecognizeSimultaneously = gestureHandler.gestureRecognizer(
+                gestureRecognizer,
+                shouldRecognizeSimultaneouslyWith: recognizer
+            )
+
+            XCTAssertFalse(shouldRecognizeSimultaneously)
+        }
     }
 }


### PR DESCRIPTION
Resolves an issue with the `singleTapGestureHandler` not recognizing taps on the mapview ([1697](https://github.com/mapbox/mapbox-maps-ios/issues/1697)) after implementing isSelected/isDraggable [feature](https://github.com/mapbox/mapbox-maps-ios/pull/1659).  A gesture recognizer method has been added to the `singleTapGestureHandler` to allow simultaneous recognition when using the tap gesture.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
