### PR TITLE
Fixing heatmap example

### DIFF
--- a/Apps/Examples/Examples/All Examples/HeatmapLayerGlobeExample.swift
+++ b/Apps/Examples/Examples/All Examples/HeatmapLayerGlobeExample.swift
@@ -129,6 +129,7 @@ final class HeatmapLayerGlobeExample: UIViewController, ExampleProtocol {
         // Add circle layer
         var circleLayer = CircleLayer(id: self.circleLayerId, source: self.earthquakeSourceId)
 
+        // Adjust the circle layer radius by zoom level
         circleLayer.circleRadius = .expression(
             Exp(.interpolate) {
                 Exp(.linear)

--- a/Apps/Examples/Examples/All Examples/HeatmapLayerGlobeExample.swift
+++ b/Apps/Examples/Examples/All Examples/HeatmapLayerGlobeExample.swift
@@ -133,7 +133,7 @@ final class HeatmapLayerGlobeExample: UIViewController, ExampleProtocol {
             Exp(.interpolate) {
                 Exp(.linear)
                 Exp(.zoom)
-                7  // Literal numeric zoom level
+                7
                 Exp(.interpolate) {
                     Exp(.linear)
                     Exp(.get) { "mag" }
@@ -142,7 +142,7 @@ final class HeatmapLayerGlobeExample: UIViewController, ExampleProtocol {
                     6
                     4
                 }
-                16 // Literal numeric zoom level
+                16
                 Exp(.interpolate) {
                     Exp(.linear)
                     Exp(.get) { "mag" }
@@ -196,7 +196,7 @@ final class HeatmapLayerGlobeExample: UIViewController, ExampleProtocol {
         do {
             try mapView.mapboxMap.addLayer(circleLayer, layerPosition: .below(self.heatmapLayerId))
         } catch {
-            print("Ran into an error adding a circle layer: \(error)")
+            print("Ran into an error adding a layer: \(error)")
         }
     }
 

--- a/Apps/Examples/Examples/All Examples/HeatmapLayerGlobeExample.swift
+++ b/Apps/Examples/Examples/All Examples/HeatmapLayerGlobeExample.swift
@@ -126,41 +126,26 @@ final class HeatmapLayerGlobeExample: UIViewController, ExampleProtocol {
 
     func createCircleLayer() {
 
-        var circleLayerSource = GeoJSONSource(id: self.earthquakeSourceId)
-        circleLayerSource.data = .url(self.earthquakeURL)
-        circleLayerSource.generateId = true
-
-        do {
-            try mapView.mapboxMap.addSource(circleLayerSource)
-        } catch {
-            print("Ran into an error adding a source: \(error)")
-        }
-
         // Add circle layer
         var circleLayer = CircleLayer(id: self.circleLayerId, source: self.earthquakeSourceId)
 
-        // Adjust the circle layer radius by zoom level
         circleLayer.circleRadius = .expression(
             Exp(.interpolate) {
                 Exp(.linear)
                 Exp(.zoom)
-                Exp(.literal) {
-                    7
-                }
+                7  // Literal numeric zoom level
                 Exp(.interpolate) {
                     Exp(.linear)
-                    Exp(.get) {"mag"}
+                    Exp(.get) { "mag" }
                     1
                     1
                     6
                     4
                 }
-                Exp(.literal) {
-                    16
-                }
+                16 // Literal numeric zoom level
                 Exp(.interpolate) {
                     Exp(.linear)
-                    Exp(.get) {"mag"}
+                    Exp(.get) { "mag" }
                     1
                     5
                     6
@@ -168,6 +153,7 @@ final class HeatmapLayerGlobeExample: UIViewController, ExampleProtocol {
                 }
             }
         )
+
         circleLayer.circleRadiusTransition = StyleTransition(duration: 0.5, delay: 0)
         circleLayer.circleStrokeColor = .constant(StyleColor(.black))
         circleLayer.circleStrokeWidth = .constant(1)
@@ -179,7 +165,7 @@ final class HeatmapLayerGlobeExample: UIViewController, ExampleProtocol {
                 Exp(.get) { "mag" }
                 1
                 "rgba(33.0, 102.0, 172.0, 0.0)"
-                1
+                2
                 "rgb(102.0, 169.0, 207.0)"
                 3
                 "rgb(209.0, 229.0, 240.0)"
@@ -210,7 +196,7 @@ final class HeatmapLayerGlobeExample: UIViewController, ExampleProtocol {
         do {
             try mapView.mapboxMap.addLayer(circleLayer, layerPosition: .below(self.heatmapLayerId))
         } catch {
-            print("Ran into an error adding a layer: \(error)")
+            print("Ran into an error adding a circle layer: \(error)")
         }
     }
 


### PR DESCRIPTION
## Changes in this PR
This PR fixes errors in the `HeatmapLayerGlobeExample.swift` file which was causing the circle Layer to not render on the map.  This was discovered when I was working on creating an example description for this example in [this PR](https://github.com/mapbox/ios-sdk/pull/2251) and realized that the `createCircleLayer()` was failing to render.  

The error had 2 causes

1. `createCircleLayer()` declares the Earthquakes source after it is already declared above
2. The `interpolate` function requires literal numeric values and this was using expressions.
3. `Interpolate` requires numeric literals in strictly ascending order and this example included 2 steps with the value of `1`.

All of the above errors are fixed in this PR.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
        
| Before | After |
| ----- | ----- |
| <img width="352" alt="Screenshot 2024-12-03 at 10 58 27 AM" src="https://github.com/user-attachments/assets/682e10bb-4aae-44dd-ad59-c061b9c3ebee">| <img width="361" alt="Screenshot 2024-12-03 at 10 56 28 AM" src="https://github.com/user-attachments/assets/7575c67c-093b-4923-b93e-56d5cd51d444"> |


## Video with transition of layers
https://github.com/user-attachments/assets/9c85a43f-c1e1-4b24-9424-e80bf50e7f3b

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
