### PR TITLE
Replace occurrences of `VisionOS` with `visionOS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### Features ✨ and improvements 🏁
 
-* Vision OS support. 🚀
+* visionOS support. 🚀
 * Add easing curve parameter to `CameraAnimationsManager.fly(to:duration:curve:completion)`, make `TimingCurve` public with few more options.
 * Expose `MapboxMap.centerAltitudeMode` and ensure correct `centerAltitudeMode` on gesture ending.
 * Expose extra configuration methods for `MapboxMap`: `setNorthOrientation(_:)`, `setConstrainMode(_:)` and `setViewportMode(_:)`.

--- a/Sources/MapboxMaps/Documentation.docc/Articles/Work with visionOS.md
+++ b/Sources/MapboxMaps/Documentation.docc/Articles/Work with visionOS.md
@@ -1,4 +1,4 @@
-# Work with VisionOS
+# Work with visionOS
 
 Use Mapbox Maps in native applications for Apple Vision Pro.
 
@@ -10,11 +10,11 @@ Starting from version `11.2.0-beta.1` of Mapbox Maps, you can use the Mapbox Map
 
 - Note: Currently, visionOS is not supported in CocoaPods. Please use SPM or the binary [distribution](https://docs.mapbox.com/ios/maps/guides/install/) of MapboxMaps.
 
-### Make use of Mapbox Maps on VisionOS
+### Make use of Mapbox Maps on visionOS
 
-Working with Mapbox Maps on VisionOS is very similar to iOS. As the entry point to the map, you use ``Map`` if your application uses SwiftUI, and ``MapView`` if the application uses UIKit. You can find more information about SwiftUI support in <doc:SwiftUI-User-Guide>.
+Working with Mapbox Maps on visionOS is very similar to iOS. As the entry point to the map, you use ``Map`` if your application uses SwiftUI, and ``MapView`` if the application uses UIKit. You can find more information about SwiftUI support in <doc:SwiftUI-User-Guide>.
 
-Most of the Maps SDK's features from iOS are supported on VisionOS out-of-the-box. However, there are some platform limitations discussed below.
+Most of the Maps SDK's features from iOS are supported on visionOS out-of-the-box. However, there are some platform limitations discussed below.
 
 ### Limitations
 

--- a/Sources/MapboxMaps/Documentation.docc/Articles/Work with visionOS.md
+++ b/Sources/MapboxMaps/Documentation.docc/Articles/Work with visionOS.md
@@ -20,7 +20,7 @@ Most of the Maps SDK's features from iOS are supported on visionOS out-of-the-bo
 
 #### Eye tracking feedback
 
-All the interactive UI elements on Vision OS are expected to have visual feedback when the user looks at them. Currently, this effect is only available for native views and can be applied with [hoverEffect](https://developer.apple.com/documentation/swiftui/view/hovereffect(_:)). Mapbox Map renders most of the map content in Metal, which means the hover won't be available for map symbols, lines, polygons, and others. However, you can use [view annotations](https://docs.mapbox.com/ios/maps/guides/annotations/view-annotations/) to place interactive elements onto the map.
+All the interactive UI elements on visionOS are expected to have visual feedback when the user looks at them. Currently, this effect is only available for native views and can be applied with [hoverEffect](https://developer.apple.com/documentation/swiftui/view/hovereffect(_:)). Mapbox Map renders most of the map content in Metal, which means the hover won't be available for map symbols, lines, polygons, and others. However, you can use [view annotations](https://docs.mapbox.com/ios/maps/guides/annotations/view-annotations/) to place interactive elements onto the map.
 
 ```swift
 Map {

--- a/Sources/MapboxMaps/Foundation/MetalView.swift
+++ b/Sources/MapboxMaps/Foundation/MetalView.swift
@@ -1,7 +1,7 @@
 import MetalKit
 
 #if swift(>=5.9) && os(visionOS)
-/// Implements analog of MTKView on top of CAMetalLayer. Currently is used only for VisionOS rendering.
+/// Implements analog of MTKView on top of CAMetalLayer. Currently is used only for visionOS rendering.
 class MetalView: UIView, CoreMetalView {
     var presentsWithTransaction: Bool {
         get { metalLayer.presentsWithTransaction }

--- a/Sources/MapboxMaps/Location/LocationManager.swift
+++ b/Sources/MapboxMaps/Location/LocationManager.swift
@@ -63,7 +63,7 @@ public final class LocationManager {
 
     /// Sets the custom provider that supply puck with the location and heading data.
     ///
-    /// - Note: On VisionOS, the ``AppleLocationProvider`` doesn't implement ``HeadingProvider``.
+    /// - Note: On visionOS, the ``AppleLocationProvider`` doesn't implement ``HeadingProvider``.
     /// If you are using a custom instance of a location provider, override it using the ``LocationManager/override(locationProvider:headingProvider:)-8xcsf`` .
     ///
     /// - Parameters:

--- a/scripts/api-compatibility-check/breakage_allowlist.txt
+++ b/scripts/api-compatibility-check/breakage_allowlist.txt
@@ -1324,7 +1324,7 @@ Func CameraAnimationsManager.fly(to:duration:completion:) has parameter 2 type c
 Func MapboxMap.camera(for:padding:bearing:pitch:maxZoom:offset:) has parameter 1 type change from UIKit.UIEdgeInsets to UIKit.UIEdgeInsets?
 
 
-// VisionOS support
+// visionOS support
 Func MapViewMetricsReporter.afterMetalViewDrawCallback(metalView:) has been renamed to Func afterMetalViewDrawCallback()
 Func MapViewMetricsReporter.beforeMetalViewDrawCallback(metalView:) has been renamed to Func beforeMetalViewDrawCallback()
 Constructor MapOptions.init(constrainMode:viewportMode:orientation:crossSourceCollisions:size:pixelRatio:glyphsRasterizationOptions:) has parameter 5 type change from CoreGraphics.CGFloat to CoreGraphics.CGFloat?


### PR DESCRIPTION
According to [Apple guidelines](https://developer.apple.com/visionos/submit/#describing-your-app), `visionOS` should not be capitalized,  even when it’s the first word in a sentence. Think about it like writing `iOS` or `macOS`.

Ideally we should also fix the changelog in GitHub Releases: https://github.com/mapbox/mapbox-maps-ios/releases/tag/v11.2.0-beta.1