### PR TITLE
Fix static linking cocoapods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 Mapbox welcomes participation and contributions from everyone.
 
 ## main
+
 * Added basic signposts for performance profiling. To enable them, use `MAPBOX_MAPS_SIGNPOSTS_ENABLED` environment variable. ([#1818](https://github.com/mapbox/mapbox-maps-ios/pull/1818))
+* Fix build erros appearing when SDK distributed as a static library through Cocoapods. ([#1888](https://github.com/mapbox/mapbox-maps-ios/pull/1888))
 
 ## 10.11.0-rc.1 - January 26, 2023
 

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -19,11 +19,14 @@ Pod::Spec.new do |m|
   m.swift_version = '5.5'
 
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
-  m.resource_bundles = { 'MapboxMapsResources' => ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json'] }
 
 # Xcode 14.x throws an error about code signing on resource bundles, turn it off for now.
 #  m.pod_target_xcconfig = { 'CODE_SIGNING_ALLOWED' => 'NO' }
 # configuration.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+
+  m.subspec 'Resources' do |r|
+    r.resource_bundles = { 'MapboxMapsResources' => ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json'] }
+  end
 
   m.dependency 'MapboxCoreMaps', '10.11.0-rc.1'
   m.dependency 'MapboxMobileEvents', '1.0.10'

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -24,7 +24,6 @@ Pod::Spec.new do |m|
   # Xcode 14.x throws an error about code signing on resource bundles, turn it off for now.
   m.pod_target_xcconfig = { 'CODE_SIGNING_ALLOWED' => 'NO' }
 
-  m.default_subspec = 'Resources'
   m.dependency 'MapboxCoreMaps', '10.11.0-rc.1'
   m.dependency 'MapboxMobileEvents', '1.0.10'
   m.dependency 'MapboxCommon', '23.3.0-rc.1'

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -22,6 +22,7 @@ Pod::Spec.new do |m|
   m.resource_bundles = { 'MapboxMapsResources' => ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json'] }
 
   # Xcode 14.x throws an error about code signing on resource bundles, turn it off for now.
+  # TODO: remove after Cocoapods 1.12 is released
   m.pod_target_xcconfig = { 'CODE_SIGNING_ALLOWED' => 'NO' }
 
   m.dependency 'MapboxCoreMaps', '10.11.0-rc.1'

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -21,6 +21,10 @@ Pod::Spec.new do |m|
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
   m.resources = ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json']
 
+# Xcode 14.x throws an error about code signing on resource bundles, turn it off for now.
+  m.pod_target_xcconfig = { 'CODE_SIGNING_ALLOWED' => 'NO' }
+# configuration.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+
   m.dependency 'MapboxCoreMaps', '10.11.0-rc.1'
   m.dependency 'MapboxMobileEvents', '1.0.10'
   m.dependency 'MapboxCommon', '23.3.0-rc.1'

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |m|
   m.swift_version = '5.5'
 
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
-  m.resources = ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json']
+  m.resource_bundles = { 'MapboxMapsResources' => ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json'] }
 
 # Xcode 14.x throws an error about code signing on resource bundles, turn it off for now.
   m.pod_target_xcconfig = { 'CODE_SIGNING_ALLOWED' => 'NO' }

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -29,6 +29,7 @@ Pod::Spec.new do |m|
     r.pod_target_xcconfig = { 'CODE_SIGNING_ALLOWED' => 'NO' }
   end
 
+  m.default_subspec = 'Resources'
   m.dependency 'MapboxCoreMaps', '10.11.0-rc.1'
   m.dependency 'MapboxMobileEvents', '1.0.10'
   m.dependency 'MapboxCommon', '23.3.0-rc.1'

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |m|
   m.resource_bundles = { 'MapboxMapsResources' => ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json'] }
 
 # Xcode 14.x throws an error about code signing on resource bundles, turn it off for now.
-  m.pod_target_xcconfig = { 'CODE_SIGNING_ALLOWED' => 'NO' }
+#  m.pod_target_xcconfig = { 'CODE_SIGNING_ALLOWED' => 'NO' }
 # configuration.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
 
   m.dependency 'MapboxCoreMaps', '10.11.0-rc.1'

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -26,6 +26,7 @@ Pod::Spec.new do |m|
 
   m.subspec 'Resources' do |r|
     r.resource_bundles = { 'MapboxMapsResources' => ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json'] }
+    r.pod_target_xcconfig = { 'CODE_SIGNING_ALLOWED' => 'NO' }
   end
 
   m.dependency 'MapboxCoreMaps', '10.11.0-rc.1'

--- a/MapboxMaps.podspec
+++ b/MapboxMaps.podspec
@@ -19,15 +19,10 @@ Pod::Spec.new do |m|
   m.swift_version = '5.5'
 
   m.source_files = 'Sources/MapboxMaps/**/*.{swift,h}'
+  m.resource_bundles = { 'MapboxMapsResources' => ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json'] }
 
-# Xcode 14.x throws an error about code signing on resource bundles, turn it off for now.
-#  m.pod_target_xcconfig = { 'CODE_SIGNING_ALLOWED' => 'NO' }
-# configuration.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
-
-  m.subspec 'Resources' do |r|
-    r.resource_bundles = { 'MapboxMapsResources' => ['Sources/**/*.{xcassets,strings}', 'Sources/MapboxMaps/MapboxMaps.json'] }
-    r.pod_target_xcconfig = { 'CODE_SIGNING_ALLOWED' => 'NO' }
-  end
+  # Xcode 14.x throws an error about code signing on resource bundles, turn it off for now.
+  m.pod_target_xcconfig = { 'CODE_SIGNING_ALLOWED' => 'NO' }
 
   m.default_subspec = 'Resources'
   m.dependency 'MapboxCoreMaps', '10.11.0-rc.1'

--- a/Sources/MapboxMaps/Foundation/Extensions/Bundle+MapboxMaps.swift
+++ b/Sources/MapboxMaps/Foundation/Extensions/Bundle+MapboxMaps.swift
@@ -11,7 +11,16 @@ extension Bundle {
         #if SWIFT_PACKAGE
         return Bundle.module
         #else
-        return Bundle(for: BundleLocator.self)
+        // When using frameworks this bundle will be our `.framework` bundle.
+        // When using static linking this bundle will be the the host application's `.app` bundle.
+        let bundle = Bundle(for: BundleLocator.self)
+
+        // When using CocoaPods a "resource bundle" will be used to avoid resource conflicts with the host application.
+        // Check for the existence of the resource bundle and use that instead if it is present.
+        let resourceBundle = bundle.path(forResource: "MapboxMapsResources", ofType: "bundle")
+            .flatMap(Bundle.init(path:))
+
+        return resourceBundle ?? bundle
         #endif
     }
 


### PR DESCRIPTION
This PR is based on https://github.com/mapbox/mapbox-maps-ios/pull/1759:
> When using CocoaPods with static linking the resources will be copied to the root of the .app. When copying these resources the build will fail if the application already contains any resources with the same name. This will happen in any application that has its own Assets.xcassets since the application will generate an Assets.car and the MapboxMaps pod will also try to copy its own Assets.car to the .app.
>
> The recommended solution for this with CocoaPods is to use resource_bundles. This will cause CocoaPods to create a bundle with the name specified in resource_bundles. The created resource bundle will be copied to either the .framework or .app depending on the linking method used, resolving any resource conflicts with the hosting application.

Additionally code signing is disabled for Cocoapods distribution pending Cocoapods issue https://github.com/CocoaPods/CocoaPods/issues/11402 to be included in the upcoming release.
