### PR TITLE
Support internal forks and SDK bump PRs before tag created

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1640,7 +1640,17 @@ commands:
           command: |
             xcodebuild -version | head -1 | cut -d ' ' -f 2 >> /tmp/xcode_version.txt
             if [ << parameters.baseline >> = true ]; then
-              git rev-parse v$(jq -r .version Sources/MapboxMaps/MapboxMaps.json) > /tmp/MapboxMaps-version.txt
+              TAG_SUFFIX="${CIRCLE_PROJECT_REPONAME:15}"
+              CURRENT_MAPS_VERSION="v$(jq -r .version Sources/MapboxMaps/MapboxMaps.json)$TAG_SUFFIX"
+
+              PREVIOUS_MAPS_JSON_REVISION=$(git rev-list -1 --skip 1 HEAD -- Sources/MapboxMaps/MapboxMaps.json)
+              PREVIOUS_MAPS_VERSION="v$(git show $PREVIOUS_MAPS_JSON_REVISION:Sources/MapboxMaps/MapboxMaps.json | jq -r .version)$TAG_SUFFIX"
+
+              if [ $(git tag -l "$CURRENT_MAPS_VERSION") ]; then
+                  git rev-parse "$CURRENT_MAPS_VERSION" > /tmp/MapboxMaps-version.txt
+              elif [ $(git tag -l "$PREVIOUS_MAPS_VERSION") ]; then
+                  git rev-parse "$PREVIOUS_MAPS_VERSION" > /tmp/MapboxMaps-version.txt
+              fi
             else
               git rev-parse HEAD > /tmp/MapboxMaps-version.txt
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1647,11 +1647,14 @@ commands:
               PREVIOUS_MAPS_VERSION="v$(git show $PREVIOUS_MAPS_JSON_REVISION:Sources/MapboxMaps/MapboxMaps.json | jq -r .version)$TAG_SUFFIX"
 
               if [ $(git tag -l "$CURRENT_MAPS_VERSION") ]; then
+                  echo "Using current version: $CURRENT_MAPS_VERSION"
                   git rev-parse "$CURRENT_MAPS_VERSION" > /tmp/MapboxMaps-version.txt
               elif [ $(git tag -l "$PREVIOUS_MAPS_VERSION") ]; then
+                  echo "No tag for current version, using previous version: $PREVIOUS_MAPS_VERSION"
                   git rev-parse "$PREVIOUS_MAPS_VERSION" > /tmp/MapboxMaps-version.txt
               fi
             else
+              echo "Using current commit: $(git rev-parse HEAD)"
               git rev-parse HEAD > /tmp/MapboxMaps-version.txt
             fi
       - restore_cache:


### PR DESCRIPTION
There is two main improvements:
1. Previously when Maps bump version happens build would fail since bumping happens **before** tag creation. The workaround is to lookup for a previous version if "current" doesn't exist yet
2. Another fix would be suitable for internal forks like private – we now include the same tag suffix as we have in repo name. 

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

## Pull request checklist:
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
   - [ ] If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
