### PR TITLE
Switch to iPad mini 4 for device tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -706,7 +706,7 @@ jobs:
           --device model=iphone11pro,version=14.7 \
           --device model=iphone8,version=13.6 \
           --device model=iphonexr,version=12.4 \
-          --device model=ipad5,version=15.4 \
+          --device model=ipadmini4,version=15.4 \
         type: string
       scheme:
         type: string


### PR DESCRIPTION
Firebase's iPad mini 4 is proven to be more stable than iPad 5, mistakenly #1770 specified the incorrect iPad.