### PR TITLE
Address high CPU usage on idle

### DIFF
--- a/Sources/MapboxMaps/Location/Puck/Puck2D.swift
+++ b/Sources/MapboxMaps/Location/Puck/Puck2D.swift
@@ -124,7 +124,7 @@ internal final class Puck2D: Puck {
         newLayerPaintProperties[.location] = [
             location.coordinate.latitude,
             location.coordinate.longitude,
-            location.altitude
+            0
         ]
         switch location.accuracyAuthorization {
         case .fullAccuracy:

--- a/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
+++ b/Tests/MapboxMapsTests/Location/Puck/Puck2DTests.swift
@@ -235,7 +235,7 @@ final class Puck2DTests: XCTestCase {
         let scale = try! resolvedScale.toJSON()
 
         var expectedPaintLayerProperties = [LocationIndicatorLayer.PaintCodingKeys: Any]()
-        expectedPaintLayerProperties[.location] = [location.coordinate.latitude, location.coordinate.longitude, location.altitude]
+        expectedPaintLayerProperties[.location] = [location.coordinate.latitude, location.coordinate.longitude, 0]
         expectedPaintLayerProperties[.locationTransition] = ["duration": 0, "delay": 0]
         expectedPaintLayerProperties[.topImageSize] = scale
         expectedPaintLayerProperties[.bearingImageSize] = scale
@@ -450,7 +450,7 @@ final class Puck2DTests: XCTestCase {
         expectedProperties["location"] = [
             location.coordinate.latitude,
             location.coordinate.longitude,
-            location.altitude
+            0
         ]
         expectedProperties["accuracy-radius"] = [
             "interpolate",
@@ -522,7 +522,7 @@ final class Puck2DTests: XCTestCase {
         expectedProperties["location"] = [
             location.coordinate.latitude,
             location.coordinate.longitude,
-            location.altitude
+            0
         ]
         expectedProperties["accuracy-radius"] = [
             "interpolate",


### PR DESCRIPTION
This PR addresses the excessively high CPU usage on map idle with user location indicator enabled. 

The high CPU usage is caused by excessive map redraws which happen because location altitude seems to fluctuate all the time. Additionally, the altitude has no effect on the appearance of the location indicator, which allows us to simply remove it(always set to `0`) in order to address this.

| | |
| ----- | ----- |
| **Before** | <img src="https://user-images.githubusercontent.com/1478430/206446189-a9e0a70f-7bcb-4ca4-b71e-75a738f7bdce.png" width = 750/> 
| **After** | <img src="https://user-images.githubusercontent.com/1478430/206446253-d4d551d8-989c-49c5-adeb-313a673855ef.png" width = 750/> |

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
   - [ ] If tests were not written, please explain why.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
