### PR TITLE
Fixes incorrect conversion from MapboxMaps.ResourceOptions to MapboxCoreMaps.ResourceOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+## main
+
+* Fix loading errors appearing when providing custom endpoint for `ResourceOptions.baseURL`. ([#1749](https://github.com/mapbox/mapbox-maps-ios/pull/1749))
+
 ## 10.10.0-rc.1 - November 18, 2022
 
 * Fix memory leak when viewport is being deallocated while transition is running. ([#1691](https://github.com/mapbox/mapbox-maps-ios/pull/1691))

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/ResourceOptions.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/ResourceOptions.swift
@@ -163,7 +163,7 @@ extension ResourceOptions {
 extension MapboxCoreMaps.ResourceOptions {
     internal convenience init(_ swiftValue: ResourceOptions) {
         self.init(accessToken: swiftValue.accessToken,
-                  baseURL: swiftValue.baseURL?.path,
+                  baseURL: swiftValue.baseURL?.absoluteString,
                   dataPath: swiftValue.dataPathURL?.path,
                   assetPath: swiftValue.assetPathURL?.path,
                   tileStore: swiftValue.tileStore,

--- a/Sources/MapboxMaps/Foundation/Extensions/Core/ResourceOptions.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Core/ResourceOptions.swift
@@ -147,7 +147,12 @@ extension ResourceOptions: CustomStringConvertible, CustomDebugStringConvertible
 extension ResourceOptions {
     internal init(_ objcValue: MapboxCoreMaps.ResourceOptions) {
 
-        let baseURL      = objcValue.baseURL.flatMap { URL(fileURLWithPath: $0) }
+        let baseURL: URL?
+        if let baseURLString = objcValue.baseURL {
+            baseURL = URL(string: baseURLString)
+        } else {
+            baseURL = nil
+        }
         let dataPathURL = objcValue.dataPath.flatMap { URL(fileURLWithPath: $0) }
         let assetPathURL = objcValue.assetPath.flatMap { URL(fileURLWithPath: $0) }
 

--- a/Tests/MapboxMapsTests/Foundation/Extensions/Core/ResourceOptionsTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Extensions/Core/ResourceOptionsTests.swift
@@ -1,5 +1,6 @@
 import XCTest
-import MapboxMaps
+@testable import MapboxMaps
+import MapboxCoreMaps
 
 class ResourceOptionsTests: XCTestCase {
 
@@ -26,5 +27,13 @@ class ResourceOptionsTests: XCTestCase {
     func testAccessTokenIsObfuscated() {
         let a = ResourceOptions(accessToken: "pk.HelloWorld")
         XCTAssertEqual(a.description, "ResourceOptions: pk.H◻︎◻︎◻︎◻︎◻︎◻︎◻︎◻︎◻︎")
+    }
+
+    func testBaseUrl() {
+        let expectedBaseUrl = URL(string: "https://api.mapbox.com")
+        let a = ResourceOptions(accessToken: "pk.HelloWorld", baseURL: expectedBaseUrl)
+        let c = MapboxCoreMaps.ResourceOptions(a)
+        XCTAssertNotNil(c.baseURL)
+        XCTAssertEqual(a.baseURL?.absoluteString, c.baseURL)
     }
 }

--- a/Tests/MapboxMapsTests/Foundation/Extensions/Core/ResourceOptionsTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Extensions/Core/ResourceOptionsTests.swift
@@ -31,23 +31,23 @@ class ResourceOptionsTests: XCTestCase {
 
     func testBaseUrlConversionToCore() {
         let expectedBaseUrl = URL(string: "https://api.mapbox.com")!
-        let a = ResourceOptions(accessToken: "pk.HelloWorld", baseURL: expectedBaseUrl)
-        let c = MapboxCoreMaps.ResourceOptions(a)
+        let sdkOptions = ResourceOptions(accessToken: "pk.HelloWorld", baseURL: expectedBaseUrl)
+        let coreOptions = MapboxCoreMaps.ResourceOptions(sdkOptions)
 
-        XCTAssertEqual(c.baseURL, expectedBaseUrl.absoluteString)
+        XCTAssertEqual(coreOptions.baseURL, expectedBaseUrl.absoluteString)
     }
 
     func testBaseUrlConversionFromCore() {
         let expectedBaseUrl = URL(string: "https://api.mapbox.com")!
-        let a = MapboxCoreMaps.ResourceOptions(
+        let coreOptions = MapboxCoreMaps.ResourceOptions(
             accessToken: "pk.HelloWorld",
             baseURL: expectedBaseUrl.absoluteString,
             dataPath: nil,
             assetPath: nil,
             tileStore: nil
         )
-        let c = ResourceOptions(a)
+        let sdkOptions = ResourceOptions(coreOptions)
 
-        XCTAssertEqual(c.baseURL, expectedBaseUrl)
+        XCTAssertEqual(sdkOptions.baseURL, expectedBaseUrl)
     }
 }

--- a/Tests/MapboxMapsTests/Foundation/Extensions/Core/ResourceOptionsTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Extensions/Core/ResourceOptionsTests.swift
@@ -49,4 +49,17 @@ class ResourceOptionsTests: XCTestCase {
 
         XCTAssertEqual(sdkOptions.baseURL, expectedBaseUrl)
     }
+
+    func testNilBaseUrlConversionFromCore() {
+        let coreOptions = MapboxCoreMaps.ResourceOptions(
+            accessToken: "pk.HelloWorld",
+            baseURL: nil,
+            dataPath: nil,
+            assetPath: nil,
+            tileStore: nil
+        )
+        let sdkOptions = ResourceOptions(coreOptions)
+
+        XCTAssertNil(sdkOptions.baseURL)
+    }
 }

--- a/Tests/MapboxMapsTests/Foundation/Extensions/Core/ResourceOptionsTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Extensions/Core/ResourceOptionsTests.swift
@@ -29,11 +29,25 @@ class ResourceOptionsTests: XCTestCase {
         XCTAssertEqual(a.description, "ResourceOptions: pk.H◻︎◻︎◻︎◻︎◻︎◻︎◻︎◻︎◻︎")
     }
 
-    func testBaseUrl() {
-        let expectedBaseUrl = URL(string: "https://api.mapbox.com")
+    func testBaseUrlConversionToCore() {
+        let expectedBaseUrl = URL(string: "https://api.mapbox.com")!
         let a = ResourceOptions(accessToken: "pk.HelloWorld", baseURL: expectedBaseUrl)
         let c = MapboxCoreMaps.ResourceOptions(a)
-        XCTAssertNotNil(c.baseURL)
-        XCTAssertEqual(a.baseURL?.absoluteString, c.baseURL)
+
+        XCTAssertEqual(c.baseURL, expectedBaseUrl.absoluteString)
+    }
+
+    func testBaseUrlConversionFromCore() {
+        let expectedBaseUrl = URL(string: "https://api.mapbox.com")!
+        let a = MapboxCoreMaps.ResourceOptions(
+            accessToken: "pk.HelloWorld",
+            baseURL: expectedBaseUrl.absoluteString,
+            dataPath: nil,
+            assetPath: nil,
+            tileStore: nil
+        )
+        let c = ResourceOptions(a)
+
+        XCTAssertEqual(c.baseURL, expectedBaseUrl)
     }
 }

--- a/Tests/MapboxMapsTests/Foundation/Extensions/Core/ResourceOptionsTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Extensions/Core/ResourceOptionsTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 @testable import MapboxMaps
-import MapboxCoreMaps
 
 class ResourceOptionsTests: XCTestCase {
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

Taking path from web URL is incorrect conversion from Foundation.URL to Swift.String. The correct way is taking `absoluteString` property.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
