### PR TITLE
Run unit tests on multiple supported iOS versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,8 @@ workflows:
           report_failure: true
           matrix:
             parameters:
-              xcode: "13.2.1"
-              os: "latest"
+              xcode: ["13.2.1"]
+              os: ["latest"]
       - build-tests:
           name: Build MapboxTestHost tests
       - run-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -531,12 +531,10 @@ jobs:
       - run:
           name: Building MapboxMaps for simulator
           command: |
-            JOBS=$(sysctl -n hw.ncpu)
             xcodebuild build-for-testing \
               -scheme MapboxMaps \
               -sdk iphonesimulator \
               -configuration << parameters.configuration >> \
-              -jobs $(JOBS) \
               -destination 'generic/platform=iOS Simulator' \
               -derivedDataPath build \
               -enableCodeCoverage YES \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,15 @@ workflows:
           report_failure: true
           matrix:
             parameters:
-              xcode: ["13.1.0", "13.2.1"]
+              xcode: ["13.1.0"]
+              os: ["11.4", "12.5", "13.7", "14.8", "15.7", "16.1"]
+      - unit-test-sdk:
+          configuration: "Release"
+          report_failure: true
+          matrix:
+            parameters:
+              xcode: "13.2.1"
+              os: "latest"
       - build-tests:
           name: Build MapboxTestHost tests
       - run-tests:
@@ -150,6 +158,7 @@ workflows:
       - unit-test-sdk:
           name: "Run Unit tests"
           xcode: "13.1.0"
+          os: ["11.4", "12.5", "13.7", "14.8", "15.7", "16.1"]
 
       - unit-test-sdk:
           name: "Run Unit Tests with min Turf"
@@ -508,6 +517,11 @@ jobs:
 
   unit-test-sdk:
     <<: *base-job
+    parameters:
+      os:
+        default: |
+          latest
+        type: string
     resource_class: macos.x86.medium.gen2
     steps:
       - checkout
@@ -526,8 +540,8 @@ jobs:
           command: make build-sdk-for-testing-simulator
           no_output_timeout: 5m
       - run:
-          name: Testing MapboxMaps with simulator
-          command: make test-sdk-without-building-simulator | xcpretty --report junit --output build/reports/junit.xml
+          name: Testing MapboxMaps with iOS << parameters.os >> simulator
+          command: make test-sdk-without-building-simulator OS=<< parameters.os >>| xcpretty --report junit --output build/reports/junit.xml
       - store_test_results:
           path: build/reports
       - run:
@@ -961,7 +975,7 @@ jobs:
           no_output_timeout: 5m
       - run:
           name: Testing MapboxMaps with simulator
-          command: make test-sdk-without-building-simulator
+          command: make test-sdk-without-building-simulator OS=latest
       - run:
           name: Compress XCResult
           command: zip -r MapboxMapsTests.xcresult.zip MapboxMapsTests.xcresult

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,7 @@ workflows:
               only: main
 
       # Run unit tests on CI simulator
+      - build-unit-tests
       - unit-test-sdk:
           name: "Run Unit tests"
           xcode: "14.0.0"
@@ -517,6 +518,35 @@ jobs:
                           echo "Run E2E tests with ${E2E_VERSION_CONFIG} config."
                           scripts/ci-trigger/ci-e2e-compatibility-start-pipeline.py --config mapbox-maps-ios=${CIRCLE_SHA1} --platform all --versions ${E2E_VERSION_CONFIG}
                       name: Trigger E2E SDK test validation pipeline
+
+  build-unit-tests:
+    parameters:
+      configuration:
+        type: string
+        default: "Debug"
+    executor: xcode-sdk-min
+    steps:
+      - checkout
+      - run:
+          name: Building MapboxMaps for simulator
+          command: |
+            JOBS=$(sysctl -n hw.ncpu)
+            xcodebuild \
+              build-for-testing \
+              -scheme MapboxMaps \
+              -sdk iphonesimulator \
+              -configuration << parameters.configuration >> \-jobs $(JOBS) \
+              -destination 'generic/platform=iOS Simulator' \
+              -derivedDataPath build \
+              -enableCodeCoverage YES \
+              COMPILER_INDEX_STORE_ENABLE=NO \
+              ENABLE_TESTABILITY=YES \
+              ONLY_ACTIVE_ARCH=YES
+      - persist_to_workspace:
+          root: build
+          paths:
+            - << parameters.configuration >>-iphonesimulator
+            - "*.xctestrun"
 
   unit-test-sdk:
     <<: *base-job
@@ -1443,3 +1473,5 @@ commands:
               --header 'Accept: application/vnd.github.v3+json' \
               --header "Authorization: token $(mbx-ci github notifier token)" \
               --data "{\"state\":\"failure\",\"target_url\":\"$CIRCLE_BUILD_URL\",\"description\":\"MapboxMaps SDK integration tests failed\",\"context\":\"Maps SDK Integration\"}"
+
+# VS Code Extension Version: 1.0.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,37 @@ workflows:
 
       # Run unit tests on CI simulator
       - build-unit-tests
+      - run-unit-tests:
+          os: "12.4"
+          device: "iPhone 8"
+          xcode: "11.7.0"
+          requires:
+            - build-unit-tests
+      - run-unit-tests:
+          os: "13.7"
+          device: iPhone 11
+          xcode: "12.5.1"
+          requires:
+            - build-unit-tests
+      - run-unit-tests:
+          os: "14.5"
+          device: iPhone 11
+          xcode: "13.4.1"
+          requires:
+            - build-unit-tests
+      - run-unit-tests:
+          os: "15.5"
+          device: iPhone 13
+          xcode: "14.1.0"
+          requires:
+            - build-unit-tests
+      - run-unit-tests:
+          os: "16.1"
+          device: iPhone 14
+          xcode: "14.1.0"
+          requires:
+            - build-unit-tests
+
       - unit-test-sdk:
           name: "Run Unit tests"
           xcode: "14.0.0"
@@ -528,6 +559,10 @@ jobs:
     resource_class: macos.x86.medium.gen2
     steps:
       - checkout
+      - configure-environment
+      - run:
+          name: Checkout xcodebuild deps
+          command: xcodebuild -resolvePackageDependencies -scheme MapboxMaps -derivedDataPath build
       - run:
           name: Building MapboxMaps for simulator
           command: |
@@ -542,10 +577,49 @@ jobs:
               ENABLE_TESTABILITY=YES \
               ONLY_ACTIVE_ARCH=YES
       - persist_to_workspace:
-          root: build
+          root: build/Build/Products
           paths:
             - << parameters.configuration >>-iphonesimulator
             - "*.xctestrun"
+
+  run-unit-tests:
+    parameters:
+      os:
+        type: string
+        default: "latest"
+      device:
+        type: string
+        default: "iPhone 11"
+      xcode:
+        type: string
+        default: "13.1.0"
+    macos:
+      xcode: << parameters.xcode >>
+    resource_class: macos.x86.medium.gen2
+    steps:
+      - attach_workspace:
+          at: build
+      - run:
+          name: Run MapboxMaps unit test on iOS << parameters.os >> << parameters.device >> simulator
+          command: |
+            XCTESTRUN_PATH=$(find build -type f -name '*.xctestrun')
+            xcodebuild \
+              test-without-building \
+              -xctestrun "$XCTESTRUN_PATH" \
+              -destination 'platform=iOS Simulator,OS=<< parameters.os >>,name=<< parameters.device >>' \
+              -enableCodeCoverage YES \
+              -resultBundlePath MapboxMapsTests.xcresult | xcpretty --report junit --output junit.xml
+      - run:
+          name: Compress XCResult
+          command: zip -r MapboxMapsTests.xcresult.zip MapboxMapsTests.xcresult
+          when: always
+      - store_test_results:
+          path: junit.xml
+      - store_artifacts:
+          path: MapboxMapsTests.xcresult.zip
+      - store_artifacts:
+          path: ~/Library/Logs/DiagnosticReports
+      
 
   unit-test-sdk:
     <<: *base-job
@@ -790,7 +864,7 @@ jobs:
   validate-integrations:
     description: <
       This job is designed to be called after SDK Registry PR merge.
-      It requires binaries to be publicly available and downloadable.
+      It requires binaries to be publicly available and downloadable
       SPM, Cocoapods and DirectDownload tests would be called.
     executor: xcode-latest
     resource_class: macos.x86.medium.gen2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,12 +158,15 @@ workflows:
       - unit-test-sdk:
           name: "Run Unit tests"
           xcode: "13.1.0"
-          os: ["11.4", "12.5", "13.7", "14.8", "15.7", "16.1"]
+          matrix:
+            parameters:
+              os: ["11.4", "12.5", "13.7", "14.8", "15.7", "16.1"]
 
       - unit-test-sdk:
           name: "Run Unit Tests with min Turf"
           xcode: "13.1.0"
           turf-revision: v2.0.0
+          os: "latest"
 
       # Build all tests with host application
       # Run on main by default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,6 +525,7 @@ jobs:
         type: string
         default: "Debug"
     executor: xcode-sdk-min
+    resource_class: macos.x86.medium.gen2
     steps:
       - checkout
       - run:
@@ -535,7 +536,8 @@ jobs:
               build-for-testing \
               -scheme MapboxMaps \
               -sdk iphonesimulator \
-              -configuration << parameters.configuration >> \-jobs $(JOBS) \
+              -configuration << parameters.configuration >> \ 
+              -jobs $(JOBS) \
               -destination 'generic/platform=iOS Simulator' \
               -derivedDataPath build \
               -enableCodeCoverage YES \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,9 @@ workflows:
           matrix:
             parameters:
               xcode: ["13.1.0", "13.2.1"]
-      - build-unit-tests
+      - build-unit-tests:
+          configuration: "Release"
+          report_failure: true
       - run-unit-tests:
           xcode: 14.1.0
           matrix:
@@ -541,6 +543,9 @@ jobs:
       turf-revision:
         type: string
         default: ""
+      report_failure:
+        type: boolean
+        default: false
     executor: xcode-sdk-min
     resource_class: macos.x86.medium.gen2
     steps:
@@ -574,6 +579,9 @@ jobs:
           paths:
             - << parameters.configuration >>-iphonesimulator
             - "*.xctestrun"
+      - report-failure:
+           report_failure: << parameters.report_failure >>
+           message: "unit-test-sdk"
 
   run-unit-tests:
     parameters:
@@ -581,7 +589,6 @@ jobs:
         type: string
       xcode:
         type: string
-        default: "13.1.0"
     macos:
       xcode: << parameters.xcode >>
     resource_class: macos.x86.medium.gen2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,20 +54,21 @@ workflows:
           matrix:
             parameters:
               xcode: ["13.1.0", "13.2.1"]
-      - unit-test-sdk:
-          configuration: "Release"
-          report_failure: true
+      - build-unit-tests
+      - run-unit-tests:
+          xcode: 14.1.0
           matrix:
             parameters:
-              xcode: ["14.0.0"]
-              os: ["11.4", "12.5", "13.7", "14.8", "15.7", "16.0"]
-      - unit-test-sdk:
-          configuration: "Release"
-          report_failure: true
+              destination: ["OS=15.5,name=iPhone 13", "OS=16.1,name=iPhone 14"]
+          requires:
+            - build-unit-tests
+      - run-unit-tests:
+          xcode: 12.5.1
           matrix:
             parameters:
-              xcode: ["13.1.0"]
-              os: ["latest"]
+              destination: ["OS=13.7,name=iPhone 11", "OS=14.5,name=iPhone 11"]
+          requires:
+            - build-unit-tests
       - build-tests:
           name: Build MapboxTestHost tests
       - run-tests:
@@ -157,48 +158,30 @@ workflows:
       # Run unit tests on CI simulator
       - build-unit-tests
       - run-unit-tests:
-          os: "12.4"
-          device: "iPhone 8"
-          xcode: "11.7.0"
-          requires:
-            - build-unit-tests
-      - run-unit-tests:
-          os: "13.7"
-          device: iPhone 11
-          xcode: "12.5.1"
-          requires:
-            - build-unit-tests
-      - run-unit-tests:
-          os: "14.5"
-          device: iPhone 11
-          xcode: "13.4.1"
-          requires:
-            - build-unit-tests
-      - run-unit-tests:
-          os: "15.5"
-          device: iPhone 13
-          xcode: "14.1.0"
-          requires:
-            - build-unit-tests
-      - run-unit-tests:
-          os: "16.1"
-          device: iPhone 14
-          xcode: "14.1.0"
-          requires:
-            - build-unit-tests
-
-      - unit-test-sdk:
-          name: "Run Unit tests"
-          xcode: "14.0.0"
+          xcode: 14.1.0
           matrix:
             parameters:
-              os: ["11.4", "12.5", "13.7", "14.8", "15.7", "16.0"]
+              destination: ["OS=15.5,name=iPhone 13", "OS=16.1,name=iPhone 14"]
+          requires:
+            - build-unit-tests
+      - run-unit-tests:
+          xcode: 12.5.1
+          matrix:
+            parameters:
+              destination: ["OS=13.7,name=iPhone 11", "OS=14.5,name=iPhone 11"]
+          requires:
+            - build-unit-tests
 
-      - unit-test-sdk:
-          name: "Run Unit Tests with min Turf"
-          xcode: "13.1.0"
+      - build-unit-tests:
+          name: build-unit-tests-min-turf
           turf-revision: v2.0.0
-          os: "latest"
+
+      - run-unit-tests:
+          name: run-unit-tests-min-turf
+          xcode: 13.1.0
+          destination: OS=15.0,name=iPhone 12
+          requires:
+            - build-unit-tests-min-turf
 
       # Build all tests with host application
       # Run on main by default
@@ -326,7 +309,7 @@ jobs:
   # and aliases as described here
   # https://circleci.com/docs/2.0/writing-yaml/#merging-maps
   base-job: &base-job
-    parameters: &base-parameters
+    parameters:
       xcode:
         type: string
         default: "13.1.0"
@@ -555,11 +538,21 @@ jobs:
       configuration:
         type: string
         default: "Debug"
+      turf-revision:
+        type: string
+        default: ""
     executor: xcode-sdk-min
     resource_class: macos.x86.medium.gen2
     steps:
       - checkout
       - configure-environment
+      - when:
+          condition: << parameters.turf-revision >>
+          steps:
+            - run:
+                name: Set Turf Revision
+                command: |
+                  sed -i '' 's/turf-swift.git", from: "2.0.0"/turf-swift.git", .revision("<< parameters.turf-revision >>")/' Package.swift
       - run:
           name: Checkout xcodebuild deps
           command: xcodebuild -resolvePackageDependencies -scheme MapboxMaps -derivedDataPath build
@@ -584,12 +577,8 @@ jobs:
 
   run-unit-tests:
     parameters:
-      os:
+      destination:
         type: string
-        default: "latest"
-      device:
-        type: string
-        default: "iPhone 11"
       xcode:
         type: string
         default: "13.1.0"
@@ -600,13 +589,13 @@ jobs:
       - attach_workspace:
           at: build
       - run:
-          name: Run MapboxMaps unit test on iOS << parameters.os >> << parameters.device >> simulator
+          name: Run MapboxMaps unit test on << parameters.destination >>  simulator
           command: |
             XCTESTRUN_PATH=$(find build -type f -name '*.xctestrun')
             xcodebuild \
               test-without-building \
               -xctestrun "$XCTESTRUN_PATH" \
-              -destination 'platform=iOS Simulator,OS=<< parameters.os >>,name=<< parameters.device >>' \
+              -destination 'platform=iOS Simulator,<< parameters.destination >>' \
               -enableCodeCoverage YES \
               -resultBundlePath MapboxMapsTests.xcresult | xcpretty --report junit --output junit.xml
       - run:
@@ -619,58 +608,6 @@ jobs:
           path: MapboxMapsTests.xcresult.zip
       - store_artifacts:
           path: ~/Library/Logs/DiagnosticReports
-      
-
-  unit-test-sdk:
-    <<: *base-job
-    parameters:
-      <<: *base-parameters
-      os:
-        default: "latest"
-        type: string
-    resource_class: macos.x86.medium.gen2
-    steps:
-      - checkout
-      - configure-environment
-      - when:
-          condition: << parameters.turf-revision >>
-          steps:
-            - run:
-                name: Set Turf Revision
-                command: |
-                  sed -i '' 's/turf-swift.git", from: "2.0.0"/turf-swift.git", .revision("<< parameters.turf-revision >>")/' Package.swift
-      # Building and testing are split into 2, with the aim that we'll be able to reuse
-      # the build product and test on multiple simulators
-      - run:
-          name: Building MapboxMaps for simulator
-          command: make build-sdk-for-testing-simulator
-          no_output_timeout: 5m
-      - run:
-          name: Testing MapboxMaps with iOS << parameters.os >> simulator
-          command: make test-sdk-without-building-simulator OS=<< parameters.os >>| xcpretty --report junit --output build/reports/junit.xml
-      - store_test_results:
-          path: build/reports
-      - run:
-          name: Compress XCResult
-          command: zip -r MapboxMapsTests.xcresult.zip MapboxMapsTests.xcresult
-          when: always
-      - store_artifacts:
-          path: MapboxMapsTests.xcresult.zip
-      - store_artifacts:
-          path: ~/Library/Logs/DiagnosticReports
-      - locate-derived-data-directory:
-          base_name: $(basename $(pwd))
-      - run:
-          name: Converting and uploading coverage
-          command: |
-            pip3 install awscli gitpython
-            make update-codecov-with-profdata SCHEME=MapboxMaps BUILD_DIR="$DERIVED_DATA_PATH"
-      - store-logs:
-          artifact_name: MapboxMaps
-          derived_data_path: $DERIVED_DATA_PATH
-      - report-failure:
-          report_failure: << parameters.report_failure >>
-          message: "unit-test-sdk"
 
   build-tests:
     executor: xcode-latest
@@ -1081,7 +1018,7 @@ jobs:
           no_output_timeout: 5m
       - run:
           name: Testing MapboxMaps with simulator
-          command: make test-sdk-without-building-simulator OS=latest
+          command: make test-sdk-without-building-simulator
       - run:
           name: Compress XCResult
           command: zip -r MapboxMapsTests.xcresult.zip MapboxMapsTests.xcresult
@@ -1546,5 +1483,3 @@ commands:
               --header 'Accept: application/vnd.github.v3+json' \
               --header "Authorization: token $(mbx-ci github notifier token)" \
               --data "{\"state\":\"failure\",\"target_url\":\"$CIRCLE_BUILD_URL\",\"description\":\"MapboxMaps SDK integration tests failed\",\"context\":\"Maps SDK Integration\"}"
-
-# VS Code Extension Version: 1.0.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,8 +532,7 @@ jobs:
           name: Building MapboxMaps for simulator
           command: |
             JOBS=$(sysctl -n hw.ncpu)
-            xcodebuild \
-              build-for-testing \
+            xcodebuild build-for-testing \
               -scheme MapboxMaps \
               -sdk iphonesimulator \
               -configuration << parameters.configuration >> \ 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -604,7 +604,7 @@ jobs:
               -xctestrun "$XCTESTRUN_PATH" \
               -destination 'platform=iOS Simulator,<< parameters.destination >>' \
               -enableCodeCoverage YES \
-              -resultBundlePath MapboxMapsTests.xcresult | xcpretty --report junit --output junit.xml
+              -resultBundlePath MapboxMapsTests.xcresult | tee run_log.txt | xcpretty --report junit --output junit.xml
       - run:
           name: Compress XCResult
           command: zip -r MapboxMapsTests.xcresult.zip MapboxMapsTests.xcresult
@@ -613,6 +613,8 @@ jobs:
           path: junit.xml
       - store_artifacts:
           path: MapboxMapsTests.xcresult.zip
+      - store_artifacts:
+          path: run_log.txt
       - store_artifacts:
           path: ~/Library/Logs/DiagnosticReports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,14 +59,14 @@ workflows:
           report_failure: true
           matrix:
             parameters:
-              xcode: ["13.1.0"]
-              os: ["11.4", "12.5", "13.7", "14.8", "15.7", "16.1"]
+              xcode: ["14.0.0"]
+              os: ["11.4", "12.5", "13.7", "14.8", "15.7", "16.0"]
       - unit-test-sdk:
           configuration: "Release"
           report_failure: true
           matrix:
             parameters:
-              xcode: ["13.2.1"]
+              xcode: ["13.1.0"]
               os: ["latest"]
       - build-tests:
           name: Build MapboxTestHost tests
@@ -157,10 +157,10 @@ workflows:
       # Run unit tests on CI simulator
       - unit-test-sdk:
           name: "Run Unit tests"
-          xcode: "13.1.0"
+          xcode: "14.0.0"
           matrix:
             parameters:
-              os: ["11.4", "12.5", "13.7", "14.8", "15.7", "16.1"]
+              os: ["11.4", "12.5", "13.7", "14.8", "15.7", "16.0"]
 
       - unit-test-sdk:
           name: "Run Unit Tests with min Turf"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -535,7 +535,7 @@ jobs:
             xcodebuild build-for-testing \
               -scheme MapboxMaps \
               -sdk iphonesimulator \
-              -configuration << parameters.configuration >> \ 
+              -configuration << parameters.configuration >> \
               -jobs $(JOBS) \
               -destination 'generic/platform=iOS Simulator' \
               -derivedDataPath build \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,7 @@ jobs:
   # and aliases as described here
   # https://circleci.com/docs/2.0/writing-yaml/#merging-maps
   base-job: &base-job
-    parameters:
+    parameters: &base-parameters
       xcode:
         type: string
         default: "13.1.0"
@@ -521,9 +521,9 @@ jobs:
   unit-test-sdk:
     <<: *base-job
     parameters:
+      <<: *base-parameters
       os:
-        default: |
-          latest
+        default: "latest"
         type: string
     resource_class: macos.x86.medium.gen2
     steps:

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ build-sdk-for-simulator:
 .PHONY: build-sdk-for-testing-simulator
 build-sdk-for-testing-simulator:
 	$(XCODE_BUILD_SIM_SDK) \
-		-destination 'platform=iOS Simulator,OS=latest,name=iPhone 11' \
+		-destination 'generic/platform=iOS Simulator' \
 		-enableCodeCoverage YES \
 		build-for-testing \
 		ENABLE_TESTABILITY=YES \
@@ -107,7 +107,7 @@ build-sdk-for-testing-simulator:
 .PHONY: test-sdk-without-building-simulator
 test-sdk-without-building-simulator:
 	$(XCODE_BUILD_SIM_SDK) \
-		-destination 'platform=iOS Simulator,OS=latest,name=iPhone 11' \
+		-destination 'platform=iOS Simulator,OS=$(OS)' \
 		-enableCodeCoverage YES \
 		test-without-building \
 		-resultBundlePath MapboxMapsTests.xcresult \

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ build-sdk-for-simulator:
 .PHONY: build-sdk-for-testing-simulator
 build-sdk-for-testing-simulator:
 	$(XCODE_BUILD_SIM_SDK) \
-		-destination 'generic/platform=iOS Simulator' \
+		-destination 'platform=iOS Simulator,OS=latest,name=iPhone 11' \
 		-enableCodeCoverage YES \
 		build-for-testing \
 		ENABLE_TESTABILITY=YES \
@@ -107,7 +107,7 @@ build-sdk-for-testing-simulator:
 .PHONY: test-sdk-without-building-simulator
 test-sdk-without-building-simulator:
 	$(XCODE_BUILD_SIM_SDK) \
-		-destination 'platform=iOS Simulator,OS=$(OS)' \
+		-destination 'platform=iOS Simulator,OS=latest,name=iPhone 11' \
 		-enableCodeCoverage YES \
 		test-without-building \
 		-resultBundlePath MapboxMapsTests.xcresult \


### PR DESCRIPTION
This PR splits Run Unit tests job into build-unit-tests and run-unit tests. Unit tests are run on iOS 13.7, 14.5, 15.5, and 16.1.

| Before | After |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/1478430/201365469-e6d7b78d-27d3-4811-8a1e-a159af891ee6.png" width = 1000/> | <img src="https://user-images.githubusercontent.com/1478430/201365536-c2b7eb03-f0fe-4fb5-a554-5fd28907e9fd.png" width = 1000/> |

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
