### PR TITLE
Fixed ambiguous 'Polygon' type error for Mac Catalyst target

### DIFF
--- a/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
+++ b/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift
@@ -1,6 +1,10 @@
 // This file is generated.
 import Foundation
 
+#if targetEnvironment(macCatalyst)
+import struct Turf.Polygon
+#endif
+
 public struct PolygonAnnotation: Annotation {
 
     /// Identifier for this annotation

--- a/Sources/MapboxMaps/Annotations/OffsetGeometryCalculator.swift
+++ b/Sources/MapboxMaps/Annotations/OffsetGeometryCalculator.swift
@@ -1,6 +1,10 @@
 import UIKit
 @_implementationOnly import MapboxCommon_Private
 
+#if targetEnvironment(macCatalyst)
+import struct Turf.Polygon
+#endif
+
 internal protocol OffsetGeometryCalculator {
     associatedtype GeometryType: GeometryConvertible
     func geometry(for translation: CGPoint, from geometry: GeometryType) -> GeometryType?


### PR DESCRIPTION
This Pull Request fixes #1997 

:warning: ```PolygonAnnotation.swift``` is a generated file. I am not aware about the generation process. The fix needs to be applied to the source file whatsoever.

https://github.com/mapbox/mapbox-maps-ios/blob/58af389f41ba9aa9e019e83d261e207e6a9d9be4/Sources/MapboxMaps/Annotations/Generated/PolygonAnnotation.swift#L1
