### PR TITLE
Add accessibility voice over for map view.

### DIFF
--- a/Sources/MapboxMaps/Foundation/MapView.swift
+++ b/Sources/MapboxMaps/Foundation/MapView.swift
@@ -10,6 +10,9 @@ import os
 
 // swiftlint:disable type_body_length
 open class MapView: UIView {
+    private enum Constants {
+        static let localizableTableName = "MapLocalizable"
+    }
 
     // `mapboxMap` depends on `MapInitOptions`, which is not available until
     // awakeFromNib() when instantiating MapView from a xib or storyboard.
@@ -383,6 +386,20 @@ open class MapView: UIView {
 
         // Set up managers
         setupManagers()
+
+        // Accessibility
+        let bundle = Bundle.mapboxMaps
+        isAccessibilityElement = true
+        accessibilityLabel = NSLocalizedString("MAP_A11Y_LABEL",
+                                               tableName: Constants.localizableTableName,
+                                               bundle: bundle,
+                                               value: "Map View",
+                                               comment: "MapInfo Accessibility label")
+        accessibilityHint = NSLocalizedString("MAP_A11Y_HINT",
+                                              tableName: Constants.localizableTableName,
+                                              bundle: bundle,
+                                              value: "Showing a Map created with Mapbox. Scroll by dragging two fingers. Zoom by pinching two fingers.",
+                                              comment: "MapInfo Accessibility hint")
     }
 
     internal func sendInitialTelemetryEvents() {

--- a/Sources/MapboxMaps/Foundation/en.lproj/MapLocalizable.strings
+++ b/Sources/MapboxMaps/Foundation/en.lproj/MapLocalizable.strings
@@ -1,0 +1,5 @@
+/* Accessibility hint */
+"MAP_A11Y_HINT" = "Showing a Map created with Mapbox. Scroll by dragging two fingers. Zoom by pinching two fingers.";
+
+/* Accessibility label */
+"MAP_A11Y_LABEL" = "Map View";


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->

<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.
-->

This adds accessibility label and hint for the map view. The android app provides voice over support for map view but is missing from the iOS app.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
   - [ ] If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
 - [ ] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
