### PR TITLE
Allow expressions for text-color in format expression

### DIFF
--- a/Sources/MapboxMaps/Style/Layer.swift
+++ b/Sources/MapboxMaps/Style/Layer.swift
@@ -5,7 +5,7 @@ public protocol Layer: Codable, StyleEncodable, StyleDecodable {
     /// Rendering type of this layer.
     var type: LayerType { get }
 
-    /// A expression specifying conditions on source features.
+    /// An expression specifying conditions on source features.
     /// Only features that match the filter are displayed.
     var filter: Expression? { get set }
 

--- a/Sources/MapboxMaps/Style/Types/ExpressionOptions.swift
+++ b/Sources/MapboxMaps/Style/Types/ExpressionOptions.swift
@@ -46,32 +46,52 @@ extension Expression {
 public struct FormatOptions: Codable, Equatable, ExpressionArgumentConvertible {
 
     /// Applies a scaling factor on text-size as specified by the root layout property.
-    public var fontScale: Double?
+    public var fontScaleValue: Value<Double>?
+    /// Applies a scaling factor on text-size as specified by the root layout property.
+    public var fontScale: Double? {
+        get { fontScaleValue?.asConstant }
+        set { fontScaleValue = newValue.map(Value.init(constant:)) }
+    }
 
-    /// Overrides the font stack specified by the root layout property
-    public var textFont: [String]?
+    /// Overrides the font stack specified by the root layout property.
+    public var textFontValue: Value<[String]>?
+    /// Overrides the font stack specified by the root layout property.
+    public var textFont: [String]? {
+        get { textFontValue?.asConstant }
+        set { textFontValue = newValue.map(Value.init(constant:)) }
+    }
 
     /// Overrides the color specified by the root paint property.
-    public var textColor: StyleColor?
+    public var textColorValue: Value<StyleColor>?
+    /// Overrides the color specified by the root paint property.
+    public var textColor: StyleColor? {
+        get { textColorValue?.asConstant }
+        set { textColorValue = newValue.map(Value.init(constant:)) }
+    }
 
     internal enum CodingKeys: String, CodingKey {
-        case fontScale = "font-scale"
-        case textFont = "text-font"
-        case textColor = "text-color"
+        case fontScaleValue = "font-scale"
+        case textFontValue = "text-font"
+        case textColorValue = "text-color"
     }
 
     public var expressionArguments: [Expression.Argument] {
         return [.option(.format(self))]
     }
 
+    public init(fontScale: Value<Double>? = nil, textFont: Value<[String]>? = nil, textColor: Value<StyleColor>? = nil) {
+        self.fontScaleValue = fontScale
+        self.textFontValue = textFont
+        self.textColorValue = textColor
+    }
+
     public init(fontScale: Double? = nil, textFont: [String]? = nil, textColor: UIColor? = nil) {
         self.fontScale = fontScale
         self.textFont = textFont
-
-        if let textColor = textColor {
-            self.textColor = StyleColor(textColor)
-        }
+        self.textColor = textColor.map(StyleColor.init(_:))
     }
+
+    public init() {}
 }
 
 public struct NumberFormatOptions: Codable, Equatable, ExpressionArgumentConvertible {

--- a/Sources/MapboxMaps/Style/Types/Value.swift
+++ b/Sources/MapboxMaps/Style/Types/Value.swift
@@ -34,6 +34,19 @@ public enum Value<T: Codable>: Codable {
     }
 }
 
-extension Value: Equatable where T: Equatable {
+extension Value: Equatable where T: Equatable {}
 
+extension Value {
+    internal init(constant: T) {
+        self = .constant(constant)
+    }
+
+    internal var asConstant: T? {
+        switch self {
+        case let .constant(c):
+            return c
+        case .expression:
+            return nil
+        }
+    }
 }

--- a/Tests/MapboxMapsTests/Style/ExpressionTests/FormatOptionsTests.swift
+++ b/Tests/MapboxMapsTests/Style/ExpressionTests/FormatOptionsTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+@testable import MapboxMaps
+
+final class FormatOptionsTests: XCTestCase {
+    private let jsonString = """
+        {
+                "font-scale": [
+                    "case",
+                    [
+                        ">=",
+                        ["to-number", ["get", "point_count"]],
+                        4
+                    ],
+                    1,
+                    2
+                ],
+                "text-font": [
+                    "case",
+                    [
+                        ">=",
+                        ["to-number", ["get", "point_count"]],
+                        4
+                    ],
+                    ["Open Sans Semibold"],
+                    ["Arial Unicode MS Bold"]
+                ],
+                "text-color": [
+                    "case",
+                    [
+                        ">=",
+                        ["to-number", ["get", "point_count"]],
+                        4
+                    ],
+                    "#ffffff",
+                    "#000000"
+                ]
+        }
+        """
+
+    func testDecodeWithExpression() throws {
+        let formatOptions = try JSONDecoder().decode(FormatOptions.self, from: try XCTUnwrap(jsonString.data(using: .utf8)))
+        XCTAssertEqual(
+            try formatOptions.fontScaleValue?.toString(),
+            #"["case",[">=",["to-number",["get","point_count"]],4],1,2]"#)
+        XCTAssertEqual(
+            try formatOptions.textFontValue?.toString(),
+            #"["case",[">=",["to-number",["get","point_count"]],4],["Open Sans Semibold"],["Arial Unicode MS Bold"]]"#)
+        XCTAssertEqual(
+            try formatOptions.textColorValue?.toString(),
+            ##"["case",[">=",["to-number",["get","point_count"]],4],"#ffffff","#000000"]"##)
+    }
+
+    func testDecodeWithValue() throws {
+        let formatOptionsData = """
+            {
+                "font-scale": 1,
+                "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
+                "text-color": "rgba(0,0,0,0)"
+            }
+            """.data(using: .utf8)
+
+        let formatOptions = try JSONDecoder().decode(FormatOptions.self, from: try XCTUnwrap(formatOptionsData))
+        XCTAssertEqual(formatOptions.fontScale, 1)
+        XCTAssertEqual(formatOptions.textFont, ["Open Sans Semibold", "Arial Unicode MS Bold"])
+        XCTAssertEqual(formatOptions.textColor?.rgbaString, "rgba(0.0, 0.0, 0.0, 0.0)")
+    }
+
+    func testEncodeWithValue() throws {
+        let formatOptions = FormatOptions(fontScale: 1, textFont: ["Open Sans Semibold", "Arial Unicode MS Bold"], textColor: .black)
+        let encoded = try DictionaryEncoder().encode(formatOptions)
+
+        XCTAssertEqual(encoded["font-scale"] as? Double, 1)
+        XCTAssertEqual(encoded["text-font"] as? [String], ["Open Sans Semibold", "Arial Unicode MS Bold"])
+        XCTAssertEqual(encoded["text-color"] as? String, "rgba(0.0, 0.0, 0.0, 1.0)")
+    }
+
+    func testEncodeWithConstantAndExpression() throws {
+        let formatOptions = FormatOptions(
+            fontScale: .constant(1),
+            textFont: .constant(["Open Sans Semibold", "Arial Unicode MS Bold"]),
+            textColor: .expression(Exp(.switchCase) {
+                Exp(.gte) {
+                    Exp(.toNumber) {
+                        Exp(.get) { "point_count" }
+                    }
+                    4
+                }
+                "#ffffff"
+                "#000000"
+            }))
+        XCTAssertEqual(formatOptions.fontScale, 1)
+        XCTAssertEqual(formatOptions.textFont, ["Open Sans Semibold", "Arial Unicode MS Bold"])
+        XCTAssertNil(formatOptions.textColor)
+        let encoded = try formatOptions.toString()
+        XCTAssertEqual(encoded, ##"{"text-color":["case",[">=",["to-number",["get","point_count"]],4],"#ffffff","#000000"],"font-scale":1,"text-font":["Open Sans Semibold","Arial Unicode MS Bold"]}"##)
+    }
+
+    func testEncodeWithExpression() throws {
+        var formatOptions = FormatOptions(fontScale: 1, textFont: ["Open Sans Semibold", "Arial Unicode MS Bold"], textColor: .black)
+        formatOptions.fontScaleValue = .expression(Exp(.switchCase) {
+            Exp(.gte) {
+                Exp(.toNumber) {
+                    Exp(.get) { "point_count" }
+                }
+                4
+            }
+            1
+            2
+        })
+        formatOptions.textFontValue = .expression(Exp(.switchCase) {
+            Exp(.gte) {
+                Exp(.toNumber) {
+                    Exp(.get) { "point_count" }
+                }
+                4
+            }
+            ["Open Sans Semibold"]
+            ["Arial Unicode MS Bold"]
+        })
+        formatOptions.textColorValue = .expression(Exp(.switchCase) {
+            Exp(.gte) {
+                Exp(.toNumber) {
+                    Exp(.get) { "point_count" }
+                }
+                4
+            }
+            "#ffffff"
+            "#000000"
+        })
+
+        let encoded = try DictionaryEncoder().encode(formatOptions)
+        XCTAssertEqual(
+            String(data: try JSONSerialization.data(withJSONObject: encoded["font-scale"] as Any), encoding: .utf8),
+            #"["case",[">=",["to-number",["get","point_count"]],4],1,2]"#
+        )
+        XCTAssertEqual(
+            String(data: try JSONSerialization.data(withJSONObject: encoded["text-font"] as Any), encoding: .utf8),
+            #"["case",[">=",["to-number",["get","point_count"]],4],["Open Sans Semibold"],["Arial Unicode MS Bold"]]"#
+        )
+        XCTAssertEqual(
+            String(data: try JSONSerialization.data(withJSONObject: encoded["text-color"] as Any), encoding: .utf8),
+            ##"["case",[">=",["to-number",["get","point_count"]],4],"#ffffff","#000000"]"##
+        )
+    }
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

Adds ability to use expressions for `text-color` property in `format` expression. https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#types-format

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
   - [ ] If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).

[MAPSIOS-520](https://mapbox.atlassian.net/browse/MAPSIOS-520)