### PR TITLE
Fix AnnotationManager isDraggable behavior

### DIFF
--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotation.swift
@@ -41,18 +41,20 @@ public struct CircleAnnotation: Annotation {
     }
 
     /// Create a circle annotation with a `Point` and an optional identifier.
-    public init(id: String = UUID().uuidString, point: Point) {
+    public init(id: String = UUID().uuidString, point: Point, isSelected: Bool = false, isDraggable: Bool = false) {
         self.id = id
         self.point = point
+        self.isSelected = isSelected
+        self.isDraggable = isDraggable
     }
 
     /// Create a circle annotation with a center coordinate and an optional identifier
     /// - Parameters:
     ///   - id: Optional identifier for this annotation
     ///   - coordinate: Coordinate where this circle annotation should be centered
-    public init(id: String = UUID().uuidString, centerCoordinate: CLLocationCoordinate2D) {
+    public init(id: String = UUID().uuidString, centerCoordinate: CLLocationCoordinate2D, isSelected: Bool = false, isDraggable: Bool = false) {
         let point = Point(centerCoordinate)
-        self.init(id: id, point: point)
+        self.init(id: id, point: point, isSelected: isSelected, isDraggable: isDraggable)
     }
 
     // MARK: - Style Properties -

--- a/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/CircleAnnotationManager.swift
@@ -270,7 +270,7 @@ public class CircleAnnotationManager: AnnotationManagerInternal {
     }
 
     internal func handleDragBegin(with featureIdentifiers: [String]) {
-        guard let annotation = annotations.first(where: { featureIdentifiers.contains($0.id) }) else { return }
+        guard let annotation = annotations.first(where: { featureIdentifiers.contains($0.id) && $0.isDraggable }) else { return }
         createDragSourceAndLayer()
 
         annotationBeingDragged = annotation

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotation.swift
@@ -41,18 +41,20 @@ public struct PointAnnotation: Annotation {
     }
 
     /// Create a point annotation with a `Point` and an optional identifier.
-    public init(id: String = UUID().uuidString, point: Point) {
+    public init(id: String = UUID().uuidString, point: Point, isSelected: Bool = false, isDraggable: Bool = false) {
         self.id = id
         self.point = point
+        self.isSelected = isSelected
+        self.isDraggable = isDraggable
     }
 
     /// Create a point annotation with a coordinate and an optional identifier
     /// - Parameters:
     ///   - id: Optional identifier for this annotation
     ///   - coordinate: Coordinate where this annotation should be rendered
-    public init(id: String = UUID().uuidString, coordinate: CLLocationCoordinate2D) {
+    public init(id: String = UUID().uuidString, coordinate: CLLocationCoordinate2D, isSelected: Bool = false, isDraggable: Bool = false) {
         let point = Point(coordinate)
-        self.init(id: id, point: point)
+        self.init(id: id, point: point, isSelected: isSelected, isDraggable: isDraggable)
     }
 
     // MARK: - Style Properties -

--- a/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PointAnnotationManager.swift
@@ -615,7 +615,7 @@ public class PointAnnotationManager: AnnotationManagerInternal {
     }
 
     internal func handleDragBegin(with featureIdentifiers: [String]) {
-        guard let annotation = annotations.first(where: { featureIdentifiers.contains($0.id) }) else { return }
+        guard let annotation = annotations.first(where: { featureIdentifiers.contains($0.id) && $0.isDraggable }) else { return }
         createDragSourceAndLayer()
 
         annotationBeingDragged = annotation

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
@@ -41,9 +41,11 @@ public struct PolygonAnnotation: Annotation {
     }
 
     /// Create a polygon annotation with a `Polygon` and an optional identifier.
-    public init(id: String = UUID().uuidString, polygon: Polygon) {
+    public init(id: String = UUID().uuidString, polygon: Polygon, isSelected: Bool = false, isDraggable: Bool = false) {
         self.id = id
         self.polygon = polygon
+        self.isSelected = isSelected
+        self.isDraggable = isDraggable
     }
 
     // MARK: - Style Properties -

--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotationManager.swift
@@ -260,7 +260,7 @@ public class PolygonAnnotationManager: AnnotationManagerInternal {
     }
 
     internal func handleDragBegin(with featureIdentifiers: [String]) {
-        guard let annotation = annotations.first(where: { featureIdentifiers.contains($0.id) }) else { return }
+        guard let annotation = annotations.first(where: { featureIdentifiers.contains($0.id) && $0.isDraggable }) else { return }
         createDragSourceAndLayer()
 
         annotationBeingDragged = annotation

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotation.swift
@@ -41,15 +41,17 @@ public struct PolylineAnnotation: Annotation {
     }
 
     /// Create a polyline annotation with a `LineString` and an optional identifier.
-    public init(id: String = UUID().uuidString, lineString: LineString) {
+    public init(id: String = UUID().uuidString, lineString: LineString, isSelected: Bool = false, isDraggable: Bool = false) {
         self.id = id
         self.lineString = lineString
+        self.isSelected = isSelected
+        self.isDraggable = isDraggable
     }
 
     /// Create a polyline annotation with an array of coordinates and an optional identifier.
-    public init(id: String = UUID().uuidString, lineCoordinates: [CLLocationCoordinate2D]) {
+    public init(id: String = UUID().uuidString, lineCoordinates: [CLLocationCoordinate2D], isSelected: Bool = false, isDraggable: Bool = false) {
         let lineString = LineString(lineCoordinates)
-        self.init(id: id, lineString: lineString)
+        self.init(id: id, lineString: lineString, isSelected: isSelected, isDraggable: isDraggable)
     }
 
     // MARK: - Style Properties -

--- a/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolylineAnnotationManager.swift
@@ -300,7 +300,7 @@ public class PolylineAnnotationManager: AnnotationManagerInternal {
     }
 
     internal func handleDragBegin(with featureIdentifiers: [String]) {
-        guard let annotation = annotations.first(where: { featureIdentifiers.contains($0.id) }) else { return }
+        guard let annotation = annotations.first(where: { featureIdentifiers.contains($0.id) && $0.isDraggable }) else { return }
         createDragSourceAndLayer()
 
         annotationBeingDragged = annotation

--- a/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationIntegrationTests.swift
@@ -37,7 +37,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testSynchronizesAnnotationsEventually() throws {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.circleRadius = 10
 
         manager.annotations.append(annotation)
@@ -168,7 +168,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testCircleSortKey() throws {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: -100000...100000)
         annotation.circleSortKey = value
@@ -204,7 +204,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testCircleBlur() throws {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: -100000...100000)
         annotation.circleBlur = value
@@ -240,7 +240,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testCircleColor() throws {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = StyleColor.random()
         annotation.circleColor = value
@@ -276,7 +276,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testCircleOpacity() throws {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...1)
         annotation.circleOpacity = value
@@ -312,7 +312,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testCircleRadius() throws {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...100000)
         annotation.circleRadius = value
@@ -348,7 +348,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testCircleStrokeColor() throws {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = StyleColor.random()
         annotation.circleStrokeColor = value
@@ -384,7 +384,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testCircleStrokeOpacity() throws {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...1)
         annotation.circleStrokeOpacity = value
@@ -420,7 +420,7 @@ final class CircleAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testCircleStrokeWidth() throws {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...100000)
         annotation.circleStrokeWidth = value

--- a/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationManagerTests.swift
@@ -493,6 +493,21 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
         expectation = nil
     }
 
+    func testHandleDragBeginIsDraggableFalse() throws {
+        manager.annotations = [
+            CircleAnnotation(id: "circle1", centerCoordinate: .random())
+        ]
+
+        style.addSourceStub.reset()
+        style.addPersistentLayerWithPropertiesStub.reset()
+
+        manager.handleDragBegin(with: ["line1"])
+
+        XCTAssertEqual(style.addSourceStub.invocations.count, 0)
+        XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.invocations.count, 0)
+        XCTAssertEqual(style.updateGeoJSONSourceStub.invocations.count, 0)
+    }
+
     func testHandleDragBeginNoFeatureId() {
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
@@ -520,6 +535,12 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
             CircleAnnotation(id: "circle1", centerCoordinate: .random())
         ]
 
+        annotations = annotations.map { annotation in
+            var annotation = annotation
+            annotation.isDraggable = true
+            return annotation
+        }
+
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
 
@@ -545,6 +566,12 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
             CircleAnnotation(id: "circle1", centerCoordinate: .init(latitude: 0, longitude: 0))
         ]
 
+        annotations = annotations.map { annotation in
+            var annotation = annotation
+            annotation.isDraggable = true
+            return annotation
+        }
+
         manager.handleDragChanged(with: .random())
         XCTAssertTrue(style.updateGeoJSONSourceStub.invocations.isEmpty)
 
@@ -564,6 +591,12 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
         manager.annotations = [
             CircleAnnotation(id: "circle1", centerCoordinate: .init(latitude: 0, longitude: 0))
         ]
+
+        annotations = annotations.map { annotation in
+            var annotation = annotation
+            annotation.isDraggable = true
+            return annotation
+        }
 
         manager.handleDragEnded()
         eventually(timeout: 0.2) {

--- a/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationManagerTests.swift
@@ -493,6 +493,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
         expectation = nil
     }
 
+
     func testHandleDragBeginIsDraggableFalse() throws {
         manager.annotations = [
             CircleAnnotation(id: "circle1", centerCoordinate: .random())
@@ -501,7 +502,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
 
-        manager.handleDragBegin(with: ["line1"])
+        manager.handleDragBegin(with: ["circle1"])
 
         XCTAssertEqual(style.addSourceStub.invocations.count, 0)
         XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.invocations.count, 0)
@@ -535,7 +536,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
             CircleAnnotation(id: "circle1", centerCoordinate: .random())
         ]
 
-        annotations = annotations.map { annotation in
+        manager.annotations = manager.annotations.map { annotation in
             var annotation = annotation
             annotation.isDraggable = true
             return annotation
@@ -566,7 +567,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
             CircleAnnotation(id: "circle1", centerCoordinate: .init(latitude: 0, longitude: 0))
         ]
 
-        annotations = annotations.map { annotation in
+        manager.annotations = manager.annotations.map { annotation in
             var annotation = annotation
             annotation.isDraggable = true
             return annotation
@@ -592,7 +593,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
             CircleAnnotation(id: "circle1", centerCoordinate: .init(latitude: 0, longitude: 0))
         ]
 
-        annotations = annotations.map { annotation in
+        manager.annotations = manager.annotations.map { annotation in
             var annotation = annotation
             annotation.isDraggable = true
             return annotation

--- a/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationManagerTests.swift
@@ -29,7 +29,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
         )
 
         for _ in 0...10 {
-            let annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            let annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
     }
@@ -81,7 +81,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
     func testAddManagerWithDuplicateId() {
         var annotations2 = [CircleAnnotation]()
         for _ in 0...50 {
-            let annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            let annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotations2.append(annotation)
         }
 
@@ -158,7 +158,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
     func testfeatureCollectionPassedtoGeoJSON() {
         var annotations = [CircleAnnotation]()
         for _ in 0...5 {
-            let annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            let annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
         let featureCollection = FeatureCollection(features: annotations.map(\.feature))
@@ -174,7 +174,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
     func testHandleQueriedFeatureIdsPassesNotificationToDelegate() throws {
         var annotations = [CircleAnnotation]()
         for _ in 0...5 {
-            let annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            let annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
         let queriedFeatureIds = [annotations[0].id]
@@ -190,7 +190,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
     func testHandleQueriedFeatureIdsDoesNotPassNotificationToDelegateWhenNoMatch() throws {
         var annotations = [CircleAnnotation]()
         for _ in 0...5 {
-            let annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            let annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
         let queriedFeatureIds = ["NotAnAnnotationID"]
@@ -238,7 +238,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
     func testNewCirclePitchAlignmentPropertyMergedWithAnnotationProperties() {
         var annotations = [CircleAnnotation]()
         for _ in 0...5 {
-            var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.circleSortKey = Double.random(in: -100000...100000)
             annotation.circleBlur = Double.random(in: -100000...100000)
             annotation.circleColor = StyleColor.random()
@@ -309,7 +309,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
     func testNewCirclePitchScalePropertyMergedWithAnnotationProperties() {
         var annotations = [CircleAnnotation]()
         for _ in 0...5 {
-            var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.circleSortKey = Double.random(in: -100000...100000)
             annotation.circleBlur = Double.random(in: -100000...100000)
             annotation.circleColor = StyleColor.random()
@@ -380,7 +380,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
     func testNewCircleTranslatePropertyMergedWithAnnotationProperties() {
         var annotations = [CircleAnnotation]()
         for _ in 0...5 {
-            var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.circleSortKey = Double.random(in: -100000...100000)
             annotation.circleBlur = Double.random(in: -100000...100000)
             annotation.circleColor = StyleColor.random()
@@ -451,7 +451,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
     func testNewCircleTranslateAnchorPropertyMergedWithAnnotationProperties() {
         var annotations = [CircleAnnotation]()
         for _ in 0...5 {
-            var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.circleSortKey = Double.random(in: -100000...100000)
             annotation.circleBlur = Double.random(in: -100000...100000)
             annotation.circleColor = StyleColor.random()
@@ -496,7 +496,7 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
 
     func testHandleDragBeginIsDraggableFalse() throws {
         manager.annotations = [
-            CircleAnnotation(id: "circle1", centerCoordinate: .random())
+            CircleAnnotation(id: "circle1", centerCoordinate: .random(), isSelected: false, isDraggable: false)
         ]
 
         style.addSourceStub.reset()
@@ -533,14 +533,8 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
 
     func testHandleDragBegin() throws {
         manager.annotations = [
-            CircleAnnotation(id: "circle1", centerCoordinate: .random())
+            CircleAnnotation(id: "circle1", centerCoordinate: .random(), isSelected: false, isDraggable: true)
         ]
-
-        manager.annotations = manager.annotations.map { annotation in
-            var annotation = annotation
-            annotation.isDraggable = true
-            return annotation
-        }
 
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
@@ -564,14 +558,8 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
         mapboxMap.cameraState.zoom = 1
 
         manager.annotations = [
-            CircleAnnotation(id: "circle1", centerCoordinate: .init(latitude: 0, longitude: 0))
+            CircleAnnotation(id: "circle1", centerCoordinate: .init(latitude: 0, longitude: 0), isSelected: false, isDraggable: true)
         ]
-
-        manager.annotations = manager.annotations.map { annotation in
-            var annotation = annotation
-            annotation.isDraggable = true
-            return annotation
-        }
 
         manager.handleDragChanged(with: .random())
         XCTAssertTrue(style.updateGeoJSONSourceStub.invocations.isEmpty)
@@ -590,14 +578,8 @@ final class CircleAnnotationManagerTests: XCTestCase, AnnotationInteractionDeleg
 
     func testHandleDragEnded() throws {
         manager.annotations = [
-            CircleAnnotation(id: "circle1", centerCoordinate: .init(latitude: 0, longitude: 0))
+            CircleAnnotation(id: "circle1", centerCoordinate: .init(latitude: 0, longitude: 0), isSelected: false, isDraggable: true)
         ]
-
-        manager.annotations = manager.annotations.map { annotation in
-            var annotation = annotation
-            annotation.isDraggable = true
-            return annotation
-        }
 
         manager.handleDragEnded()
         eventually(timeout: 0.2) {

--- a/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/CircleAnnotationTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class CircleAnnotationTests: XCTestCase {
 
     func testCircleSortKey() {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.circleSortKey =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -19,7 +19,7 @@ final class CircleAnnotationTests: XCTestCase {
     }
 
     func testCircleBlur() {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.circleBlur =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -33,7 +33,7 @@ final class CircleAnnotationTests: XCTestCase {
     }
 
     func testCircleColor() {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.circleColor =  StyleColor.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -47,7 +47,7 @@ final class CircleAnnotationTests: XCTestCase {
     }
 
     func testCircleOpacity() {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.circleOpacity =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -61,7 +61,7 @@ final class CircleAnnotationTests: XCTestCase {
     }
 
     func testCircleRadius() {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.circleRadius =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -75,7 +75,7 @@ final class CircleAnnotationTests: XCTestCase {
     }
 
     func testCircleStrokeColor() {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.circleStrokeColor =  StyleColor.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -89,7 +89,7 @@ final class CircleAnnotationTests: XCTestCase {
     }
 
     func testCircleStrokeOpacity() {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.circleStrokeOpacity =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -103,7 +103,7 @@ final class CircleAnnotationTests: XCTestCase {
     }
 
     func testCircleStrokeWidth() {
-        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = CircleAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.circleStrokeWidth =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {

--- a/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationIntegrationTests.swift
@@ -37,7 +37,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testSynchronizesAnnotationsEventually() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textSize = 10
 
         manager.annotations.append(annotation)
@@ -796,7 +796,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testIconAnchor() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = IconAnchor.allCases.randomElement()!
         annotation.iconAnchor = value
@@ -832,7 +832,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testIconImage() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = String.randomASCII(withLength: .random(in: 0...100))
         annotation.iconImage = value
@@ -868,7 +868,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testIconOffset() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
         annotation.iconOffset = value
@@ -906,7 +906,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testIconRotate() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: -100000...100000)
         annotation.iconRotate = value
@@ -942,7 +942,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testIconSize() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...100000)
         annotation.iconSize = value
@@ -978,7 +978,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testSymbolSortKey() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: -100000...100000)
         annotation.symbolSortKey = value
@@ -1014,7 +1014,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextAnchor() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = TextAnchor.allCases.randomElement()!
         annotation.textAnchor = value
@@ -1050,7 +1050,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextField() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = String.randomASCII(withLength: .random(in: 0...100))
         annotation.textField = value
@@ -1090,7 +1090,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextJustify() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = TextJustify.allCases.randomElement()!
         annotation.textJustify = value
@@ -1126,7 +1126,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextLetterSpacing() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: -100000...100000)
         annotation.textLetterSpacing = value
@@ -1162,7 +1162,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextLineHeight() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: -100000...100000)
         annotation.textLineHeight = value
@@ -1198,7 +1198,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextMaxWidth() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...100000)
         annotation.textMaxWidth = value
@@ -1234,7 +1234,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextOffset() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
         annotation.textOffset = value
@@ -1272,7 +1272,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextRadialOffset() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: -100000...100000)
         annotation.textRadialOffset = value
@@ -1308,7 +1308,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextRotate() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: -100000...100000)
         annotation.textRotate = value
@@ -1344,7 +1344,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextSize() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...100000)
         annotation.textSize = value
@@ -1380,7 +1380,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextTransform() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = TextTransform.allCases.randomElement()!
         annotation.textTransform = value
@@ -1416,7 +1416,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testIconColor() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = StyleColor.random()
         annotation.iconColor = value
@@ -1452,7 +1452,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testIconHaloBlur() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...100000)
         annotation.iconHaloBlur = value
@@ -1488,7 +1488,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testIconHaloColor() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = StyleColor.random()
         annotation.iconHaloColor = value
@@ -1524,7 +1524,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testIconHaloWidth() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...100000)
         annotation.iconHaloWidth = value
@@ -1560,7 +1560,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testIconOpacity() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...1)
         annotation.iconOpacity = value
@@ -1596,7 +1596,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextColor() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = StyleColor.random()
         annotation.textColor = value
@@ -1632,7 +1632,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextHaloBlur() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...100000)
         annotation.textHaloBlur = value
@@ -1668,7 +1668,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextHaloColor() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = StyleColor.random()
         annotation.textHaloColor = value
@@ -1704,7 +1704,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextHaloWidth() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...100000)
         annotation.textHaloWidth = value
@@ -1740,7 +1740,7 @@ final class PointAnnotationIntegrationTests: MapViewIntegrationTestCase {
     }
 
     func testTextOpacity() throws {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...1)
         annotation.textOpacity = value

--- a/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationManagerTests.swift
@@ -2766,7 +2766,6 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
         XCTAssertTrue(annotations.compactMap(\.image?.name).allSatisfy(manager.isUsingStyleImage(_:)))
     }
 
-
     func testUnusedImagesRemovedFromStyle() {
         // given
         let allAnnotations = Array.random(withLength: 10) {
@@ -3121,6 +3120,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
         XCTAssertEqual(removeLayerInvocations[1].parameters, "mapbox-iOS-cluster-text-layer-manager-" + id)
         XCTAssertEqual(removeLayerInvocations[2].parameters, id)
     }
+
     func testHandleDragBeginIsDraggableFalse() throws {
         manager.annotations = [
             PointAnnotation(id: "point1", coordinate: .random())
@@ -3129,7 +3129,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
 
-        manager.handleDragBegin(with: ["line1"])
+        manager.handleDragBegin(with: ["point1"])
 
         XCTAssertEqual(style.addSourceStub.invocations.count, 0)
         XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.invocations.count, 0)
@@ -3163,7 +3163,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
             PointAnnotation(id: "point1", coordinate: .random())
         ]
 
-        annotations = annotations.map { annotation in
+        manager.annotations = manager.annotations.map { annotation in
             var annotation = annotation
             annotation.isDraggable = true
             return annotation
@@ -3194,7 +3194,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
             PointAnnotation(id: "point1", coordinate: .init(latitude: 0, longitude: 0))
         ]
 
-        annotations = annotations.map { annotation in
+        manager.annotations = manager.annotations.map { annotation in
             var annotation = annotation
             annotation.isDraggable = true
             return annotation
@@ -3220,7 +3220,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
             PointAnnotation(id: "point1", coordinate: .init(latitude: 0, longitude: 0))
         ]
 
-        annotations = annotations.map { annotation in
+        manager.annotations = manager.annotations.map { annotation in
             var annotation = annotation
             annotation.isDraggable = true
             return annotation

--- a/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationManagerTests.swift
@@ -32,7 +32,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
         )
 
         for _ in 0...10 {
-            let annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            let annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
     }
@@ -87,7 +87,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testAddManagerWithDuplicateId() {
         var annotations2 = [PointAnnotation]()
         for _ in 0...50 {
-            let annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            let annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotations2.append(annotation)
         }
 
@@ -166,7 +166,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testfeatureCollectionPassedtoGeoJSON() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            let annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            let annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
         let featureCollection = FeatureCollection(features: annotations.map(\.feature))
@@ -182,7 +182,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testHandleQueriedFeatureIdsPassesNotificationToDelegate() throws {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            let annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            let annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
         let queriedFeatureIds = [annotations[0].id]
@@ -198,7 +198,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testHandleQueriedFeatureIdsDoesNotPassNotificationToDelegateWhenNoMatch() throws {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            let annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            let annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
         let queriedFeatureIds = ["NotAnAnnotationID"]
@@ -246,7 +246,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewIconAllowOverlapPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -336,7 +336,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewIconIgnorePlacementPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -426,7 +426,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewIconKeepUprightPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -516,7 +516,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewIconOptionalPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -606,7 +606,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewIconPaddingPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -696,7 +696,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewIconPitchAlignmentPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -786,7 +786,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewIconRotationAlignmentPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -876,7 +876,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewIconTextFitPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -966,7 +966,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewIconTextFitPaddingPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -1056,7 +1056,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewSymbolAvoidEdgesPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -1146,7 +1146,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewSymbolPlacementPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -1236,7 +1236,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewSymbolSpacingPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -1326,7 +1326,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewSymbolZOrderPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -1416,7 +1416,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewTextAllowOverlapPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -1506,7 +1506,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewTextFontPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -1596,7 +1596,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewTextIgnorePlacementPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -1686,7 +1686,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewTextKeepUprightPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -1776,7 +1776,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewTextMaxAnglePropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -1866,7 +1866,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewTextOptionalPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -1956,7 +1956,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewTextPaddingPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -2046,7 +2046,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewTextPitchAlignmentPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -2136,7 +2136,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewTextRotationAlignmentPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -2228,7 +2228,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewTextVariableAnchorPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -2320,7 +2320,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewTextWritingModePropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -2410,7 +2410,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewIconTranslatePropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -2500,7 +2500,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewIconTranslateAnchorPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -2590,7 +2590,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewTextTranslatePropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -2680,7 +2680,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
     func testNewTextTranslateAnchorPropertyMergedWithAnnotationProperties() {
         var annotations = [PointAnnotation]()
         for _ in 0...5 {
-            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+            var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
             annotation.iconAnchor = IconAnchor.allCases.randomElement()!
             annotation.iconImage = String.randomASCII(withLength: .random(in: 0...100))
             annotation.iconOffset = [Double.random(in: -100000...100000), Double.random(in: -100000...100000)]
@@ -2858,7 +2858,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
         let clusterOptions = ClusterOptions()
         var annotations = [PointAnnotation]()
         for _ in 0...500 {
-            let annotation = PointAnnotation(coordinate: .random())
+            let annotation = PointAnnotation(coordinate: .random(), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
 
@@ -2902,7 +2902,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
                                             clusterProperties: testClusterProperties)
         var annotations = [PointAnnotation]()
         for _ in 0...500 {
-            let annotation = PointAnnotation(coordinate: .random())
+            let annotation = PointAnnotation(coordinate: .random(), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
 
@@ -2938,7 +2938,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
                                             circleColor: testCircleColor)
         var annotations = [PointAnnotation]()
         for _ in 0...500 {
-            let annotation = PointAnnotation(coordinate: .random())
+            let annotation = PointAnnotation(coordinate: .random(), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
 
@@ -2981,7 +2981,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
                                             textField: testTextField)
         var annotations = [PointAnnotation]()
         for _ in 0...500 {
-            let annotation = PointAnnotation(coordinate: .random())
+            let annotation = PointAnnotation(coordinate: .random(), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
 
@@ -3016,7 +3016,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
         let clusterOptions = ClusterOptions()
         var annotations = [PointAnnotation]()
         for _ in 0...500 {
-            let annotation = PointAnnotation(coordinate: .random())
+            let annotation = PointAnnotation(coordinate: .random(), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
 
@@ -3053,12 +3053,12 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
         let clusterOptions = ClusterOptions()
         var annotations = [PointAnnotation]()
         for _ in 0...500 {
-            let annotation = PointAnnotation(coordinate: .random())
+            let annotation = PointAnnotation(coordinate: .random(), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
         var newAnnotations = [PointAnnotation]()
         for _ in 0...100 {
-            let annotation = PointAnnotation(coordinate: .random())
+            let annotation = PointAnnotation(coordinate: .random(), isSelected: false, isDraggable: false)
             newAnnotations.append(annotation)
         }
 
@@ -3123,7 +3123,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
 
     func testHandleDragBeginIsDraggableFalse() throws {
         manager.annotations = [
-            PointAnnotation(id: "point1", coordinate: .random())
+            PointAnnotation(id: "point1", coordinate: .random(), isSelected: false, isDraggable: false)
         ]
 
         style.addSourceStub.reset()
@@ -3160,14 +3160,8 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
 
     func testHandleDragBegin() throws {
         manager.annotations = [
-            PointAnnotation(id: "point1", coordinate: .random())
+            PointAnnotation(id: "point1", coordinate: .random(), isSelected: false, isDraggable: true)
         ]
-
-        manager.annotations = manager.annotations.map { annotation in
-            var annotation = annotation
-            annotation.isDraggable = true
-            return annotation
-        }
 
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
@@ -3191,14 +3185,8 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
         mapboxMap.cameraState.zoom = 1
 
         manager.annotations = [
-            PointAnnotation(id: "point1", coordinate: .init(latitude: 0, longitude: 0))
+            PointAnnotation(id: "point1", coordinate: .init(latitude: 0, longitude: 0), isSelected: false, isDraggable: true)
         ]
-
-        manager.annotations = manager.annotations.map { annotation in
-            var annotation = annotation
-            annotation.isDraggable = true
-            return annotation
-        }
 
         manager.handleDragChanged(with: .random())
         XCTAssertTrue(style.updateGeoJSONSourceStub.invocations.isEmpty)
@@ -3217,14 +3205,8 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
 
     func testHandleDragEnded() throws {
         manager.annotations = [
-            PointAnnotation(id: "point1", coordinate: .init(latitude: 0, longitude: 0))
+            PointAnnotation(id: "point1", coordinate: .init(latitude: 0, longitude: 0), isSelected: false, isDraggable: true)
         ]
-
-        manager.annotations = manager.annotations.map { annotation in
-            var annotation = annotation
-            annotation.isDraggable = true
-            return annotation
-        }
 
         manager.handleDragEnded()
         eventually(timeout: 0.2) {

--- a/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationManagerTests.swift
@@ -2766,7 +2766,7 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
         XCTAssertTrue(annotations.compactMap(\.image?.name).allSatisfy(manager.isUsingStyleImage(_:)))
     }
 
-    
+
     func testUnusedImagesRemovedFromStyle() {
         // given
         let allAnnotations = Array.random(withLength: 10) {
@@ -3121,6 +3121,21 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
         XCTAssertEqual(removeLayerInvocations[1].parameters, "mapbox-iOS-cluster-text-layer-manager-" + id)
         XCTAssertEqual(removeLayerInvocations[2].parameters, id)
     }
+    func testHandleDragBeginIsDraggableFalse() throws {
+        manager.annotations = [
+            PointAnnotation(id: "point1", coordinate: .random())
+        ]
+
+        style.addSourceStub.reset()
+        style.addPersistentLayerWithPropertiesStub.reset()
+
+        manager.handleDragBegin(with: ["line1"])
+
+        XCTAssertEqual(style.addSourceStub.invocations.count, 0)
+        XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.invocations.count, 0)
+        XCTAssertEqual(style.updateGeoJSONSourceStub.invocations.count, 0)
+    }
+
     func testHandleDragBeginNoFeatureId() {
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
@@ -3148,6 +3163,12 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
             PointAnnotation(id: "point1", coordinate: .random())
         ]
 
+        annotations = annotations.map { annotation in
+            var annotation = annotation
+            annotation.isDraggable = true
+            return annotation
+        }
+
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
 
@@ -3173,6 +3194,12 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
             PointAnnotation(id: "point1", coordinate: .init(latitude: 0, longitude: 0))
         ]
 
+        annotations = annotations.map { annotation in
+            var annotation = annotation
+            annotation.isDraggable = true
+            return annotation
+        }
+
         manager.handleDragChanged(with: .random())
         XCTAssertTrue(style.updateGeoJSONSourceStub.invocations.isEmpty)
 
@@ -3192,6 +3219,12 @@ final class PointAnnotationManagerTests: XCTestCase, AnnotationInteractionDelega
         manager.annotations = [
             PointAnnotation(id: "point1", coordinate: .init(latitude: 0, longitude: 0))
         ]
+
+        annotations = annotations.map { annotation in
+            var annotation = annotation
+            annotation.isDraggable = true
+            return annotation
+        }
 
         manager.handleDragEnded()
         eventually(timeout: 0.2) {

--- a/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PointAnnotationTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class PointAnnotationTests: XCTestCase {
 
     func testIconAnchor() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.iconAnchor =  IconAnchor.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -19,7 +19,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testIconImage() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.iconImage =  String.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -33,7 +33,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testIconOffset() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.iconOffset =  [Double].testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -47,7 +47,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testIconRotate() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.iconRotate =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -61,7 +61,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testIconSize() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.iconSize =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -75,7 +75,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testSymbolSortKey() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.symbolSortKey =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -89,7 +89,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextAnchor() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textAnchor =  TextAnchor.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -103,7 +103,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextField() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textField =  String.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -117,7 +117,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextJustify() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textJustify =  TextJustify.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -131,7 +131,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextLetterSpacing() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textLetterSpacing =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -145,7 +145,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextLineHeight() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textLineHeight =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -159,7 +159,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextMaxWidth() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textMaxWidth =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -173,7 +173,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextOffset() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textOffset =  [Double].testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -187,7 +187,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextRadialOffset() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textRadialOffset =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -201,7 +201,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextRotate() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textRotate =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -215,7 +215,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextSize() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textSize =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -229,7 +229,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextTransform() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textTransform =  TextTransform.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -243,7 +243,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testIconColor() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.iconColor =  StyleColor.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -257,7 +257,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testIconHaloBlur() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.iconHaloBlur =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -271,7 +271,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testIconHaloColor() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.iconHaloColor =  StyleColor.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -285,7 +285,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testIconHaloWidth() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.iconHaloWidth =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -299,7 +299,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testIconOpacity() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.iconOpacity =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -313,7 +313,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextColor() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textColor =  StyleColor.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -327,7 +327,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextHaloBlur() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textHaloBlur =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -341,7 +341,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextHaloColor() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textHaloColor =  StyleColor.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -355,7 +355,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextHaloWidth() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textHaloWidth =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -369,7 +369,7 @@ final class PointAnnotationTests: XCTestCase {
     }
 
     func testTextOpacity() {
-        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)))
+        var annotation = PointAnnotation(point: .init(.init(latitude: 0, longitude: 0)), isSelected: false, isDraggable: false)
         annotation.textOpacity =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationIntegrationTests.swift
@@ -44,7 +44,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
             CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
             CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
         ]
-        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
         annotation.fillOpacity = 10
 
         manager.annotations.append(annotation)
@@ -156,7 +156,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
             CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
             CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
         ]
-        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: -100000...100000)
         annotation.fillSortKey = value
@@ -199,7 +199,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
             CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
             CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
         ]
-        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = StyleColor.random()
         annotation.fillColor = value
@@ -242,7 +242,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
             CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
             CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
         ]
-        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...1)
         annotation.fillOpacity = value
@@ -285,7 +285,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
             CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
             CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
         ]
-        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = StyleColor.random()
         annotation.fillOutlineColor = value
@@ -328,7 +328,7 @@ final class PolygonAnnotationIntegrationTests: MapViewIntegrationTestCase {
             CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
             CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
         ]
-        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = String.randomASCII(withLength: .random(in: 0...100))
         annotation.fillPattern = value

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationManagerTests.swift
@@ -469,6 +469,27 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
         expectation = nil
     }
 
+    func testHandleDragBeginIsDraggableFalse() throws {
+        manager.annotations = [
+            PolygonAnnotation(id: "polygon1", polygon: .init([[
+                CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375),
+                CLLocationCoordinate2DMake(24.51713945052515, -87.967529296875),
+                CLLocationCoordinate2DMake(26.244156283890756, -87.967529296875),
+                CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
+                CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
+            ]]))
+        ]
+
+        style.addSourceStub.reset()
+        style.addPersistentLayerWithPropertiesStub.reset()
+
+        manager.handleDragBegin(with: ["line1"])
+
+        XCTAssertEqual(style.addSourceStub.invocations.count, 0)
+        XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.invocations.count, 0)
+        XCTAssertEqual(style.updateGeoJSONSourceStub.invocations.count, 0)
+    }
+
     func testHandleDragBeginNoFeatureId() {
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
@@ -502,6 +523,12 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
             ]]))
         ]
 
+        annotations = annotations.map { annotation in
+            var annotation = annotation
+            annotation.isDraggable = true
+            return annotation
+        }
+
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
 
@@ -533,6 +560,12 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
             ]]))
         ]
 
+        annotations = annotations.map { annotation in
+            var annotation = annotation
+            annotation.isDraggable = true
+            return annotation
+        }
+
         manager.handleDragChanged(with: .random())
         XCTAssertTrue(style.updateGeoJSONSourceStub.invocations.isEmpty)
 
@@ -558,6 +591,12 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
                 CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
             ]]))
         ]
+
+        annotations = annotations.map { annotation in
+            var annotation = annotation
+            annotation.isDraggable = true
+            return annotation
+        }
 
         manager.handleDragEnded()
         eventually(timeout: 0.2) {

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationManagerTests.swift
@@ -36,7 +36,7 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
                 CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
                 CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
             ]
-            let annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+            let annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
     }
@@ -95,7 +95,7 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
                 CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
                 CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
             ]
-            let annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+            let annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
             annotations2.append(annotation)
         }
 
@@ -179,7 +179,7 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
                 CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
                 CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
             ]
-            let annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+            let annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
         let featureCollection = FeatureCollection(features: annotations.map(\.feature))
@@ -202,7 +202,7 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
                 CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
                 CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
             ]
-            let annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+            let annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
         let queriedFeatureIds = [annotations[0].id]
@@ -225,7 +225,7 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
                 CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
                 CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
             ]
-            let annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+            let annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
         let queriedFeatureIds = ["NotAnAnnotationID"]
@@ -280,7 +280,7 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
                 CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
                 CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
             ]
-            var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+            var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
             annotation.fillSortKey = Double.random(in: -100000...100000)
             annotation.fillColor = StyleColor.random()
             annotation.fillOpacity = Double.random(in: 0...1)
@@ -355,7 +355,7 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
                 CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
                 CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
             ]
-            var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+            var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
             annotation.fillSortKey = Double.random(in: -100000...100000)
             annotation.fillColor = StyleColor.random()
             annotation.fillOpacity = Double.random(in: 0...1)
@@ -430,7 +430,7 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
                 CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
                 CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
             ]
-            var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+            var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
             annotation.fillSortKey = Double.random(in: -100000...100000)
             annotation.fillColor = StyleColor.random()
             annotation.fillOpacity = Double.random(in: 0...1)
@@ -478,7 +478,7 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
                 CLLocationCoordinate2DMake(26.244156283890756, -87.967529296875),
                 CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
                 CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
-            ]]))
+            ]]), isSelected: false, isDraggable: false)
         ]
 
         style.addSourceStub.reset()
@@ -521,14 +521,8 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
                 CLLocationCoordinate2DMake(26.244156283890756, -87.967529296875),
                 CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
                 CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
-            ]]))
+            ]]), isSelected: false, isDraggable: true)
         ]
-
-        manager.annotations = manager.annotations.map { annotation in
-            var annotation = annotation
-            annotation.isDraggable = true
-            return annotation
-        }
 
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
@@ -558,14 +552,8 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
                 CLLocationCoordinate2DMake(26.244156283890756, -87.967529296875),
                 CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
                 CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
-            ]]))
+            ]]), isSelected: false, isDraggable: true)
         ]
-
-        manager.annotations = manager.annotations.map { annotation in
-            var annotation = annotation
-            annotation.isDraggable = true
-            return annotation
-        }
 
         manager.handleDragChanged(with: .random())
         XCTAssertTrue(style.updateGeoJSONSourceStub.invocations.isEmpty)
@@ -590,14 +578,8 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
                 CLLocationCoordinate2DMake(26.244156283890756, -87.967529296875),
                 CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
                 CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
-            ]]))
+            ]]), isSelected: false, isDraggable: true)
         ]
-
-        manager.annotations = manager.annotations.map { annotation in
-            var annotation = annotation
-            annotation.isDraggable = true
-            return annotation
-        }
 
         manager.handleDragEnded()
         eventually(timeout: 0.2) {

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationManagerTests.swift
@@ -469,6 +469,7 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
         expectation = nil
     }
 
+
     func testHandleDragBeginIsDraggableFalse() throws {
         manager.annotations = [
             PolygonAnnotation(id: "polygon1", polygon: .init([[
@@ -483,7 +484,7 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
 
-        manager.handleDragBegin(with: ["line1"])
+        manager.handleDragBegin(with: ["polygon1"])
 
         XCTAssertEqual(style.addSourceStub.invocations.count, 0)
         XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.invocations.count, 0)
@@ -523,7 +524,7 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
             ]]))
         ]
 
-        annotations = annotations.map { annotation in
+        manager.annotations = manager.annotations.map { annotation in
             var annotation = annotation
             annotation.isDraggable = true
             return annotation
@@ -560,7 +561,7 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
             ]]))
         ]
 
-        annotations = annotations.map { annotation in
+        manager.annotations = manager.annotations.map { annotation in
             var annotation = annotation
             annotation.isDraggable = true
             return annotation
@@ -592,7 +593,7 @@ final class PolygonAnnotationManagerTests: XCTestCase, AnnotationInteractionDele
             ]]))
         ]
 
-        annotations = annotations.map { annotation in
+        manager.annotations = manager.annotations.map { annotation in
             var annotation = annotation
             annotation.isDraggable = true
             return annotation

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolygonAnnotationTests.swift
@@ -12,7 +12,7 @@ final class PolygonAnnotationTests: XCTestCase {
             CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
             CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
         ]
-        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
         annotation.fillSortKey =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -33,7 +33,7 @@ final class PolygonAnnotationTests: XCTestCase {
             CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
             CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
         ]
-        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
         annotation.fillColor =  StyleColor.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -54,7 +54,7 @@ final class PolygonAnnotationTests: XCTestCase {
             CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
             CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
         ]
-        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
         annotation.fillOpacity =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -75,7 +75,7 @@ final class PolygonAnnotationTests: XCTestCase {
             CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
             CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
         ]
-        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
         annotation.fillOutlineColor =  StyleColor.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -96,7 +96,7 @@ final class PolygonAnnotationTests: XCTestCase {
             CLLocationCoordinate2DMake(26.244156283890756, -89.857177734375),
             CLLocationCoordinate2DMake(24.51713945052515, -89.857177734375)
         ]
-        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)))
+        var annotation = PolygonAnnotation(polygon: .init(outerRing: .init(coordinates: polygonCoords)), isSelected: false, isDraggable: false)
         annotation.fillPattern =  String.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationIntegrationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationIntegrationTests.swift
@@ -38,7 +38,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
 
     func testSynchronizesAnnotationsEventually() throws {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         annotation.lineWidth = 10
 
         manager.annotations.append(annotation)
@@ -252,7 +252,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
 
     func testLineJoin() throws {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = LineJoin.allCases.randomElement()!
         annotation.lineJoin = value
@@ -289,7 +289,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
 
     func testLineSortKey() throws {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: -100000...100000)
         annotation.lineSortKey = value
@@ -326,7 +326,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
 
     func testLineBlur() throws {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...100000)
         annotation.lineBlur = value
@@ -363,7 +363,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
 
     func testLineColor() throws {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = StyleColor.random()
         annotation.lineColor = value
@@ -400,7 +400,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
 
     func testLineGapWidth() throws {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...100000)
         annotation.lineGapWidth = value
@@ -437,7 +437,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
 
     func testLineOffset() throws {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: -100000...100000)
         annotation.lineOffset = value
@@ -474,7 +474,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
 
     func testLineOpacity() throws {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...1)
         annotation.lineOpacity = value
@@ -511,7 +511,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
 
     func testLinePattern() throws {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = String.randomASCII(withLength: .random(in: 0...100))
         annotation.linePattern = value
@@ -548,7 +548,7 @@ final class PolylineAnnotationIntegrationTests: MapViewIntegrationTestCase {
 
     func testLineWidth() throws {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         // Test that the setter and getter work
         let value = Double.random(in: 0...100000)
         annotation.lineWidth = value

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationManagerTests.swift
@@ -30,7 +30,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
 
         for _ in 0...10 {
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-            let annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+            let annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
     }
@@ -83,7 +83,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         var annotations2 = [PolylineAnnotation]()
         for _ in 0...50 {
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-            let annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+            let annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
             annotations2.append(annotation)
         }
 
@@ -161,7 +161,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         var annotations = [PolylineAnnotation]()
         for _ in 0...5 {
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-            let annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+            let annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
         let featureCollection = FeatureCollection(features: annotations.map(\.feature))
@@ -178,7 +178,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         var annotations = [PolylineAnnotation]()
         for _ in 0...5 {
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-            let annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+            let annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
         let queriedFeatureIds = [annotations[0].id]
@@ -195,7 +195,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         var annotations = [PolylineAnnotation]()
         for _ in 0...5 {
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-            let annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+            let annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
             annotations.append(annotation)
         }
         let queriedFeatureIds = ["NotAnAnnotationID"]
@@ -244,7 +244,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         var annotations = [PolylineAnnotation]()
         for _ in 0...5 {
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
             annotation.lineJoin = LineJoin.allCases.randomElement()!
             annotation.lineSortKey = Double.random(in: -100000...100000)
             annotation.lineBlur = Double.random(in: 0...100000)
@@ -317,7 +317,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         var annotations = [PolylineAnnotation]()
         for _ in 0...5 {
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
             annotation.lineJoin = LineJoin.allCases.randomElement()!
             annotation.lineSortKey = Double.random(in: -100000...100000)
             annotation.lineBlur = Double.random(in: 0...100000)
@@ -390,7 +390,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         var annotations = [PolylineAnnotation]()
         for _ in 0...5 {
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
             annotation.lineJoin = LineJoin.allCases.randomElement()!
             annotation.lineSortKey = Double.random(in: -100000...100000)
             annotation.lineBlur = Double.random(in: 0...100000)
@@ -463,7 +463,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         var annotations = [PolylineAnnotation]()
         for _ in 0...5 {
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
             annotation.lineJoin = LineJoin.allCases.randomElement()!
             annotation.lineSortKey = Double.random(in: -100000...100000)
             annotation.lineBlur = Double.random(in: 0...100000)
@@ -536,7 +536,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         var annotations = [PolylineAnnotation]()
         for _ in 0...5 {
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
             annotation.lineJoin = LineJoin.allCases.randomElement()!
             annotation.lineSortKey = Double.random(in: -100000...100000)
             annotation.lineBlur = Double.random(in: 0...100000)
@@ -609,7 +609,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         var annotations = [PolylineAnnotation]()
         for _ in 0...5 {
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
             annotation.lineJoin = LineJoin.allCases.randomElement()!
             annotation.lineSortKey = Double.random(in: -100000...100000)
             annotation.lineBlur = Double.random(in: 0...100000)
@@ -682,7 +682,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         var annotations = [PolylineAnnotation]()
         for _ in 0...5 {
             let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+            var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
             annotation.lineJoin = LineJoin.allCases.randomElement()!
             annotation.lineSortKey = Double.random(in: -100000...100000)
             annotation.lineBlur = Double.random(in: 0...100000)
@@ -728,7 +728,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
 
     func testHandleDragBeginIsDraggableFalse() throws {
         manager.annotations = [
-            PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)])
+            PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)], isSelected: false, isDraggable: false)
         ]
 
         style.addSourceStub.reset()
@@ -765,14 +765,8 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
 
     func testHandleDragBegin() throws {
         manager.annotations = [
-            PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)])
+            PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)], isSelected: false, isDraggable: true)
         ]
-
-        manager.annotations = manager.annotations.map { annotation in
-            var annotation = annotation
-            annotation.isDraggable = true
-            return annotation
-        }
 
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
@@ -796,14 +790,8 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         mapboxMap.cameraState.zoom = 1
 
         manager.annotations = [
-            PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)])
+            PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)], isSelected: false, isDraggable: true)
         ]
-
-        manager.annotations = manager.annotations.map { annotation in
-            var annotation = annotation
-            annotation.isDraggable = true
-            return annotation
-        }
 
         manager.handleDragChanged(with: .random())
         XCTAssertTrue(style.updateGeoJSONSourceStub.invocations.isEmpty)
@@ -822,14 +810,8 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
 
     func testHandleDragEnded() throws {
         manager.annotations = [
-            PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)])
+            PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)], isSelected: false, isDraggable: true)
         ]
-
-        manager.annotations = manager.annotations.map { annotation in
-            var annotation = annotation
-            annotation.isDraggable = true
-            return annotation
-        }
 
         manager.handleDragEnded()
         eventually(timeout: 0.2) {

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationManagerTests.swift
@@ -725,6 +725,21 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         expectation = nil
     }
 
+    func testHandleDragBeginIsDraggableFalse() throws {
+        manager.annotations = [
+            PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)])
+        ]
+
+        style.addSourceStub.reset()
+        style.addPersistentLayerWithPropertiesStub.reset()
+
+        manager.handleDragBegin(with: ["line1"])
+
+        XCTAssertEqual(style.addSourceStub.invocations.count, 0)
+        XCTAssertEqual(style.addPersistentLayerWithPropertiesStub.invocations.count, 0)
+        XCTAssertEqual(style.updateGeoJSONSourceStub.invocations.count, 0)
+    }
+
     func testHandleDragBeginNoFeatureId() {
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
@@ -752,6 +767,12 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
             PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)])
         ]
 
+        annotations = annotations.map { annotation in
+            var annotation = annotation
+            annotation.isDraggable = true
+            return annotation
+        }
+
         style.addSourceStub.reset()
         style.addPersistentLayerWithPropertiesStub.reset()
 
@@ -777,6 +798,12 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
             PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)])
         ]
 
+        annotations = annotations.map { annotation in
+            var annotation = annotation
+            annotation.isDraggable = true
+            return annotation
+        }
+
         manager.handleDragChanged(with: .random())
         XCTAssertTrue(style.updateGeoJSONSourceStub.invocations.isEmpty)
 
@@ -796,6 +823,12 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         manager.annotations = [
             PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)])
         ]
+
+        annotations = annotations.map { annotation in
+            var annotation = annotation
+            annotation.isDraggable = true
+            return annotation
+        }
 
         manager.handleDragEnded()
         eventually(timeout: 0.2) {

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationManagerTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationManagerTests.swift
@@ -725,6 +725,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
         expectation = nil
     }
 
+
     func testHandleDragBeginIsDraggableFalse() throws {
         manager.annotations = [
             PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)])
@@ -767,7 +768,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
             PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)])
         ]
 
-        annotations = annotations.map { annotation in
+        manager.annotations = manager.annotations.map { annotation in
             var annotation = annotation
             annotation.isDraggable = true
             return annotation
@@ -798,7 +799,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
             PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)])
         ]
 
-        annotations = annotations.map { annotation in
+        manager.annotations = manager.annotations.map { annotation in
             var annotation = annotation
             annotation.isDraggable = true
             return annotation
@@ -824,7 +825,7 @@ final class PolylineAnnotationManagerTests: XCTestCase, AnnotationInteractionDel
             PolylineAnnotation(id: "line1", lineCoordinates: [ CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 10, longitude: 10)])
         ]
 
-        annotations = annotations.map { annotation in
+        manager.annotations = manager.annotations.map { annotation in
             var annotation = annotation
             annotation.isDraggable = true
             return annotation

--- a/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationTests.swift
+++ b/Tests/MapboxMapsTests/Annotations/Generated/PolylineAnnotationTests.swift
@@ -6,7 +6,7 @@ final class PolylineAnnotationTests: XCTestCase {
 
     func testLineJoin() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         annotation.lineJoin =  LineJoin.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -21,7 +21,7 @@ final class PolylineAnnotationTests: XCTestCase {
 
     func testLineSortKey() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         annotation.lineSortKey =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -36,7 +36,7 @@ final class PolylineAnnotationTests: XCTestCase {
 
     func testLineBlur() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         annotation.lineBlur =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -51,7 +51,7 @@ final class PolylineAnnotationTests: XCTestCase {
 
     func testLineColor() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         annotation.lineColor =  StyleColor.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -66,7 +66,7 @@ final class PolylineAnnotationTests: XCTestCase {
 
     func testLineGapWidth() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         annotation.lineGapWidth =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -81,7 +81,7 @@ final class PolylineAnnotationTests: XCTestCase {
 
     func testLineOffset() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         annotation.lineOffset =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -96,7 +96,7 @@ final class PolylineAnnotationTests: XCTestCase {
 
     func testLineOpacity() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         annotation.lineOpacity =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -111,7 +111,7 @@ final class PolylineAnnotationTests: XCTestCase {
 
     func testLinePattern() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         annotation.linePattern =  String.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {
@@ -126,7 +126,7 @@ final class PolylineAnnotationTests: XCTestCase {
 
     func testLineWidth() {
         let lineCoordinates = [ CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10) ]
-        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates))
+        var annotation = PolylineAnnotation(lineString: .init(lineCoordinates), isSelected: false, isDraggable: false)
         annotation.lineWidth =  Double.testConstantValue()
 
         guard let featureProperties = try? XCTUnwrap(annotation.feature.properties) else {

--- a/scripts/api-compatibility-check/breakage_allowlist.txt
+++ b/scripts/api-compatibility-check/breakage_allowlist.txt
@@ -1,3 +1,11 @@
 // Converted parametreless constructors into a parametrized one
 Constructor GestureOptions.init() has been removed
 Constructor LocationOptions.init() has been removed
+// Annotation initializers changed to incorporate isSelected and isDraggable
+Constructor CircleAnnotation.init(id:centerCoordinate:) has been removed
+Constructor CircleAnnotation.init(id:point:) has been removed
+Constructor PointAnnotation.init(id:coordinate:) has been removed
+Constructor PointAnnotation.init(id:point:) has been removed
+Constructor PolygonAnnotation.init(id:polygon:) has been removed
+Constructor PolylineAnnotation.init(id:lineCoordinates:) has been removed
+Constructor PolylineAnnotation.init(id:lineString:) has been removed


### PR DESCRIPTION
Currently, annotations behave as though isDraggable is always set to true, even when set to false. Correcting this behavior to make sure that the AnnotationManager takes into account the configuration for this property.

Fixes https://github.com/mapbox/mapbox-maps-ios/issues/1817

## Pull request checklist:
 - [ ] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
   - [ ] If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
