### PR TITLE
Throttle location and heading updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## main
 
+* Throttle location and heading updates. ([#1747](https://github.com/mapbox/mapbox-maps-ios/pull/1747))
 * Fix memory leak when viewport is being deallocated while transition is running. ([#1691](https://github.com/mapbox/mapbox-maps-ios/pull/1691))
 * Fix issue with simultaneous recognition of tap gesture. ([#1712](https://github.com/mapbox/mapbox-maps-ios/pull/1712))
 * Fix label localization to properly handle Simplified and Traditional Chinese. ([#1687](https://github.com/mapbox/mapbox-maps-ios/pull/1687))

--- a/Sources/MapboxMaps/Foundation/Helpers/MainQueueWrapper.swift
+++ b/Sources/MapboxMaps/Foundation/Helpers/MainQueueWrapper.swift
@@ -4,6 +4,10 @@ import Dispatch
 internal protocol MainQueueProtocol: DispatchQueueProtocol { }
 
 internal final class MainQueueWrapper: MainQueueProtocol {
+    func asyncAfter(deadline: DispatchTime, execute: DispatchWorkItem) {
+        DispatchQueue.main.asyncAfter(deadline: deadline, execute: execute)
+    }
+
     func async(
         group: DispatchGroup?,
         qos: DispatchQoS,

--- a/Sources/MapboxMaps/Foundation/ObservableValue.swift
+++ b/Sources/MapboxMaps/Foundation/ObservableValue.swift
@@ -1,9 +1,97 @@
-internal final class ObservableValue<Value> where Value: Equatable {
-    private var observers = [Observer]() {
+import Foundation
+
+/// Wrapper for ``ObservableValue`` to throttle its value updates.
+/// Republishes only the latest event received during the time window interval.
+internal final class Throttle<Value> where Value: Equatable {
+    private var subscriptions = [BlockSubscription<Value>]() {
         didSet {
-            if !observers.isEmpty, oldValue.isEmpty {
+            if !subscriptions.isEmpty, oldValue.isEmpty {
+                cancelToken = observableValue.observe { [weak self] newValue in
+                    if self?.value == nil { // first update
+                        self?.notifyImmediately(with: newValue)
+                    } else {
+                        self?.onValueUpdated(newValue: newValue)
+                    }
+                    return true
+                }
+            } else if subscriptions.isEmpty, !oldValue.isEmpty {
+                cancelToken = nil
+            }
+        }
+    }
+
+    internal var value: Value?
+    private var latestValue: Value? { observableValue.value }
+
+    private let observableValue: ObservableValue<Value>
+    private let windowDuration: TimeInterval
+    private var cancelToken: Cancelable?
+    private var item: DispatchWorkItem?
+
+    deinit {
+        cancelToken?.cancel()
+    }
+
+    init(value: ObservableValue<Value>, windowDuration: TimeInterval) {
+        self.observableValue = value
+        self.windowDuration = windowDuration
+    }
+
+    internal func notify(with newValue: Value) {
+        observableValue.notify(with: newValue)
+    }
+
+    internal func notifyImmediately(with newValue: Value) {
+        item?.cancel()
+        item = nil
+
+        self.value = newValue
+        self.subscriptions.forEach { subscription in
+            subscription.invokeHandler(with: self.value!)
+        }
+    }
+
+    internal func flush() {
+        guard let latestValue = latestValue, value != latestValue else { return }
+
+        notifyImmediately(with: latestValue)
+    }
+
+    internal func observe(with handler: @escaping (Value) -> Void) -> Cancelable {
+        let observer = BlockSubscription<Value> { _, value in
+            handler(value)
+        }
+        subscriptions.append(observer)
+
+        return BlockCancelable { [weak self] in
+            self?.subscriptions.removeAll { $0 === observer }
+        }
+    }
+
+    private func onValueUpdated(newValue: Value) {
+        guard item == nil else { return }
+
+        let item = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+
+            self.value = self.latestValue
+            self.subscriptions.forEach { subscription in
+                subscription.invokeHandler(with: self.value!)
+            }
+            self.item = nil
+        }
+
+        self.item = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + windowDuration, execute: item)
+    }
+}
+
+internal final class ObservableValue<Value> where Value: Equatable {
+    private var subscriptions = [BlockSubscription<Value>]() {
+        didSet {
+            if !subscriptions.isEmpty, oldValue.isEmpty {
                 onFirstSubscribe?()
-            } else if observers.isEmpty, !oldValue.isEmpty {
+            } else if subscriptions.isEmpty, !oldValue.isEmpty {
                 onLastUnsubscribe?()
             }
         }
@@ -16,40 +104,40 @@ internal final class ObservableValue<Value> where Value: Equatable {
             return
         }
         value = newValue
-        observers.forEach { (observer) in
+        subscriptions.forEach { (observer) in
             observer.invokeHandler(with: newValue)
         }
     }
 
     internal func observe(with handler: @escaping (Value) -> Bool) -> Cancelable {
-        let observer = Observer { [weak self] (observer, value) in
+        let observer = BlockSubscription<Value> { [weak self] (observer, value) in
             // handler returns false if it wants to stop receiving updates
             if !handler(value) {
-                self?.observers.removeAll { $0 === observer }
+                self?.subscriptions.removeAll { $0 === observer }
             }
         }
-        observers.append(observer)
+        subscriptions.append(observer)
         if let value = value {
             observer.invokeHandler(with: value)
         }
         return BlockCancelable { [weak self] in
-            self?.observers.removeAll { $0 === observer }
+            self?.subscriptions.removeAll { $0 === observer }
         }
     }
 
     internal var onFirstSubscribe: (() -> Void)?
 
     internal var onLastUnsubscribe: (() -> Void)?
+}
 
-    private final class Observer {
-        private let handler: (Observer, Value) -> Void
+fileprivate final class BlockSubscription<Value> where Value: Equatable {
+    private let handler: (BlockSubscription, Value) -> Void
 
-        internal init(handler: @escaping (Observer, Value) -> Void) {
-            self.handler = handler
-        }
+    internal init(handler: @escaping (BlockSubscription, Value) -> Void) {
+        self.handler = handler
+    }
 
-        internal func invokeHandler(with value: Value) {
-            handler(self, value)
-        }
+    internal func invokeHandler(with value: Value) {
+        handler(self, value)
     }
 }

--- a/Sources/MapboxMaps/Foundation/ObservableValue.swift
+++ b/Sources/MapboxMaps/Foundation/ObservableValue.swift
@@ -32,7 +32,7 @@ internal final class Throttle<Value> where Value: Equatable {
         cancelToken?.cancel()
     }
 
-    init(value: ObservableValue<Value>, windowDuration: TimeInterval) {
+    init(value: ObservableValue<Value> = .init(), windowDuration: TimeInterval) {
         self.observableValue = value
         self.windowDuration = windowDuration
     }
@@ -42,6 +42,8 @@ internal final class Throttle<Value> where Value: Equatable {
     }
 
     internal func notifyImmediately(with newValue: Value) {
+        guard value != newValue else { return }
+
         item?.cancel()
         item = nil
 

--- a/Sources/MapboxMaps/Foundation/RetroactiveConformances/DispatchQueueProtocol.swift
+++ b/Sources/MapboxMaps/Foundation/RetroactiveConformances/DispatchQueueProtocol.swift
@@ -10,6 +10,7 @@ internal protocol DispatchQueueProtocol: AnyObject {
         execute work: @escaping @convention(block) () -> Void
     )
     func async(execute workItem: DispatchWorkItem)
+    func asyncAfter(deadline: DispatchTime, execute: DispatchWorkItem)
 }
 
 extension DispatchQueueProtocol {

--- a/Tests/MapboxMapsTests/Foundation/ThrottleTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/ThrottleTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import XCTest
+@testable import MapboxMaps
+
+final class ThrottleTests: XCTestCase {
+
+    var observableValue: ObservableValue<Int>!
+    var dispatchQueue: MockDispatchQueue!
+    var throttle: Throttle<Int>!
+
+    override func setUp() {
+        super.setUp()
+        observableValue = ObservableValue()
+        dispatchQueue = MockDispatchQueue()
+        throttle = Throttle(value: observableValue, windowDuration: 1, dispatchQueue: dispatchQueue)
+    }
+
+    override func tearDown() {
+        observableValue = nil
+        dispatchQueue = nil
+        throttle = nil
+        super.tearDown()
+    }
+
+    func testSubscribestoValueChangesDuringInit() {
+        // given
+        let observableValue = ObservableValue<Int>()
+        var observableSubscribed = false
+        observableValue.onFirstSubscribe = {
+            observableSubscribed = true
+        }
+
+        // when
+        _ = Throttle(value: observableValue, windowDuration: 1, dispatchQueue: dispatchQueue)
+
+        // then
+        XCTAssertTrue(observableSubscribed)
+    }
+
+    func testNoThrottlingForTheFirstValueUpdate() {
+        // given
+        let value = Int.random(in: 0...100)
+
+        // when
+        observableValue.notify(with: value)
+
+        // then
+        XCTAssertEqual(throttle.value, value)
+    }
+
+    func testThrottlingForSecondValueUpdate() throws {
+        // given
+        let originalValue = Int.random(in: 0...100)
+        observableValue.notify(with: originalValue)
+        let updatedValue = Int.random(in: 101...1000)
+
+        // when
+        observableValue.notify(with: updatedValue)
+        XCTAssertEqual(throttle.value, originalValue)
+
+        // then
+        XCTAssertEqual(dispatchQueue.asyncAfterItemStub.invocations.count, 1)
+        let invocation = try XCTUnwrap(dispatchQueue.asyncAfterItemStub.invocations.first)
+        let timeToleranceInNanoseconds = 1_000_000
+        XCTAssertTrue(((DispatchTime.now() + 1).rawValue - invocation.parameters.deadline.rawValue) < timeToleranceInNanoseconds)
+
+        invocation.parameters.item.perform()
+
+        XCTAssertEqual(throttle.value, updatedValue)
+    }
+
+    func testSubsequentValueUpdatesOverrideScheduledUpdates() throws {
+        // given
+        observableValue.notify(with: 8) // initial update
+        observableValue.notify(with: 9) // scheduled update
+
+        // when
+        observableValue.notify(with: 10) // subsequent update
+
+        // then
+        XCTAssertEqual(dispatchQueue.asyncAfterItemStub.invocations.count, 1)
+        let invocation = try XCTUnwrap(dispatchQueue.asyncAfterItemStub.invocations.first)
+
+        XCTAssertFalse(invocation.parameters.item.isCancelled)
+
+        invocation.parameters.item.perform()
+
+        XCTAssertEqual(throttle.value, 10)
+    }
+
+    func testNotifyImmediatelyCancelsUpcomingUpdates() throws {
+        // given
+        observableValue.notify(with: 8) // initial update
+        observableValue.notify(with: 9) // scheduled update
+
+        // when
+        throttle.notifyImmediately(with: 10)
+
+        // then
+        XCTAssertEqual(dispatchQueue.asyncAfterItemStub.invocations.count, 1)
+        let invocation = try XCTUnwrap(dispatchQueue.asyncAfterItemStub.invocations.first)
+
+        XCTAssertTrue(invocation.parameters.item.isCancelled)
+        XCTAssertEqual(throttle.value, 10)
+    }
+
+    func testFlushNotifiesImmediatelyAboutUpcomingUpdate() throws {
+        // given
+        observableValue.notify(with: 8) // initial update
+        observableValue.notify(with: 9) // scheduled update
+        observableValue.notify(with: 10) // scheduled update
+
+        // when
+        throttle.flush()
+
+        // then
+        XCTAssertEqual(dispatchQueue.asyncAfterItemStub.invocations.count, 1)
+        let invocation = try XCTUnwrap(dispatchQueue.asyncAfterItemStub.invocations.first)
+
+        XCTAssertTrue(invocation.parameters.item.isCancelled)
+        XCTAssertEqual(throttle.value, 10)
+    }
+
+    func testFlushDoesNothingWhenNoUpcomingUpdate() {
+        // given
+        observableValue.notify(with: 8) // initial update
+
+        // when
+        throttle.flush()
+
+        // then
+        XCTAssertEqual(dispatchQueue.asyncAfterItemStub.invocations.count, 0)
+        XCTAssertEqual(throttle.value, 8)
+
+    }
+
+    func testObserving() throws {
+        // given
+        var receivedValue: Int?
+        _ = throttle.observe { value in
+            receivedValue = value
+        }
+
+        // when
+        throttle.notify(with: 8)
+
+        // then
+        XCTAssertEqual(receivedValue, 8)
+
+        // when
+        throttle.notify(with: 10)
+
+        // then
+        XCTAssertEqual(dispatchQueue.asyncAfterItemStub.invocations.count, 1)
+        let invocation = try XCTUnwrap(dispatchQueue.asyncAfterItemStub.invocations.first)
+
+        XCTAssertFalse(invocation.parameters.item.isCancelled)
+
+        invocation.parameters.item.perform()
+
+        XCTAssertEqual(receivedValue, 10)
+    }
+
+    func testCancelTokenCancelsObserving() {
+        // given
+        var receivedValue: Int?
+        let cancelToken = throttle.observe { value in
+            receivedValue = value
+        }
+        cancelToken.cancel()
+
+        // when
+        throttle.notify(with: 8)
+
+        // then
+        XCTAssertEqual(throttle.value, 8)
+        XCTAssertNil(receivedValue)
+    }
+
+    func testCancelTokenCancelsObservingForScheduledUpdate() throws {
+        // given
+        throttle.notify(with: 8)
+        var receivedValue: Int?
+        let cancelToken = throttle.observe { value in
+            receivedValue = value
+        }
+        cancelToken.cancel()
+
+        // when
+        throttle.notify(with: 9)
+
+        XCTAssertEqual(dispatchQueue.asyncAfterItemStub.invocations.count, 1)
+        let invocation = try XCTUnwrap(dispatchQueue.asyncAfterItemStub.invocations.first)
+
+        XCTAssertFalse(invocation.parameters.item.isCancelled)
+
+        invocation.parameters.item.perform()
+
+        // then
+        XCTAssertEqual(throttle.value, 9)
+        XCTAssertNil(receivedValue)
+    }
+}

--- a/Tests/MapboxMapsTests/Location/LocationProducerTests.swift
+++ b/Tests/MapboxMapsTests/Location/LocationProducerTests.swift
@@ -282,7 +282,7 @@ final class LocationProducerTests: XCTestCase {
         let newHeading = MockHeading()
         locationProducer.locationProvider(locationProvider, didUpdateHeading: newHeading)
         locationThrottle.flush()
-        
+
         XCTAssertTrue(consumer.locationUpdateStub.invocations.isEmpty)
 
         // send a location update and verify that the observers are notified

--- a/Tests/MapboxMapsTests/Viewport/Helpers/Mocks/MockDispatchQueue.swift
+++ b/Tests/MapboxMapsTests/Viewport/Helpers/Mocks/MockDispatchQueue.swift
@@ -1,6 +1,15 @@
 @testable import MapboxMaps
 
 final class MockMainQueue: MainQueueProtocol {
+    struct AsyncAfterItemParams {
+        let deadline: DispatchTime
+        let item: DispatchWorkItem
+    }
+    let asyncAfterItemStub = Stub<AsyncAfterItemParams, Void>()
+    func asyncAfter(deadline: DispatchTime, execute: DispatchWorkItem) {
+        asyncAfterItemStub.call(with: .init(deadline: deadline, item: execute))
+    }
+
     struct AsyncParams {
         let group: DispatchGroup?
         let qos: DispatchQoS
@@ -24,6 +33,15 @@ final class MockMainQueue: MainQueueProtocol {
 }
 
 final class MockDispatchQueue: DispatchQueueProtocol {
+    struct AsyncAfterItemParams {
+        let deadline: DispatchTime
+        let item: DispatchWorkItem
+    }
+    let asyncAfterItemStub = Stub<AsyncAfterItemParams, Void>()
+    func asyncAfter(deadline: DispatchTime, execute: DispatchWorkItem) {
+        asyncAfterItemStub.call(with: .init(deadline: deadline, item: execute))
+    }
+
     struct AsyncParams {
         let group: DispatchGroup?
         let qos: DispatchQoS


### PR DESCRIPTION
This PR adds throttling to the streams of location and heading updates coming from a location provider to the location producer. This doesn't matter much for location updates as they are coming in with ~1sec interval usually. Heading updates on the other hand may come in much more frequently - especially for handheld devices, we don't make a good use of these updates as our location update animation duration is a bit over 1 second.

As part of supporting infrastructure this PR also introduces an observable entity called `Throttle` - it works as a wrapper on top of `ObservableValue`, allowing the user to specify a time window during which all value updates will be ignored except the very last one. 


## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
