### PR TITLE
Disable iPad device tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -708,7 +708,6 @@ jobs:
           --device model=iphone11pro,version=14.7 \
           --device model=iphone8,version=13.6 \
           --device model=iphonexr,version=12.4 \
-          --device model=ipadmini4,version=15.4 \
         type: string
       scheme:
         type: string


### PR DESCRIPTION
Due to device tests constant failures iPad is removed from the list of test devices.