### PR TITLE
Allow external initialization of options

### DIFF
--- a/Sources/MapboxMaps/Gestures/GestureOptions.swift
+++ b/Sources/MapboxMaps/Gestures/GestureOptions.swift
@@ -34,48 +34,78 @@ public struct GestureOptions: Equatable {
 
     /// Whether rotation gesture is enabled.
     /// Defaults to `true`.
-    public var rotateEnabled: Bool = true
+    public var rotateEnabled: Bool
 
     /// Whether rotation is enabled for the pinch to zoom gesture.
     /// Defaults to `true`.
-    public var simultaneousRotateAndPinchZoomEnabled: Bool = true
+    public var simultaneousRotateAndPinchZoomEnabled: Bool
 
     /// Whether zoom is enabled for the pinch gesture.
     /// Defaults to `true`.
-    public var pinchZoomEnabled: Bool = true
+    public var pinchZoomEnabled: Bool
 
     /// Whether pan is enabled for the pinch gesture.
     /// Defaults to `true`.
-    public var pinchPanEnabled: Bool = true
+    public var pinchPanEnabled: Bool
 
     /// Whether the pitch gesture is enabled. Defaults to `true`.
-    public var pitchEnabled: Bool = true
+    public var pitchEnabled: Bool
 
     /// Whether double tapping the map with one touch results in a zoom-in animation.
     /// Defaults to `true`.
-    public var doubleTapToZoomInEnabled: Bool = true
+    public var doubleTapToZoomInEnabled: Bool
 
     /// Whether single tapping the map with two touches results in a zoom-out animation.
     /// Defaults to `true`.
-    public var doubleTouchToZoomOutEnabled: Bool = true
+    public var doubleTouchToZoomOutEnabled: Bool
 
     /// Whether the quick zoom gesture is enabled. Defaults to `true`.
-    public var quickZoomEnabled: Bool = true
+    public var quickZoomEnabled: Bool
 
     /// Configures the directions in which the map is allowed to move during a pan gesture.
     /// Defaults to `PanMode.horizontalAndVertical`. Called `scrollMode` in
     /// the Android SDK for consistency with platform conventions.
-    public var panMode: PanMode = .horizontalAndVertical
+    public var panMode: PanMode
 
     /// A constant factor that determines how quickly pan deceleration animations happen.
     /// Multiplied with the velocity vector once per millisecond during deceleration animations.
     /// Defaults to `UIScrollView.DecelerationRate.normal.rawValue`
-    public var panDecelerationFactor: CGFloat = UIScrollView.DecelerationRate.normal.rawValue
+    public var panDecelerationFactor: CGFloat
 
     /// By default, gestures rotate and zoom around the center of the gesture. Set this property to rotate and zoom around a fixed point instead.
     ///
     /// This property will be ignored by the pinch gesture if ``GestureOptions/pinchPanEnabled`` is set to `true`.
     public var focalPoint: CGPoint?
 
-    public init() {}
+    /// Initializes a `GestureOptions`.
+    public init(
+        panEnabled: Bool = true,
+        pinchEnabled: Bool = true,
+        rotateEnabled: Bool = true,
+        simultaneousRotateAndPinchZoomEnabled: Bool = true,
+        pinchZoomEnabled: Bool = true,
+        pinchPanEnabled: Bool = true,
+        pitchEnabled: Bool = true,
+        doubleTapToZoomInEnabled: Bool = true,
+        doubleTouchToZoomOutEnabled: Bool = true,
+        quickZoomEnabled: Bool = true,
+        panMode: PanMode = .horizontalAndVertical,
+        panDecelerationFactor: CGFloat = UIScrollView.DecelerationRate.normal.rawValue,
+        focalPoint: CGPoint? = nil
+    ) {
+        self.panEnabled = panEnabled
+        self.pinchEnabled = pinchEnabled
+        self.rotateEnabled = rotateEnabled
+        self.simultaneousRotateAndPinchZoomEnabled = simultaneousRotateAndPinchZoomEnabled
+        self.pinchZoomEnabled = pinchZoomEnabled
+        self.pinchPanEnabled = pinchPanEnabled
+        self.pitchEnabled = pitchEnabled
+        self.doubleTapToZoomInEnabled = doubleTapToZoomInEnabled
+        self.doubleTouchToZoomOutEnabled = doubleTouchToZoomOutEnabled
+        self.quickZoomEnabled = quickZoomEnabled
+        self.panMode = panMode
+        self.panDecelerationFactor = panDecelerationFactor
+        self.focalPoint = focalPoint
+    }
+
 }

--- a/Sources/MapboxMaps/Location/LocationOptions.swift
+++ b/Sources/MapboxMaps/Location/LocationOptions.swift
@@ -3,32 +3,46 @@ import CoreLocation
 
 /// A struct to configure a `LocationManager`
 public struct LocationOptions: Equatable {
-
     /// Specifies the minimum distance (measured in meters) a device must move horizontally
     /// before a location update is generated.
 
     /// The default value of this property is `kCLDistanceFilterNone`.
-    public var distanceFilter: CLLocationDistance = kCLDistanceFilterNone
+    public var distanceFilter: CLLocationDistance
 
     /// Specifies the accuracy of the location data.
     /// The default value is `kCLLocationAccuracyBest`.
-    public var desiredAccuracy: CLLocationAccuracy = kCLLocationAccuracyBest
+    public var desiredAccuracy: CLLocationAccuracy
 
     /// Sets the type of user activity associated with the location updates.
     /// The default value is `CLActivityType.other`.
-    public var activityType: CLActivityType = .other
+    public var activityType: CLActivityType
 
     /// Sets the type of puck that should be used
     public var puckType: PuckType?
 
     /// Specifies if a `Puck` should use `Heading` or `Course` for the bearing
     /// This is an experimental option. The default value is `PuckBearingSource.heading`.
-    public var puckBearingSource: PuckBearingSource = .heading
+    public var puckBearingSource: PuckBearingSource
 
     /// Whether the puck rotates to track the bearing source.
-    public var puckBearingEnabled: Bool = true
+    public var puckBearingEnabled: Bool
 
-    public init() {}
+    /// Initializes a `LocationOptions`.
+    public init(
+        distanceFilter: CLLocationDistance = kCLDistanceFilterNone,
+        desiredAccuracy: CLLocationAccuracy = kCLLocationAccuracyBest,
+        activityType: CLActivityType = .other,
+        puckType: PuckType? = nil,
+        puckBearingSource: PuckBearingSource = .heading,
+        puckBearingEnabled: Bool = true
+    ) {
+        self.distanceFilter = distanceFilter
+        self.desiredAccuracy = desiredAccuracy
+        self.activityType = activityType
+        self.puckType = puckType
+        self.puckBearingSource = puckBearingSource
+        self.puckBearingEnabled = puckBearingEnabled
+    }
 }
 
 /// Controls how the puck is oriented

--- a/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
+++ b/Sources/MapboxMaps/Ornaments/OrnamentOptions.swift
@@ -1,7 +1,5 @@
 import UIKit
 
-private let defaultOrnamentsMargin = CGPoint(x: 8.0, y: 8.0)
-
 /// Used to configure Ornament-specific capabilities of the map
 ///
 /// All margin values are relative to the ``MapView``'s safe area. To allow the safe area
@@ -11,12 +9,12 @@ public struct OrnamentOptions: Equatable {
 
     // MARK: - Scale Bar
     /// The ornament options for the map's scale bar.
-    public var scaleBar = ScaleBarViewOptions()
+    public var scaleBar: ScaleBarViewOptions
 
     // MARK: - Compass
 
     /// The ornament options for the map's compass view.
-    public var compass = CompassViewOptions()
+    public var compass: CompassViewOptions
 
     // MARK: - Logo View
     /**
@@ -27,12 +25,25 @@ public struct OrnamentOptions: Equatable {
      */
 
     /// The ornament options for the map's logo view.
-    public var logo = LogoViewOptions()
+    public var logo: LogoViewOptions
 
     // MARK: - Attribution Button
 
     /// The ornament options for the map's attribution button.
-    public var attributionButton = AttributionButtonOptions()
+    public var attributionButton: AttributionButtonOptions
+
+    /// Initializes an `OrnamentOptions`.
+    public init(
+        scaleBar: ScaleBarViewOptions = .init(),
+        compass: CompassViewOptions = .init(),
+        logo: LogoViewOptions = .init(),
+        attributionButton: AttributionButtonOptions = .init()
+    ) {
+        self.scaleBar = scaleBar
+        self.compass = compass
+        self.logo = logo
+        self.attributionButton = attributionButton
+    }
 }
 
 /// :nodoc:
@@ -46,53 +57,97 @@ public protocol OrnamentOptionsProtocol {
 
 /// Used to configure position, margin, and visibility for the map's scale bar view.
 public struct ScaleBarViewOptions: OrnamentOptionsProtocol, Equatable {
-    /// The default value for this property is `.topLeft`.
-    public var position: OrnamentPosition = .topLeading
+    /// The default value for this property is `.topLeading`.
+    public var position: OrnamentPosition
     /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
-    public var margins: CGPoint = defaultOrnamentsMargin
+    public var margins: CGPoint
     /// The default value for this property is `.adaptive`.
-    public var visibility: OrnamentVisibility = .adaptive
+    public var visibility: OrnamentVisibility
     /// Specifies the whether the scale bar uses the metric system.
     /// True if the scale bar is using metric units, false if the scale bar is using imperial units.
-    public var useMetricUnits: Bool = Locale.current.usesMetricSystem
+    public var useMetricUnits: Bool
+
+    /// Initializes a `ScaleBarViewOptions`.
+    public init(
+        position: OrnamentPosition = .topLeading,
+        margins: CGPoint = .init(x: 8.0, y: 8.0),
+        visibility: OrnamentVisibility = .adaptive,
+        useMetricUnits: Bool = Locale.current.usesMetricSystem
+    ) {
+        self.position = position
+        self.margins = margins
+        self.visibility = visibility
+        self.useMetricUnits = useMetricUnits
+    }
 }
 
 /// Used to configure position, margin, image, and visibility for the map's compass view.
 public struct CompassViewOptions: OrnamentOptionsProtocol, Equatable {
-    /// The default value for this property is `.topRight`.
-    public var position: OrnamentPosition = .topTrailing
+    /// The default value for this property is `.topTrailing`.
+    public var position: OrnamentPosition
     /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
-    public var margins: CGPoint = defaultOrnamentsMargin
+    public var margins: CGPoint
     /// The default value for this property is nil, default compass image will be drawn.
     public var image: UIImage?
     /// The default value for this property is `.adaptive`.
-    public var visibility: OrnamentVisibility = .adaptive
+    public var visibility: OrnamentVisibility
+
+    /// Initializes a `CompassViewOptions`.
+    public init(
+        position: OrnamentPosition = .topTrailing,
+        margins: CGPoint = .init(x: 8.0, y: 8.0),
+        image: UIImage? = nil,
+        visibility: OrnamentVisibility = .adaptive
+    ) {
+        self.position = position
+        self.margins = margins
+        self.image = image
+        self.visibility = visibility
+    }
 }
 
 /// Used to configure position, margin, and visibility for the map's attribution button.
 public struct AttributionButtonOptions: OrnamentOptionsProtocol, Equatable {
-    /// The default value for this property is `.bottomRight`.
-    public var position: OrnamentPosition = .bottomTrailing
+    /// The default value for this property is `.bottomTrailing`.
+    public var position: OrnamentPosition
     /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
-    public var margins: CGPoint = defaultOrnamentsMargin
+    public var margins: CGPoint
     /// The default value for this property is `visible`. Setting this property to `.adaptive`
     /// will lead to the same behavior as `.visible`. The attribution button will be visible
     /// as long as the map view is visible.
     /// :nodoc:
     /// Restricted API. Please contact Mapbox to discuss your use case if you intend to use this property.
     @_spi(Restricted) public var visibility: OrnamentVisibility = .visible
+
+    /// Initializes an `AttributionButtonOptions`.
+    public init(
+        position: OrnamentPosition = .bottomTrailing,
+        margins: CGPoint = .init(x: 8.0, y: 8.0)
+    ) {
+        self.position = position
+        self.margins = margins
+    }
 }
 
 /// Used to configure position, margin, and visibility for the map's logo view.
 public struct LogoViewOptions: OrnamentOptionsProtocol, Equatable {
-    /// The default value for this property is `.bottomLeft`.
-    public var position: OrnamentPosition = .bottomLeading
+    /// The default value for this property is `.bottomLeading`.
+    public var position: OrnamentPosition
     /// The default value for this property is `CGPoint(x: 8.0, y: 8.0)`.
-    public var margins: CGPoint = defaultOrnamentsMargin
+    public var margins: CGPoint
     /// The default value for this property is `visible`. Setting this property to `.adaptive`
     /// willl lead to the same behavior as `.visible`. The logo view will be visible as long
     /// as the map view is visible.
     /// :nodoc:
     /// Restricted API. Please contact Mapbox to discuss your use case if you intend to use this property.
     @_spi(Restricted) public var visibility: OrnamentVisibility = .visible
+
+    /// Initializes a `LogoViewOptions`.
+    public init(
+        position: OrnamentPosition = .bottomLeading,
+        margins: CGPoint = .init(x: 8.0, y: 8.0)
+    ) {
+        self.position = position
+        self.margins = margins
+    }
 }


### PR DESCRIPTION
This PR adds the ability to externally initialize the `GestureOptions`, `LocationOptions`, and `OrnamentOptions` structs.

These changes should make it easier to provide configuration options to a `MapView` that is bridged to SwiftUI. Currently there is no way to create `OrnamentOptions` at the SwiftUI `View` layer. This means that to update ornaments in the bridged `MapView` you would have to duplicate any options to wanted to customize from `OrnamentOptions` in to your own struct and modify the properties on the `OrnamentOptions` exposed by the `MapView` in your `updateUIView` function. 

While the `GestureOptions` and `LocationOptions` did allow external initialization they did not allow upfront initialization of the options, making the API feel clunky to use.

The `@_spi(Restricted)` variables are excluded from the `OrnamentOptions` public initializer.

## Pull request checklist:
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
   - [ ] If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
