### PR TITLE
Updates typo in v11 migration docs

### DIFF
--- a/Sources/MapboxMaps/Documentation.docc/Migrate to v11.md
+++ b/Sources/MapboxMaps/Documentation.docc/Migrate to v11.md
@@ -28,7 +28,7 @@ mapView.mapboxMap.styleURI = .standard
 The Mapbox Standard style features 4 light presets: Day, Dusk, Dawn, and Night. The style light preset can be changed from the default, “Day”, to another preset with a single line of code:
 
 ```swift
-mapView.mapboxMap.setStyleImportConfigProperty(for: "standard", config: "lightPreset", value: "dusk")
+mapView.mapboxMap.setStyleImportConfigProperty(for: "basemap", config: "lightPreset", value: "dusk")
 ```
 
 Changing the light preset will alter the colors and shadows on your map to reflect the time of day. For more information, check out the New-3D Lighting API section.
@@ -36,7 +36,7 @@ Changing the light preset will alter the colors and shadows on your map to refle
 Similarly, you can set other configuration properties on the Standard style such as showing POIs, place labels, or specific fonts:
 
 ```swift
-mapView.mapboxMap.setStyleImportConfigProperty(for: "standard", config: "showPointOfInterestLabels", value: false)
+mapView.mapboxMap.setStyleImportConfigProperty(for: "basemap", config: "showPointOfInterestLabels", value: false)
 ```
 
 The Standard style offers 6 configuration properties for developers to change when they import it into their own style:


### PR DESCRIPTION
<!--
Describe the changes in this PR here.

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include before/after visuals or gifs if this PR includes visual changes.
• Add a line with "Fixes: #issue-number" or "Fixes: issue URL" for each publicly-visible issue that is fixed by this PR.

-->


### Changes
The configuration example code to change the standard style's 6 configurable properties used an incorrect `importId`

NOTE: No tests or jazzy updates should be necessary as this is only a documentation change.

Fixes: #2001

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
   - [x] If tests were not written, please explain why.

 - [x] Add documentation comments for any added or updated public APIs.
 - [x] Add any new public, top-level symbols to the Jazzy config's `custom_categories` (scripts/doc-generation/.jazzy.yaml)
 - [x] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top).
 - [x] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).



## main
Updates v100 migration docs to use correct `importId`

