### PR TITLE
Forward detected AI coding-agent id into XCUITest simulator runs

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -7,6 +7,7 @@ This guide contains the steps required to contribute to the development of this 
 * [Running Unit Tests On Devices](#running-unit-tests-on-devices)
 * [Running Integration Tests](#running-integration-tests)
 * [Making an Example](#making-an-example)
+* [Verifying AI coding-agent User-Agent tagging](#verifying-ai-coding-agent-user-agent-tagging)
 
 ## Setting Up a Development Environment
 
@@ -131,6 +132,23 @@ own `UIWindow` and root view controller, before adding the MapView to it.
 
 * Check out this [project](https://github.com/mapbox/mapbox-maps-ios/blob/main/Examples.xcodeproj)
   to get more information about adding examples to our project.
+
+## Verifying AI coding-agent User-Agent tagging
+
+Mapbox measures how much SDK traffic is driven by AI coding agents (Claude
+Code, Codex, Cursor, etc.) by appending an `agent/<id>` token to the outbound
+`User-Agent` header when one can be detected. `scripts/agent-detect.sh`
+detects the agent (if any) driving the current shell, and
+`scripts/run-uitests-with-agent-tag.sh` forwards that id into an
+`ExamplesUITests` simulator run so the tagging can be verified end-to-end:
+
+```sh
+scripts/run-uitests-with-agent-tag.sh
+```
+
+This is test-tooling only: a normal app run, or a UI test run started any
+other way, is unaffected. See the comments in both scripts for how the id
+is forwarded from the host shell into the launched app's environment.
 
 ## Tracing map performance
 

--- a/Tests/ExamplesUITests/ExamplesUITests.swift
+++ b/Tests/ExamplesUITests/ExamplesUITests.swift
@@ -22,7 +22,7 @@ final class ExamplesUITests: XCTestCase {
 
     func test_GrantLocationPermission() throws {
         let app = XCUIApplication()
-        app.launch()
+        app.launchForwardingAgentTag()
 
         // Navigate to an example that should trigger location permissoon alert to be shown
         let searchField = app.searchFields.firstMatch
@@ -36,7 +36,7 @@ final class ExamplesUITests: XCTestCase {
     func testEveryExample() throws {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
-        app.launch()
+        app.launchForwardingAgentTag()
 
         // Tap every example cell in the table view, and then dismiss the example.
         for cell in app.tables.element(boundBy: 0).cells.allElementsBoundByIndex {
@@ -45,6 +45,36 @@ final class ExamplesUITests: XCTestCase {
             // Navigate back to the table view
             app.navigationBars.buttons.element(boundBy: 0).tap()
         }
+    }
+}
+
+extension XCUIApplication {
+    /// Name of the environment variable that, when present in this process's
+    /// (the XCUITest runner's) own environment, identifies the AI coding
+    /// agent (if any) driving the host machine that invoked `xcodebuild
+    /// test` - see `scripts/agent-detect.sh` and
+    /// `scripts/run-uitests-with-agent-tag.sh`.
+    private static let agentTagEnvKey = "MAPBOX_AGENT"
+
+    /// Launches the app, forwarding a detected AI coding-agent id (if any)
+    /// into its `launchEnvironment` so outbound Mapbox requests made during
+    /// this run can be verified to carry an `agent/<id>` token in their
+    /// User-Agent header.
+    ///
+    /// The app under test does not automatically inherit this test runner's
+    /// environment, so the value has to be copied into `launchEnvironment`
+    /// explicitly. When the variable isn't present (a normal run, not
+    /// launched via `run-uitests-with-agent-tag.sh`), nothing is added and
+    /// this behaves exactly like a plain `launch()`.
+    ///
+    /// This is test-tooling only, used to verify an upcoming Common SDK
+    /// User-Agent change; it has no effect on the production app.
+    func launchForwardingAgentTag() {
+        if let agentId = ProcessInfo.processInfo.environment[Self.agentTagEnvKey],
+            !agentId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            launchEnvironment[Self.agentTagEnvKey] = agentId
+        }
+        launch()
     }
 }
 

--- a/scripts/agent-detect.sh
+++ b/scripts/agent-detect.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Detect the AI coding agent (if any) driving the *host* shell that is about
+# to invoke `xcodebuild test` (e.g. a Claude Code, Codex, or Cursor session
+# running on a developer's or CI machine).
+#
+# This is test-tooling only, used to forward a detected agent id into an
+# XCUITest simulator run so it can be verified that Mapbox requests made by
+# the app under test carry an `agent/<id>` token in their User-Agent header.
+# It has no effect on, and is never invoked by, a normal (non-XCUITest) app
+# run or the production SDK.
+#
+# Ported from mapbox-sdk-js's `lib/helpers/agent-detect.js` (that repo's
+# canonical implementation of this allowlist - keep the two in sync).
+# Canonical origin of the allowlist itself: HuggingFace's public
+# `agent-harnesses.ts` registry.
+#
+# Prints the detected agent id to stdout (and nothing else) when a match is
+# found; prints nothing when no agent is detected. Always exits 0: an
+# unexpected error while reading the environment must never fail the
+# caller's build/test invocation, so no condition in this script should be
+# treated as fatal.
+#
+# Usage:
+#   agent_id="$(scripts/agent-detect.sh)"
+
+set -uo pipefail # deliberately not `-e` - see note above about never failing
+
+# A safe charset for an agent id that ends up appended to a User-Agent header:
+# fallback env vars below are not validated by whoever sets them, so a value
+# like $'foo\nbar: injected' must be rejected here rather than reaching
+# xcodebuild/the app process as-is.
+SAFE_FALLBACK_REGEX='^[A-Za-z0-9_.-]{1,64}$'
+
+# trim VALUE -> VALUE with leading/trailing whitespace removed.
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+# is_set VAR_NAME -> true (0) if VAR_NAME exists in the environment with a
+# non-empty, non-whitespace-only value.
+is_set() {
+  local name="$1"
+  local value
+  value="$(trim "${!name-}")"
+  [[ -n "$value" ]]
+}
+
+# is_equal VAR_NAME EXPECTED -> true (0) if VAR_NAME's value equals EXPECTED
+# exactly (no trimming).
+is_equal() {
+  local name="$1"
+  local expected="$2"
+  [[ "${!name-}" == "$expected" ]]
+}
+
+# Scans the environment for a matching agent indicator. Table order (as
+# checks below) is precedence order - the first entry with any matching
+# condition wins.
+detect_agent() {
+  if is_set ANTIGRAVITY_AGENT; then echo "antigravity"; return; fi
+  if is_set AUGMENT_AGENT; then echo "augment-cli"; return; fi
+  if is_set CLINE_ACTIVE; then echo "cline"; return; fi
+  if is_set CLAUDE_CODE_IS_COWORK; then echo "cowork"; return; fi
+  if is_set CLAUDECODE || is_set CLAUDE_CODE; then echo "claude-code"; return; fi
+  if is_set CODEX_SANDBOX || is_set CODEX_CI || is_set CODEX_THREAD_ID; then echo "codex"; return; fi
+  if is_set CRUSH; then echo "crush"; return; fi
+  if is_set GEMINI_CLI; then echo "gemini-cli"; return; fi
+  if is_set COPILOT_MODEL || is_set COPILOT_ALLOW_ALL || is_set COPILOT_GITHUB_TOKEN; then echo "github-copilot"; return; fi
+  if is_set GOOSE_TERMINAL; then echo "goose"; return; fi
+  if is_set HERMES_SESSION_ID; then echo "hermes-agent"; return; fi
+  if is_set KILOCODE_FEATURE; then echo "kilo-code"; return; fi
+  if is_set AGENT_CONTEXT_OUT; then echo "kiro"; return; fi
+  if is_set OPENCLAW_SHELL; then echo "openclaw"; return; fi
+  if is_set OPENCODE_CLIENT; then echo "opencode"; return; fi
+  if is_set PI_CODING_AGENT; then echo "pi"; return; fi
+  if is_set REPL_ID; then echo "replit"; return; fi
+  if is_set TRAE_AI_SHELL_ID; then echo "trae"; return; fi
+  if is_equal VTCODE "1"; then echo "vtcode"; return; fi
+  if is_equal TERM_PROGRAM "WarpTerminal"; then echo "warp"; return; fi
+  if is_set ZED_TERM; then echo "zed"; return; fi
+  if is_set CURSOR_AGENT; then echo "cursor-cli"; return; fi
+  if is_set CURSOR_TRACE_ID; then echo "cursor"; return; fi
+
+  # Checked only if nothing above matched. First candidate with a non-empty
+  # (after trimming) value matching SAFE_FALLBACK_REGEX wins; an unsafe or
+  # empty value falls through to the next var rather than being returned
+  # as-is.
+  local name candidate
+  for name in AI_AGENT AGENT; do
+    candidate="$(trim "${!name-}")"
+    if [[ -n "$candidate" && "$candidate" =~ $SAFE_FALLBACK_REGEX ]]; then
+      echo "$candidate"
+      return
+    fi
+  done
+}
+
+
+# Lightweight regression check for detect_agent's precedence/fallback rules,
+# run in a subshell per case so no case leaks environment into the next one.
+# Usage: scripts/agent-detect.sh --self-test
+run_self_test() {
+  local failures=0
+  local description="$1"
+  local expected="$2"
+  shift 2
+  local actual
+  actual="$(env -i HOME="$HOME" PATH="$PATH" "$@" bash "${BASH_SOURCE[0]}")"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "FAIL: $description - expected '$expected', got '$actual'"
+    return 1
+  fi
+  echo "OK: $description"
+  return 0
+}
+
+self_test() {
+  local failures=0
+
+  run_self_test "no agent vars -> nothing detected" "" || ((failures++))
+  run_self_test "CLAUDECODE=1 -> claude-code" "claude-code" CLAUDECODE=1 || ((failures++))
+  run_self_test "CURSOR_TRACE_ID set -> cursor" "cursor" CURSOR_TRACE_ID=abc123 || ((failures++))
+  run_self_test "table order: claude-code beats cursor when both set" "claude-code" \
+    CLAUDECODE=1 CURSOR_TRACE_ID=abc || ((failures++))
+  run_self_test "VTCODE=0 does not match (exact-equality check)" "" VTCODE=0 || ((failures++))
+  run_self_test "VTCODE=1 -> vtcode" "vtcode" VTCODE=1 || ((failures++))
+  run_self_test "TERM_PROGRAM=WarpTerminal -> warp" "warp" TERM_PROGRAM=WarpTerminal || ((failures++))
+  run_self_test "fallback AGENT with a safe value is used" "my-custom-agent" \
+    AGENT="my-custom-agent" || ((failures++))
+  run_self_test "fallback AI_AGENT takes precedence over AGENT" "agent-one" \
+    AI_AGENT="agent-one" AGENT="agent-two" || ((failures++))
+  run_self_test "whitespace-only fallback value is rejected" "" AI_AGENT="   " || ((failures++))
+  run_self_test "unsafe fallback value (header-injection shape) is rejected" "" \
+    AGENT=$'evil\nInjected: yes' || ((failures++))
+
+  if ((failures > 0)); then
+    echo "$failures self-test case(s) failed"
+    return 1
+  fi
+  echo "All self-test cases passed"
+  return 0
+}
+
+if [[ "${1-}" == "--self-test" ]]; then
+  self_test
+  exit $?
+fi
+
+detect_agent
+exit 0

--- a/scripts/run-uitests-with-agent-tag.sh
+++ b/scripts/run-uitests-with-agent-tag.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Run the Examples app's XCUITest suite on a simulator, forwarding a detected
+# AI coding-agent id (see agent-detect.sh) into the app process so it can be
+# verified end-to-end that outbound Mapbox requests carry an `agent/<id>`
+# token in their User-Agent header.
+#
+# This is test-tooling only - it has no effect on, and is not part of, the
+# production SDK or a normal (non-XCUITest) app run.
+#
+# How the id reaches the app process:
+#   1. This script detects the agent id from *this* host shell's environment
+#      and passes it to `xcodebuild test` as `TEST_RUNNER_MAPBOX_AGENT=<id>`.
+#      Xcode automatically strips the `TEST_RUNNER_` prefix and exposes the
+#      remainder (`MAPBOX_AGENT`) as an environment variable of the *test
+#      runner* process (i.e. `ProcessInfo.processInfo.environment` inside the
+#      XCUITest target).
+#   2. The XCUITest setup (see `Tests/ExamplesUITests/ExamplesUITests.swift`)
+#      reads `MAPBOX_AGENT` from its own environment and copies it into
+#      `XCUIApplication().launchEnvironment["MAPBOX_AGENT"]` before `.launch()`
+#      - the app under test does not automatically inherit the test runner's
+#      environment, so this explicit copy is required.
+#   3. The app process (and therefore Common's HttpService) reads
+#      `MAPBOX_AGENT` via `getenv`/`ProcessInfo` as it would in any other
+#      context.
+#
+# If no agent is detected, no TEST_RUNNER_MAPBOX_AGENT argument is passed at
+# all, so the run behaves exactly as it did before this tooling existed.
+#
+# Usage:
+#   scripts/run-uitests-with-agent-tag.sh
+#
+# Optional environment overrides:
+#   SCHEME       (default: Examples)
+#   TEST_PLAN    (default: "Examples no unit tests")
+#   DESTINATION  (default: "platform=iOS Simulator,name=iPhone 16")
+
+set -eou pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+SCHEME="${SCHEME:-Examples}"
+TEST_PLAN="${TEST_PLAN:-Examples no unit tests}"
+DESTINATION="${DESTINATION:-platform=iOS Simulator,name=iPhone 16}"
+
+AGENT_ID="$("$SCRIPT_DIR/agent-detect.sh")"
+
+XCODEBUILD_ARGS=(
+  test
+  -project "$SCRIPT_DIR/../Examples.xcodeproj"
+  -scheme "$SCHEME"
+  -testPlan "$TEST_PLAN"
+  -destination "$DESTINATION"
+)
+
+if [[ -n "$AGENT_ID" ]]; then
+  echo "agent-detect: forwarding TEST_RUNNER_MAPBOX_AGENT=$AGENT_ID"
+  XCODEBUILD_ARGS+=("TEST_RUNNER_MAPBOX_AGENT=$AGENT_ID")
+else
+  echo "agent-detect: no coding agent detected; running without agent tag forwarding"
+fi
+
+set -x
+xcodebuild "${XCODEBUILD_ARGS[@]}"

--- a/scripts/validate-integrations/MapLoadingUITest.swift
+++ b/scripts/validate-integrations/MapLoadingUITest.swift
@@ -3,6 +3,20 @@ import XCTest
 class MapLoadingUITest: XCTestCase {
     func testExample() throws {
         let app = XCUIApplication()
+
+        // Forward a detected AI coding-agent id (see
+        // ../agent-detect.sh and ../run-uitests-with-agent-tag.sh, both in
+        // the scripts/ directory) into the launched app's environment, for verifying
+        // that outbound Mapbox requests carry an `agent/<id>` token in their
+        // User-Agent header. The app does not automatically inherit this
+        // test runner's environment, so it's copied explicitly; when the
+        // variable isn't set (a normal run), nothing is added here and this
+        // behaves exactly like a plain `launch()`. Test-tooling only - no
+        // effect on the production app.
+        if let agentId = ProcessInfo.processInfo.environment["MAPBOX_AGENT"],
+            !agentId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            app.launchEnvironment["MAPBOX_AGENT"] = agentId
+        }
         app.launch()
 
         let existancePredicate = NSPredicate(format: "exists == 1")


### PR DESCRIPTION
## Summary

Mapbox wants to measure how much SDK traffic across its client SDKs comes from AI coding agents (Claude Code, Codex, Cursor, and similar tools), by appending an `agent/<id>` token to the outbound `User-Agent` header whenever an agent can be detected. This repo doesn't build that header itself - that happens in a shared native HTTP layer this SDK depends on - but verifying the tagging end-to-end on iOS means a detected agent id needs a way to reach the running app process during a test run. This PR adds that path, for XCUITest simulator runs only.

- `scripts/agent-detect.sh` detects the AI coding agent (if any) driving the *host* shell about to invoke `xcodebuild`, using the same allowlist, precedence order, and sanitized fallback rules as this project's sibling SDK implementations of the same detection logic (kept in sync across those SDKs).
- `scripts/run-uitests-with-agent-tag.sh` runs the `ExamplesUITests` scheme on a simulator, forwarding the detected id to `xcodebuild test` via the `TEST_RUNNER_MAPBOX_AGENT` environment variable, which Xcode automatically strips and exposes as `MAPBOX_AGENT` to the XCUITest runner process.
- `ExamplesUITests.swift` and `MapLoadingUITest.swift` read `MAPBOX_AGENT` from `ProcessInfo.processInfo.environment` and copy it into `XCUIApplication().launchEnvironment` before `.launch()`, since the app under test doesn't automatically inherit the test runner's environment.

A normal app run is unaffected, and a UI test run started any other way (without `TEST_RUNNER_MAPBOX_AGENT` set) behaves exactly as before - nothing gets added to `launchEnvironment`. No production SDK code is touched. Actually seeing the `agent/<id>` token show up server-side still depends on a separate, not-yet-merged change to the shared native HTTP layer's User-Agent construction; this PR just makes sure a detected id can reach the app process once that lands.

I ran `scripts/agent-detect.sh` directly against a battery of scenarios: each supported agent's indicator var, precedence when multiple are set at once, the `VTCODE`/`TERM_PROGRAM` exact-match cases, safe and unsafe fallback-variable handling (including a header-injection-shaped value), and the "nothing detected" case. All produced the expected output, and that same battery runs as a self-check via `scripts/agent-detect.sh --self-test`. Both scripts pass `shellcheck` and `bash -n`. I also parsed and typechecked the modified Swift files standalone with `swiftc` against the iOS Simulator SDK; the only errors reported are pre-existing and unrelated to this change (an `XCTAssertTrue`/`XCTAssertEqual` macro-import limitation specific to typechecking a single file outside the full Xcode project build).

What I couldn't verify here: a full `xcodebuild test` simulator run of `ExamplesUITests`, since it needs Carthage/CocoaPods binary dependency downloads gated on a Mapbox secret token and `~/.netrc`, plus `carthage`/`pod` tooling not available in this environment. A reviewer with a normal local dev setup (per `DEVELOPING.md`) should run `scripts/run-uitests-with-agent-tag.sh` to confirm the app process actually receives `MAPBOX_AGENT`, and later, once the native HTTP layer change lands, that outbound `User-Agent` headers carry the `agent/<id>` token. Real-device and CI runs weren't exercised either.

## Test plan

- [ ] Run `scripts/run-uitests-with-agent-tag.sh` from a machine with an AI coding agent's environment indicator set (e.g. inside a Claude Code session) and confirm the launched app's process environment contains `MAPBOX_AGENT`.
- [ ] Run the same script from a plain shell (no agent indicator set) and confirm no `TEST_RUNNER_MAPBOX_AGENT` argument is passed and the run behaves as before.
- [ ] Once the corresponding native HTTP layer change lands, re-run the positive case and confirm outbound Mapbox request `User-Agent` headers include ` agent/<id>`.

## Pull request checklist:
 - [x] Describe the changes in this PR, especially public API changes. (No public API changes - this is internal test tooling only.)
 - [ ] Include before/after visuals or gifs if this PR includes visual changes. N/A, no visual changes.
 - [x] Write tests for all new functionality. Put tests in correct [Test Plan](https://github.com/mapbox/mapbox-maps-ios/tree/main/Tests/TestPlans) (Unit, Integration, All)
   - `scripts/agent-detect.sh --self-test` covers the detection logic itself; the XCUITest-side plumbing is exercised by the manual Test plan below since it depends on a real simulator run.
 - [ ] Add documentation comments for any added or updated public APIs. N/A, no public APIs added or changed.
 - [ ] Add any new public, top-level symbols to the DocC custom catatlog (Sources/MapboxMaps/Documentation.docc/API Catalogs). N/A, no new public symbols.
 - [ ] Add a changelog entry to to bottom of the relevant section (typically the `## main` heading near the top). Not added yet - open to adding one if maintainers want this test-tooling change logged.
 - [ ] Update the guides (internal access only), README.md, and DEVELOPING.md if their contents are impacted by these changes. Not yet updated; happy to add a short DEVELOPING.md note on the new scripts if useful.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` first and then port to `v10.[version]` release branch. N/A, targeting `main` directly.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-ios/blob/main/CONTRIBUTING.md#contributor-license-agreement).
