### PR TITLE
Fix a issue with compass not updated when setting compass.image to nil

### DIFF
--- a/Sources/MapboxMaps/Ornaments/Compass/MapboxCompassOrnamentView.swift
+++ b/Sources/MapboxMaps/Ornaments/Compass/MapboxCompassOrnamentView.swift
@@ -17,7 +17,7 @@ internal class MapboxCompassOrnamentView: UIButton {
     }
 
     internal var tapAction: (() -> Void)?
-
+    private var originalImage: UIImage?
     private var compassBackgroundColor: UIColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
     private var needleColor: UIColor = #colorLiteral(red: 0.9971256852, green: 0.2427211106, blue: 0.196741581, alpha: 1)
     private var lineColor: UIColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
@@ -52,7 +52,8 @@ internal class MapboxCompassOrnamentView: UIButton {
                                               comment: "Accessibility hint")
 
         containerView.translatesAutoresizingMaskIntoConstraints = false
-        if let image = createCompassImage() {
+        self.originalImage = createCompassImage()
+        if let image = self.originalImage {
             updateImage(image: image)
         }
         addSubview(containerView)
@@ -60,6 +61,7 @@ internal class MapboxCompassOrnamentView: UIButton {
     }
 
     func updateImage(image: UIImage?) {
+        let image = image ?? self.originalImage
         guard let image = image else { return }
         NSLayoutConstraint.deactivate(containerViewConstraints)
         containerView.image = image

--- a/Tests/MapboxMapsTests/Ornaments/Compass/MapboxCompassOrnamentViewTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/Compass/MapboxCompassOrnamentViewTests.swift
@@ -113,14 +113,29 @@ class MapboxCompassOrnamentViewTests: XCTestCase {
         // And
         XCTAssertFalse(compass.containerView.image!.isEqual(originalImage))
 
-        //Given
-        let nilImage: UIImage? = nil
-        //When
-        compass.updateImage(image: nilImage)
-        //Then
-        XCTAssertFalse(compass.containerView.image!.isEqual(expectedImage))
-        //And
-        XCTAssertTrue(compass.containerView.image!.isEqual(originalImage))
+    }
+
+    func testReturningDefaultCompassImage() {
+        // Given
+        let compass = MapboxCompassOrnamentView()
+        let originalImage = compass.containerView.image
+        let customImage = emptyImage(with: CGSize(width: 25, height: 25))
+
+        // When
+        compass.updateImage(image: customImage)
+
+        // Then
+        XCTAssertEqual(compass.containerView.image, customImage)
+
+        // When
+        compass.updateImage(image: nil)
+
+        // Then
+        XCTAssertNotEqual(compass.containerView.image, customImage)
+        // And
+        XCTAssertNotNil(compass.containerView.image)
+        // And
+        XCTAssertEqual(compass.containerView.image, originalImage)
     }
 
     private func emptyImage(with size: CGSize) -> UIImage? {

--- a/Tests/MapboxMapsTests/Ornaments/Compass/MapboxCompassOrnamentViewTests.swift
+++ b/Tests/MapboxMapsTests/Ornaments/Compass/MapboxCompassOrnamentViewTests.swift
@@ -112,6 +112,15 @@ class MapboxCompassOrnamentViewTests: XCTestCase {
         XCTAssertTrue(compass.containerView.image!.isEqual(expectedImage))
         // And
         XCTAssertFalse(compass.containerView.image!.isEqual(originalImage))
+
+        //Given
+        let nilImage: UIImage? = nil
+        //When
+        compass.updateImage(image: nilImage)
+        //Then
+        XCTAssertFalse(compass.containerView.image!.isEqual(expectedImage))
+        //And
+        XCTAssertTrue(compass.containerView.image!.isEqual(originalImage))
     }
 
     private func emptyImage(with size: CGSize) -> UIImage? {


### PR DESCRIPTION
This PR addresses #1673

Before this change, compass is not updated when setting compass.image to nil after setting it to some value. 

<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
   - [ ] If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
