### PR TITLE
Improve performance by setting geojson data directly

### DIFF
--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -46,6 +46,10 @@ internal extension StyleProtocol {
 ///
 /// - Important: Style should only be used from the main thread.
 public final class Style: StyleProtocol {
+    internal static var enableDirecGeoJSONUpdate: Bool {
+        get { StyleSourceManager.enableDirectGeoJSONUpdate }
+        set { StyleSourceManager.enableDirectGeoJSONUpdate = newValue }
+    }
 
     private let sourceManager: StyleSourceManagerProtocol
     private let _styleManager: StyleManagerProtocol

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -46,10 +46,6 @@ internal extension StyleProtocol {
 ///
 /// - Important: Style should only be used from the main thread.
 public final class Style: StyleProtocol {
-    internal static var enableDirecGeoJSONUpdate: Bool {
-        get { StyleSourceManager.enableDirectGeoJSONUpdate }
-        set { StyleSourceManager.enableDirectGeoJSONUpdate = newValue }
-    }
 
     private let sourceManager: StyleSourceManagerProtocol
     private let _styleManager: StyleManagerProtocol

--- a/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
+++ b/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
@@ -142,7 +142,9 @@ internal protocol StyleManagerProtocol {
         forSourceId sourceId: String,
         bounds: CoordinateBounds) -> Expected<NSNull, NSString>
 
-    func setStyleSourceDataForSourceId(_ sourceId: String, geojson: GeoJSON) -> Expected<NSNull, NSString>
+    func setStyleSourceDataForSourceId(_ sourceId: String, data: GeoJSON) -> Expected<NSNull, NSString>
+
+    func setStyleSourceDataForSourceId(_ sourceId: String, value: Any) -> Expected<NSNull, NSString>
 }
 
 // MARK: Conformance

--- a/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
+++ b/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
@@ -142,9 +142,9 @@ internal protocol StyleManagerProtocol {
         forSourceId sourceId: String,
         bounds: CoordinateBounds) -> Expected<NSNull, NSString>
 
-    func __setStyleSourceDataForSourceId(
+    func __setStyleGeoJSONSourceDataForSourceId(
         _ sourceId: String,
-        geojsonSourceData: MapboxCoreMaps.GeoJSONSourceData
+        data: MapboxCoreMaps.GeoJSONSourceData
     ) -> Expected<NSNull, NSString>
 }
 

--- a/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
+++ b/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
@@ -142,9 +142,10 @@ internal protocol StyleManagerProtocol {
         forSourceId sourceId: String,
         bounds: CoordinateBounds) -> Expected<NSNull, NSString>
 
-    func setStyleSourceDataForSourceId(_ sourceId: String, data: GeoJSON) -> Expected<NSNull, NSString>
-
-    func setStyleSourceDataForSourceId(_ sourceId: String, value: Any) -> Expected<NSNull, NSString>
+    func __setStyleSourceDataForSourceId(
+        _ sourceId: String,
+        geojsonSourceData: MapboxCoreMaps.GeoJSONSourceData
+    ) -> Expected<NSNull, NSString>
 }
 
 // MARK: Conformance

--- a/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
+++ b/Sources/MapboxMaps/Style/StyleManagerProtocol.swift
@@ -141,6 +141,8 @@ internal protocol StyleManagerProtocol {
     func invalidateStyleCustomGeometrySourceRegion(
         forSourceId sourceId: String,
         bounds: CoordinateBounds) -> Expected<NSNull, NSString>
+
+    func setStyleSourceDataForSourceId(_ sourceId: String, geojson: GeoJSON) -> Expected<NSNull, NSString>
 }
 
 // MARK: Conformance

--- a/Sources/MapboxMaps/Style/StyleSourceManager.swift
+++ b/Sources/MapboxMaps/Style/StyleSourceManager.swift
@@ -223,6 +223,10 @@ internal final class StyleSourceManager: StyleSourceManagerProtocol {
 
 private extension SettingsServiceInterface {
     var shouldUseDirectGeoJSONUpdate: Bool {
-        return (try? self.get(key: "geojson_allow_direct_setter", type: Bool.self).get()) ?? false
+        do {
+            return try get(key: "geojson_allow_direct_setter", type: Bool.self).get()
+        } catch {
+            return false
+        }
     }
 }

--- a/Sources/MapboxMaps/Style/StyleSourceManager.swift
+++ b/Sources/MapboxMaps/Style/StyleSourceManager.swift
@@ -147,9 +147,9 @@ internal final class StyleSourceManager: StyleSourceManagerProtocol {
         }
     }
 
-    private func setStyleSourceDataForSourceId(_ id: String, geojsonSourceData: MapboxCoreMaps.GeoJSONSourceData) throws {
+    private func setStyleGeoJSONSourceDataForSourceId(_ id: String, data: MapboxCoreMaps.GeoJSONSourceData) throws {
         try handleExpected {
-            return styleManager.__setStyleSourceDataForSourceId(id, geojsonSourceData: geojsonSourceData)
+            return styleManager.__setStyleGeoJSONSourceDataForSourceId(id, geojsonSourceData: geojsonSourceData)
         }
     }
 
@@ -186,7 +186,7 @@ internal final class StyleSourceManager: StyleSourceManagerProtocol {
 
             let data = data.coreData
             do {
-                try self?.setStyleSourceDataForSourceId(id, geojsonSourceData: data)
+                try self?.setStyleGeoJSONSourceDataForSourceId(id, data: data)
             } catch {
                 Log.error(forMessage: "Failed to set data for source with id: \(id), error: \(error)")
             }

--- a/Sources/MapboxMaps/Style/StyleSourceManager.swift
+++ b/Sources/MapboxMaps/Style/StyleSourceManager.swift
@@ -147,18 +147,11 @@ internal final class StyleSourceManager: StyleSourceManagerProtocol {
         }
     }
 
-    private func setStyleSourceDataForSourceId(_ id: String, geojson: GeoJSON) throws {
+    private func setStyleSourceDataForSourceId(_ id: String, geojsonSourceData: MapboxCoreMaps.GeoJSONSourceData) throws {
         try handleExpected {
-            return styleManager.setStyleSourceDataForSourceId(id, data: geojson)
+            return styleManager.__setStyleSourceDataForSourceId(id, geojsonSourceData: geojsonSourceData)
         }
     }
-
-    private func setStyleSourceDataForSourceId(_ id: String, string: String) throws {
-        try handleExpected {
-            return styleManager.setStyleSourceDataForSourceId(id, value: string)
-        }
-    }
-
 
     // MARK: - Async GeoJSON source data parsing
 
@@ -191,15 +184,9 @@ internal final class StyleSourceManager: StyleSourceManagerProtocol {
         let item = DispatchWorkItem { [weak self] in
             if self == nil { return } // not capturing self here as conversion below can take some time
 
+            let data = data.coreData
             do {
-                switch data {
-                case .feature, .featureCollection, .geometry:
-                    try self?.setStyleSourceDataForSourceId(id, geojson: data.geoJSON)
-                case .url(let url):
-                    try self?.setStyleSourceDataForSourceId(id, string: url.absoluteString)
-                case .empty:
-                    break
-                }
+                try self?.setStyleSourceDataForSourceId(id, geojsonSourceData: data)
             } catch {
                 Log.error(forMessage: "Failed to set data for source with id: \(id), error: \(error)")
             }

--- a/Sources/MapboxMaps/Style/StyleSourceManager.swift
+++ b/Sources/MapboxMaps/Style/StyleSourceManager.swift
@@ -149,7 +149,7 @@ internal final class StyleSourceManager: StyleSourceManagerProtocol {
 
     private func setStyleGeoJSONSourceDataForSourceId(_ id: String, data: MapboxCoreMaps.GeoJSONSourceData) throws {
         try handleExpected {
-            return styleManager.__setStyleGeoJSONSourceDataForSourceId(id, geojsonSourceData: geojsonSourceData)
+            return styleManager.__setStyleGeoJSONSourceDataForSourceId(id, data: data)
         }
     }
 

--- a/Sources/MapboxMaps/Style/Types/GeoJSONSourceData.swift
+++ b/Sources/MapboxMaps/Style/Types/GeoJSONSourceData.swift
@@ -86,8 +86,10 @@ extension GeoJSONSourceData {
         case .featureCollection(let collection):
             let features = collection.features.map(MapboxCommon.Feature.init)
             return .fromNSArray(features)
-        case .url, .empty:
-            return .fromNSArray([])
+        case .url(let url):
+            return .fromNSString(url.absoluteString)
+        case .empty:
+            return .fromNSString("")
         }
     }
 }

--- a/Sources/MapboxMaps/Style/Types/GeoJSONSourceData.swift
+++ b/Sources/MapboxMaps/Style/Types/GeoJSONSourceData.swift
@@ -85,4 +85,18 @@ extension GeoJSONObject {
             return .featureCollection(collection)
         }
     }
+
+    internal var geoJSON: GeoJSON {
+        switch self {
+        case .geometry(let geometry):
+            let geometry = MapboxCommon.Geometry(geometry)
+            return .fromGeometry(geometry)
+        case .feature(let feature):
+            let feature = MapboxCommon.Feature(feature)
+            return .fromFeature(feature)
+        case .featureCollection(let collection):
+            let features = collection.features.map(MapboxCommon.Feature.init)
+            return .fromNSArray(features)
+        }
+    }
 }

--- a/Sources/MapboxMaps/Style/Types/GeoJSONSourceData.swift
+++ b/Sources/MapboxMaps/Style/Types/GeoJSONSourceData.swift
@@ -75,7 +75,7 @@ public enum GeoJSONSourceData: Codable {
 }
 
 extension GeoJSONSourceData {
-    internal var geoJSON: GeoJSON {
+    internal var coreData: MapboxCoreMaps.GeoJSONSourceData {
         switch self {
         case .geometry(let geometry):
             let geometry = MapboxCommon.Geometry(geometry)

--- a/Sources/MapboxMaps/Style/Types/GeoJSONSourceData.swift
+++ b/Sources/MapboxMaps/Style/Types/GeoJSONSourceData.swift
@@ -74,18 +74,7 @@ public enum GeoJSONSourceData: Codable {
     }
 }
 
-extension GeoJSONObject {
-    internal var sourceData: GeoJSONSourceData {
-        switch self {
-        case .geometry(let geometry):
-            return .geometry(geometry)
-        case .feature(let feature):
-            return .feature(feature)
-        case .featureCollection(let collection):
-            return .featureCollection(collection)
-        }
-    }
-
+extension GeoJSONSourceData {
     internal var geoJSON: GeoJSON {
         switch self {
         case .geometry(let geometry):
@@ -97,6 +86,21 @@ extension GeoJSONObject {
         case .featureCollection(let collection):
             let features = collection.features.map(MapboxCommon.Feature.init)
             return .fromNSArray(features)
+        case .url, .empty:
+            return .fromNSArray([])
+        }
+    }
+}
+
+extension GeoJSONObject {
+    internal var sourceData: GeoJSONSourceData {
+        switch self {
+        case .geometry(let geometry):
+            return .geometry(geometry)
+        case .feature(let feature):
+            return .feature(feature)
+        case .featureCollection(let collection):
+            return .featureCollection(collection)
         }
     }
 }

--- a/Tests/MapboxMapsTests/Foundation/Mocks/MockStyleManager.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/MockStyleManager.swift
@@ -454,6 +454,17 @@ class MockStyleManager: StyleManagerProtocol {
 
         invalidateStyleCustomGeometrySourceRegionStub.call(with: .init(sourceId: sourceId, bounds: bounds))
     }
+
+    struct SetStyleGeoJSONSourceDataForSourceIdParams {
+        let sourceId: String
+        let data: MapboxCoreMaps.GeoJSONSourceData
+    }
+    let setStyleGeoJSONSourceDataForSourceIdStub = Stub<SetStyleGeoJSONSourceDataForSourceIdParams, Expected<NSNull, NSString>>(
+        defaultReturnValue: .init(value: .init())
+    )
+    func __setStyleGeoJSONSourceDataForSourceId(_ sourceId: String, data: MapboxCoreMaps.GeoJSONSourceData) -> Expected<NSNull, NSString> {
+        setStyleGeoJSONSourceDataForSourceIdStub.call(with: .init(sourceId: sourceId, data: data))
+    }
 }
 
 struct NonEncodableLayer: Layer {

--- a/Tests/MapboxMapsTests/Foundation/Mocks/SettingsServiceMock.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/SettingsServiceMock.swift
@@ -18,6 +18,7 @@ final class MockSettingsService: SettingsServiceInterface {
     }
     let getStub = Stub<GetParams, Result<Any, SettingsServiceError>>(defaultReturnValue: .success(()))
     func get<T>(key: String, type: T.Type) -> Result<T, SettingsServiceError> {
+        // swiftlint:disable:next force_cast
         getStub.call(with: .init(key: key, type: type)).map { $0 as! T }
     }
 
@@ -28,6 +29,7 @@ final class MockSettingsService: SettingsServiceInterface {
     }
     let getDefaultStub = Stub<GetDefaultParams, Result<Any, SettingsServiceError>>(defaultReturnValue: .success(()))
     func get<T>(key: String, type: T.Type, defaultValue: T) -> Result<T, SettingsServiceError> {
+        // swiftlint:disable:next force_cast
         getDefaultStub.call(with: .init(key: key, type: type, defaultValue: defaultValue)).map { $0 as! T }
     }
 

--- a/Tests/MapboxMapsTests/Foundation/Mocks/SettingsServiceMock.swift
+++ b/Tests/MapboxMapsTests/Foundation/Mocks/SettingsServiceMock.swift
@@ -1,0 +1,43 @@
+import Foundation
+import MapboxCommon
+
+final class MockSettingsService: SettingsServiceInterface {
+
+    struct SetParams {
+        let key: String
+        let value: Any
+    }
+    let setStub = Stub<SetParams, Result<Void, SettingsServiceError>>(defaultReturnValue: .success(()))
+    func set<T>(key: String, value: T) -> Result<Void, SettingsServiceError> {
+        setStub.call(with: .init(key: key, value: value))
+    }
+
+    struct GetParams {
+        let key: String
+        let type: Any
+    }
+    let getStub = Stub<GetParams, Result<Any, SettingsServiceError>>(defaultReturnValue: .success(()))
+    func get<T>(key: String, type: T.Type) -> Result<T, SettingsServiceError> {
+        getStub.call(with: .init(key: key, type: type)).map { $0 as! T }
+    }
+
+    struct GetDefaultParams {
+        let key: String
+        let type: Any
+        let defaultValue: Any
+    }
+    let getDefaultStub = Stub<GetDefaultParams, Result<Any, SettingsServiceError>>(defaultReturnValue: .success(()))
+    func get<T>(key: String, type: T.Type, defaultValue: T) -> Result<T, SettingsServiceError> {
+        getDefaultStub.call(with: .init(key: key, type: type, defaultValue: defaultValue)).map { $0 as! T }
+    }
+
+    let eraseStub = Stub<String, Result<Void, SettingsServiceError>>(defaultReturnValue: .success(()))
+    func erase(key: String) -> Result<Void, SettingsServiceError> {
+        return eraseStub.call(with: key)
+    }
+
+    let hasStub = Stub<String, Result<Bool, SettingsServiceError>>(defaultReturnValue: .success(false))
+    func has(key: String) -> Result<Bool, MapboxCommon.SettingsServiceError> {
+        return hasStub.call(with: key)
+    }
+}

--- a/Tests/MapboxMapsTests/Foundation/Style/StyleSourceManagerTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Style/StyleSourceManagerTests.swift
@@ -165,7 +165,7 @@ final class StyleSourceManagerTests: XCTestCase {
         let setGeoJSONParams = try XCTUnwrap(styleManager.setStyleGeoJSONSourceDataForSourceIdStub.invocations.first?.parameters)
         XCTAssertEqual(setGeoJSONParams.sourceId, id)
         // swiftlint:disable:next force_cast
-        XCTAssertTrue((setGeoJSONParams.data.value as! Array<Any>).isEmpty)
+        XCTAssertTrue((setGeoJSONParams.data.value as! [Any]).isEmpty)
     }
 
     func testAsyncGeoJSONUpdateSkipsParsingWhenCancelled() throws {

--- a/Tests/MapboxMapsTests/Foundation/Style/StyleSourceManagerTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Style/StyleSourceManagerTests.swift
@@ -164,9 +164,9 @@ final class StyleSourceManagerTests: XCTestCase {
         XCTAssertEqual(styleManager.setStyleGeoJSONSourceDataForSourceIdStub.invocations.count, 1)
         let setGeoJSONParams = try XCTUnwrap(styleManager.setStyleGeoJSONSourceDataForSourceIdStub.invocations.first?.parameters)
         XCTAssertEqual(setGeoJSONParams.sourceId, id)
+        // swiftlint:disable:next force_cast
         XCTAssertTrue((setGeoJSONParams.data.value as! Array<Any>).isEmpty)
     }
-
 
     func testAsyncGeoJSONUpdateSkipsParsingWhenCancelled() throws {
         // given


### PR DESCRIPTION
This PR adds a non-persistent runtime setting option `geojson_allow_direct_setter` to enable passing GeoJSON data directly to core, avoiding extra conversions. There is one conversion still that happens - Turf's GeoJSON types have to be converted to their core counterparts, however this is cheaper than converting them into JSON string and back.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
