### PR TITLE
Default to source map loading error type in case of unexpected type in payload

### DIFF
--- a/Sources/MapboxMaps/Style/StyleErrors.swift
+++ b/Sources/MapboxMaps/Style/StyleErrors.swift
@@ -72,7 +72,8 @@ public enum MapLoadingError: LocalizedError {
         case "glyphs":
             self = .glyphs(message)
         default:
-            fatalError("Unknown map load error \(type):\(message)")
+            // TODO: Revert this after the underlying issue(MAPSNAT-896) is fixed on GL Native side
+            self = .source(message)
         }
     }
 


### PR DESCRIPTION
This PR addresses a crash caused by unexpected type in map loading error payload.
