### PR TITLE
Fast&unsafe forwarding display link target

### DIFF
--- a/Sources/MapboxMaps/Foundation/DelegatingDisplayLinkParticipant.swift
+++ b/Sources/MapboxMaps/Foundation/DelegatingDisplayLinkParticipant.swift
@@ -4,7 +4,7 @@ internal protocol DelegatingDisplayLinkParticipantDelegate: AnyObject {
     func participate(for participant: DelegatingDisplayLinkParticipant)
 }
 
-final internal class DelegatingDisplayLinkParticipant: NSObject, DisplayLinkParticipant {
+final internal class DelegatingDisplayLinkParticipant: DisplayLinkParticipant {
 
     weak var delegate: DelegatingDisplayLinkParticipantDelegate?
 

--- a/Sources/MapboxMaps/Foundation/ForwardingDispalyLinkTarget.swift
+++ b/Sources/MapboxMaps/Foundation/ForwardingDispalyLinkTarget.swift
@@ -1,14 +1,17 @@
 import QuartzCore
 
-internal class ForwardingDisplayLinkTarget: NSObject {
-    private let handler: (CADisplayLink) -> Void
+internal protocol ForwardingDisplayLinkTargetDelegate: AnyObject {
+    func update(with displayLink: CADisplayLink)
+}
 
-    internal init(handler: @escaping (CADisplayLink) -> Void) {
-        self.handler = handler
-        super.init()
+internal final class ForwardingDisplayLinkTarget {
+    weak var delegate: ForwardingDisplayLinkTargetDelegate?
+
+    internal init(delegate: ForwardingDisplayLinkTargetDelegate) {
+        self.delegate = delegate
     }
 
     @objc internal func update(with displayLink: CADisplayLink) {
-        handler(displayLink)
+        delegate?.update(with: displayLink)
     }
 }

--- a/Sources/MapboxMaps/Foundation/ForwardingDispalyLinkTarget.swift
+++ b/Sources/MapboxMaps/Foundation/ForwardingDispalyLinkTarget.swift
@@ -1,17 +1,19 @@
 import QuartzCore
 
-internal protocol ForwardingDisplayLinkTargetDelegate: AnyObject {
-    func update(with displayLink: CADisplayLink)
-}
-
 internal final class ForwardingDisplayLinkTarget {
-    weak var delegate: ForwardingDisplayLinkTargetDelegate?
+    private let mapView: Unmanaged<MapView>
+    private var invalidated = false
 
-    internal init(delegate: ForwardingDisplayLinkTargetDelegate) {
-        self.delegate = delegate
+    internal init(mapView: MapView) {
+        self.mapView = Unmanaged.passUnretained(mapView)
+    }
+
+    internal func invalidate() {
+        invalidated = true
     }
 
     @objc internal func update(with displayLink: CADisplayLink) {
-        delegate?.update(with: displayLink)
+        guard invalidated == false else { return }
+        mapView._withUnsafeGuaranteedRef { $0.update(with: displayLink) }
     }
 }

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -81,7 +81,7 @@ open class MapView: UIView {
     internal let resourceOptions: ResourceOptions
 
     private var needsDisplayRefresh: Bool = false
-    private var displayLink: DisplayLinkProtocol?
+    private weak var displayLink: DisplayLinkProtocol?
 
     /// Holding onto this value that comes from `MapOptions` since there is a race condition between
     /// getting a `MetalView`, and intializing a `MapView`
@@ -601,7 +601,7 @@ open class MapView: UIView {
 
         displayLink = dependencyProvider.makeDisplayLink(
             window: window,
-            target: ForwardingDisplayLinkTarget(delegate: self),
+            target: ForwardingDisplayLinkTarget(mapView: self),
             selector: #selector(ForwardingDisplayLinkTarget.update(with:)))
 
         guard let displayLink = displayLink else {
@@ -634,9 +634,7 @@ open class MapView: UIView {
 
         return false
     }
-}
 
-extension MapView: ForwardingDisplayLinkTargetDelegate {
     func update(with displayLink: CADisplayLink) {
         metricsReporter?.beforeDisplayLinkCallback(displayLink: displayLink)
         defer { metricsReporter?.afterDisplayLinkCallback(displayLink: displayLink) }

--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -82,6 +82,7 @@ open class MapView: UIView {
 
     private var needsDisplayRefresh: Bool = false
     private weak var displayLink: DisplayLinkProtocol?
+    private var displayLinkTarget: ForwardingDisplayLinkTarget?
 
     /// Holding onto this value that comes from `MapOptions` since there is a race condition between
     /// getting a `MetalView`, and intializing a `MapView`
@@ -448,6 +449,7 @@ open class MapView: UIView {
     }
 
     deinit {
+        displayLinkTarget?.invalidate()
         displayLink?.invalidate()
         cameraAnimatorsRunner.cancelAnimations()
         cameraAnimatorsRunnerEnablable.isEnabled = false
@@ -599,9 +601,10 @@ open class MapView: UIView {
             return
         }
 
+        displayLinkTarget = ForwardingDisplayLinkTarget(mapView: self)
         displayLink = dependencyProvider.makeDisplayLink(
             window: window,
-            target: ForwardingDisplayLinkTarget(mapView: self),
+            target: displayLinkTarget,
             selector: #selector(ForwardingDisplayLinkTarget.update(with:)))
 
         guard let displayLink = displayLink else {


### PR DESCRIPTION
This PR makes `ForwardingDisplayLinkTarget` faster by keeping an unsafe unmanaged pointer to its map view. This avoids overhead of relatively expensive `weak`/`unowned` references.

Is this worth the trouble? - To be confirmed

## Pull request checklist:
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
   - [ ] If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
