### PR TITLE
Fix examples crash on iPad when presenting an action sheet

### DIFF
--- a/Apps/Examples/Examples/All Examples/BasicLocationPulsingExample.swift
+++ b/Apps/Examples/Examples/All Examples/BasicLocationPulsingExample.swift
@@ -90,6 +90,11 @@ final class BasicLocationPulsingExample: UIViewController, ExampleProtocol {
 
         let controller = UIAlertController(title: "Puck circle", message: nil, preferredStyle: .actionSheet)
         controller.modalPresentationStyle = .popover
+        if #available(iOS 16.0, *) {
+            controller.popoverPresentationController?.sourceItem = navigationItem.rightBarButtonItem
+        } else {
+            controller.popoverPresentationController?.barButtonItem = navigationItem.rightBarButtonItem
+        }
         [constantPulseAction, accuracyPulseAction, staticAccuracyRingAction, stopPulseAction, cancelAction]
             .forEach(controller.addAction)
 

--- a/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
+++ b/Apps/Examples/Examples/All Examples/Custom2DPuckExample.swift
@@ -208,6 +208,7 @@ public class Custom2DPuckExample: UIViewController, ExampleProtocol {
         let alert = UIAlertController(title: "Toggle Puck Options",
                                       message: "Select an options to toggle.",
                                       preferredStyle: .actionSheet)
+        alert.popoverPresentationController?.sourceView = sender
 
         alert.addAction(UIAlertAction(title: "Toggle Puck visibility", style: .default) { _ in
             self.showsPuck.toggle()

--- a/Apps/Examples/Examples/All Examples/LayerPositionExample.swift
+++ b/Apps/Examples/Examples/All Examples/LayerPositionExample.swift
@@ -56,6 +56,12 @@ public class LayerPositionExample: UIViewController, ExampleProtocol {
                                       message: "Please select the position of polygon layer.",
                                       preferredStyle: .actionSheet)
 
+        if case .pad = UIDevice.current.userInterfaceIdiom {
+            alert.popoverPresentationController?.sourceView = sender
+            alert.popoverPresentationController?.sourceRect = CGRect(x: 0, y: 0, width:
+                                      sender.frame.size.width, height: sender.frame.size.height)
+        }
+
         alert.addAction(UIAlertAction(title: "Above state label", style: .default, handler: { [weak self] _ in
             guard let self = self else { return }
             try? self.mapView.mapboxMap.style.removeLayer(withId: self.layer.id)

--- a/Apps/Examples/Examples/All Examples/LayerPositionExample.swift
+++ b/Apps/Examples/Examples/All Examples/LayerPositionExample.swift
@@ -55,12 +55,7 @@ public class LayerPositionExample: UIViewController, ExampleProtocol {
         let alert = UIAlertController(title: "Polygon Layer",
                                       message: "Please select the position of polygon layer.",
                                       preferredStyle: .actionSheet)
-
-        if case .pad = UIDevice.current.userInterfaceIdiom {
-            alert.popoverPresentationController?.sourceView = sender
-            alert.popoverPresentationController?.sourceRect = CGRect(x: 0, y: 0, width:
-                                      sender.frame.size.width, height: sender.frame.size.height)
-        }
+        alert.popoverPresentationController?.sourceView = sender
 
         alert.addAction(UIAlertAction(title: "Above state label", style: .default, handler: { [weak self] _ in
             guard let self = self else { return }

--- a/Apps/Examples/Examples/All Examples/LocalizationExample.swift
+++ b/Apps/Examples/Examples/All Examples/LocalizationExample.swift
@@ -46,6 +46,7 @@ public class LocalizationExample: UIViewController, ExampleProtocol {
         let alert = UIAlertController(title: "Languages",
                                       message: "Please select a language to localize to.",
                                       preferredStyle: .actionSheet)
+        alert.popoverPresentationController?.sourceView = sender
 
         alert.addAction(UIAlertAction(title: "Device Locale", style: .default, handler: { [weak self] _ in
             do {


### PR DESCRIPTION
Before this commit, LayerPositionExample crashes on iPad with the following error .

```
Thread 1: "Your application has presented a UIAlertController (<UIAlertController: 0x10851ca00>) of style UIAlertControllerStyleActionSheet from UINavigationController (<UINavigationController: 0x10881e800>). 
The modalPresentationStyle of a UIAlertController with this style is UIModalPresentationPopover. 
You must provide location information for this popover through the alert controller's popoverPresentationController. 
You must provide either a sourceView and sourceRect or a barButtonItem.  
If this information is not known when you present the alert controller, you may provide it in the UIPopoverPresentationControllerDelegate method -prepareForPopoverPresentation."
```

To fix it, provide a sourceView and sourceRect .