### PR TITLE
Use sdf param when adding style image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Fix loading errors appearing when providing custom endpoint for `ResourceOptions.baseURL`. ([#1749](https://github.com/mapbox/mapbox-maps-ios/pull/1749))
 * Remove delegate requirement for annotation interaction. ([#1750](https://github.com/mapbox/mapbox-maps-ios/pull/1750))
 * Reset compass image to default one if `nil` was passed to the `MapboxCompassOrnamentView.updateImage(image:)`. ([#1766](https://github.com/mapbox/mapbox-maps-ios/pull/1766), [#1772](https://github.com/mapbox/mapbox-maps-ios/pull/1772))
+* Use `sdf` parameter when adding a style image. ([#1803](https://github.com/mapbox/mapbox-maps-ios/pull/1803))
 
 ## 10.10.0 - December 8, 2022
 

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -769,6 +769,7 @@ public final class Style: StyleProtocol {
                                       bottom: contentBoxBottom)
         try addImage(image,
                      id: id,
+                     sdf: sdf,
                      stretchX: [ImageStretches(first: stretchXFirst, second: stretchXSecond)],
                      stretchY: [ImageStretches(first: stretchYFirst, second: stretchYSecond)],
                      content: contentBox)

--- a/Sources/MapboxMaps/Style/Style.swift
+++ b/Sources/MapboxMaps/Style/Style.swift
@@ -724,13 +724,13 @@ public final class Style: StyleProtocol {
         }
 
         try handleExpected {
-            return styleManager.addStyleImage(forImageId: id,
-                                              scale: Float(image.scale),
-                                              image: mbmImage,
-                                              sdf: sdf,
-                                              stretchX: stretchX,
-                                              stretchY: stretchY,
-                                              content: content)
+            return _styleManager.addStyleImage(forImageId: id,
+                                               scale: Float(image.scale),
+                                               image: mbmImage,
+                                               sdf: sdf,
+                                               stretchX: stretchX,
+                                               stretchY: stretchY,
+                                               content: content)
         }
     }
 

--- a/Tests/MapboxMapsTests/Foundation/Style/StyleTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Style/StyleTests.swift
@@ -431,10 +431,7 @@ final class StyleTests: XCTestCase {
     }
 
     func testAddImageWithStretches() throws {
-        guard #available(iOS 13.0, *) else {
-            throw XCTSkip("Test requires iOS 13 or higher.")
-        }
-        let image = UIImage.add
+        let image = UIImage.empty
         let id = UUID().uuidString
         let sdf = Bool.random()
         let stretchX = [ImageStretches(first: .random(in: 1...100), second: .random(in: 1...100))]
@@ -458,11 +455,7 @@ final class StyleTests: XCTestCase {
     }
 
     func testAddImageWithInsets() throws {
-        guard #available(iOS 13.0, *) else {
-            throw XCTSkip("Test requires iOS 13 or higher.")
-        }
-
-        let image = UIImage.add
+        let image = UIImage.empty
         let id = UUID().uuidString
         let sdf = Bool.random()
         let insets = UIEdgeInsets(top: 10, left: 20, bottom: 10, right: 2)
@@ -473,7 +466,7 @@ final class StyleTests: XCTestCase {
         let params = try XCTUnwrap(styleManager.addStyleImageStub.invocations.first?.parameters)
         XCTAssertEqual(params.imageId, id)
         XCTAssertEqual(params.sdf, sdf)
-        XCTAssertEqual(params.stretchX, [ImageStretches(first: 0, second: 59)])
-        XCTAssertEqual(params.stretchY, [ImageStretches(first: 0, second: 57)])
+        XCTAssertEqual(params.stretchX, [ImageStretches(first: 0, second: 1)])
+        XCTAssertEqual(params.stretchY, [ImageStretches(first: 0, second: 1)])
     }
 }

--- a/Tests/MapboxMapsTests/Foundation/Style/StyleTests.swift
+++ b/Tests/MapboxMapsTests/Foundation/Style/StyleTests.swift
@@ -429,4 +429,51 @@ final class StyleTests: XCTestCase {
         let layoutProperties = try XCTUnwrap(rootProperties["layout"] as? [String: Any])
         XCTAssertEqual(layoutProperties["visibility"] as? String, "visible", "visibility is not reset and should keep old value")
     }
+
+    func testAddImageWithStretches() throws {
+        guard #available(iOS 13.0, *) else {
+            throw XCTSkip("Test requires iOS 13 or higher.")
+        }
+        let image = UIImage.add
+        let id = UUID().uuidString
+        let sdf = Bool.random()
+        let stretchX = [ImageStretches(first: .random(in: 1...100), second: .random(in: 1...100))]
+        let stretchY = [ImageStretches(first: .random(in: 1...100), second: .random(in: 1...100))]
+        let content = ImageContent(
+            left: .random(in: 1...100),
+            top: .random(in: 1...100),
+            right: .random(in: 1...100),
+            bottom: .random(in: 1...100)
+        )
+
+        try style.addImage(image, id: id, sdf: sdf, stretchX: stretchX, stretchY: stretchY, content: content)
+
+        XCTAssertEqual(styleManager.addStyleImageStub.invocations.count, 1)
+        let params = try XCTUnwrap(styleManager.addStyleImageStub.invocations.first?.parameters)
+        XCTAssertEqual(params.imageId, id)
+        XCTAssertEqual(params.sdf, sdf)
+        XCTAssertEqual(params.stretchX, stretchX)
+        XCTAssertEqual(params.stretchY, stretchY)
+        XCTAssertEqual(params.content, content)
+    }
+
+    func testAddImageWithInsets() throws {
+        guard #available(iOS 13.0, *) else {
+            throw XCTSkip("Test requires iOS 13 or higher.")
+        }
+
+        let image = UIImage.add
+        let id = UUID().uuidString
+        let sdf = Bool.random()
+        let insets = UIEdgeInsets(top: 10, left: 20, bottom: 10, right: 2)
+
+        try style.addImage(image, id: id, sdf: sdf, contentInsets: insets)
+
+        XCTAssertEqual(styleManager.addStyleImageStub.invocations.count, 1)
+        let params = try XCTUnwrap(styleManager.addStyleImageStub.invocations.first?.parameters)
+        XCTAssertEqual(params.imageId, id)
+        XCTAssertEqual(params.sdf, sdf)
+        XCTAssertEqual(params.stretchX, [ImageStretches(first: 0, second: 59)])
+        XCTAssertEqual(params.stretchY, [ImageStretches(first: 0, second: 57)])
+    }
 }

--- a/Tests/MapboxMapsTests/Helpers/UIImage+Empty.swift
+++ b/Tests/MapboxMapsTests/Helpers/UIImage+Empty.swift
@@ -1,0 +1,11 @@
+import Foundation
+import UIKit
+
+extension UIImage {
+    class var empty: UIImage {
+        UIGraphicsBeginImageContext(.init(width: 1, height: 1))
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image!
+    }
+}


### PR DESCRIPTION
`sdf` parameter accidentally got left out when adding an image to the style with `Style.addImage(_:id:sdf:contentInsets:) throws` method.

## Pull request checklist:
 - [x] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
