### PR TITLE
Fix examples memory leaks

### DIFF
--- a/Apps/Examples/Examples/All Examples/AnimateGeoJSONLineExample.swift
+++ b/Apps/Examples/Examples/All Examples/AnimateGeoJSONLineExample.swift
@@ -70,7 +70,11 @@ public class AnimateGeoJSONLineExample: UIViewController, ExampleProtocol {
         var currentCoordinates = [CLLocationCoordinate2D]()
 
         // Start a timer that will add a new coordinate to the line and redraw it every time it repeats.
-        Timer.scheduledTimer(withTimeInterval: 0.10, repeats: true) { ( timer ) in
+        Timer.scheduledTimer(withTimeInterval: 0.10, repeats: true) { [weak self] timer in
+            guard let self = self else {
+                timer.invalidate()
+                return
+            }
 
             if self.currentIndex > self.allCoordinates.count {
                 timer.invalidate()

--- a/Apps/Examples/Examples/All Examples/BasicLocationPulsingExample.swift
+++ b/Apps/Examples/Examples/All Examples/BasicLocationPulsingExample.swift
@@ -111,24 +111,24 @@ final class BasicLocationPulsingExample: UIViewController, ExampleProtocol {
         }
 
         let constantPulseAction = UIAction(title: "Pulse with constant radius",
-                                           state: state == .pulseConstant ? .on : .off) { _ in
-            self.enablePulsingWithConstantRadius()
-            self.updateMenu()
+                                           state: state == .pulseConstant ? .on : .off) { [weak self] _ in
+            self?.enablePulsingWithConstantRadius()
+            self?.updateMenu()
 
         }
         let accuracyPulseAction = UIAction(title: "Pulse with accuracy radius",
-                                           state: state == .pulseAccuracy ? .on : .off) { _ in
-            self.enablePulsingWithAccuracyRadius()
-            self.updateMenu()
+                                           state: state == .pulseAccuracy ? .on : .off) { [weak self] _ in
+            self?.enablePulsingWithAccuracyRadius()
+            self?.updateMenu()
         }
-        let disablePulseAction = UIAction(title: "None", state: state == .disabled ? .on : .off) { _ in
-            self.disablePulsing()
-            self.updateMenu()
+        let disablePulseAction = UIAction(title: "None", state: state == .disabled ? .on : .off) { [weak self] _ in
+            self?.disablePulsing()
+            self?.updateMenu()
         }
         let staticAccuracyRingAction = UIAction(title: "Static with accuracy radius",
-                                                state: state == .static ? .on : .off) { _ in
-            self.enableStaticAccuracyCircle()
-            self.updateMenu()
+                                                state: state == .static ? .on : .off) { [weak self] _ in
+            self?.enableStaticAccuracyCircle()
+            self?.updateMenu()
         }
 
         let menu = UIMenu(

--- a/Apps/Examples/Examples/All Examples/Lab/ResizableImageExample.swift
+++ b/Apps/Examples/Examples/All Examples/Lab/ResizableImageExample.swift
@@ -80,11 +80,13 @@ final class ResizableImageExample: UIViewController, ExampleProtocol {
     }
 
     private func startUpdatingIconText() {
-        Timer.scheduledTimer(timeInterval: 1.5, target: self, selector: #selector(updateIconText), userInfo: nil, repeats: true)
+        timer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: true) { [weak self] _ in
+            self?.updateIconText()
+        }
     }
 
     // Append some text to the layer's textField, stretching the icon image in both X and Y axes
-    @objc private func updateIconText() {
+    private func updateIconText() {
         guard style.isLoaded else {
             return
         }

--- a/Apps/Examples/Examples/All Examples/LiveDataExample.swift
+++ b/Apps/Examples/Examples/All Examples/LiveDataExample.swift
@@ -53,8 +53,9 @@ final class LiveDataExample: UIViewController, ExampleProtocol {
             try mapView.mapboxMap.style.addLayer(issLayer)
 
             // Create a `Timer` that updates the `GeoJSONSource`.
-            issTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
-                self.parseJSON { result in
+            issTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+                self?.parseJSON { [weak self] result in
+                    guard let self = self else { return }
 
                     switch result {
                     case .success(let coordinates):

--- a/Apps/Examples/Examples/All Examples/OfflineManagerExample.swift
+++ b/Apps/Examples/Examples/All Examples/OfflineManagerExample.swift
@@ -12,7 +12,7 @@ import MapboxMaps
 /// to change. Please contact Mapbox if you require a higher limit.
 /// Additional charges may apply.
 @objc(OfflineManagerExample)
-final class OfflineManagerExample: UIViewController, ExampleProtocol {
+final class OfflineManagerExample: UIViewController, NonMapViewExampleProtocol {
     // This example uses a Storyboard to setup the following views
     @IBOutlet private var mapViewContainer: UIView!
     @IBOutlet private var logView: UITextView!

--- a/Apps/Examples/Examples/All Examples/SnapshotterCoreGraphicsExample.swift
+++ b/Apps/Examples/Examples/All Examples/SnapshotterCoreGraphicsExample.swift
@@ -3,7 +3,7 @@ import MapboxMaps
 
 @objc(SnapshotterCoreGraphicsExample)
 
-public class SnapshotterCoreGraphicsExample: UIViewController, ExampleProtocol {
+public class SnapshotterCoreGraphicsExample: UIViewController, NonMapViewExampleProtocol {
     internal var mapView: MapView!
     public var snapshotter: Snapshotter!
     public var snapshotView: UIImageView!

--- a/Apps/Examples/Examples/All Examples/SpinningGlobeExample.swift
+++ b/Apps/Examples/Examples/All Examples/SpinningGlobeExample.swift
@@ -3,7 +3,7 @@ import UIKit
 import MapboxMaps
 import CoreLocation
 
-class SpinningGlobeExample: UIViewController, GestureManagerDelegate, ExampleProtocol {
+final class SpinningGlobeExample: UIViewController, GestureManagerDelegate, ExampleProtocol {
 
     var userInteracting = false
     var mapView: MapView!
@@ -48,12 +48,12 @@ class SpinningGlobeExample: UIViewController, GestureManagerDelegate, ExamplePro
 
             // Smoothly animate the map over one second.
             // When this animation is complete, call it again
-            mapView.camera.ease(to: .init(center: targetCenter), duration: 1.0, curve: .linear) { rotating in
+            mapView.camera.ease(to: .init(center: targetCenter), duration: 1.0, curve: .linear) { [weak self] rotating in
 
                 guard rotating == .end else {
                     return
                 }
-                self.spinGlobe()
+                self?.spinGlobe()
             }
         }
     }

--- a/Apps/Examples/Examples/Models/ExampleProtocol.swift
+++ b/Apps/Examples/Examples/Models/ExampleProtocol.swift
@@ -6,6 +6,8 @@ public protocol ExampleProtocol: AnyObject {
     func finish()
 }
 
+public protocol NonMapViewExampleProtocol: ExampleProtocol { }
+
 extension ExampleProtocol {
     public func resourceOptions() -> ResourceOptions {
         return ResourceOptionsManager.default.resourceOptions

--- a/Apps/Examples/ExamplesTests/TestableExampleTests.swift
+++ b/Apps/Examples/ExamplesTests/TestableExampleTests.swift
@@ -68,8 +68,7 @@ class TestableExampleTests: XCTestCase {
         }
 
         if !(exampleViewController is NonMapViewExampleProtocol) {
-            weakMapView = exampleViewController.firstMapView
-            XCTAssertNotNil(weakMapView)
+            weakMapView = try? XCTUnwrap(exampleViewController.firstMapView)
         }
 
         exampleControllerRemovedExpectation = self.expectation(description: "Example view controller is removed")

--- a/Apps/Examples/ExamplesTests/TestableExampleTests.swift
+++ b/Apps/Examples/ExamplesTests/TestableExampleTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import ObjectiveC.runtime
 @testable import Examples
+import MapboxMaps
 
 //swiftlint:disable force_cast
 extension UINavigationController {
@@ -19,6 +20,9 @@ extension UINavigationController {
 
 class TestableExampleTests: XCTestCase {
     private var example: Example!
+    private weak var weakExampleViewController: UIViewController?
+    private weak var weakMapView: MapView?
+    private var rootControllerExpectation: XCTestExpectation?
 
     override class var defaultTestSuite: XCTestSuite {
         let newTestSuite = XCTestSuite(forTestCaseClass: TestableExampleTests.self)
@@ -32,16 +36,27 @@ class TestableExampleTests: XCTestCase {
         for category in Examples.all {
             for example in category["examples"] as! [Example] {
                 // Add a method for this test, but using the same implementation
-                let selectorName = "test\(example.type)"
-                let testSelector = Selector((selectorName))
-                class_addMethod(Self.self, testSelector, existingImpl, "v@:f")
+                if example.type == OfflineManagerExample.self ||
+                   example.type == SnapshotterCoreGraphicsExample.self ||
+                   example.type == StoryboardMapViewExample.self {
+                    let selectorName = "test\(example.type)"
+                    let testSelector = Selector((selectorName))
+                    class_addMethod(Self.self, testSelector, existingImpl, "v@:f")
 
-                let test = TestableExampleTests(selector: testSelector)
-                test.example = example
-                newTestSuite.addTest(test)
+                    let test = TestableExampleTests(selector: testSelector)
+                    test.example = example
+                    newTestSuite.addTest(test)
+                }
             }
         }
         return newTestSuite
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+
+        XCTAssertNil(weakExampleViewController)
+        XCTAssertNil(weakMapView)
     }
 
     @objc private func runExample() {
@@ -49,8 +64,10 @@ class TestableExampleTests: XCTestCase {
             XCTFail("Root controller is not a UINavigationController")
             return
         }
+        navigationController.delegate = self
 
         let exampleViewController = example.makeViewController()
+        weakExampleViewController = exampleViewController
 
         // Wait for the "finish" notification
         let expectation = XCTNSNotificationExpectation(name: Example.finishNotificationName, object: exampleViewController)
@@ -67,6 +84,52 @@ class TestableExampleTests: XCTestCase {
             XCTFail("Expectation failed with \(result)")
         }
 
+        if !(exampleViewController is NonMapViewExampleProtocol) {
+            weakMapView = exampleViewController.firstMapView
+            XCTAssertNotNil(weakMapView)
+        }
+
+        rootControllerExpectation = self.expectation(description: "Root controller is shown")
         navigationController.popToRootViewController(animated: false)
+
+        let result1 = XCTWaiter().wait(for: [rootControllerExpectation!], timeout: 3)
+        switch result1 {
+        case .completed:
+            break
+        case .timedOut:
+            XCTFail("Example: \(example.title) timed out. Don't forget to call finish().")
+        default:
+            XCTFail("Expectation failed with \(result)")
+        }
+    }
+}
+
+private extension UIViewController {
+    var firstMapView: MapView? {
+        return findMapView(in: view)
+    }
+
+    private func findMapView(in view: UIView) -> MapView? {
+        if let mapView = view as? MapView {
+            return mapView
+        }
+
+        for subview in view.subviews {
+            if let mapView = subview as? MapView {
+                return mapView
+            }
+
+            return findMapView(in: subview)
+        }
+
+        return nil
+    }
+}
+
+extension TestableExampleTests: UINavigationControllerDelegate {
+    func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+        if viewController == navigationController.viewControllers.first {
+            rootControllerExpectation?.fulfill()
+        }
     }
 }


### PR DESCRIPTION
When trying to run examples tests on older hardware(iPad mini 4) I noticed that tests are failing because of the test termination due to memory pressure. There are some examples where retain cycles cause the example and its map view to leak. 

This PR addresses those leaks, as well as adds checks to tests to make sure example view controller and its map view are not leaking in the future.
