### PR TITLE
Allow simultaneous recognition of map- and annotation- handling gesture recognizers

### DIFF
--- a/Sources/MapboxMaps/Annotations/AnnotationOrchestratorImpl.swift
+++ b/Sources/MapboxMaps/Annotations/AnnotationOrchestratorImpl.swift
@@ -13,7 +13,7 @@ internal protocol AnnotationOrchestratorImplProtocol: AnyObject {
     func removeAnnotationManager(withId id: String)
 }
 
-internal final class AnnotationOrchestratorImpl: AnnotationOrchestratorImplProtocol {
+internal final class AnnotationOrchestratorImpl: NSObject, AnnotationOrchestratorImplProtocol {
 
     private let tapGestureRecognizer: UIGestureRecognizer
 
@@ -48,8 +48,11 @@ internal final class AnnotationOrchestratorImpl: AnnotationOrchestratorImplProto
         self.offsetLineStringCalculator = offsetLineStringCalculator
         self.offsetPolygonCalculator = offsetPolygonCalculator
 
+        super.init()
         tapGestureRecognizer.addTarget(self, action: #selector(handleTap(_:)))
         longPressGestureRecognizer.addTarget(self, action: #selector(handleDrag(_:)))
+        longPressGestureRecognizer.delegate = self
+        tapGestureRecognizer.delegate = self
     }
 
     /// Dictionary of annotation managers keyed by their identifiers.
@@ -257,6 +260,19 @@ internal final class AnnotationOrchestratorImpl: AnnotationOrchestratorImplProto
             fallthrough
         @unknown default:
             break
+        }
+    }
+}
+
+extension AnnotationOrchestratorImpl: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        switch gestureRecognizer {
+        case self.tapGestureRecognizer where otherGestureRecognizer is UITapGestureRecognizer:
+            return true
+        case self.longPressGestureRecognizer where otherGestureRecognizer is UILongPressGestureRecognizer:
+            return true
+        default:
+            return false
         }
     }
 }

--- a/Sources/MapboxMaps/Gestures/GestureHandlers/SingleTapGestureHandler.swift
+++ b/Sources/MapboxMaps/Gestures/GestureHandlers/SingleTapGestureHandler.swift
@@ -12,7 +12,6 @@ internal final class SingleTapGestureHandler: GestureHandler {
         self.cameraAnimationsManager = cameraAnimationsManager
         super.init(gestureRecognizer: gestureRecognizer)
         gestureRecognizer.addTarget(self, action: #selector(handleGesture(_:)))
-        gestureRecognizer.delegate = self
     }
 
     @objc private func handleGesture(_ gestureRecognizer: UITapGestureRecognizer) {
@@ -24,12 +23,5 @@ internal final class SingleTapGestureHandler: GestureHandler {
         default:
             break
         }
-    }
-}
-
-extension SingleTapGestureHandler: UIGestureRecognizerDelegate {
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return self.gestureRecognizer === gestureRecognizer &&
-        otherGestureRecognizer is UITapGestureRecognizer
     }
 }

--- a/Tests/MapboxMapsTests/Annotations/AnnotationOrchestratorImplTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/AnnotationOrchestratorImplTests.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Roman Laitarenko on 18.11.2022.
+//
+
+import Foundation

--- a/Tests/MapboxMapsTests/Annotations/AnnotationOrchestratorImplTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/AnnotationOrchestratorImplTests.swift
@@ -105,7 +105,7 @@ final class AnnotationOrchestratorImplTests: XCTestCase {
 
     func testShouldNotRecognizeSimultaneouslyWithUnrecognizedGestureRecognizer() {
         let recognizers = [UILongPressGestureRecognizer(), UIPanGestureRecognizer(), UITapGestureRecognizer(), UISwipeGestureRecognizer(), UIScreenEdgePanGestureRecognizer(), UIPinchGestureRecognizer(), UIRotationGestureRecognizer()]
-        
+
         for outerRecognizer in recognizers {
             for innerRecognizer in recognizers {
                 let shouldRecognizeSimultaneously = impl.gestureRecognizer(

--- a/Tests/MapboxMapsTests/Annotations/AnnotationOrchestratorImplTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/AnnotationOrchestratorImplTests.swift
@@ -1,8 +1,120 @@
-//
-//  File.swift
-//  
-//
-//  Created by Roman Laitarenko on 18.11.2022.
-//
-
 import Foundation
+import XCTest
+@testable import MapboxMaps
+
+final class AnnotationOrchestratorImplTests: XCTestCase {
+    var tapGestureRecognizer: MockGestureRecognizer!
+    var longPressGestureRecognizer: MapboxLongPressGestureRecognizer!
+    var mapFeatureQueryable: MockMapFeatureQueryable!
+    var style: MockStyle!
+    var displayLinkCoordinator: MockDisplayLinkCoordinator!
+    var offsetPointCalculator: OffsetPointCalculator!
+    var offsetLineStringCalculator: OffsetLineStringCalculator!
+    var offsetPolygonCalculator: OffsetPolygonCalculator!
+    var impl: AnnotationOrchestratorImpl!
+
+    override func setUp() {
+        super.setUp()
+
+        tapGestureRecognizer = MockGestureRecognizer()
+        longPressGestureRecognizer = MapboxLongPressGestureRecognizer()
+        mapFeatureQueryable = MockMapFeatureQueryable()
+        style = MockStyle()
+        displayLinkCoordinator = MockDisplayLinkCoordinator()
+        offsetPointCalculator = OffsetPointCalculator(mapboxMap: MockMapboxMap())
+        offsetLineStringCalculator = OffsetLineStringCalculator(mapboxMap: MockMapboxMap())
+        offsetPolygonCalculator = OffsetPolygonCalculator(mapboxMap: MockMapboxMap())
+        impl = AnnotationOrchestratorImpl(
+            tapGestureRecognizer: tapGestureRecognizer,
+            longPressGestureRecognizer: longPressGestureRecognizer,
+            mapFeatureQueryable: mapFeatureQueryable,
+            style: style,
+            displayLinkCoordinator: displayLinkCoordinator,
+            offsetPointCalculator: offsetPointCalculator,
+            offsetLineStringCalculator: offsetLineStringCalculator,
+            offsetPolygonCalculator: offsetPolygonCalculator
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        tapGestureRecognizer = nil
+        longPressGestureRecognizer = nil
+        mapFeatureQueryable = nil
+        style = nil
+        displayLinkCoordinator = nil
+        offsetPointCalculator = nil
+        offsetLineStringCalculator = nil
+        offsetPolygonCalculator = nil
+        impl = nil
+    }
+
+    func testSingleTapRecognizesSimultaneouslyWithOtherTapRecognizer() {
+        let shouldRecognizeSimultaneously = impl.gestureRecognizer(
+            tapGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith: UITapGestureRecognizer()
+        )
+
+        XCTAssertTrue(shouldRecognizeSimultaneously)
+    }
+
+    func testLongPressRecognizesSimultaneouslyWithOtherLongPressRecognizer() {
+        let shouldRecognizeSimultaneously = impl.gestureRecognizer(
+            longPressGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith: UILongPressGestureRecognizer()
+        )
+
+        XCTAssertTrue(shouldRecognizeSimultaneously)
+    }
+
+    func testLongPressRecognizesSimultaneouslyWithMapboxLongPressRecognizer() {
+        let shouldRecognizeSimultaneously = impl.gestureRecognizer(
+            longPressGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith: MapboxLongPressGestureRecognizer()
+        )
+
+        XCTAssertTrue(shouldRecognizeSimultaneously)
+    }
+
+    func testSingleTapShouldNotRecognizeSimultaneouslyWithNonTapGesture() {
+        let recognizers = [UIPanGestureRecognizer(), UILongPressGestureRecognizer(), UISwipeGestureRecognizer(), UIScreenEdgePanGestureRecognizer(), UIPinchGestureRecognizer(), UIRotationGestureRecognizer()]
+
+        for recognizer in recognizers {
+            let shouldRecognizeSimultaneously = impl.gestureRecognizer(
+                tapGestureRecognizer,
+                shouldRecognizeSimultaneouslyWith: recognizer
+            )
+
+            XCTAssertFalse(shouldRecognizeSimultaneously)
+        }
+    }
+
+    func testLongPressShouldNotRecognizeSimultaneouslyWithNonLongPressGesture() {
+        let recognizers = [UIPanGestureRecognizer(), UITapGestureRecognizer(), UISwipeGestureRecognizer(), UIScreenEdgePanGestureRecognizer(), UIPinchGestureRecognizer(), UIRotationGestureRecognizer()]
+
+        for recognizer in recognizers {
+            let shouldRecognizeSimultaneously = impl.gestureRecognizer(
+                longPressGestureRecognizer,
+                shouldRecognizeSimultaneouslyWith: recognizer
+            )
+
+            XCTAssertFalse(shouldRecognizeSimultaneously)
+        }
+    }
+
+    func testShouldNotRecognizeSimultaneouslyWithUnrecognizedGestureRecognizer() {
+        let recognizers = [UILongPressGestureRecognizer(), UIPanGestureRecognizer(), UITapGestureRecognizer(), UISwipeGestureRecognizer(), UIScreenEdgePanGestureRecognizer(), UIPinchGestureRecognizer(), UIRotationGestureRecognizer()]
+        
+        for outerRecognizer in recognizers {
+            for innerRecognizer in recognizers {
+                let shouldRecognizeSimultaneously = impl.gestureRecognizer(
+                    outerRecognizer,
+                    shouldRecognizeSimultaneouslyWith: innerRecognizer
+                )
+
+                XCTAssertFalse(shouldRecognizeSimultaneously)
+            }
+        }
+    }
+}

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMapFeatureQueryable.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMapFeatureQueryable.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Roman Laitarenko on 18.11.2022.
+//
+
+import Foundation

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockMapFeatureQueryable.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockMapFeatureQueryable.swift
@@ -1,8 +1,90 @@
-//
-//  File.swift
-//  
-//
-//  Created by Roman Laitarenko on 18.11.2022.
-//
-
 import Foundation
+@testable import MapboxMaps
+
+final class MockMapFeatureQueryable: MapFeatureQueryable {
+    typealias Completion = (Result<[QueriedFeature], Error>) -> Void
+    struct QueryRenderedFeaturesForParams {
+        let shape: [CGPoint]
+        let options: RenderedQueryOptions?
+        let completion: Completion
+    }
+    let queryRenderedFeaturesForStub = Stub<QueryRenderedFeaturesForParams, Void>()
+    func queryRenderedFeatures(for shape: [CGPoint], options: RenderedQueryOptions?, completion: @escaping (Result<[QueriedFeature], Error>) -> Void) {
+        queryRenderedFeaturesForStub.call(with: .init(shape: shape, options: options, completion: completion))
+    }
+
+    struct QueryRenderedFeaturesInParams {
+        let rect: CGRect
+        let options: RenderedQueryOptions?
+        let completion: Completion
+    }
+    let queryRenderedFeaturesInStub = Stub<QueryRenderedFeaturesInParams, Void>()
+    func queryRenderedFeatures(in rect: CGRect, options: RenderedQueryOptions?, completion: @escaping (Result<[QueriedFeature], Error>) -> Void) {
+        queryRenderedFeaturesInStub.call(with: .init(rect: rect, options: options, completion: completion))
+    }
+
+    struct QueryRenderedFeaturesAtParams {
+        let point: CGPoint
+        let options: RenderedQueryOptions?
+        let completion: Completion
+    }
+    let queryRenderedFeaturesAtStub = Stub<QueryRenderedFeaturesAtParams, Void>()
+    func queryRenderedFeatures(at point: CGPoint, options: RenderedQueryOptions?, completion: @escaping (Result<[QueriedFeature], Error>) -> Void) {
+        queryRenderedFeaturesAtStub.call(with: .init(point: point, options: options, completion: completion))
+    }
+
+    struct QuerySourceFeaturesForParams {
+        let sourceId: String
+        let options: SourceQueryOptions
+        let completion: Completion
+    }
+    let querySourceFeaturesForStub = Stub<QuerySourceFeaturesForParams, Void>()
+    func querySourceFeatures(for sourceId: String, options: SourceQueryOptions, completion: @escaping (Result<[QueriedFeature], Error>) -> Void) {
+        querySourceFeaturesForStub.call(with: .init(sourceId: sourceId, options: options, completion: completion))
+    }
+
+    struct QueryFeatureExtensionParams {
+        let sourceId: String
+        let feature: Feature
+        let `extension`: String
+        let extensionField: String
+        let args: [String: Any]?
+        let completion: (Result<FeatureExtensionValue, Error>) -> Void
+    }
+    let queryFeatureExtensionStub = Stub<QueryFeatureExtensionParams, Void>()
+    func queryFeatureExtension(for sourceId: String, feature: Feature, extension: String, extensionField: String, args: [String : Any]?, completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void) {
+        queryFeatureExtensionStub.call(with: .init(sourceId: sourceId, feature: feature, extension: `extension`, extensionField: extensionField, args: args, completion: completion))
+    }
+
+    struct GetGeoJsonClusterLeavesParams {
+        let sourceId: String
+        let feature: Feature
+        let limit: UInt64
+        let offset: UInt64
+        let completion: (Result<FeatureExtensionValue, Error>) -> Void
+    }
+    let getGeoJsonClusterLeavesStub = Stub<GetGeoJsonClusterLeavesParams, Void>()
+    func getGeoJsonClusterLeaves(forSourceId sourceId: String, feature: Feature, limit: UInt64, offset: UInt64, completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void) {
+        getGeoJsonClusterLeavesStub.call(with: .init(sourceId: sourceId, feature: feature, limit: limit, offset: offset, completion: completion))
+    }
+
+    struct GetGeoJsonClusterChildrenParams {
+        let sourceId: String
+        let feature: Feature
+        let completion: (Result<FeatureExtensionValue, Error>) -> Void
+    }
+    let getGeoJsonClusterChildrenStub = Stub<GetGeoJsonClusterChildrenParams, Void>()
+    func getGeoJsonClusterChildren(forSourceId sourceId: String, feature: MapboxMaps.Feature, completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void) {
+        getGeoJsonClusterChildrenStub.call(with: .init(sourceId: sourceId, feature: feature, completion: completion))
+    }
+
+    struct GetGeoJsonClusterExpansionZoomParams {
+        let sourceId: String
+        let feature: Feature
+        let completion: (Result<FeatureExtensionValue, Error>) -> Void
+    }
+    let getGeoJsonClusterExpansionZoomStub = Stub<GetGeoJsonClusterExpansionZoomParams, Void>()
+    func getGeoJsonClusterExpansionZoom(forSourceId sourceId: String, feature: MapboxMaps.Feature, completion: @escaping (Result<FeatureExtensionValue, Error>) -> Void) {
+        getGeoJsonClusterExpansionZoomStub.call(with: .init(sourceId: sourceId, feature: feature, completion: completion))
+    }
+}

--- a/Tests/MapboxMapsTests/Gestures/GestureHandlers/SingleTapGestureHandlerTests.swift
+++ b/Tests/MapboxMapsTests/Gestures/GestureHandlers/SingleTapGestureHandlerTests.swift
@@ -44,26 +44,4 @@ final class SingleTapGestureHandlerTests: XCTestCase {
         XCTAssertEqual(delegate.gestureEndedStub.invocations.first?.parameters.gestureType, .singleTap)
         XCTAssertEqual(delegate.gestureEndedStub.invocations.first?.parameters.willAnimate, false)
     }
-
-    func testSingleTapRecognizesSimultaneouslyWithTapGesture() {
-        let shouldRecognizeSimultaneously = gestureHandler.gestureRecognizer(
-            gestureRecognizer,
-            shouldRecognizeSimultaneouslyWith: UITapGestureRecognizer()
-        )
-
-        XCTAssertTrue(shouldRecognizeSimultaneously)
-    }
-
-    func testSingleTapShouldNotRecognizeSimultaneouslyWithNonTapGesture() {
-        let recognizers = [UIPanGestureRecognizer(), UILongPressGestureRecognizer(), UISwipeGestureRecognizer(), UIScreenEdgePanGestureRecognizer(), UIPinchGestureRecognizer()]
-
-        for recognizer in recognizers {
-            let shouldRecognizeSimultaneously = gestureHandler.gestureRecognizer(
-                gestureRecognizer,
-                shouldRecognizeSimultaneouslyWith: recognizer
-            )
-
-            XCTAssertFalse(shouldRecognizeSimultaneously)
-        }
-    }
 }


### PR DESCRIPTION
This PR fixes issue when a custom long press/tap gesture recognizers not working because of map view's corresponding gesture recognizers take the user input over. This is addressed by allowing annotation-handing long press and tap gesture recognizers to be recognized simultaneously with other gesture recognizers of the same type.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
