### PR TITLE
Updated podspec to use resource_bundles

### DIFF
--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |m|
   m.swift_version = '5.5'
 
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
-  m.resources = ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json']
+  m.resource_bundles = { 'MapboxMapsResources' => ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json'] }
 
   m.dependency 'MapboxCoreMaps', '10.10.0-rc.1'
   m.dependency 'MapboxMobileEvents', '1.0.8'

--- a/Sources/MapboxMaps/Foundation/Extensions/Bundle+MapboxMaps.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Bundle+MapboxMaps.swift
@@ -11,7 +11,16 @@ extension Bundle {
         #if SWIFT_PACKAGE
         return Bundle.module
         #else
-        return Bundle(for: BundleLocator.self)
+        // When using frameworks this bundle will be our `.framework` bundle.
+        // When using static linking this bundle will be the the host application's `.app` bundle.
+        let bundle = Bundle(for: BundleLocator.self)
+
+        // When using CocoaPods a "resource bundle" will be used to avoid resource conflicts with the host application.
+        // Check for the existence of the resource bundle and use that instead if it is present.
+        let resourceBundle = bundle.path(forResource: "MapboxMapsResources", ofType: "bundle")
+            .flatMap(Bundle.init(path:))
+
+        return resourceBundle ?? bundle
         #endif
     }
 


### PR DESCRIPTION
This PR updates the CocoaPods podspec to use `resource_bundles` instead of `resources`.

When using CocoaPods with static linking the `resources` will be copied to the root of the `.app`. When copying these resources the build will fail if the application already contains any resources with the same name. This will happen in any application that has its own `Assets.xcassets` since the application will generate an `Assets.car` and the `MapboxMaps` pod will also try to copy its own `Assets.car` to the `.app`.

The recommended solution for this with CocoaPods is to use `resource_bundles`. This will cause CocoaPods to create a bundle with the name specified in `resource_bundles`. The created resource bundle will be copied to either the `.framework` or `.app` depending on the linking method used, resolving any resource conflicts with the hosting application.

## Pull request checklist:
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
   - [ ] If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
