### PR TITLE
update license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,13 +3,9 @@
 Mapbox Maps for iOS version 10.0
 Mapbox Maps iOS SDK
 
-Copyright © 2021 Mapbox
+Copyright &copy; 2021 - 2023 Mapbox, Inc. All rights reserved.
 
-All rights reserved.
-
-Mapbox Maps for iOS version 10.0 (“Mapbox Maps iOS SDK”) or higher must be used according to the Mapbox Terms of Service. This license allows developers with a current active Mapbox account to use and modify the Mapbox Maps iOS SDK. Developers may modify the Mapbox Maps iOS SDK code so long as the modifications do not change or interfere with marked portions of the code related to billing, accounting, and anonymized data collection. The Mapbox Maps iOS SDK sends anonymized location and usage data, which Mapbox uses for fixing bugs and errors, accounting, and generating aggregated anonymized statistics. This license terminates automatically if a user no longer has an active Mapbox account.
-
-For the full license terms, please see the Mapbox Terms of Service at https://www.mapbox.com/legal/tos/
+The software and files in this repository (collectively, “Software”) are licensed under the Mapbox TOS for use only with the relevant Mapbox product(s) listed at www.mapbox.com/pricing. This license allows developers with a current active Mapbox account to use and modify the authorized portions of the Software as needed for use only with the relevant Mapbox product(s) through their Mapbox account in accordance with the Mapbox TOS.  This license terminates automatically if a developer no longer has a Mapbox account in good standing or breaches the Mapbox TOS. For the license terms, please see the Mapbox TOS at https://www.mapbox.com/legal/tos/ which incorporates the Mapbox Product Terms at www.mapbox.com/legal/service-terms.  If this Software is a SDK, modifications that change or interfere with marked portions of the code related to billing, accounting, or data collection are not authorized and the SDK sends limited de-identified location and usage data which is used in accordance with the Mapbox TOS. [Updated 2023-01]
 
 ## Acknowledgements
 

--- a/scripts/release/LICENSE-template.md
+++ b/scripts/release/LICENSE-template.md
@@ -3,10 +3,6 @@
 Mapbox Maps for iOS version 10.0
 Mapbox Maps iOS SDK
 
-Copyright © 2021 Mapbox
+Copyright &copy; 2021 - 2023 Mapbox, Inc. All rights reserved.
 
-All rights reserved.
-
-Mapbox Maps for iOS version 10.0 (“Mapbox Maps iOS SDK”) or higher must be used according to the Mapbox Terms of Service. This license allows developers with a current active Mapbox account to use and modify the Mapbox Maps iOS SDK. Developers may modify the Mapbox Maps iOS SDK code so long as the modifications do not change or interfere with marked portions of the code related to billing, accounting, and anonymized data collection. The Mapbox Maps iOS SDK sends anonymized location and usage data, which Mapbox uses for fixing bugs and errors, accounting, and generating aggregated anonymized statistics. This license terminates automatically if a user no longer has an active Mapbox account.
-
-For the full license terms, please see the Mapbox Terms of Service at https://www.mapbox.com/legal/tos/
+The software and files in this repository (collectively, “Software”) are licensed under the Mapbox TOS for use only with the relevant Mapbox product(s) listed at www.mapbox.com/pricing. This license allows developers with a current active Mapbox account to use and modify the authorized portions of the Software as needed for use only with the relevant Mapbox product(s) through their Mapbox account in accordance with the Mapbox TOS.  This license terminates automatically if a developer no longer has a Mapbox account in good standing or breaches the Mapbox TOS. For the license terms, please see the Mapbox TOS at https://www.mapbox.com/legal/tos/ which incorporates the Mapbox Product Terms at www.mapbox.com/legal/service-terms.  If this Software is a SDK, modifications that change or interfere with marked portions of the code related to billing, accounting, or data collection are not authorized and the SDK sends limited de-identified location and usage data which is used in accordance with the Mapbox TOS. [Updated 2023-01]


### PR DESCRIPTION
update license to reflect current language associated with Mapbox TOS

*NOTE:* the `scripts/release/collect_license.py` file (which is where `LICENSE-template.md` is used) still counts on the presence of a Carthage Cartfile. Obviously, we no longer have this since the move to SPM. Should this script be removed from the project, and the dependency licenses managed manually? Or can the logic be ported over to use an SPM equivalent?

I believe this PR can be merged, but work to address ☝️ should be ticketed.
