### PR TITLE
Collect unit and integration tests coverage separately

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,6 +666,8 @@ jobs:
           when: always
       - store_test_results:
           path: junit.xml
+      - store_test_results:
+          path: junit-integrations.xml
       - store_artifacts:
           path: MapboxMapsTests.xcresult.zip
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -614,6 +614,7 @@ jobs:
             xcodebuild \
               test-without-building \
               -xctestrun "$XCTESTRUN_PATH" \
+              -parallel-testing-enabled NO \
               -destination 'platform=iOS Simulator,<< parameters.destination >>' \
               -resultBundlePath MapboxMapsTests-integration.xcresult | tee -a xcodebuild.log | xcpretty --report junit --output junit/integration/junit.xml
 
@@ -639,7 +640,7 @@ jobs:
                     -instr-profile="Coverage-integrationtests.profdata" \
                     "$BINARY_PATH" > coverage-integrationtests.txt
 
-                    zip coverage.zip coverage.lcov coverage-integrationtests.lcov coverage.txt coverage-integrationtests.txt "$BINARY_PATH" "$COVERAGE_PATH" junit
+                    zip -r coverage.zip coverage.lcov coverage-integrationtests.lcov coverage.txt coverage-integrationtests.txt "$BINARY_PATH" "$COVERAGE_PATH" junit
             - install-python-dependencies
             - install-mbx-ci
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -567,7 +567,7 @@ jobs:
               -destination "generic/platform=iOS Simulator" \
               -derivedDataPath build \
               -enableCodeCoverage YES \
-              -testPlan "MapboxMapsAll" \
+              -testPlan "UnitTests" -testPlan "IntegrationTests" \
               COMPILER_INDEX_STORE_ENABLE=NO \
               ENABLE_TESTABILITY=YES \
               ONLY_ACTIVE_ARCH=YES
@@ -596,32 +596,52 @@ jobs:
       - attach_workspace:
           at: build
       - run:
-          name: Run MapboxMaps unit test on << parameters.destination >>  simulator
+          name: Run MapboxMaps unit tests on << parameters.destination >>  simulator
           command: |
-            XCTESTRUN_PATH=$(find build -type f -name '*.xctestrun')
+            XCTESTRUN_PATH=$(find build -type f -name 'MapboxMaps_UnitTests*.xctestrun' | head -1)
             xcodebuild \
               test-without-building \
               -xctestrun "$XCTESTRUN_PATH" \
               -destination 'platform=iOS Simulator,<< parameters.destination >>' \
               -enableCodeCoverage YES \
               -resultBundlePath MapboxMapsTests.xcresult | tee xcodebuild.log | xcpretty --report junit --output junit.xml
+
+            find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profdata' -exec mv {} Coverage-unittests.profdata \;
+            find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profraw' -exec mv {} . \;
+      - run:
+          name: Run MapboxMaps integration tests on << parameters.destination >>  simulator
+          command: |
+            XCTESTRUN_PATH=$(find build -type f -name 'MapboxMaps_IntegrationTests*.xctestrun' | head -1)
+            xcodebuild \
+              test-without-building \
+              -xctestrun "$XCTESTRUN_PATH" \
+              -destination 'platform=iOS Simulator,<< parameters.destination >>' \
+              -enableCodeCoverage YES \
+              -resultBundlePath MapboxMapsTests.xcresult | tee -a xcodebuild.log | xcpretty --report junit --output junit-integrations.xml
+
+            find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profdata' -exec mv {} Coverage-integrationtests.profdata \;
       - when:
           condition: << parameters.codecoverage >>
           steps:
             - run:
                 name: Generate code coverage report
                 command: |
-                  COVERAGE_PATH="$(find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profdata' | head -n 1)"
                   BINARY_PATH="$(find build -name "MapboxMaps.o")"
 
                   xcrun llvm-cov export -arch $(uname -m) -format="lcov" \
-                    -instr-profile="$COVERAGE_PATH" \
+                    -instr-profile="Coverage-unittests.profdata" \
                     "$BINARY_PATH" > coverage.lcov
+                  xcrun llvm-cov export -arch $(uname -m) -format="lcov" \
+                    -instr-profile="Coverage-integrationtests.profdata" \
+                    "$BINARY_PATH" > coverage-integrationtests.lcov
                   xcrun llvm-cov export -arch $(uname -m) -format=text \
-                    -instr-profile="$COVERAGE_PATH" \
+                    -instr-profile="Coverage-unittests.profdata" \
                     "$BINARY_PATH" > coverage.txt
+                  xcrun llvm-cov export -arch $(uname -m) -format=text \
+                    -instr-profile="Coverage-integrationtests.profdata" \
+                    "$BINARY_PATH" > coverage-integrationtests.txt
 
-                    zip coverage.zip coverage.lcov coverage.txt "$BINARY_PATH" "$COVERAGE_PATH"
+                    zip coverage.zip coverage.lcov coverage-integrationtests.lcov coverage.txt coverage-integrationtests.txt "$BINARY_PATH" "$COVERAGE_PATH"
             - install-python-dependencies
             - install-mbx-ci
             - run:
@@ -629,7 +649,8 @@ jobs:
                 command: |
                   curl -Os https://uploader.codecov.io/latest/macos/codecov
                   chmod +x codecov
-                  ./codecov -f coverage.lcov
+                  ./codecov -f coverage.lcov -F unit
+                  ./codecov -f coverage-integrationtests.lcov -F integration
 
                   echo "Uploading to S3" ; \
                   python3 ./scripts/code-coverage/parse-code-coverage.py \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -617,7 +617,7 @@ jobs:
               -xctestrun "$XCTESTRUN_PATH" \
               -destination 'platform=iOS Simulator,<< parameters.destination >>' \
               -enableCodeCoverage YES \
-              -resultBundlePath MapboxMapsTests.xcresult | tee -a xcodebuild.log | xcpretty --report junit --output junit-integrations.xml
+              -resultBundlePath MapboxMapsTests-integration.xcresult | tee -a xcodebuild.log | xcpretty --report junit --output junit-integrations.xml
 
             find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profdata' -exec mv {} Coverage-integrationtests.profdata \;
       - when:
@@ -662,7 +662,7 @@ jobs:
                 path: coverage.zip
       - run:
           name: Compress XCResult
-          command: zip -r MapboxMapsTests.xcresult.zip MapboxMapsTests.xcresult
+          command: zip -r MapboxMapsTests.xcresult.zip MapboxMapsTests.xcresult MapboxMapsTests-integration.xcresult
           when: always
       - store_test_results:
           path: junit.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,7 +602,7 @@ jobs:
               test-without-building \
               -xctestrun "$XCTESTRUN_PATH" \
               -destination 'platform=iOS Simulator,<< parameters.destination >>' \
-              -resultBundlePath MapboxMapsTests.xcresult | tee xcodebuild.log | xcpretty --report junit --output junit.xml
+              -resultBundlePath MapboxMapsTests.xcresult | tee xcodebuild.log | xcpretty --report junit --output junit/unitTests/junit.xml
 
             find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profdata' -exec mv {} Coverage-unittests.profdata \;
             find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profraw' -exec mv {} . \;
@@ -614,7 +614,7 @@ jobs:
               test-without-building \
               -xctestrun "$XCTESTRUN_PATH" \
               -destination 'platform=iOS Simulator,<< parameters.destination >>' \
-              -resultBundlePath MapboxMapsTests-integration.xcresult | tee -a xcodebuild.log | xcpretty --report junit --output junit-integrations.xml
+              -resultBundlePath MapboxMapsTests-integration.xcresult | tee -a xcodebuild.log | xcpretty --report junit --output junit/integration/junit.xml
 
             find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profdata' -exec mv {} Coverage-integrationtests.profdata \;
       - when:
@@ -662,9 +662,7 @@ jobs:
           command: zip -r MapboxMapsTests.xcresult.zip MapboxMapsTests.xcresult MapboxMapsTests-integration.xcresult
           when: always
       - store_test_results:
-          path: junit.xml
-      - store_test_results:
-          path: junit-integrations.xml
+          path: junit
       - store_artifacts:
           path: MapboxMapsTests.xcresult.zip
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -566,7 +566,6 @@ jobs:
               -configuration << parameters.configuration >> \
               -destination "generic/platform=iOS Simulator" \
               -derivedDataPath build \
-              -enableCodeCoverage YES \
               -testPlan "UnitTests" -testPlan "IntegrationTests" \
               COMPILER_INDEX_STORE_ENABLE=NO \
               ENABLE_TESTABILITY=YES \
@@ -603,7 +602,6 @@ jobs:
               test-without-building \
               -xctestrun "$XCTESTRUN_PATH" \
               -destination 'platform=iOS Simulator,<< parameters.destination >>' \
-              -enableCodeCoverage YES \
               -resultBundlePath MapboxMapsTests.xcresult | tee xcodebuild.log | xcpretty --report junit --output junit.xml
 
             find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profdata' -exec mv {} Coverage-unittests.profdata \;
@@ -616,7 +614,6 @@ jobs:
               test-without-building \
               -xctestrun "$XCTESTRUN_PATH" \
               -destination 'platform=iOS Simulator,<< parameters.destination >>' \
-              -enableCodeCoverage YES \
               -resultBundlePath MapboxMapsTests-integration.xcresult | tee -a xcodebuild.log | xcpretty --report junit --output junit-integrations.xml
 
             find "${HOME}/Library/Developer/Xcode/DerivedData" -name '*.profdata' -exec mv {} Coverage-integrationtests.profdata \;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,7 +626,7 @@ jobs:
             - run:
                 name: Generate code coverage report
                 command: |
-                  BINARY_PATH="$(find build -name "MapboxMaps.o")"
+                  BINARY_PATH="$(find build -name "MapboxMaps.o" | head -1)"
 
                   xcrun llvm-cov export -arch $(uname -m) -format="lcov" \
                     -instr-profile="Coverage-unittests.profdata" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,6 +601,7 @@ jobs:
             xcodebuild \
               test-without-building \
               -xctestrun "$XCTESTRUN_PATH" \
+              -parallel-testing-enabled NO \
               -destination 'platform=iOS Simulator,<< parameters.destination >>' \
               -resultBundlePath MapboxMapsTests.xcresult | tee xcodebuild.log | xcpretty --report junit --output junit/unitTests/junit.xml
 
@@ -638,7 +639,7 @@ jobs:
                     -instr-profile="Coverage-integrationtests.profdata" \
                     "$BINARY_PATH" > coverage-integrationtests.txt
 
-                    zip coverage.zip coverage.lcov coverage-integrationtests.lcov coverage.txt coverage-integrationtests.txt "$BINARY_PATH" "$COVERAGE_PATH"
+                    zip coverage.zip coverage.lcov coverage-integrationtests.lcov coverage.txt coverage-integrationtests.txt "$BINARY_PATH" "$COVERAGE_PATH" junit
             - install-python-dependencies
             - install-mbx-ci
             - run:

--- a/Tests/TestPlans/IntegrationTests.xctestplan
+++ b/Tests/TestPlans/IntegrationTests.xctestplan
@@ -2,17 +2,17 @@
   "configurations" : [
     {
       "id" : "86BCF7AC-2BA2-468F-BE79-EDD42CCF1C4F",
-      "name" : "Configuration 1",
+      "name" : "Address Sanitizer",
       "options" : {
-
+        "addressSanitizer" : {
+          "detectStackUseAfterReturn" : true,
+          "enabled" : true
+        }
       }
     }
   ],
   "defaultOptions" : {
-    "addressSanitizer" : {
-      "detectStackUseAfterReturn" : true,
-      "enabled" : true
-    }
+
   },
   "testTargets" : [
     {

--- a/Tests/TestPlans/IntegrationTests.xctestplan
+++ b/Tests/TestPlans/IntegrationTests.xctestplan
@@ -12,10 +12,11 @@
     }
   ],
   "defaultOptions" : {
-
+    "language" : "en"
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "selectedTests" : [
         "BackgroundLayerIntegrationTests",
         "BasicCameraAnimatorImplIntegrationTests",

--- a/Tests/TestPlans/MapboxMapsAll.xctestplan
+++ b/Tests/TestPlans/MapboxMapsAll.xctestplan
@@ -12,7 +12,8 @@
     "addressSanitizer" : {
       "detectStackUseAfterReturn" : true,
       "enabled" : true
-    }
+    },
+    "language" : "en"
   },
   "testTargets" : [
     {

--- a/Tests/TestPlans/MapboxMapsAll.xctestplan
+++ b/Tests/TestPlans/MapboxMapsAll.xctestplan
@@ -17,6 +17,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:",
         "identifier" : "MapboxMapsTests",

--- a/Tests/TestPlans/UnitTests.xctestplan
+++ b/Tests/TestPlans/UnitTests.xctestplan
@@ -1,21 +1,46 @@
 {
   "configurations" : [
     {
-      "id" : "D4553FD6-392E-4B22-9D1D-F47D55866A9B",
-      "name" : "Configuration 1",
+      "id" : "AB060B2F-57FF-4678-9396-AEE47962A9FB",
+      "name" : "Default",
       "options" : {
 
+      }
+    },
+    {
+      "id" : "D4553FD6-392E-4B22-9D1D-F47D55866A9B",
+      "name" : "Address Sanitizer",
+      "options" : {
+        "addressSanitizer" : {
+          "detectStackUseAfterReturn" : true,
+          "enabled" : true
+        }
+      }
+    },
+    {
+      "id" : "F72FA70C-FDEC-4A5B-B35C-796A825F874D",
+      "name" : "Thread Sanitizer",
+      "options" : {
+        "threadSanitizerEnabled" : true
       }
     }
   ],
   "defaultOptions" : {
-    "addressSanitizer" : {
-      "detectStackUseAfterReturn" : true,
-      "enabled" : true
-    }
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:",
+          "identifier" : "MapboxMaps",
+          "name" : "MapboxMaps"
+        }
+      ]
+    },
+    "language" : "en",
+    "testExecutionOrdering" : "random"
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "skippedTests" : [
         "BackgroundLayerIntegrationTests",
         "BasicCameraAnimatorImplIntegrationTests",

--- a/Tests/TestPlans/UnitTests.xctestplan
+++ b/Tests/TestPlans/UnitTests.xctestplan
@@ -16,13 +16,6 @@
           "enabled" : true
         }
       }
-    },
-    {
-      "id" : "F72FA70C-FDEC-4A5B-B35C-796A825F874D",
-      "name" : "Thread Sanitizer",
-      "options" : {
-        "threadSanitizerEnabled" : true
-      }
     }
   ],
   "defaultOptions" : {

--- a/Tests/TestPlans/UnitTests.xctestplan
+++ b/Tests/TestPlans/UnitTests.xctestplan
@@ -2,13 +2,6 @@
   "configurations" : [
     {
       "id" : "AB060B2F-57FF-4678-9396-AEE47962A9FB",
-      "name" : "Default",
-      "options" : {
-
-      }
-    },
-    {
-      "id" : "D4553FD6-392E-4B22-9D1D-F47D55866A9B",
       "name" : "Address Sanitizer",
       "options" : {
         "addressSanitizer" : {

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,3 +26,6 @@ flag_management:
         threshold: 2%
       - type: patch
         target: 90%
+    individual_flags: # exceptions to the default rules above, stated flag by flag
+    - name: unit
+    - name: integration

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,7 +14,15 @@ coverage:
         threshold: 2%
     patch:
       default:
-        target: auto
+        target: 90%
 comment:
   require_changes: true
   layout: "reach, diff, flags, files"
+
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
+    statuses:
+      - type: project
+        threshold: 2%
+      - type: patch
+        target: 90%

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,14 +18,3 @@ coverage:
 comment:
   require_changes: true
   layout: "reach, diff, flags, files"
-
-flag_management:
-  default_rules: # the rules that will be followed for any flag added, generally
-    statuses:
-      - type: project
-        threshold: 2%
-      - type: patch
-        target: 90%
-    individual_flags: # exceptions to the default rules above, stated flag by flag
-    - name: unit
-    - name: integration


### PR DESCRIPTION
* Split testing run by type of test – unit vs integration. This PR also reports coverage based on type test to enable coverage tracking per type.
* Fix failing tests for non-en languages
* Enable parallelization in test plans
  * Parallelisation is disabled on CI because `xcpretty` cannot generate junit reports with that feature. However, parallel testing didn't add a log to the CI testing time kind of 5-10 seconds decrease.
 

<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
