### PR TITLE
Run nightly tests on iPad

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ workflows:
           scheme: Examples
           requires:
             - Build Examples tests [non-main]
-          devices: --device model=ipad5,version=15.4
+          devices: --device model=ipadmini4,version=15.4
 
   steve:
     unless: << pipeline.parameters.turf-revision >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -702,10 +702,11 @@ jobs:
     parameters:
       devices:
         default: |
-          --device model=iphone13pro,version=15.2 \
+          --device model=iphone13pro,version=15.7 \
           --device model=iphone11pro,version=14.7 \
           --device model=iphone8,version=13.6 \
           --device model=iphonexr,version=12.4 \
+          --device model=ipad5,version=15.4 \
         type: string
       scheme:
         type: string
@@ -724,9 +725,6 @@ jobs:
             gcloud firebase test ios run --test output/build_products.zip \
               << parameters.devices >> 2>&1 | tee firebase_test_lab_run.log
           no_output_timeout: 30m
-      - run:
-          name: Print device list
-          command: gcloud firebase test ios models list
       - run:
           name: Download XCResults
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -725,6 +725,9 @@ jobs:
               << parameters.devices >> 2>&1 | tee firebase_test_lab_run.log
           no_output_timeout: 30m
       - run:
+          name: Print device list
+          command: gcloud firebase test android models list
+      - run:
           name: Download XCResults
           command: |
             TEST_LAB_PATH=$(cat firebase_test_lab_run.log | grep -o "test-lab.*/")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ workflows:
           scheme: Examples
           requires:
             - Build Examples tests [non-main]
-          devices: --device model=iphone13pro,version=15.7
+          devices: --device model=ipad5,version=15.4
 
   steve:
     unless: << pipeline.parameters.turf-revision >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -726,7 +726,7 @@ jobs:
           no_output_timeout: 30m
       - run:
           name: Print device list
-          command: gcloud firebase test android models list
+          command: gcloud firebase test ios models list
       - run:
           name: Download XCResults
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ workflows:
           scheme: Examples
           requires:
             - Build Examples tests [non-main]
-          devices: --device model=ipadmini4,version=15.4
+          devices: --device model=iphone13pro,version=15.7
 
   steve:
     unless: << pipeline.parameters.turf-revision >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ workflows:
           scheme: Examples
           requires:
             - Build Examples tests [non-main]
-          devices: --device model=ipadmini4,version=15.4
+          devices: --device model=ipad5,version=15.4
 
   steve:
     unless: << pipeline.parameters.turf-revision >>


### PR DESCRIPTION
This PR adds an iPad mini 4 to nightly examples tests run. I noticed that iPads are severely underrepresented when it comes to running tests and with examples tests serving a role of a "smoke test" - it would be useful to run this tests on an iPad as well just make sure there are not critical failures.

This PR depends on https://github.com/mapbox/mapbox-maps-ios/pull/1769 as memory leaks in the existing examples tests make iPad mini 4 terminate test runs due to memory pressure, thus failing them.
