### PR TITLE
Remove MME configuration options from Debug app

### DIFF
--- a/Apps/DebugApp/DebugApp/Info.plist
+++ b/Apps/DebugApp/DebugApp/Info.plist
@@ -48,9 +48,5 @@
 		<key>LocationAccuracyAuthorizationDescription</key>
 		<string>Debug App temporarily requires your precise location</string>
 	</dict>
-	<key>MMEDebugLogging</key>
-	<false/>
-	<key>MMECollectionEnabledInSimulator</key>
-	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Removing these will also prevent their warning messages appear in the debugger console.